### PR TITLE
Extend documentation for `jittered`

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -597,7 +597,8 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
    * interval size`.
    *
    * [Research](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
-   * shows that `jittered(0.0, 1.0)` is a suitable range for a retrying schedule.
+   * shows that `jittered(0.0, 1.0)` is a suitable range for a retrying
+   * schedule.
    */
   def jittered(min: Double, max: Double)(implicit
     trace: Trace

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -595,6 +595,9 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
    *
    * The new interval size is between `min * old interval size` and `max * old
    * interval size`.
+   *
+   * [Research](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
+   * shows that `jittered(0.0, 1.0)` is a suitable range for a retrying schedule.
    */
   def jittered(min: Double, max: Double)(implicit
     trace: Trace

--- a/docs/guides/migrate/migration-guide.md
+++ b/docs/guides/migrate/migration-guide.md
@@ -2477,9 +2477,12 @@ Pipelines are basically an abstraction for composing a bunch of operations toget
 
 ## ZIO Schedules
 
-`Schedule.jittered` in ZIO 1 is equivalent to `Schedule.jittered(0.0, 1.0)`. In ZIO this changed to `Schedule.jittered(0.8, 1.2)`.
+`Schedule.jittered` in ZIO 1 is equivalent to `Schedule.jittered(0.0, 1.0)`. In ZIO 2 this changed to `Schedule.jittered(0.8, 1.2)`.
 
-In ZIO 1 the average throughput of the updated schedule was twice the original schedule. In ZIO 2 the average thoughput of the updated schedule is the same as the orginal schedule.
+In ZIO 1 the average throughput of the updated schedule was twice the original schedule. In ZIO 2 the average throughput of the updated schedule is the same as the original schedule.
+
+The new behavior is more in line with the definition of 'jitter' as used in signal processing.
+Even so, [research](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) shows that `Schedule.jittered(0.0, 1.0)` is better for retrying.
 
 ## ZIO Services
 

--- a/docs/reference/schedule/combinators.md
+++ b/docs/reference/schedule/combinators.md
@@ -105,6 +105,8 @@ When a resource is out of service due to overload or contention, retrying and ba
 
 The form with parameters `min` and `max` creates a new schedule where the new interval size is randomly distributed between `min * old interval` and `max * old interval`.
 
+[Research](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) shows that `Schedule.jittered(0.0, 1.0)` is very suitable for retrying.
+
 ## Collecting
 
 A `collectAll` is a combinator that when we call it on a schedule, produces a new schedule that collects the outputs of the first schedule into a chunk.


### PR DESCRIPTION
In particular, we now link to empirical research on good jitter configuration for retrying. (In retrospect, we should not have changed the default jittered configuration from ZIO 1 to 2.)

Also: fixed minor documentation typos.