### PR TITLE
Implement FiberRefs.Patch

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4125,7 +4125,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Applies the specified changes to the `FiberRef` values for the fiber
    * running this workflow.
    */
-  def patchFiberRefs[R, E, A](patch: FiberRefs.Patch)(implicit trace: Trace): ZIO[Any, Nothing, Unit] =
+  def patchFiberRefs(patch: FiberRefs.Patch)(implicit trace: Trace): ZIO[Any, Nothing, Unit] =
     updateFiberRefs(patch)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -462,6 +462,22 @@ sealed trait ZIO[-R, +E, +A]
     Clock.sleep(duration) *> self
 
   /**
+   * Returns a new workflow that executes this one and captures the changes in
+   * `FiberRef` values.
+   */
+  def diffFiberRefs(implicit trace: Trace): ZIO[R, E, (FiberRefs.Patch, A)] =
+    summarized(ZIO.getFiberRefs) { (start, end) =>
+      val fiberRefs = start.fiberRefs | end.fiberRefs
+      val patches = fiberRefs.flatMap { case fiberRef =>
+        val oldValue = start.getOrDefault(fiberRef)
+        val newValue = end.getOrDefault(fiberRef)
+        if (oldValue == newValue) None
+        else Some(fiberRef -> fiberRef.diff(oldValue, newValue))
+      }
+      FiberRefs.Patch(patches.toMap)
+    }
+
+  /**
    * Returns an effect that is always interruptible, but whose interruption will
    * be performed in the background.
    *
@@ -972,9 +988,9 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def memoize(implicit trace: Trace): UIO[ZIO[R, E, A]] =
     for {
-      promise  <- Promise.make[E, A]
-      complete <- self.intoPromise(promise).once
-    } yield complete *> promise.await
+      promise  <- Promise.make[E, (FiberRefs.Patch, A)]
+      complete <- self.diffFiberRefs.intoPromise(promise).once
+    } yield complete *> promise.await.flatMap { case (patch, a) => ZIO.patchFiberRefs(patch).as(a) }
 
   /**
    * Returns a new effect where the error channel has been merged into the
@@ -4021,19 +4037,19 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Returns a memoized version of the specified effectual function.
    */
   def memoize[R, E, A, B](f: A => ZIO[R, E, B])(implicit trace: Trace): UIO[A => ZIO[R, E, B]] =
-    Ref.Synchronized.make(Map.empty[A, Promise[E, B]]).map { ref => a =>
+    Ref.Synchronized.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]]).map { ref => a =>
       for {
         promise <- ref.modifyZIO { map =>
                      map.get(a) match {
                        case Some(promise) => ZIO.succeedNow((promise, map))
                        case None =>
                          for {
-                           promise <- Promise.make[E, B]
-                           _       <- f(a).intoPromise(promise).fork
+                           promise <- Promise.make[E, (FiberRefs.Patch, B)]
+                           _       <- f(a).diffFiberRefs.intoPromise(promise).fork
                          } yield (promise, map.updated(a, promise))
                      }
                    }
-        b <- promise.await
+        b <- promise.await.flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
       } yield b
     }
 
@@ -4100,6 +4116,13 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       if (descriptor.isLocked) ZIO.acquireReleaseWith(ZIO.shift(newExecutor))(_ => ZIO.shift(oldExecutor))(_ => zio)
       else ZIO.acquireReleaseWith(ZIO.shift(newExecutor))(_ => ZIO.unshift)(_ => zio)
     }
+
+  /**
+   * Applies the specified changes to the `FiberRef` values for the fiber
+   * running this workflow.
+   */
+  def patchFiberRefs[R, E, A](patch: FiberRefs.Patch)(implicit trace: Trace): ZIO[Any, Nothing, Unit] =
+    updateFiberRefs(patch)
 
   /**
    * Returns a new scoped workflow that runs finalizers added to the scope of

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -466,20 +466,7 @@ sealed trait ZIO[-R, +E, +A]
    * `FiberRef` values.
    */
   def diffFiberRefs(implicit trace: Trace): ZIO[R, E, (FiberRefs.Patch, A)] =
-    summarized(ZIO.getFiberRefs) { (start, end) =>
-      val fiberRefs = start.fiberRefs | end.fiberRefs
-      val patches = fiberRefs.foldLeft[Map[FiberRef[_], Any]](Map.empty) { (patches, fiberRef) =>
-        val oldValue = start.getOrDefault(fiberRef)
-        val newValue = end.getOrDefault(fiberRef)
-        if (oldValue == newValue) patches
-        else
-          patches.updated(
-            fiberRef,
-            fiberRef.diff(oldValue.asInstanceOf[fiberRef.Value], newValue.asInstanceOf[fiberRef.Value])
-          )
-      }
-      FiberRefs.Patch(patches)
-    }
+    summarized(ZIO.getFiberRefs)(FiberRefs.Patch.diff)
 
   /**
    * Returns an effect that is always interruptible, but whose interruption will

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -242,7 +242,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
    * result of this layer.
    */
   final def memoize(implicit trace: Trace): ZIO[Scope, Nothing, ZLayer[RIn, E, ROut]] =
-    ZIO.serviceWithZIO[Scope](build(_)).memoize.map(ZLayer.scopedEnvironment[RIn](_))
+    ZIO.scopeWith(build(_).memoize.map(ZLayer.fromZIOEnvironment(_)))
 
   /**
    * Translates effect failure into death of the fiber, making all failures


### PR DESCRIPTION
Resolves #7470.

When we memoize ZIO workflows we want users of the memoized workflow to obtain both the result of the workflow and any `FiberRef` changes made by the workflow.

Currently we do this by capturing the `FiberRef` values at the end of the workflow and then having the users of the memoized workflow inherit the `FiberRef` values. However, this can result in the users of the memoized workflow updating "too much" because they inherit all of the `FiberRef` values of the fiber that originally executed the workflow, even if those values are unrelated to changes made by the memoized workflow.

We can improve this by creating a `Patch` data type that captures the changes in `FiberRef` values made by a single fiber in executing a workflow. Then we can apply just that patch to the user of the memoized workflow so they get the `FiberRef` changes made by the memoized workflow and nothing else.