### PR TITLE
Metric listeners

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
@@ -1,0 +1,52 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.Unsafe
+import zio.metrics.MetricKeyType.Frequency
+import zio.metrics._
+
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 15, time = 1)
+@Measurement(iterations = 15, time = 1)
+@Fork(3)
+class MetricBenchmark {
+
+  @Param(Array("true", "false"))
+  var registerListener: String = _
+
+  @Setup
+  def setup(): Unit = {
+    if (registerListener == "true") {
+      MetricClient.addListener(listener)
+    }
+  }
+
+  @TearDown
+  def tearDown(): Unit = {
+    MetricClient.removeListener(listener)
+  }
+
+  private val metric = Metric.counter("Test counter")
+
+  private val listener = new MetricListener {
+    override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateFrequency(key: MetricKey[Frequency], value: String)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit = ()
+  }
+
+  @Benchmark
+  def updateMetric(): Unit = {
+    metric.unsafe.update(3L)(Unsafe.unsafe)
+  }
+}

--- a/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
@@ -20,33 +20,34 @@ class MetricBenchmark {
   var registerListener: String = _
 
   @Setup
-  def setup(): Unit = {
+  def setup(): Unit =
     if (registerListener == "true") {
       MetricClient.addListener(listener)
     }
-  }
 
   @TearDown
-  def tearDown(): Unit = {
+  def tearDown(): Unit =
     MetricClient.removeListener(listener)
-  }
 
   private val metric = Metric.counter("Test counter")
 
   private val listener = new MetricListener {
-    override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit unsafe: Unsafe): Unit = ()
+    override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit
+      unsafe: Unsafe
+    ): Unit = ()
 
     override def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit = ()
 
     override def updateFrequency(key: MetricKey[Frequency], value: String)(implicit unsafe: Unsafe): Unit = ()
 
-    override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit unsafe: Unsafe): Unit = ()
+    override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit
+      unsafe: Unsafe
+    ): Unit = ()
 
     override def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit = ()
   }
 
   @Benchmark
-  def updateMetric(): Unit = {
+  def updateMetric(): Unit =
     metric.unsafe.update(3L)(Unsafe.unsafe)
-  }
 }

--- a/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/MetricBenchmark.scala
@@ -22,12 +22,12 @@ class MetricBenchmark {
   @Setup
   def setup(): Unit =
     if (registerListener == "true") {
-      MetricClient.addListener(listener)
+      MetricClient.addListener(listener)(Unsafe.unsafe)
     }
 
   @TearDown
   def tearDown(): Unit =
-    MetricClient.removeListener(listener)
+    MetricClient.removeListener(listener)(Unsafe.unsafe)
 
   private val metric = Metric.counter("Test counter")
 

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
@@ -48,7 +48,7 @@ object MetricListenerSpec extends ZIOBaseSpec {
             (key, value) = event
           } yield assert(key.name)(equalTo("test")) && assert(value)(equalTo(3.3))
         )
