### PR TITLE
Make Tags A Region Setting

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+import zio.ZIOAspect._
 import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram
 import zio.test._
@@ -387,6 +388,13 @@ object MetricSpec extends ZIOBaseSpec {
           r2.occurrences.toSet == Set("world" -> 1L)
         )
       }
-    )
+    ),
+    test("tags are a region setting") {
+      val counter = Metric.counter("counter")
+      for {
+        _     <- counter.increment @@ tagged("key" -> "value")
+        state <- counter.tagged(MetricLabel("key", "value")).value
+      } yield assertTrue(state == MetricState.Counter(1L))
+    }
   )
 }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -17,6 +17,7 @@
 package zio
 
 import zio.internal.{FiberScope, IsFatal}
+import zio.metrics.MetricLabel
 
 /**
  * A `FiberRef` is ZIO's equivalent of Java's `ThreadLocal`. The value of a
@@ -337,6 +338,9 @@ object FiberRef {
 
   lazy val currentLogAnnotations: FiberRef[Map[String, String]] =
     FiberRef.unsafe.make[Map[String, String]](Map.empty)(Unsafe.unsafe)
+
+  lazy val currentTags: FiberRef.WithPatch[Set[MetricLabel], SetPatch[MetricLabel]] =
+    FiberRef.unsafe.makeSet(Set.empty)(Unsafe.unsafe)
 
   /**
    * Creates a new `FiberRef` with given initial value.

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -177,6 +177,15 @@ object ZIOAspect {
     }
 
   /**
+   * An aspect that tags each metric in this effect with the specified tags.
+   */
+  def tagged(tags: (String, String)*): ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        ZIO.tagged(tags.map { case (key, value) => MetricLabel(key, value) }.toSet)(zio)
+    }
+
+  /**
    * An aspect that times out effects.
    */
   def timeoutFail[E1](e: => E1)(d: Duration): ZIOAspect[Nothing, Any, E1, Any, Nothing, Any] =

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -321,7 +321,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
    */
   final def value(implicit trace: Trace): UIO[Out] =
     FiberRef.currentTags.getWith { tags =>
-      ZIO.succeed(unsafe.value(tags)(Unsafe.unsafe))
+      ZIO.succeedNow(unsafe.value(tags)(Unsafe.unsafe))
     }
 
   final def withNow[In2](implicit ev: (In2, java.time.Instant) <:< In): Metric[Type, In2, Out] =

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -133,7 +133,9 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
    * amount.
    */
   final def modify(in: => In)(implicit trace: Trace): UIO[Unit] =
-    ZIO.succeed(unsafe.modify(in, Set.empty)(Unsafe.unsafe))
+    FiberRef.currentTags.getWith { tags =>
+      ZIO.succeedNow(unsafe.modify(in, tags)(Unsafe.unsafe))
+    }
 
   /**
    * Returns a new metric, which is identical in every way to this one, except
@@ -310,13 +312,17 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
    * provided amount.
    */
   final def update(in: => In)(implicit trace: Trace): UIO[Unit] =
-    ZIO.succeed(unsafe.update(in, Set.empty)(Unsafe.unsafe))
+    FiberRef.currentTags.getWith { tags =>
+      ZIO.succeedNow(unsafe.update(in, tags)(Unsafe.unsafe))
+    }
 
   /**
    * Retrieves a snapshot of the value of the metric at this moment in time.
    */
   final def value(implicit trace: Trace): UIO[Out] =
-    ZIO.succeed(unsafe.value(Set.empty)(Unsafe.unsafe))
+    FiberRef.currentTags.getWith { tags =>
+      ZIO.succeed(unsafe.value(tags)(Unsafe.unsafe))
+    }
 
   final def withNow[In2](implicit ev: (In2, java.time.Instant) <:< In): Metric[Type, In2, Out] =
     contramap[In2](in2 => ev((in2, java.time.Instant.now())))

--- a/streams/shared/src/main/scala/zio/stream/ZStreamAspect.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStreamAspect.scala
@@ -85,4 +85,13 @@ object ZStreamAspect {
       def apply[R, E, A](stream: ZStream[R, E, A])(implicit trace: Trace): ZStream[R, E, A] =
         stream.rechunk(n)
     }
+
+  /**
+   * An aspect that tags each metric in this stream with the specified tag.
+   */
+  def tagged(key: String, value: String): ZStreamAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZStreamAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](stream: ZStream[R, E, A])(implicit trace: Trace): ZStream[R, E, A] =
+        ZStream.tagged(key, value) *> stream
+    }
 }


### PR DESCRIPTION
Currently it is possible to add tags to individual metrics but it is not possible to apply tags to all metrics in a region. This PR makes tags a region setting like the log level, log span, and log annotations for logging.

The main disadvantage of this change is that there is some cost to getting the tags from the `FiberRef` each time a metric is updated. This can be avoided by using the unsafe interface directly though the user is then responsible for propagating the `FiberRef` values. However, this does seem to be a valuable feature for specifying tags for an entire region, especially when the underlying metric is not under the user's control and so they cannot add tags directly.