### PR TITLE
ZIO Stream: Join Fibers Interruptibly In ZChannel#mergeWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -830,8 +830,8 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         def go(state: MergeState): ZChannel[Env1, Any, Any, Any, OutErr3, OutElem1, OutDone3] =
           state match {
             case BothRunning(leftFiber, rightFiber) =>
-              val lj: ZIO[Env1, OutErr, Either[OutDone, OutElem1]]   = leftFiber.join
-              val rj: ZIO[Env1, OutErr2, Either[OutDone2, OutElem1]] = rightFiber.join
+              val lj: ZIO[Env1, OutErr, Either[OutDone, OutElem1]]   = leftFiber.join.interruptible
+              val rj: ZIO[Env1, OutErr2, Either[OutDone2, OutElem1]] = rightFiber.join.interruptible
 
               ZChannel.unwrap {
                 lj.raceWith(rj)(


### PR DESCRIPTION
Resolves #7460.

In the implementation of `ZChannel.mergeWith` we race joining the two workflows. We should perform the joins interruptibly so that we can continue the merge if it is being performed in an uninterruptible region. Note that this does not impact the interruptibility of any user code.