### PR TITLE
Add tests for `ConfigProvider.fromMap`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -103,6 +103,17 @@ object ConfigProviderSpec extends ZIOBaseSpec {
               .load(HostPorts.config)
         } yield assertTrue(value.hostPorts.length == 3)
       } +
+      test("top-level lists with special regex multi-character sequence delimiter") {
+        for {
+          value <-
+            ConfigProvider
+              .fromMap(
+                Map("hostPorts.host" -> "localhost|||localhost|||localhost", "hostPorts.port" -> "8080|||8080|||8080"),
+                seqDelim = "|||"
+              )
+              .load(HostPorts.config)
+        } yield assertTrue(value.hostPorts.length == 3)
+      } +
       test("top-level lists with special regex character sequence delimiter") {
         for {
           value <-
@@ -113,7 +124,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
               )
               .load(HostPorts.config)
         } yield assertTrue(value.hostPorts.length == 3)
-      } @@ TestAspect.failing +
+      } +
       test("top-level list with different number of elements per key fails") {
         for {
           exit <-

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -173,7 +173,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
                        )
                      ).load(SNP500.config)
           } yield assertTrue(value == SNP500.default)
-        } @@ TestAspect.failing +
+        } +
         test("collection of atoms") {
           for {
             value <-

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -27,6 +27,41 @@ object ConfigProviderSpec extends ZIOBaseSpec {
     val default: HostPorts = HostPorts(List(HostPort.default))
   }
 
+  final case class StockDay(
+    date: java.time.LocalDate,
+    open: BigDecimal,
+    close: BigDecimal,
+    low: BigDecimal,
+    high: BigDecimal,
+    volume: BigInt
+  )
+  object StockDay {
+    val config: Config[StockDay] =
+      (Config.localDate("date") ++ Config.bigDecimal("open") ++ Config.bigDecimal("close") ++ Config.bigDecimal(
+        "low"
+      ) ++ Config.bigDecimal("high") ++ Config.bigInt("volume")).map { case (a, b, c, d, e, f) =>
+        StockDay(a, b, c, d, e, f)
+      }
+
+    val default: StockDay = StockDay(java.time.LocalDate.of(2022, 10, 28), 98.8, 150.0, 98.0, 151.5, 100091990)
+  }
+
+  final case class SNP500(stockDays: Map[String, StockDay])
+  object SNP500 {
+    val config: Config[SNP500] = Config.table(StockDay.config).map(SNP500(_))
+
+    val default: SNP500 = SNP500(Map("ZIO" -> StockDay.default))
+  }
+
+  final case class WebScrapingTargets(targets: Set[java.net.URI])
+  object WebScrapingTargets {
+    val config: Config[WebScrapingTargets] = (Config.setOf("targets", Config.uri)).map(WebScrapingTargets(_))
+
+    val default: WebScrapingTargets = WebScrapingTargets(
+      Set(new java.net.URI("https://zio.dev"), new java.net.URI("https://github.com/zio"))
+    )
+  }
+
   def spec = suite("ConfigProviderSpec") {
     test("flat atoms") {
       for {
@@ -39,7 +74,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
                      .load(ServiceConfig.config)
         } yield assertTrue(value == ServiceConfig.default)
       } +
-      test("top-level list") {
+      test("top-level list with same number of elements per key") {
         for {
           value <-
             provider(Map("hostPorts.host" -> "localhost,localhost,localhost", "hostPorts.port" -> "8080,8080,8080"))
@@ -56,6 +91,74 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           value <- provider(Map("name" -> "Sherlock Holmes", "address" -> "221B Baker Street"))
                      .load(Config.table(Config.string))
         } yield assertTrue(value == Map("name" -> "Sherlock Holmes", "address" -> "221B Baker Street"))
+      } +
+      test("top-level lists with multi-character sequence delimiters") {
+        for {
+          value <-
+            ConfigProvider
+              .fromMap(
+                Map("hostPorts.host" -> "localhost///localhost///localhost", "hostPorts.port" -> "8080///8080///8080"),
+                seqDelim = "///"
+              )
+              .load(HostPorts.config)
+        } yield assertTrue(value.hostPorts.length == 3)
+      } +
+      test("top-level lists with special regex character sequence delimiter") {
+        for {
+          value <-
+            ConfigProvider
+              .fromMap(
+                Map("hostPorts.host" -> "localhost*localhost*localhost", "hostPorts.port" -> "8080*8080*8080"),
+                seqDelim = "*"
+              )
+              .load(HostPorts.config)
+        } yield assertTrue(value.hostPorts.length == 3)
+      } @@ TestAspect.failing +
+      test("top-level list with different number of elements per key fails") {
+        for {
+          exit <-
+            provider(Map("hostPorts.host" -> "localhost", "hostPorts.port" -> "8080,8080,8080"))
+              .load(HostPorts.config)
+              .exit
+        } yield assert(exit)(Assertion.failsWithA[Config.Error])
+      } +
+      test("flat atoms of different types") {
+        for {
+          value <- provider(
+                     Map(
+                       "date"   -> "2022-10-28",
+                       "open"   -> "98.8",
+                       "close"  -> "150.0",
+                       "low"    -> "98.0",
+                       "high"   -> "151.5",
+                       "volume" -> "100091990"
+                     )
+                   ).load(StockDay.config)
+        } yield assertTrue(value == StockDay.default)
+      } +
+      test("tables") {
+        for {
+          value <- provider(
+                     Map(
+                       "ZIO.date"   -> "2022-10-28",
+                       "ZIO.open"   -> "98.8",
+                       "ZIO.close"  -> "150.0",
+                       "ZIO.low"    -> "98.0",
+                       "ZIO.high"   -> "151.5",
+                       "ZIO.volume" -> "100091990"
+                     )
+                   ).load(SNP500.config)
+        } yield assertTrue(value == SNP500.default)
+      } @@ TestAspect.failing +
+      test("collection of atoms") {
+        for {
+          value <- provider(Map("targets" -> "https://zio.dev,https://github.com/zio")).load(WebScrapingTargets.config)
+        } yield assertTrue(value == WebScrapingTargets.default)
+      } +
+      test("accessing a non-existent key fails") {
+        for {
+          exit <- provider(Map("k1.k3" -> "v")).load(Config.string("k2").nested("k1")).exit
+        } yield assert(exit)(Assertion.failsWithA[Config.Error])
       }
   }
 }

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -71,13 +71,16 @@ object ConfigProvider {
         atom: Config.Primitive[A],
         delim: String
       ): IO[Config.Error, Chunk[A]] = {
-        val name    = path.lastOption.getOrElse("<unnamed>")
-        val unsplit = atom == Config.Secret
+        val name         = path.lastOption.getOrElse("<unnamed>")
+        val unsplit      = atom == Config.Secret
+        val escapedDelim = java.util.regex.Pattern.quote(delim)
 
         if (unsplit) ZIO.fromEither(atom.parse(text)).map(Chunk(_))
         else
           ZIO
-            .foreach(Chunk.fromArray(text.split("\\s*" + delim + "\\s*")))(s => ZIO.fromEither(atom.parse(s.trim)))
+            .foreach(Chunk.fromArray(text.split("\\s*" + escapedDelim + "\\s*")))(s =>
+              ZIO.fromEither(atom.parse(s.trim))
+            )
             .mapError(_.prefixed(path))
       }
     }


### PR DESCRIPTION
I have added some happy and unhappy path tests for `ConfigProvider.fromMap` which try to use the more "complex" atoms in `Config.scala` and their composition.

There are currently two tests marked with `TestAspect.failing`: `top-level lists with special regex character sequence delimiter` which fails when using a `*` or `|`, for example, as delimiters; and `tables` which fails because doing `"ZIO.high" -> "151.5"` there's an error that, for example, `"ZIO.high.high"` doesn't exist.

I will be more than happy to add more test cases and/or revise the current ones.