### PR TITLE
Make an exception message readable for Cause.squashWith()

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -402,7 +402,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
       (if (isInterrupted)
          Some(
            new InterruptedException(
-             "Interrupted by fibers: " + interruptors.flatMap(_.ids.toString()).map("#" + _).mkString(", ")
+             "Interrupted by fibers: " + interruptors.map(_.ids.map("#" + _).mkString("(", ", ", ")")).mkString(", ")
            )
          )
        else None) orElse


### PR DESCRIPTION
Before this change, the message looked like the one below, which was difficult to interpret:
```
Interrupted by fibers: #S, #4, #3, #t, #5, #2, #(, #e, #)
```