### PR TITLE
ignoreLogged does not log fix

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -849,7 +849,7 @@ sealed trait ZIO[-R, +E, +A]
         ZIO.logLevel(LogLevel.Debug) {
           ZIO.logCause("An error was silently ignored because it is not anticipated to be useful", cause)
         },
-      ZIO.unitFn
+      _ => ZIO.unit
     )
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -844,7 +844,7 @@ sealed trait ZIO[-R, +E, +A]
    * turns out to be important.
    */
   final def ignoreLogged(implicit trace: Trace): URIO[R, Unit] =
-    self.foldCause(
+    self.foldCauseZIO(
       cause =>
         ZIO.logLevel(LogLevel.Debug) {
           ZIO.logCause("An error was silently ignored because it is not anticipated to be useful", cause)


### PR DESCRIPTION
ignoreLogged is using foldCause but the parameter functions return ZIO so as the logging is never evaluated.