-      } @@ timeout(1.second),
+      },
       test("can remove listeners") {
         for {
           listenerQueue <- Queue.bounded[(MetricKey[MetricKeyType.Histogram], Double)](1)

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
@@ -1,0 +1,48 @@
+package zio.internal.metrics
+
+import zio.metrics.MetricKeyType.Histogram.Boundaries
+import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
+import zio.metrics._
+import zio.test.Assertion._
+import zio.test.TestAspect.timeout
+import zio.test.{Spec, _}
+import zio.{ZIOBaseSpec, _}
+
+import java.time.Instant
+
+object MetricListenerSpec extends ZIOBaseSpec {
+
+  case class HistogramListener(queue: Queue[(MetricKey[MetricKeyType.Histogram], Double)]) extends MetricListener {
+    override def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit
+      unsafe: Unsafe
+    ): Unit = {
+      val _ = Runtime.default.unsafe.run(queue.offer((key, value)))
+    }
+
+    override def updateGauge(key: MetricKey[Gauge], value: Double)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateFrequency(key: MetricKey[Frequency], value: String)(implicit unsafe: Unsafe): Unit = ()
+
+    override def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: Instant)(implicit
+      unsafe: Unsafe
+    ): Unit = ()
+
+    override def updateCounter(key: MetricKey[Counter], value: Double)(implicit unsafe: Unsafe): Unit = ()
+  }
+
+  override def spec: Spec[Environment, Any] =
+    suite("MetricListenerSpec")(
+      test("listeners get notified") {
+        for {
+          listenerQueue <- Queue.bounded[(MetricKey[MetricKeyType.Histogram], Double)](1)
+          listener       = HistogramListener(listenerQueue)
+          _              = MetricClient.addListener(listener)
+          metric         = Metric.histogram("test", Boundaries(Chunk.empty))
+          _             <- ZIO.succeed(3.3) @@ metric
+          event         <- listenerQueue.take
+          (key, value)   = event
+        } yield assert(key.name)(equalTo("test")) && assert(value)(equalTo(3.3))
+      } @@ timeout(1.second)
+    )
+
+}

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
@@ -4,7 +4,6 @@ import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
 import zio.metrics._
 import zio.test.Assertion._
-import zio.test.TestAspect.timeout
 import zio.test.{Spec, _}
 import zio.{ZIOBaseSpec, _}
 

--- a/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/metrics/MetricListenerSpec.scala
@@ -33,32 +33,36 @@ object MetricListenerSpec extends ZIOBaseSpec {
   override def spec: Spec[Environment, Any] =
     suite("MetricListenerSpec")(
       test("listeners get notified") {
-        ZIO.scoped(
+        Unsafe.unsafe { implicit unsafe =>
+          ZIO.scoped(
+            for {
+              listenerQueue <- Queue.bounded[(MetricKey[MetricKeyType.Histogram], Double)](1)
+              runtime       <- ZIO.runtime[Any]
+              listener       = HistogramListener(listenerQueue, runtime)
+              _ <- ZIO.acquireRelease(ZIO.succeed(MetricClient.addListener(listener)))(_ =>
+                     ZIO.succeed(MetricClient.removeListener(listener))
+                   )
+              metric       = Metric.histogram("test", Boundaries(Chunk.empty))
+              _           <- ZIO.succeed(3.3) @@ metric
+              event       <- listenerQueue.take
+              (key, value) = event
+            } yield assert(key.name)(equalTo("test")) && assert(value)(equalTo(3.3))
+          )
+        }
+      },
+      test("can remove listeners") {
+        Unsafe.unsafe { implicit unsafe =>
           for {
             listenerQueue <- Queue.bounded[(MetricKey[MetricKeyType.Histogram], Double)](1)
             runtime       <- ZIO.runtime[Any]
             listener       = HistogramListener(listenerQueue, runtime)
-            _ <- ZIO.acquireRelease(ZIO.succeed(MetricClient.addListener(listener)))(_ =>
-                   ZIO.succeed(MetricClient.removeListener(listener))
-                 )
-            metric       = Metric.histogram("test", Boundaries(Chunk.empty))
-            _           <- ZIO.succeed(3.3) @@ metric
-            event       <- listenerQueue.take
-            (key, value) = event
-          } yield assert(key.name)(equalTo("test")) && assert(value)(equalTo(3.3))
-        )
-      },
-      test("can remove listeners") {
-        for {
-          listenerQueue <- Queue.bounded[(MetricKey[MetricKeyType.Histogram], Double)](1)
-          runtime       <- ZIO.runtime[Any]
-          listener       = HistogramListener(listenerQueue, runtime)
-          _              = MetricClient.addListener(listener)
-          _              = MetricClient.removeListener(listener)
-          metric         = Metric.histogram("test", Boundaries(Chunk.empty))
-          _             <- ZIO.succeed(3.3) @@ metric
-          isEmpty       <- listenerQueue.isEmpty
-        } yield assert(isEmpty)(isTrue)
+            _              = MetricClient.addListener(listener)
+            _              = MetricClient.removeListener(listener)
+            metric         = Metric.histogram("test", Boundaries(Chunk.empty))
+            _             <- ZIO.succeed(3.3) @@ metric
+            isEmpty       <- listenerQueue.isEmpty
+          } yield assert(isEmpty)(isTrue)
+        }
       }
     )
 

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -3,14 +3,13 @@ package zio.internal.metrics
 import zio._
 import zio.metrics._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.metrics.MetricClient.Listener
 
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
 private[zio] class ConcurrentMetricRegistry {
-  private val listeners: ConcurrentHashMap[MetricKeyType, Set[Listener]] =
-    new ConcurrentHashMap[MetricKeyType, Set[Listener]]()
+  private val listeners: ConcurrentHashMap[MetricKeyType, Set[MetricListener]] =
+    new ConcurrentHashMap[MetricKeyType, Set[MetricListener]]()
 
   private val map: ConcurrentHashMap[MetricKey[MetricKeyType], MetricHook.Root] =
     new ConcurrentHashMap[MetricKey[MetricKeyType], MetricHook.Root]()
@@ -45,7 +44,7 @@ private[zio] class ConcurrentMetricRegistry {
     } else hook0.asInstanceOf[Result]
   }
 
