### PR TITLE
Ensure that target chunk size is minimum of 1 in ZPipeline#rechunk

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -788,7 +788,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         (_: Any) => rechunker.emitIfNotEmpty()
       )
 
-    val target = n
+    val target = scala.math.max(n, 1)
     new ZPipeline(ZChannel.suspend(process(new ZStream.Rechunker(target), target)))
   }
 


### PR DESCRIPTION
A quick fix for #7445.