### PR TITLE
ZIO Stream: Execute Acquire Uninterrupibly

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -401,8 +401,8 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
     bracketOut: ZChannel.BracketOut[Env, Any, Any]
   )(implicit trace: Trace): ChannelState.Effect[Env, Any] =
     ChannelState.Effect {
-      ZIO.uninterruptibleMask { restore =>
-        restore(provide(bracketOut.acquire())).foldCauseZIO(
+      ZIO.uninterruptible {
+        provide(bracketOut.acquire()).foldCauseZIO(
           cause => ZIO.succeed { currentChannel = ZChannel.failCause(cause) },
           out =>
             ZIO.succeed {


### PR DESCRIPTION
Resolves #7526.

The `acquire` workflow in `ZChannel#acquireReleaseOut` should be performed uninterruptibly.