### PR TITLE
Fix Intellij assertion failure link click behavior

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -215,6 +215,6 @@ object ReportingTestUtils {
   }
 
   def assertSourceLocation()(implicit sourceLocation: SourceLocation): String =
-    cyan(s"at ${sourceLocation.path}:${sourceLocation.line}")
+    cyan(s"at ${sourceLocation.path}:${sourceLocation.line} ")
 
 }

--- a/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
@@ -166,7 +166,7 @@ trait TestRenderer {
                 }
               }
             ) ++
-            Chunk(detail(s"at $location").toLine)
+            Chunk(detail(s"at $location ").toLine)
 
         result.map(_.withOffset(offset + 1))
     }


### PR DESCRIPTION
Closes #7345

Initially I added a colon, because that works for compiler error links.
That worked, but looked a little weird. Adding a space also works, which is a bit surprising, but I think looks better than the extra colon.

https://user-images.githubusercontent.com/2054940/200689489-c547bd3a-3654-44e8-bed9-9b272df14338.mov

Tested with VSCode as well; it is happy to navigate to both the old and new link style.