-  def addListener(keyType: MetricKeyType)(listener: Listener): Unit =
+  def addListener(keyType: MetricKeyType)(listener: MetricListener): Unit =
     listeners.compute(
       keyType,
       { case (_, listeners) =>
@@ -56,7 +55,7 @@ private[zio] class ConcurrentMetricRegistry {
       }
     )
 
-  def removeListener(listener: Listener): Unit =
+  def removeListener(listener: MetricListener): Unit =
     listeners.keySet().forEach { metricKeyType =>
       listeners.computeIfPresent(metricKeyType, { case (a, b) => b - listener })
     }

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -3,19 +3,12 @@ package zio.internal.metrics
 import zio._
 import zio.metrics._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.metrics.MetricClient.Listener
 
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 
 private[zio] class ConcurrentMetricRegistry {
-  trait Listener {
-    def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): UIO[Unit]
-    def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): UIO[Unit]
-    def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): UIO[Unit]
-    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: (Double, java.time.Instant)): UIO[Unit]
-    def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): UIO[Unit]
-  }
-
   private val listeners: ConcurrentHashMap[MetricKeyType, Set[Listener]] =
     new ConcurrentHashMap[MetricKeyType, Set[Listener]]()
 

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -3,6 +3,7 @@ package zio.internal.metrics
 import zio._
 import zio.metrics._
 
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
 import scala.annotation.tailrec
