### PR TITLE
Add integrated config front-end to ZIO 2.0

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -1,0 +1,36 @@
+package zio
+
+import zio.test._
+
+object ConfigProviderSpec extends ZIOBaseSpec {
+  def provider(map: Map[String, String]): ConfigProvider = ConfigProvider.fromMap(map)
+
+  final case class HostPort(host: String, port: Int)
+  object HostPort {
+    val config: Config[HostPort] = (Config.string("host") ++ Config.int("port")).map { case (a, b) => HostPort(a, b) }
+
+    val default: HostPort = HostPort("localhost", 8080)
+  }
+
+  final case class ServiceConfig(hostPort: HostPort, timeout: Int)
+  object ServiceConfig {
+    val config: Config[ServiceConfig] =
+      (HostPort.config("hostPort") ++ Config.int("timeout")).map { case (a, b) => ServiceConfig(a, b) }
+
+    val default: ServiceConfig = ServiceConfig(HostPort.default, 1000)
+  }
+
+  def spec = suite("ConfigProviderSpec") {
+    test("flat atoms") {
+      for {
+        value <- provider(Map("host" -> "localhost", "port" -> "8080")).load(HostPort.config)
+      } yield assertTrue(value == HostPort.default)
+    } +
+      test("nested atoms") {
+        for {
+          value <- provider(Map("hostPort.host" -> "localhost", "hostPort.port" -> "8080", "timeout" -> "1000"))
+                     .load(ServiceConfig.config)
+        } yield assertTrue(value == ServiceConfig.default)
+      } @@ TestAspect.ignore
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -31,6 +31,6 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           value <- provider(Map("hostPort.host" -> "localhost", "hostPort.port" -> "8080", "timeout" -> "1000"))
                      .load(ServiceConfig.config)
         } yield assertTrue(value == ServiceConfig.default)
-      } @@ TestAspect.ignore
+      }
   }
 }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -59,7 +59,7 @@ sealed trait Config[+A] { self =>
    * produce a different Scala value, constructed using the specified function,
    * which may throw exceptions that will be translated into validation errors.
    */
-  def mapOrThrow[B](f: A => B): Config[B] =
+  def mapAttempt[B](f: A => B): Config[B] =
     self.mapOrFail { a =>
       try Right(f(a))
       catch {
@@ -103,9 +103,9 @@ sealed trait Config[+A] { self =>
   def zip[B](that: Config[B])(implicit z: Zippable[A, B]): Config[z.Out] = self ++ that
 }
 object Config {
-  sealed trait Atom[+A] extends Config[A] { self =>
+  sealed trait Primitive[+A] extends Config[A] { self =>
     final def description: String =
-      (self: Atom[_]) match {
+      (self: Primitive[_]) match {
         case Bool           => "a boolean property"
         case Constant(_)    => "a constant property"
         case Decimal        => "a decimal property"
@@ -127,33 +127,33 @@ object Config {
   }
   sealed trait Composite[+A] extends Config[A]
 
-  case object Bool extends Atom[Boolean] {
+  case object Bool extends Primitive[Boolean] {
     final def parse(text: String): Either[Config.Error, Boolean] = text.toLowerCase match {
       case "true" | "yes" | "on" | "1"  => Right(true)
       case "false" | "no" | "off" | "0" => Right(false)
       case _                            => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a boolean value, but found ${text}"))
     }
   }
-  final case class Constant[A](value: A) extends Atom[A] {
+  final case class Constant[A](value: A) extends Primitive[A] {
     final def parse(text: String): Either[Config.Error, A] = Right(value)
   }
-  case object Decimal extends Atom[BigDecimal] {
+  case object Decimal extends Primitive[BigDecimal] {
     final def parse(text: String): Either[Config.Error, BigDecimal] = try Right(BigDecimal(text))
     catch {
       case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a decimal value, but found ${text}"))
     }
   }
-  case object Duration extends Atom[zio.Duration] {
+  case object Duration extends Primitive[zio.Duration] {
     final def parse(text: String): Either[Config.Error, zio.Duration] = try Right(java.time.Duration.parse(text))
     catch {
       case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
     }
   }
-  final case class Fail(message: String) extends Atom[Nothing] {
+  final case class Fail(message: String) extends Primitive[Nothing] {
     final def parse(text: String): Either[Config.Error, Nothing] = Left(Config.Error.Unsupported(Chunk.empty, message))
   }
   final case class Fallback[A](first: Config[A], second: Config[A]) extends Composite[A]
-  case object Integer extends Atom[BigInt] {
+  case object Integer extends Primitive[BigInt] {
     final def parse(text: String): Either[Config.Error, BigInt] = try Right(BigInt(text))
     catch {
       case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected an integer value, but found ${text}"))
@@ -161,7 +161,7 @@ object Config {
   }
   final case class Described[A](config: Config[A], description: String) extends Composite[A]
   final case class Lazy[A](thunk: () => Config[A])                      extends Composite[A]
-  case object LocalDateTime extends Atom[java.time.LocalDateTime] {
+  case object LocalDateTime extends Primitive[java.time.LocalDateTime] {
     final def parse(text: String): Either[Config.Error, java.time.LocalDateTime] = try Right(
       java.time.LocalDateTime.parse(text)
     )
@@ -170,7 +170,7 @@ object Config {
         Left(Config.Error.InvalidData(Chunk.empty, s"Expected a local date-time value, but found ${text}"))
     }
   }
-  case object LocalDate extends Atom[java.time.LocalDate] {
+  case object LocalDate extends Primitive[java.time.LocalDate] {
     final def parse(text: String): Either[Config.Error, java.time.LocalDate] = try Right(
       java.time.LocalDate.parse(text)
     )
@@ -178,7 +178,7 @@ object Config {
       case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a local date value, but found ${text}"))
     }
   }
-  case object LocalTime extends Atom[java.time.LocalTime] {
+  case object LocalTime extends Primitive[java.time.LocalTime] {
     final def parse(text: String): Either[Config.Error, java.time.LocalTime] = try Right(
       java.time.LocalTime.parse(text)
     )
@@ -188,7 +188,7 @@ object Config {
   }
   final case class MapOrFail[A, B](original: Config[A], mapOrFail: A => Either[Config.Error, B]) extends Composite[B]
   final case class Nested[A](name: String, config: Config[A])                                    extends Composite[A]
-  case object OffsetDateTime extends Atom[java.time.OffsetDateTime] {
+  case object OffsetDateTime extends Primitive[java.time.OffsetDateTime] {
     final def parse(text: String): Either[Config.Error, java.time.OffsetDateTime] = try Right(
       java.time.OffsetDateTime.parse(text)
     )
@@ -197,14 +197,14 @@ object Config {
         Left(Config.Error.InvalidData(Chunk.empty, s"Expected an offset date-time value, but found ${text}"))
     }
   }
-  case object Secret extends Atom[zio.Secret] {
+  case object Secret extends Primitive[zio.Secret] {
     final def parse(text: String): Either[Config.Error, zio.Secret] = Right(
       zio.Secret(Chunk.fromIterable(text.getBytes()))
     )
   }
   final case class Sequence[A](config: Config[A])   extends Composite[Chunk[A]]
   final case class Table[V](valueConfig: Config[V]) extends Composite[Map[String, V]]
-  case object Text extends Atom[String] {
+  case object Text extends Primitive[String] {
     final def parse(text: String): Either[Config.Error, String] = Right(text)
   }
   final case class Zipped[A, B, C](left: Config[A], right: Config[B], zippable: Zippable.Out[A, B, C])
@@ -331,7 +331,7 @@ object Config {
 
   def table[V](name: String, value: Config[V]): Config[Map[String, V]] = table(value).nested(name)
 
-  def uri: Config[java.net.URI] = string.mapOrThrow(java.net.URI.create(_))
+  def uri: Config[java.net.URI] = string.mapAttempt(java.net.URI.create(_))
 
   def uri(name: String): Config[java.net.URI] = uri.nested(name)
 

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -41,6 +41,8 @@ sealed trait Config[+A] { self =>
    */
   def ??(label: String): Config[A] = Config.Described(self, label)
 
+  def apply(name: String): Config[A] = nested(name)
+
   /**
    * Returns a new config whose structure is the same as this one, but which
    * produces a different Scala value, constructed using the specified function.

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -54,6 +54,11 @@ sealed trait Config[+A] { self =>
    */
   def mapOrFail[B](f: A => Either[Config.Error, B]): Config[B] = Config.MapOrFail(self, f)
 
+  /**
+   * Returns a new config whose structure is the same as this one, but which may
+   * produce a different Scala value, constructed using the specified function,
+   * which may throw exceptions that will be translated into validation errors.
+   */
   def mapOrThrow[B](f: A => B): Config[B] =
     self.mapOrFail { a =>
       try Right(f(a))
@@ -61,6 +66,12 @@ sealed trait Config[+A] { self =>
         case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, e.getMessage))
       }
     }
+
+  /**
+   * Returns a new config that has this configuration nested as a property of
+   * the specified name.
+   */
+  def nested(name: String): Config[A] = Config.Nested(name, self)
 
   /**
    * Returns an optional version of this config, which will be `None` if the
@@ -92,27 +103,110 @@ sealed trait Config[+A] { self =>
   def zip[B](that: Config[B])(implicit z: Zippable[A, B]): Config[z.Out] = self ++ that
 }
 object Config {
-  sealed trait Atom[+A]      extends Config[A]
+  sealed trait Atom[+A] extends Config[A] { self =>
+    final def description: String =
+      (self: Atom[_]) match {
+        case Bool           => "a boolean value"
+        case Constant(_)    => "a constant value"
+        case Decimal        => "a decimal value"
+        case Duration       => "a duration value"
+        case Fail(_)        => "a failure"
+        case Integer        => "an integer value"
+        case LocalDateTime  => "a local date-time value"
+        case LocalDate      => "a local date value"
+        case LocalTime      => "a local time value"
+        case OffsetDateTime => "an offset date-time value"
+        case Secret         => "a secret value"
+        case Text           => "a text value"
+      }
+
+    final def missingError(name: String): Config.Error =
+      Config.Error.MissingData(Chunk.empty, s"Expected a ${description} with name ${name}")
+
+    def parse(text: String): Either[Config.Error, A]
+  }
   sealed trait Composite[+A] extends Config[A]
 
-  final case class Bool(name: String)                                                            extends Atom[Boolean]
-  final case class Constant[A](value: A)                                                         extends Atom[A]
-  final case class Decimal(name: String)                                                         extends Atom[BigDecimal]
-  final case class Duration(name: String)                                                        extends Atom[zio.Duration]
-  final case class Fail(message: String)                                                         extends Atom[Nothing]
-  final case class Fallback[A](first: Config[A], second: Config[A])                              extends Composite[A]
-  final case class Integer(name: String)                                                         extends Composite[BigInt]
-  final case class Described[A](config: Config[A], description: String)                          extends Composite[A]
-  final case class Lazy[A](thunk: () => Config[A])                                               extends Composite[A]
-  final case class LocalDateTime(name: String)                                                   extends Atom[java.time.LocalDateTime]
-  final case class LocalDate(name: String)                                                       extends Atom[java.time.LocalDate]
-  final case class LocalTime(name: String)                                                       extends Atom[java.time.LocalTime]
+  case object Bool extends Atom[Boolean] {
+    final def parse(text: String): Either[Config.Error, Boolean] = text match {
+      case "true" | "yes" | "on" | "1"  => Right(true)
+      case "false" | "no" | "off" | "0" => Right(false)
+      case _                            => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a boolean value, but got ${text}"))
+    }
+  }
+  final case class Constant[A](value: A) extends Atom[A] {
+    final def parse(text: String): Either[Config.Error, A] = Right(value)
+  }
+  case object Decimal extends Atom[BigDecimal] {
+    final def parse(text: String): Either[Config.Error, BigDecimal] = try Right(BigDecimal(text))
+    catch {
+      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a decimal value, but got ${text}"))
+    }
+  }
+  case object Duration extends Atom[zio.Duration] {
+    final def parse(text: String): Either[Config.Error, zio.Duration] = try Right(java.time.Duration.parse(text))
+    catch {
+      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but got ${text}"))
+    }
+  }
+  final case class Fail(message: String) extends Atom[Nothing] {
+    final def parse(text: String): Either[Config.Error, Nothing] = Left(Config.Error.Unsupported(Chunk.empty, message))
+  }
+  final case class Fallback[A](first: Config[A], second: Config[A]) extends Composite[A]
+  case object Integer extends Atom[BigInt] {
+    final def parse(text: String): Either[Config.Error, BigInt] = try Right(BigInt(text))
+    catch {
+      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected an integer value, but got ${text}"))
+    }
+  }
+  final case class Described[A](config: Config[A], description: String) extends Composite[A]
+  final case class Lazy[A](thunk: () => Config[A])                      extends Composite[A]
+  case object LocalDateTime extends Atom[java.time.LocalDateTime] {
+    final def parse(text: String): Either[Config.Error, java.time.LocalDateTime] = try Right(
+      java.time.LocalDateTime.parse(text)
+    )
+    catch {
+      case NonFatal(e) =>
+        Left(Config.Error.InvalidData(Chunk.empty, s"Expected a local date-time value, but got ${text}"))
+    }
+  }
+  case object LocalDate extends Atom[java.time.LocalDate] {
+    final def parse(text: String): Either[Config.Error, java.time.LocalDate] = try Right(
+      java.time.LocalDate.parse(text)
+    )
+    catch {
+      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a local date value, but got ${text}"))
+    }
+  }
+  case object LocalTime extends Atom[java.time.LocalTime] {
+    final def parse(text: String): Either[Config.Error, java.time.LocalTime] = try Right(
+      java.time.LocalTime.parse(text)
+    )
+    catch {
+      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a local time value, but got ${text}"))
+    }
+  }
   final case class MapOrFail[A, B](original: Config[A], mapOrFail: A => Either[Config.Error, B]) extends Composite[B]
-  final case class OffsetDateTime(name: String)                                                  extends Atom[java.time.OffsetDateTime]
-  final case class Secret(name: String)                                                          extends Atom[zio.Secret]
-  final case class Sequence[A](config: Config[A])                                                extends Composite[Chunk[A]]
-  final case class Table[V](valueConfig: Config[V])                                              extends Composite[Map[String, V]]
-  final case class Text(name: String)                                                            extends Atom[String]
+  final case class Nested[A](name: String, config: Config[A])                                    extends Composite[A]
+  case object OffsetDateTime extends Atom[java.time.OffsetDateTime] {
+    final def parse(text: String): Either[Config.Error, java.time.OffsetDateTime] = try Right(
+      java.time.OffsetDateTime.parse(text)
+    )
+    catch {
+      case NonFatal(e) =>
+        Left(Config.Error.InvalidData(Chunk.empty, s"Expected an offset date-time value, but got ${text}"))
+    }
+  }
+  case object Secret extends Atom[zio.Secret] {
+    final def parse(text: String): Either[Config.Error, zio.Secret] = Right(
+      zio.Secret(Chunk.fromIterable(text.getBytes()))
+    )
+  }
+  final case class Sequence[A](config: Config[A])   extends Composite[Chunk[A]]
+  final case class Table[V](valueConfig: Config[V]) extends Composite[Map[String, V]]
+  case object Text extends Atom[String] {
+    final def parse(text: String): Either[Config.Error, String] = Right(text)
+  }
   final case class Zipped[A, B, C](left: Config[A], right: Config[B], zippable: Zippable.Out[A, B, C])
       extends Composite[C]
 
@@ -148,20 +242,20 @@ object Config {
     }
   }
 
-  def bigDecimal(name: String): Config[BigDecimal] = Decimal(name)
+  def bigDecimal(name: String): Config[BigDecimal] = Decimal.nested(name)
 
-  def bigInteger(name: String): Config[BigInt] = Integer(name)
+  def bigInteger(name: String): Config[BigInt] = Integer.nested(name)
 
-  def boolean(name: String): Config[Boolean] = Bool(name)
+  def boolean(name: String): Config[Boolean] = Bool.nested(name)
 
-  def chunkOf[A](config: Config[A]): Config[Chunk[A]] = Sequence(config)
+  def chunkOf[A](name: String, config: Config[A]): Config[Chunk[A]] = Sequence(config).nested(name)
 
   def defer[A](config: => Config[A]): Config[A] =
     Lazy(() => config)
 
   def double(name: String): Config[Double] = bigDecimal(name).map(_.toDouble)
 
-  def duration(name: String): Config[zio.Duration] = Duration(name)
+  def duration(name: String): Config[zio.Duration] = Duration.nested(name)
 
   def fail(error: => String): Config[Nothing] = defer(Fail(error))
 
@@ -169,27 +263,27 @@ object Config {
 
   def int(name: String): Config[Int] = bigInteger(name).map(_.toInt)
 
-  def listOf[A](config: Config[A]): Config[List[A]] = chunkOf(config).map(_.toList)
+  def listOf[A](name: String, config: Config[A]): Config[List[A]] = chunkOf(name, config).map(_.toList)
 
-  def localDate(name: String): Config[java.time.LocalDate] = LocalDate(name)
+  def localDate(name: String): Config[java.time.LocalDate] = LocalDate.nested(name)
 
-  def localDateTime(name: String): Config[java.time.LocalDateTime] = LocalDateTime(name)
+  def localDateTime(name: String): Config[java.time.LocalDateTime] = LocalDateTime.nested(name)
 
-  def localTime(name: String): Config[java.time.LocalTime] = LocalTime(name)
+  def localTime(name: String): Config[java.time.LocalTime] = LocalTime.nested(name)
 
-  def offsetDateTime(name: String): Config[java.time.OffsetDateTime] = OffsetDateTime(name)
+  def offsetDateTime(name: String): Config[java.time.OffsetDateTime] = OffsetDateTime.nested(name)
 
-  def secret(name: String): Config[zio.Secret] = Secret(name)
+  def secret(name: String): Config[zio.Secret] = Secret.nested(name)
 
-  def setOf[A](config: Config[A]): Config[Set[A]] = chunkOf(config).map(_.toSet)
+  def setOf[A](name: String, config: Config[A]): Config[Set[A]] = chunkOf(name, config).map(_.toSet)
 
-  def string(name: String): Config[String] = Text(name)
+  def string(name: String): Config[String] = Text.nested(name)
 
   def succeed[A](value: => A): Config[A] = defer(Constant(value))
 
-  def table[V](value: Config[V]): Config[Map[String, V]] = Table(value)
+  def table[V](name: String, value: Config[V]): Config[Map[String, V]] = Table(value).nested(name)
 
   def uri(name: String): Config[java.net.URI] = string(name).mapOrThrow(java.net.URI.create(_))
 
-  def vectorOf[A](config: Config[A]): Config[Vector[A]] = chunkOf(config).map(_.toVector)
+  def vectorOf[A](name: String, config: Config[A]): Config[Vector[A]] = chunkOf(name, config).map(_.toVector)
 }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -48,8 +48,8 @@ sealed trait Config[+A] { self =>
   def map[B](f: A => B): Config[B] = self.mapOrFail(a => Right(f(a)))
 
   /**
-   * Returns a new config whose structure is the samea as this one, but which 
-   * may produce a different Scala value, constructed using the specified 
+   * Returns a new config whose structure is the samea as this one, but which
+   * may produce a different Scala value, constructed using the specified
    * fallible function.
    */
   def mapOrFail[B](f: A => Either[Config.Error, B]): Config[B] = Config.MapOrFail(self, f)
@@ -66,19 +66,17 @@ sealed trait Config[+A] { self =>
   def orElse[A1 >: A](that: Config[A1]): Config[A1] = self || that
 
   /**
-   * Returns a new config that describes a sequence of values, each of which
-   * has the structure of this config.
+   * Returns a new config that describes a sequence of values, each of which has
+   * the structure of this config.
    */
   def repeat: Config[Chunk[A]] = Config.Sequence(self)
 
   /**
-   * Returns a new config that describes the same structure as this one, but 
+   * Returns a new config that describes the same structure as this one, but
    * which performs validation during loading.
    */
   def validate[A1 >: A](message: String)(f: A1 => Boolean): Config[A1] =
-    self.mapOrFail(a =>
-      if (!f(a)) Left(Config.Error.InvalidData(Chunk.empty, message)) else Right(a)
-    )
+    self.mapOrFail(a => if (!f(a)) Left(Config.Error.InvalidData(Chunk.empty, message)) else Right(a))
 
   /**
    * A named version of `++`.
@@ -93,7 +91,7 @@ object Config {
   final case class Fail(message: String)                                                               extends Config[Nothing]
   final case class Fallback[A](first: Config[A], second: Config[A])                                    extends Config[A]
   final case class Integer(name: String)                                                               extends Config[BigInt]
-  final case class Described[A](config: Config[A], description: String)                                       extends Config[A]
+  final case class Described[A](config: Config[A], description: String)                                extends Config[A]
   final case class Lazy[A](thunk: () => Config[A])                                                     extends Config[A]
   final case class LocalDateTime(name: String)                                                         extends Config[java.time.LocalDateTime]
   final case class LocalDate(name: String)                                                             extends Config[java.time.LocalDate]

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -220,27 +220,41 @@ object Config {
     def ||(that: Error): Error = Error.And(self, that)
 
     def prefixed(prefix: Chunk[String]): Error
+
+    override def getMessage(): String = toString()
   }
   object Error {
     final case class And(left: Error, right: Error) extends Error {
       def prefixed(prefix: Chunk[String]): And =
         copy(left = left.prefixed(prefix), right = right.prefixed(prefix))
+
+      override def toString(): String = s"(${left.toString()} and ${right.toString()})"
     }
     final case class InvalidData(path: Chunk[String], message: String) extends Error {
       def prefixed(prefix: Chunk[String]): InvalidData = copy(path = prefix ++ path)
+
+      override def toString(): String = s"(Invalid data at ${path.mkString(".")}: ${message})"
     }
     final case class MissingData(path: Chunk[String], message: String) extends Error {
       def prefixed(prefix: Chunk[String]): MissingData = copy(path = prefix ++ path)
+
+      override def toString(): String = s"(Missing data at ${path.mkString(".")}: ${message})"
     }
     final case class Or(left: Error, right: Error) extends Error {
       def prefixed(prefix: Chunk[String]): Or =
         copy(left = left.prefixed(prefix), right = right.prefixed(prefix))
+
+      override def toString(): String = s"(${left.toString()} or ${right.toString()})"
     }
     final case class SourceUnavailable(path: Chunk[String], message: String, cause: Cause[Throwable]) extends Error {
       def prefixed(prefix: Chunk[String]): SourceUnavailable = copy(path = prefix ++ path)
+
+      override def toString(): String = s"(Source unavailable at ${path.mkString(".")}: ${message})"
     }
     final case class Unsupported(path: Chunk[String], message: String) extends Error {
       def prefixed(prefix: Chunk[String]): Unsupported = copy(path = prefix ++ path)
+
+      override def toString(): String = s"(Unsupported operation at ${path.mkString(".")}: ${message})"
     }
   }
 

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -26,15 +26,15 @@ sealed trait Config[+A] { self =>
    * Returns a new config that is the composition of this config and the
    * specified config.
    */
-  def ++[B](that: Config[B])(implicit zippable: Zippable[A, B]): Config[zippable.Out] =
-    Config.Zipped[A, B, zippable.Out](self, that, zippable)
+  def ++[B](that: => Config[B])(implicit zippable: Zippable[A, B]): Config[zippable.Out] =
+    Config.Zipped[A, B, zippable.Out](self, Config.defer(that), zippable)
 
   /**
    * Returns a config whose structure is preferentially described by this
    * config, but which falls back to the specified config if there is an issue
    * reading from this config.
    */
-  def ||[A1 >: A](that: Config[A1]): Config[A1] = Config.Fallback(self, that)
+  def ||[A1 >: A](that: => Config[A1]): Config[A1] = Config.Fallback(self, Config.defer(that))
 
   /**
    * Adds a description to this configuration, which is intended for humans.
@@ -100,7 +100,7 @@ sealed trait Config[+A] { self =>
   /**
    * A named version of `++`.
    */
-  def zip[B](that: Config[B])(implicit z: Zippable[A, B]): Config[z.Out] = self ++ that
+  def zip[B](that: => Config[B])(implicit z: Zippable[A, B]): Config[z.Out] = self ++ that
 }
 object Config {
   sealed trait Primitive[+A] extends Config[A] { self =>

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import scala.util.control.NoStackTrace
+
+sealed trait Config[+A] { self =>
+  def ++[B](that: Config[B])(implicit zippable: Zippable[A, B]): Config[zippable.Out] =
+    Config.Zipped[A, B, zippable.Out](self, that, zippable)
+
+  def <*>[B](that: Config[B])(implicit z: Zippable[A, B]): Config[z.Out] =
+    self.zip(that)
+
+  def ||[A1 >: A](that: Config[A1]): Config[A1] = Config.Fallback(self, that)
+
+  def ??(label: String): Config[A] = Config.Labelled(self, label)
+
+  def map[B](f: A => B): Config[B] = self.mapOrFail(a => Right(f(a)))
+
+  def mapOrFail[B](f: A => Either[Config.Error, B]): Config[B] = Config.MapOrFail(self, f)
+
+  def optional: Config[Option[A]] = Config.Optional(self)
+
+  def orElse[A1 >: A](that: Config[A1]): Config[A1] = self || that
+
+  def sequence: Config[Chunk[A]] = Config.Sequence(self)
+
+  def validate[A1 >: A](f: A1 => Boolean): Config[A1] =
+    self.mapOrFail(a =>
+      if (!f(a)) Left(Config.Error.Generic(Chunk.empty, "Validation of configuration data failed")) else Right(a)
+    )
+
+  def zip[B](that: Config[B])(implicit z: Zippable[A, B]): Config[z.Out] = self ++ that
+}
+object Config {
+  final case class Bool(name: String)                                                                  extends Config[Boolean]
+  final case class Constant[A](value: A)                                                               extends Config[A]
+  final case class Decimal(name: String)                                                               extends Config[BigDecimal]
+  final case class Duration(name: String)                                                              extends Config[java.time.Duration]
+  final case class Fail(message: String)                                                               extends Config[Nothing]
+  final case class Fallback[A](first: Config[A], second: Config[A])                                    extends Config[A]
+  final case class Integer(name: String)                                                               extends Config[BigInt]
+  final case class Labelled[A](config: Config[A], label: String)                                       extends Config[A]
+  final case class Lazy[A](thunk: () => Config[A])                                                     extends Config[A]
+  final case class LocalDateTime(name: String)                                                         extends Config[java.time.LocalDateTime]
+  final case class LocalDate(name: String)                                                             extends Config[java.time.LocalDate]
+  final case class LocalTime(name: String)                                                             extends Config[java.time.LocalTime]
+  final case class MapOrFail[A, B](original: Config[A], mapOrFail: A => Either[Config.Error, B])       extends Config[B]
+  final case class OffsetDateTime(name: String)                                                        extends Config[java.time.OffsetDateTime]
+  final case class Optional[A](config: Config[A])                                                      extends Config[Option[A]]
+  final case class Secret(name: String)                                                                extends Config[Chunk[Byte]]
+  final case class Sequence[A](config: Config[A])                                                      extends Config[Chunk[A]]
+  final case class Table[K, V](keyConfig: Config[K], valueConfig: Config[V])                           extends Config[Map[K, V]]
+  final case class Text(name: String)                                                                  extends Config[String]
+  final case class URL(name: String)                                                                   extends Config[java.net.URL]
+  final case class Zipped[A, B, C](left: Config[A], right: Config[B], zippable: Zippable.Out[A, B, C]) extends Config[C]
+
+  sealed trait Error extends Exception with NoStackTrace {
+    def prefixed(prefix: Chunk[String]): Error
+  }
+  object Error {
+    final case class And(left: Error, right: Error) extends Error {
+      def prefixed(prefix: Chunk[String]): And =
+        copy(left = left.prefixed(prefix), right = right.prefixed(prefix))
+    }
+    final case class Generic(path: Chunk[String], message: String) extends Error {
+      def prefixed(prefix: Chunk[String]): Generic = copy(path = prefix ++ path)
+    }
+    final case class InvalidData(path: Chunk[String], message: String) extends Error {
+      def prefixed(prefix: Chunk[String]): InvalidData = copy(path = prefix ++ path)
+    }
+    final case class MissingData(path: Chunk[String], message: String) extends Error {
+      def prefixed(prefix: Chunk[String]): MissingData = copy(path = prefix ++ path)
+    }
+    final case class Or(left: Error, right: Error) extends Error {
+      def prefixed(prefix: Chunk[String]): Or =
+        copy(left = left.prefixed(prefix), right = right.prefixed(prefix))
+    }
+    final case class UnreachableSource(path: Chunk[String], message: String) extends Error {
+      def prefixed(prefix: Chunk[String]): UnreachableSource = copy(path = prefix ++ path)
+    }
+  }
+
+  def bigDecimal(name: String): Config[BigDecimal] = Decimal(name)
+
+  def bigInteger(name: String): Config[BigInt] = Integer(name)
+
+  def boolean(name: String): Config[Boolean] = Bool(name)
+
+  def chunkOf[A](config: Config[A]): Config[Chunk[A]] = Sequence(config)
+
+  def defer[A](config: => Config[A]): Config[A] =
+    Lazy(() => config)
+
+  def double(name: String): Config[Double] = bigDecimal(name).map(_.toDouble)
+
+  def duration(name: String): Config[java.time.Duration] = Duration(name)
+
+  def fail(error: => String): Config[Nothing] = defer(Fail(error))
+
+  def float(name: String): Config[Float] = bigDecimal(name).map(_.toFloat)
+
+  def int(name: String): Config[Int] = bigInteger(name).map(_.toInt)
+
+  def listOf[A](config: Config[A]): Config[List[A]] = chunkOf(config).map(_.toList)
+
+  def localDate(name: String): Config[java.time.LocalDate] = LocalDate(name)
+
+  def localDateTime(name: String): Config[java.time.LocalDateTime] = LocalDateTime(name)
+
+  def localTime(name: String): Config[java.time.LocalTime] = LocalTime(name)
+
+  def offsetDateTime(name: String): Config[java.time.OffsetDateTime] = OffsetDateTime(name)
+
+  def secret(name: String): Config[Chunk[Byte]] = Secret(name)
+
+  def setOf[A](config: Config[A]): Config[Set[A]] = chunkOf(config).map(_.toSet)
+
+  def simpleTable[V](value: Config[V]): Config[Map[String, V]] = table(string("key"), value)
+
+  def string(name: String): Config[String] = Text(name)
+
+  def succeed[A](value: => A): Config[A] = defer(Constant(value))
+
+  def table[K, V](key: Config[K], value: Config[V]): Config[Map[K, V]] = Table(key, value)
+
+  def url(name: String): Config[java.net.URL] = URL(name)
+
+  def vectorOf[A](config: Config[A]): Config[Vector[A]] = chunkOf(config).map(_.toVector)
+}

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -15,6 +15,8 @@
  */
 package zio
 
+import java.time.format.DateTimeFormatter
+
 /**
  * A ConfigProvider is a service that provides configuration given a description
  * of the structure of that configuration.
@@ -33,100 +35,233 @@ trait ConfigProvider { self =>
     }
 }
 object ConfigProvider {
+  private val localDateTime  = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+  private val localDate      = DateTimeFormatter.ISO_LOCAL_DATE
+  private val localTime      = DateTimeFormatter.ISO_LOCAL_TIME
+  private val offsetDateTime = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+  private val offsetDate     = DateTimeFormatter.ISO_OFFSET_DATE
+  private val offsetTime     = DateTimeFormatter.ISO_OFFSET_TIME
+
   trait Flat {
-    def load[A](path: Chunk[String], config: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, A]
+    def load[A](path: Chunk[String], config: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]]
 
     def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]]
   }
+  object Flat {
+    object util {
+      def parseAtom[A](
+        text: String,
+        path: Chunk[String],
+        name: String,
+        atom: Config.Atom[A]
+      ): IO[Config.Error, Chunk[A]] = {
+        val name   = path.lastOption.getOrElse("<unnamed>")
+        val isText = atom == Config.Text || atom == Config.Secret
 
-  val ConsoleProviderLive: ConfigProvider =
-    new ConfigProvider {
-      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
-        ???
+        if (isText) ZIO.fromEither(atom.parse(text)).map(Chunk(_))
+        else
+          ZIO
+            .foreach(Chunk.fromArray(text.split(",")))(s => ZIO.fromEither(atom.parse(s.trim)))
+            .mapError(_.prefixed(path))
+      }
     }
+  }
 
-  val EnvProviderLive: ConfigProvider =
-    new ConfigProvider {
-      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
-        ???
-    }
+  val consoleProvider: ConfigProvider =
+    fromFlat(new Flat {
+      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+        val name        = path.lastOption.getOrElse("<unnamed>")
+        val description = atom.description
+        val sourceError = (e: Throwable) =>
+          Config.Error.SourceUnavailable(
+            path :+ name,
+            "There was a problem reading configuration from the console",
+            Cause.fail(e)
+          )
+        val isText = atom == Config.Text || atom == Config.Secret
 
-  val PropsProviderLive: ConfigProvider =
-    new ConfigProvider {
-      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
-        ???
-    }
+        for {
+          _       <- Console.printLine(s"Please enter ${description} for property ${name}:").mapError(sourceError)
+          line    <- Console.readLine.mapError(sourceError)
+          results <- Flat.util.parseAtom(line, path, name, atom)
+        } yield results
+      }
+
+      def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]] =
+        (for {
+          _    <- Console.printLine(s"Enter the keys you want for the table ${path}, separated by commas:")
+          keys <- Console.readLine.map(_.split(",").map(_.trim))
+        } yield Chunk.fromIterable(keys)).mapError(e =>
+          Config.Error
+            .SourceUnavailable(path, "There was a problem reading configuration from the console", Cause.fail(e))
+        )
+    })
+
+  val envProvider: ConfigProvider =
+    fromFlat(new Flat {
+      val sourceUnavailable = (path: Chunk[String]) =>
+        (e: Throwable) =>
+          Config.Error.SourceUnavailable(path, "There was a problem reading environment variables", Cause.fail(e))
+
+      def makePathString(path: Chunk[String]): String = path.mkString("_").toUpperCase
+
+      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+        val pathString  = makePathString(path)
+        val name        = path.lastOption.getOrElse("<unnamed>")
+        val description = atom.description
+
+        for {
+          valueOpt <- zio.System.env(pathString).mapError(sourceUnavailable(path))
+          value <-
+            ZIO
+              .fromOption(valueOpt)
+              .mapError(_ => Config.Error.MissingData(path, s"Expected ${pathString} to be set in the environment"))
+          results <- Flat.util.parseAtom(value, path, name, atom)
+        } yield results
+      }
+
+      def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]] =
+        zio.System.envs.map { envs =>
+          val pathString = makePathString(path)
+          val keyStrings = Chunk.fromIterable(envs.keys).map(_.toUpperCase)
+
+          keyStrings.filter(_.startsWith(pathString))
+        }.mapError(sourceUnavailable(path))
+    })
+
+  val propsProvider: ConfigProvider =
+    fromFlat(new Flat {
+      val sourceUnavailable = (path: Chunk[String]) =>
+        (e: Throwable) => Config.Error.SourceUnavailable(path, "There was a problem reading properties", Cause.fail(e))
+
+      def makePathString(path: Chunk[String]): String = path.mkString(".").toLowerCase
+
+      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+        val pathString  = makePathString(path)
+        val name        = path.lastOption.getOrElse("<unnamed>")
+        val description = atom.description
+
+        for {
+          valueOpt <- zio.System.property(pathString).mapError(sourceUnavailable(path))
+          value <- ZIO
+                     .fromOption(valueOpt)
+                     .mapError(_ => Config.Error.MissingData(path, s"Expected ${pathString} to be set in properties"))
+          results <- Flat.util.parseAtom(value, path, name, atom)
+        } yield results
+      }
+
+      def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]] =
+        zio.System.properties.map { envs =>
+          val pathString = makePathString(path)
+          val keyStrings = Chunk.fromIterable(envs.keys).map(_.toUpperCase)
+
+          keyStrings.filter(_.startsWith(pathString))
+        }.mapError(sourceUnavailable(path))
+    })
 
   def fromFlat(flat: Flat): ConfigProvider =
     new ConfigProvider {
       import Config._
 
-      def loop[A](prefix: Chunk[String], config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+      def extend[A, B](leftDef: A, rightDef: B)(left: Chunk[A], right: Chunk[B]): (Chunk[A], Chunk[B]) =
+        if (left.length < right.length) {
+          (left ++ Chunk.fill(right.length - left.length)(leftDef), right)
+        } else if (right.length < left.length) {
+          (left, right ++ Chunk.fill(left.length - right.length)(rightDef))
+        } else (left, right)
+
+      def loop[A](prefix: Chunk[String], config: Config[A], isEmptyOk: Boolean)(implicit
+        trace: Trace
+      ): IO[Config.Error, Chunk[A]] =
         config match {
           case Fallback(first, second) =>
-            loop(prefix, first).catchAll(e1 => loop(prefix, second).catchAll(e2 => ZIO.fail(e1 || e2)))
+            loop(prefix, first, isEmptyOk).catchAll(e1 =>
+              loop(prefix, second, isEmptyOk).catchAll(e2 => ZIO.fail(e1 || e2))
+            )
 
-          case Described(config, _) => loop(prefix, config)
+          case Described(config, _) => loop(prefix, config, isEmptyOk)
 
-          case Lazy(thunk) => loop(prefix, thunk())
+          case Lazy(thunk) => loop(prefix, thunk(), isEmptyOk)
 
           case MapOrFail(original, f) =>
-            loop(prefix, original).flatMap(a => ZIO.fromEither(f(a)))
+            loop(prefix, original, isEmptyOk).flatMap(as => ZIO.foreach(as)(a => ZIO.fromEither(f(a))))
 
           case Sequence(config) =>
-            ???
+            loop(prefix, config, true).map(Chunk(_))
+
+          case Nested(name, config) =>
+            loop(prefix ++ Chunk(name), config, isEmptyOk)
 
           case Table(valueConfig) =>
             for {
               keys   <- flat.enumerateChildren(prefix)
-              values <- ZIO.foreach(keys)(key => loop(prefix ++ Chunk(key), valueConfig))
-            } yield keys.zip(values).toMap
+              values <- ZIO.foreach(keys)(key => loop(prefix ++ Chunk(key), valueConfig, isEmptyOk))
+            } yield values.map(values => keys.zip(values).toMap)
 
-          case Zipped(left, right, zip) =>
+          case zipped: Zipped[leftType, rightType, c] =>
+            import zipped.{left, right, zippable}
             for {
-              l <- loop(prefix, left).either
-              r <- loop(prefix, right).either
+              l <- loop(prefix, left, isEmptyOk).either
+              r <- loop(prefix, right, isEmptyOk).either
               result <- (l, r) match {
                           case (Left(e1), Left(e2)) => ZIO.fail(e1 && e2)
                           case (Left(e1), Right(_)) => ZIO.fail(e1)
                           case (Right(_), Left(e2)) => ZIO.fail(e2)
-                          case (Right(l), Right(r)) => ZIO.succeed(zip.zip(l, r))
+                          case (Right(l), Right(r)) =>
+                            lazy val lfail: Config.Error =
+                              Config.Error.MissingData(prefix, "An element in a sequence was missing")
+                            lazy val rfail: Config.Error =
+                              Config.Error.MissingData(prefix, "An element in a sequence was missing")
+                            val (ls, rs) = extend[IO[Config.Error, leftType], IO[Config.Error, rightType]](
+                              ZIO.fail(lfail),
+                              ZIO.fail(rfail)
+                            )(l.map(ZIO.succeed(_)), r.map(ZIO.succeed(_)))
+
+                            ZIO.foreach(ls.zip(rs)) { case (l, r) => l.zipWith(r)(zippable.zip(_, _)) }
                         }
             } yield result
 
           case atom: Atom[A] =>
             for {
               vs <- flat.load(prefix, atom)
-            } yield vs
+              result <- if (vs.isEmpty && !isEmptyOk) ZIO.fail(atom.missingError(prefix.lastOption.getOrElse("<n/a>")))
+                        else ZIO.succeed(vs)
+            } yield result
         }
 
       def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
-        loop(Chunk.empty, config)
+        loop(Chunk.empty, config, false).flatMap { chunk =>
+          chunk.headOption match {
+            case Some(a) => ZIO.succeed(a)
+            case _ =>
+              ZIO.fail(Config.Error.MissingData(Chunk.empty, s"Expected a single value having structure ${config}"))
+          }
+        }
     }
 
-  val ConfigProviderLive: ConfigProvider =
-    EnvProviderLive.orElse(PropsProviderLive)
+  val defaultProvider: ConfigProvider =
+    envProvider.orElse(propsProvider)
 
   /**
    * A config provider layer that loads configuration from interactive console
    * prompts, using the default Console service.
    */
   val console: ZLayer[Any, Nothing, ConfigProvider] =
-    ZLayer.succeed(ConsoleProviderLive)
+    ZLayer.succeed(consoleProvider)
 
   /**
    * A config provider layer that loads configuration from environment
    * variables, using the default System service.
    */
   val env: ZLayer[Any, Nothing, ConfigProvider] =
-    ZLayer.succeed(EnvProviderLive)
+    ZLayer.succeed(envProvider)
 
   /**
    * A config provider layer that loads configuration from system properties,
    * using the default System service.
    */
   val props: ZLayer[Any, Nothing, ConfigProvider] =
-    ZLayer.succeed(PropsProviderLive)
+    ZLayer.succeed(propsProvider)
 
   val tag: Tag[ConfigProvider] = Tag[ConfigProvider]
 }

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -245,7 +245,7 @@ object ConfigProvider {
    */
   def fromMap(map: Map[String, String], pathDelim: String = "."): ConfigProvider =
     fromFlat(new Flat {
-      def makePathString(path: Chunk[String]): String = path.mkString(pathDelim).toLowerCase
+      def makePathString(path: Chunk[String]): String = path.mkString(pathDelim)
 
       def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val pathString  = makePathString(path)

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -58,7 +58,7 @@ object ConfigProvider {
    * special support for implementing them.
    */
   trait Flat {
-    def load[A](path: Chunk[String], config: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]]
+    def load[A](path: Chunk[String], config: Config.Primitive[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]]
 
     def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]]
   }
@@ -68,7 +68,7 @@ object ConfigProvider {
         text: String,
         path: Chunk[String],
         name: String,
-        atom: Config.Atom[A],
+        atom: Config.Primitive[A],
         delim: String
       ): IO[Config.Error, Chunk[A]] = {
         val name    = path.lastOption.getOrElse("<unnamed>")
@@ -92,7 +92,7 @@ object ConfigProvider {
 
   lazy val consoleProvider: ConfigProvider =
     fromFlat(new Flat {
-      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+      def load[A](path: Chunk[String], atom: Config.Primitive[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val name        = path.lastOption.getOrElse("<unnamed>")
         val description = atom.description
         val sourceError = (e: Throwable) =>
@@ -135,7 +135,7 @@ object ConfigProvider {
 
       def makePathString(path: Chunk[String]): String = path.mkString("_").toUpperCase
 
-      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+      def load[A](path: Chunk[String], atom: Config.Primitive[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val pathString  = makePathString(path)
         val name        = path.lastOption.getOrElse("<unnamed>")
         val description = atom.description
@@ -252,7 +252,7 @@ object ConfigProvider {
                         }
             } yield result
 
-          case atom: Atom[A] =>
+          case atom: Primitive[A] =>
             for {
               vs <- flat.load(prefix, atom).catchSome {
                       case Config.Error.MissingData(_, _) if isEmptyOk => ZIO.succeed(Chunk.empty)
@@ -280,7 +280,7 @@ object ConfigProvider {
     fromFlat(new Flat {
       def makePathString(path: Chunk[String]): String = path.mkString(pathDelim)
 
-      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+      def load[A](path: Chunk[String], atom: Config.Primitive[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val pathString  = makePathString(path)
         val name        = path.lastOption.getOrElse("<unnamed>")
         val description = atom.description
@@ -321,7 +321,7 @@ object ConfigProvider {
 
       def makePathString(path: Chunk[String]): String = path.mkString(".")
 
-      def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
+      def load[A](path: Chunk[String], atom: Config.Primitive[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val pathString  = makePathString(path)
         val name        = path.lastOption.getOrElse("<unnamed>")
         val description = atom.description

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+trait ConfigProvider { self =>
+  def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A]
+
+  final def orElse(that: ConfigProvider): ConfigProvider =
+    new ConfigProvider {
+      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        self.load(config).orElse(that.load(config))
+    }
+}
+object ConfigProvider {
+  val ConsoleProviderLive: ConfigProvider =
+    new ConfigProvider {
+      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        ???
+    }
+
+  val EnvProviderLive: ConfigProvider =
+    new ConfigProvider {
+      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        ???
+    }
+
+  val PropsProviderLive: ConfigProvider =
+    new ConfigProvider {
+      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        ???
+    }
+
+  val ConfigProviderLive: ConfigProvider =
+    EnvProviderLive.orElse(PropsProviderLive)
+
+  val env: ZLayer[Any, Nothing, ConfigProvider] =
+    ZLayer.succeed(EnvProviderLive)
+
+  val console: ZLayer[Any, Nothing, ConfigProvider] =
+    ZLayer.succeed(ConsoleProviderLive)
+
+  val props: ZLayer[Any, Nothing, ConfigProvider] =
+    ZLayer.succeed(PropsProviderLive)
+
+  val tag: Tag[ConfigProvider] = Tag[ConfigProvider]
+}

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -33,6 +33,12 @@ trait ConfigProvider { self =>
     }
 }
 object ConfigProvider {
+  trait Flat {
+    def load[A](path: Chunk[String], config: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, A]
+
+    def enumerateChildren(path: Chunk[String])(implicit trace: Trace): IO[Config.Error, Chunk[String]]
+  }
+
   val ConsoleProviderLive: ConfigProvider =
     new ConfigProvider {
       def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
@@ -49,6 +55,53 @@ object ConfigProvider {
     new ConfigProvider {
       def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
         ???
+    }
+
+  def fromFlat(flat: Flat): ConfigProvider =
+    new ConfigProvider {
+      import Config._
+
+      def loop[A](prefix: Chunk[String], config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        config match {
+          case Fallback(first, second) =>
+            loop(prefix, first).catchAll(e1 => loop(prefix, second).catchAll(e2 => ZIO.fail(e1 || e2)))
+
+          case Described(config, _) => loop(prefix, config)
+
+          case Lazy(thunk) => loop(prefix, thunk())
+
+          case MapOrFail(original, f) =>
+            loop(prefix, original).flatMap(a => ZIO.fromEither(f(a)))
+
+          case Sequence(config) =>
+            ???
+
+          case Table(valueConfig) =>
+            for {
+              keys   <- flat.enumerateChildren(prefix)
+              values <- ZIO.foreach(keys)(key => loop(prefix ++ Chunk(key), valueConfig))
+            } yield keys.zip(values).toMap
+
+          case Zipped(left, right, zip) =>
+            for {
+              l <- loop(prefix, left).either
+              r <- loop(prefix, right).either
+              result <- (l, r) match {
+                          case (Left(e1), Left(e2)) => ZIO.fail(e1 && e2)
+                          case (Left(e1), Right(_)) => ZIO.fail(e1)
+                          case (Right(_), Left(e2)) => ZIO.fail(e2)
+                          case (Right(l), Right(r)) => ZIO.succeed(zip.zip(l, r))
+                        }
+            } yield result
+
+          case atom: Atom[A] =>
+            for {
+              vs <- flat.load(prefix, atom)
+            } yield vs
+        }
+
+      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+        loop(Chunk.empty, config)
     }
 
   val ConfigProviderLive: ConfigProvider =

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -15,7 +15,15 @@
  */
 package zio
 
+/**
+ * A ConfigProvider is a service that provides configuration given a description
+ * of the structure of that configuration.
+ */
 trait ConfigProvider { self =>
+
+  /**
+   * Loads the specified configuration, or fails with a config error.
+   */
   def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A]
 
   final def orElse(that: ConfigProvider): ConfigProvider =
@@ -46,12 +54,24 @@ object ConfigProvider {
   val ConfigProviderLive: ConfigProvider =
     EnvProviderLive.orElse(PropsProviderLive)
 
-  val env: ZLayer[Any, Nothing, ConfigProvider] =
-    ZLayer.succeed(EnvProviderLive)
-
+  /**
+   * A config provider layer that loads configuration from interactive console
+   * prompts, using the default Console service.
+   */
   val console: ZLayer[Any, Nothing, ConfigProvider] =
     ZLayer.succeed(ConsoleProviderLive)
 
+  /**
+   * A config provider layer that loads configuration from environment
+   * variables, using the default System service.
+   */
+  val env: ZLayer[Any, Nothing, ConfigProvider] =
+    ZLayer.succeed(EnvProviderLive)
+
+  /**
+   * A config provider layer that loads configuration from system properties,
+   * using the default System service.
+   */
   val props: ZLayer[Any, Nothing, ConfigProvider] =
     ZLayer.succeed(PropsProviderLive)
 

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -16,30 +16,30 @@
 package zio
 
 trait ConfigProvider { self =>
-  def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A]
+  def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A]
 
   final def orElse(that: ConfigProvider): ConfigProvider =
     new ConfigProvider {
-      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
         self.load(config).orElse(that.load(config))
     }
 }
 object ConfigProvider {
   val ConsoleProviderLive: ConfigProvider =
     new ConfigProvider {
-      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
         ???
     }
 
   val EnvProviderLive: ConfigProvider =
     new ConfigProvider {
-      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
         ???
     }
 
   val PropsProviderLive: ConfigProvider =
     new ConfigProvider {
-      def load[A: Tag](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
+      def load[A](config: Config[A])(implicit trace: Trace): IO[Config.Error, A] =
         ???
     }
 

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -43,9 +43,9 @@ object ConfigProvider {
   private val offsetTime     = DateTimeFormatter.ISO_OFFSET_TIME
 
   /**
-   * A simplified config provider that knows only how to deal with flat 
-   * (key/value) properties. Because these providers are common, there 
-   * is special support for implementing them.
+   * A simplified config provider that knows only how to deal with flat
+   * (key/value) properties. Because these providers are common, there is
+   * special support for implementing them.
    */
   trait Flat {
     def load[A](path: Chunk[String], config: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]]
@@ -76,10 +76,10 @@ object ConfigProvider {
    * A config provider layer that loads configuration from interactive console
    * prompts, using the default Console service.
    */
-  val console: ZLayer[Any, Nothing, ConfigProvider] =
+  lazy val console: ZLayer[Any, Nothing, ConfigProvider] =
     ZLayer.succeed(consoleProvider)
 
-  val consoleProvider: ConfigProvider =
+  lazy val consoleProvider: ConfigProvider =
     fromFlat(new Flat {
       def load[A](path: Chunk[String], atom: Config.Atom[A])(implicit trace: Trace): IO[Config.Error, Chunk[A]] = {
         val name        = path.lastOption.getOrElse("<unnamed>")
@@ -109,14 +109,14 @@ object ConfigProvider {
         )
     })
 
-  val defaultProvider: ConfigProvider =
+  lazy val defaultProvider: ConfigProvider =
     envProvider.orElse(propsProvider)
 
   /**
-   * A config provider that loads configuration from environment
-   * variables, using the default System service.
+   * A config provider that loads configuration from environment variables,
+   * using the default System service.
    */
-  val envProvider: ConfigProvider =
+  lazy val envProvider: ConfigProvider =
     fromFlat(new Flat {
       val sourceUnavailable = (path: Chunk[String]) =>
         (e: Throwable) =>
@@ -152,13 +152,13 @@ object ConfigProvider {
    * A config provider layer that loads configuration from environment
    * variables, using the default System service.
    */
-  val env: ZLayer[Any, Nothing, ConfigProvider] =
+  lazy val env: ZLayer[Any, Nothing, ConfigProvider] =
     ZLayer.succeed(envProvider)
 
   /**
-    * Constructs a new ConfigProvider from a key/value (flat) provider, where 
-    * nesting is embedded into the string keys.
-    */
+   * Constructs a new ConfigProvider from a key/value (flat) provider, where
+   * nesting is embedded into the string keys.
+   */
   def fromFlat(flat: Flat): ConfigProvider =
     new ConfigProvider {
       import Config._
@@ -240,10 +240,9 @@ object ConfigProvider {
     }
 
   /**
-    * Constructs a ConfigProvider using a map and the specified delimiter 
-    * string, which determines how to split the keys in the map into 
-    * path segments.
-    */
+   * Constructs a ConfigProvider using a map and the specified delimiter string,
+   * which determines how to split the keys in the map into path segments.
+   */
   def fromMap(map: Map[String, String], pathDelim: String = "."): ConfigProvider =
     fromFlat(new Flat {
       def makePathString(path: Chunk[String]): String = path.mkString(pathDelim).toLowerCase
@@ -275,14 +274,14 @@ object ConfigProvider {
    * A config provider layer that loads configuration from system properties,
    * using the default System service.
    */
-  val props: ZLayer[Any, Nothing, ConfigProvider] =
+  lazy val props: ZLayer[Any, Nothing, ConfigProvider] =
     ZLayer.succeed(propsProvider)
 
   /**
-    * A configuration provider that loads configuration from system properties,
-    * using the default System service.
-    */
-  val propsProvider: ConfigProvider =
+   * A configuration provider that loads configuration from system properties,
+   * using the default System service.
+   */
+  lazy val propsProvider: ConfigProvider =
     fromFlat(new Flat {
       val sourceUnavailable = (path: Chunk[String]) =>
         (e: Throwable) => Config.Error.SourceUnavailable(path, "There was a problem reading properties", Cause.fail(e))
@@ -313,7 +312,7 @@ object ConfigProvider {
     })
 
   /**
-    * The tag that describes the ConfigProvider service.
-    */
-  val tag: Tag[ConfigProvider] = Tag[ConfigProvider]
+   * The tag that describes the ConfigProvider service.
+   */
+  lazy val tag: Tag[ConfigProvider] = Tag[ConfigProvider]
 }

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -24,16 +24,20 @@ object DefaultServices {
   /**
    * The default ZIO services.
    */
-  val live: ZEnvironment[Clock with Console with System with Random] =
-    ZEnvironment[Clock, Console, System, Random](
+  val live: ZEnvironment[Clock with Console with System with Random with ConfigProvider] =
+    ZEnvironment[Clock, Console, System, Random, ConfigProvider](
       Clock.ClockLive,
       Console.ConsoleLive,
       System.SystemLive,
-      Random.RandomLive
-    )(Clock.tag, Console.tag, System.tag, Random.tag)
+      Random.RandomLive,
+      ConfigProvider.ConfigProviderLive
+    )(Clock.tag, Console.tag, System.tag, Random.tag, ConfigProvider.tag)
 
   private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[
-    Clock with Console with System with Random
-  ], ZEnvironment.Patch[Clock with Console with System with Random, Clock with Console with System with Random]] =
+    Clock with Console with System with Random with ConfigProvider
+  ], ZEnvironment.Patch[
+    Clock with Console with System with Random with ConfigProvider,
+    Clock with Console with System with Random with ConfigProvider
+  ]] =
     FiberRef.unsafe.makeEnvironment(live)(Unsafe.unsafe)
 }

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -30,7 +30,7 @@ object DefaultServices {
       Console.ConsoleLive,
       System.SystemLive,
       Random.RandomLive,
-      ConfigProvider.ConfigProviderLive
+      ConfigProvider.defaultProvider
     )(Clock.tag, Console.tag, System.tag, Random.tag, ConfigProvider.tag)
 
   private[zio] val currentServices: FiberRef.WithPatch[ZEnvironment[

--- a/core/shared/src/main/scala/zio/Secret.scala
+++ b/core/shared/src/main/scala/zio/Secret.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+final case class Secret(value: Chunk[Byte]) {
+  override def toString(): String = "Secret(<redacted>)"
+}

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2942,7 +2942,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def cond[E, A](predicate: => Boolean, result: => A, error: => E)(implicit trace: Trace): IO[E, A] =
     ZIO.suspendSucceed(if (predicate) ZIO.succeedNow(result) else ZIO.fail(error))
 
-  def config[A: Tag](config: Config[A])(implicit trace: Trace): ZIO[Any, Config.Error, A] =
+  def config[A](config: Config[A])(implicit trace: Trace): ZIO[Any, Config.Error, A] =
     ZIO.configProviderWith(_.load(config))
 
   def configProviderWith[R, E, A](f: ConfigProvider => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2942,6 +2942,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def cond[E, A](predicate: => Boolean, result: => A, error: => E)(implicit trace: Trace): IO[E, A] =
     ZIO.suspendSucceed(if (predicate) ZIO.succeedNow(result) else ZIO.fail(error))
 
+  def config[A: Tag](config: Config[A])(implicit trace: Trace): ZIO[Any, Config.Error, A] =
+    ZIO.configProviderWith(_.load(config))
+
+  def configProviderWith[R, E, A](f: ConfigProvider => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    DefaultServices.currentServices.getWith(services => f(services.get(ConfigProvider.tag)))
+
   /**
    * Retrieves the `Console` service for this workflow.
    */

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2942,9 +2942,18 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def cond[E, A](predicate: => Boolean, result: => A, error: => E)(implicit trace: Trace): IO[E, A] =
     ZIO.suspendSucceed(if (predicate) ZIO.succeedNow(result) else ZIO.fail(error))
 
+  /**
+   * Uses the default config provider to load the specified config, or fail with
+   * an error of type Config.Error.
+   */
   def config[A](config: Config[A])(implicit trace: Trace): ZIO[Any, Config.Error, A] =
     ZIO.configProviderWith(_.load(config))
 
+  /**
+   * Retrieves the default config provider, and passes it to the specified
+   * function, which may return an effect that uses the provider to perform some
+   * work or compute some value.
+   */
   def configProviderWith[R, E, A](f: ConfigProvider => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
     DefaultServices.currentServices.getWith(services => f(services.get(ConfigProvider.tag)))
 


### PR DESCRIPTION
ZIO 2 integrated front-ends for both logging and metrics directly into the core, enabling all ZIO ecosystem libraries and applications to provide standardized logging and metrics, while still enabling customizability, flexibility, and significant integrations with logging and metrics backends via ecosystem projects (_ZIO Logging_, _ZIO Metrics Connectors_).

However, one remaining paint point for ecosystem libraries, as well as ZIO applications, is a lack of a standardized way to configure ZIO components. Most ecosystem libraries use layers to describe the construction of ZIO components.

As a result, we see two approaches to component configuration:

 - Layers accept configuration data as input. This is considered a "best practice", even though it still has drawbacks.
 - Functions accept configuration data as input, and produce layers. This interferes with memo-ization and generally leads to multi-step application wireup, since the configuration data is located externally and must be loaded effectfully in prior stages.

To solve these problems, I propose introducing a lightweight configuration front-end into ZIO 2.0.

This configuration front-end allows ecosystem libraries and applications to declaratively describe their configuration needs, and delegates the heavy lifting to a _ConfigProvider_, which may be supplied by third-party libraries such as _ZIO Config_.

The implementation in this pull request ships with simple system property and environment variable config providers, which can be used for development purposes or to bootstrap applications toward more sophisticated config providers.

When merged and rolled out into ZIO 2.0, it is expected that _ZIO Config_ will undergo a major overhaul to focus on providing integrations and functionality atop the config front-end in ZIO 2.