### PR TITLE
Micro-optimization for Schedule

### DIFF
--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -673,8 +673,10 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
               val newStart = now.plusNanos(duration.toNanos)
               val delta    = java.time.Duration.between(oldStart, newStart)
               val newEnd =
-                try { interval.end.plus(delta) }
-                catch { case _: java.time.DateTimeException => OffsetDateTime.MAX }
+                if (interval.end == OffsetDateTime.MAX) OffsetDateTime.MAX
+                else
+                  try { interval.end.plus(delta) }
+                  catch { case _: java.time.DateTimeException => OffsetDateTime.MAX }
 
               val newInterval = Interval(newStart, newEnd)
 


### PR DESCRIPTION
7% improvement in Schedule. Useful for low periodic timers, such as those used in ZStream.groupedWithin.

It is fairly rare that durations of timer are low enough to notice the difference in an overall application, but with a high-throughput stream that also wants to keep latency low for the downstream consumer, it is noticeable. Removing the throw stops having to fill a stack trace and throw in the normally code path where the Schedule upper-bound is OffsetDateTime.Max. An alternative change could be to substract the delta from Max and compare with interval.end. However this approach has two downsides. 1) it is not clear from the original code if overflow is the only cause of exception. 2) there is more work done on the happy path to do the subtractions then to simply compare.  

Below is a benchmark showing an (unrealistically) low duration on pretty fast desktop that shows a 7% uplift in ops/s:
```
 @Benchmark
  def zioGroupWithinShortDuration: Long = {
    val result = ZStream.tick(Duration(10, TimeUnit.MICROSECONDS))
      .groupedWithin(100, Duration(1, TimeUnit.MICROSECONDS))
      .take(10)
      .runCount

    unsafeRun(result)
  }
```

With the current ZIO head:
```
[info] Result "zio.StreamBenchmarks.zioGroupWithinShortDuration":
[info] Benchmark                             (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioGroupWithinShortDuration          1000          500              50  thrpt   25  506.861 ± 4.498  ops/s
```

With the patched version
```
[info] Result "zio.StreamBenchmarks.zioGroupWithinShortDuration":
[info] Benchmark                             (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioGroupWithinShortDuration          1000          500              50  thrpt   25  541.499 ± 2.647  ops/s
```

I didn't add the benchmark to the StreamBenchmarks as I am not sure it is worth carrying forward for such a specific case, but happy to add/refine if you fancy merging the PR


This optimization is low risk, albeit for little returns for most ZIO users.