@@ -73,27 +74,28 @@ private[zio] class ConcurrentMetricRegistry {
       key.keyType match {
         case MetricKeyType.Gauge =>
           while (i < len) {
-            listeners(i).updateGauge(key.asInstanceOf[MetricKey.Gauge], value)
+            listeners(i).updateGauge(key.asInstanceOf[MetricKey.Gauge], value.asInstanceOf[Double])
             i = i + 1
           }
         case MetricKeyType.Histogram(_) =>
           while (i < len) {
-            listeners(i).updateHistogram(key.asInstanceOf[MetricKey.Histogram], value)
+            listeners(i).updateHistogram(key.asInstanceOf[MetricKey.Histogram], value.asInstanceOf[Double])
             i = i + 1
           }
         case MetricKeyType.Frequency =>
           while (i < len) {
-            listeners(i).updateFrequency(key.asInstanceOf[MetricKey.Frequency], value)
+            listeners(i).updateFrequency(key.asInstanceOf[MetricKey.Frequency], value.asInstanceOf[String])
             i = i + 1
           }
         case MetricKeyType.Summary(_, _, _, _) =>
           while (i < len) {
-            listeners(i).updateSummary(key.asInstanceOf[MetricKey.Summary], value._1, value._2)
+            val (v, instant) = value.asInstanceOf[(Double, Instant)]
+            listeners(i).updateSummary(key.asInstanceOf[MetricKey.Summary], v, instant)
             i = i + 1
           }
         case MetricKeyType.Counter =>
           while (i < len) {
-            listeners(i).updateCounter(key.asInstanceOf[MetricKey.Counter], value)
+            listeners(i).updateCounter(key.asInstanceOf[MetricKey.Counter], value.asInstanceOf[Double])
             i = i + 1
           }
       }

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -61,7 +61,7 @@ private[zio] class ConcurrentMetricRegistry {
       listeners.computeIfPresent(metricKeyType, { case (a, b) => b - listener })
     }
 
-  def update[T](key: MetricKey[MetricKeyType.Aux[T]], value: T)(implicit trace: Trace): Unit = {
+  def update[T](key: MetricKey[MetricKeyType.WithIn[T]], value: T)(implicit trace: Trace): Unit = {
     val listenersForKey = listeners.get(key.keyType)
     val iterator        = listenersForKey.iterator
     val updateNext = () =>

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -47,7 +47,7 @@ private[zio] class ConcurrentMetricRegistry {
   }
 
   @tailrec
-  final def addListener(listener: MetricListener): Unit = {
+  final def addListener(listener: MetricListener)(implicit unsafe: Unsafe): Unit = {
     val oldListeners = listenersRef.get()
     val newListeners = oldListeners :+ listener
     if (!listenersRef.compareAndSet(oldListeners, newListeners)) addListener(listener)
@@ -55,7 +55,7 @@ private[zio] class ConcurrentMetricRegistry {
   }
 
   @tailrec
-  final def removeListener(listener: MetricListener): Unit = {
+  final def removeListener(listener: MetricListener)(implicit unsafe: Unsafe): Unit = {
     val oldListeners = listenersRef.get()
     val newListeners = oldListeners.filter(_ ne listener)
     if (!listenersRef.compareAndSet(oldListeners, newListeners)) removeListener(listener)

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -73,7 +73,7 @@ private[zio] class ConcurrentMetricRegistry {
         case MetricKeyType.Frequency =>
           iterator.next().updateFrequency(key.asInstanceOf[MetricKey.Frequency], value)
         case MetricKeyType.Summary(maxAge, maxSize, error, quantiles) =>
-          iterator.next().updateSummary(key.asInstanceOf[MetricKey.Summary], value)
+          iterator.next().updateSummary(key.asInstanceOf[MetricKey.Summary], value._1, value._2)
         case MetricKeyType.Counter =>
           iterator.next().updateCounter(key.asInstanceOf[MetricKey.Counter], value)
       }

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -66,7 +66,7 @@ private[zio] class ConcurrentMetricRegistry {
     unsafe: Unsafe
   ): Unit = {
     val listeners = listenersRef.get()
-    val len        = listeners.length
+    val len       = listeners.length
 
     if (len > 0) {
       var i = 0

--- a/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
+++ b/core/shared/src/main/scala/zio/internal/metrics/ConcurrentMetricRegistry.scala
@@ -60,7 +60,7 @@ private[zio] class ConcurrentMetricRegistry {
       listeners.computeIfPresent(metricKeyType, { case (a, b) => b - listener })
     }
 
-  def update[T](key: MetricKey[MetricKeyType.WithIn[T]], value: T)(implicit trace: Trace): Unit = {
+  def update[T](key: MetricKey[MetricKeyType.WithIn[T]], value: T)(implicit trace: Trace, unsafe: Unsafe): Unit = {
     val listenersForKey = listeners.get(key.keyType)
     val iterator        = listenersForKey.iterator
     val updateNext = () =>

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -439,7 +439,7 @@ object Metric {
           ): Unit = {
             val fullKey = key.tagged(extraTags).asInstanceOf[MetricKey[key.keyType.type]]
             hook(fullKey).update(in)
-            metricRegistry.update(fullKey, in)
+            metricRegistry.notifyListeners(fullKey, in)
           }
 
           def value(extraTags: Set[MetricLabel] = Set.empty)(implicit unsafe: Unsafe): key.keyType.Out = {

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -44,10 +44,10 @@ private[zio] object MetricClient {
   final def snapshot()(implicit unsafe: Unsafe): Set[MetricPair.Untyped] =
     metricRegistry.snapshot()
 
-  final def addListener(listener: MetricListener): Unit =
+  final def addListener(listener: MetricListener)(implicit unsafe: Unsafe): Unit =
     metricRegistry.addListener(listener)
 
-  final def removeListener(listener: MetricListener): Unit =
+  final def removeListener(listener: MetricListener)(implicit unsafe: Unsafe): Unit =
     metricRegistry.removeListener(listener)
 
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -46,11 +46,11 @@ private[zio] object MetricClient {
     metricRegistry.snapshot()
 
   trait Listener {
-    def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): UIO[Unit]
-    def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): UIO[Unit]
-    def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): UIO[Unit]
-    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: (Double, java.time.Instant)): UIO[Unit]
-    def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): UIO[Unit]
+    def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): Unit
+    def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): Unit
+    def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): Unit
+    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: (Double, java.time.Instant)): Unit
+    def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): Unit
   }
 
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -45,12 +45,4 @@ private[zio] object MetricClient {
   final def snapshot()(implicit unsafe: Unsafe): Set[MetricPair.Untyped] =
     metricRegistry.snapshot()
 
-  trait Listener {
-    def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): Unit
-    def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): Unit
-    def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): Unit
-    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant): Unit
-    def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): Unit
-  }
-
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -19,7 +19,6 @@ package zio.metrics
 import zio.Unsafe
 import zio.internal.metrics._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.UIO
 
 /**
  * A `MetricClient` provides the functionality to consume metrics produced by
@@ -44,5 +43,11 @@ private[zio] object MetricClient {
    */
   final def snapshot()(implicit unsafe: Unsafe): Set[MetricPair.Untyped] =
     metricRegistry.snapshot()
+
+  final def addListener(keyType: MetricKeyType, listener: MetricListener): Unit =
+    metricRegistry.addListener(keyType, listener)
+
+  final def removeListener(listener: MetricListener): Unit =
+    metricRegistry.removeListener(listener)
 
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -44,8 +44,8 @@ private[zio] object MetricClient {
   final def snapshot()(implicit unsafe: Unsafe): Set[MetricPair.Untyped] =
     metricRegistry.snapshot()
 
-  final def addListener(keyType: MetricKeyType, listener: MetricListener): Unit =
-    metricRegistry.addListener(keyType, listener)
+  final def addListener(listener: MetricListener): Unit =
+    metricRegistry.addListener(listener)
 
   final def removeListener(listener: MetricListener): Unit =
     metricRegistry.removeListener(listener)

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -19,6 +19,7 @@ package zio.metrics
 import zio.Unsafe
 import zio.internal.metrics._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.UIO
 
 /**
  * A `MetricClient` provides the functionality to consume metrics produced by
@@ -43,4 +44,13 @@ private[zio] object MetricClient {
    */
   final def snapshot()(implicit unsafe: Unsafe): Set[MetricPair.Untyped] =
     metricRegistry.snapshot()
+
+  trait Listener {
+    def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): UIO[Unit]
+    def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): UIO[Unit]
+    def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): UIO[Unit]
+    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: (Double, java.time.Instant)): UIO[Unit]
+    def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): UIO[Unit]
+  }
+
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricClient.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricClient.scala
@@ -49,7 +49,7 @@ private[zio] object MetricClient {
     def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): Unit
     def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): Unit
     def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): Unit
-    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: (Double, java.time.Instant)): Unit
+    def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant): Unit
     def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): Unit
   }
 

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -24,7 +24,7 @@ sealed trait MetricKeyType {
   type Out
 }
 object MetricKeyType {
-  type Aux[T] = MetricKeyType {
+  type WithIn[T] = MetricKeyType {
     type In = T
   }
   

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -24,6 +24,10 @@ sealed trait MetricKeyType {
   type Out
 }
 object MetricKeyType {
+  type Aux[T] = MetricKeyType {
+    type In = T
+  }
+  
   type Counter = Counter.type
 
   case object Counter extends MetricKeyType {

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -27,7 +27,7 @@ object MetricKeyType {
   type WithIn[T] = MetricKeyType {
     type In = T
   }
-  
+
   type Counter = Counter.type
 
   case object Counter extends MetricKeyType {

--- a/core/shared/src/main/scala/zio/metrics/MetricListener.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricListener.scala
@@ -1,0 +1,9 @@
+package zio.metrics
+
+private[zio] trait MetricListener {
+  def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): Unit
+  def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): Unit
+  def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): Unit
+  def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant): Unit
+  def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): Unit
+}

--- a/core/shared/src/main/scala/zio/metrics/MetricListener.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricListener.scala
@@ -1,9 +1,11 @@
 package zio.metrics
 
+import zio.Unsafe
+
 private[zio] trait MetricListener {
-  def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double): Unit
-  def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double): Unit
-  def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String): Unit
-  def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant): Unit
-  def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double): Unit
+  def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit unsafe: Unsafe): Unit
+  def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit
+  def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit unsafe: Unsafe): Unit
+  def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant)(implicit unsafe: Unsafe): Unit
+  def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricListener.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricListener.scala
@@ -6,6 +6,8 @@ private[zio] trait MetricListener {
   def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit unsafe: Unsafe): Unit
   def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit
   def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit unsafe: Unsafe): Unit
-  def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant)(implicit unsafe: Unsafe): Unit
+  def updateSummary(key: MetricKey[MetricKeyType.Summary], value: Double, instant: java.time.Instant)(implicit
+    unsafe: Unsafe
+  ): Unit
   def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit
 }

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -148,6 +148,11 @@ object PollingMetric {
                   pollingmetric.metric.unsafe.modify(input.asInstanceOf[pollingmetric.In])
                 }
             }
+
+          override private[zio] def notifyListeners(in: In, extraTags: Set[MetricLabel]): UIO[Unit] =
+            (ZIO.foreach(ins.zip(in)) { case (pollingmetric, input) =>
+              pollingmetric.metric.notifyListeners(input.asInstanceOf[pollingmetric.In])  
+            }).unit
         }
 
       def poll(implicit trace: Trace): ZIO[R, E, In] = ZIO.foreach(ins)(_.poll)

--- a/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
+++ b/core/shared/src/main/scala/zio/metrics/PollingMetric.scala
@@ -148,11 +148,6 @@ object PollingMetric {
                   pollingmetric.metric.unsafe.modify(input.asInstanceOf[pollingmetric.In])
                 }
             }
-
-          override private[zio] def notifyListeners(in: In, extraTags: Set[MetricLabel]): UIO[Unit] =
-            (ZIO.foreach(ins.zip(in)) { case (pollingmetric, input) =>
-              pollingmetric.metric.notifyListeners(input.asInstanceOf[pollingmetric.In])  
-            }).unit
         }
 
       def poll(implicit trace: Trace): ZIO[R, E, In] = ZIO.foreach(ins)(_.poll)


### PR DESCRIPTION
Implementation for: https://github.com/zio/zio/issues/7393

Note that this needs obviously needs more work (at least tests and benchmarks), at the current stage I'd just like to get some feedback before proceeding. 

I just learned that `zio.metrics` had listeners which were using an unsafe API without zio effects. I used effects so that from the `zio-metrics-connector` side it would be easier to use ZIO functionality, like `ZStream`. (see draft PR for zio-metrics-connectors: https://github.com/zio/zio-metrics-connectors/pull/11) I am happy to recreate the original `MetricListener` with the `unsafeUpdate` method if that is much better in terms of performance.