### PR TITLE
Render Throwable Cause

### DIFF
--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -64,7 +64,7 @@ object StackTrace {
     StackTrace(
       fiberId,
       Chunk
-        .fromArray(stackTrace.takeWhile(_.getClassName != "zio.internal.FiberRuntime"))
+        .fromArray(stackTrace.takeWhile(!_.getClassName.startsWith("zio.")))
         .map(Trace.fromJava)
         .takeWhile(!Trace.equalIgnoreLocation(_, trace))
     )


### PR DESCRIPTION
If the error type of a fail cause is a throwable we should its causes.

Example code:

```scala
import zio._

object Main extends ZIOAppDefault {

  case class FirstException(message: String) extends Exception(message)

  case class SecondException(message: String, cause: Throwable) extends Exception(message, cause)

  case class ThirdException(message: String, cause: Throwable) extends Exception(message, cause)

  val triggerException = ZIO
    .fail(FirstException("First Exception message"))
    .mapError(err => SecondException("Second exception message", err))
    .mapError(err => ThirdException("Third exception message", err))

  override def run: ZIO[Any with ZIOAppArgs with Scope, Any, Any] =
    triggerException
      .catchAllCause(err => ZIO.logErrorCause("log with ZIO Cause", err))
      .exitCode
}
```

Before:

```
[info] timestamp=2022-11-19T23:25:44.083778Z level=ERROR thread=#zio-fiber-4 message="log with ZIO Cause" cause="Exception in thread "zio-fiber-4" Main$ThirdException: Main$ThirdException: Third exception message
[info]  at <empty>.Main.triggerException(Main.scala:12)
[info]  at <empty>.Main.triggerException(Main.scala:13)
[info]  at <empty>.Main.triggerException(Main.scala:14)
[info]  at <empty>.Main.run(Main.scala:18)
[info]  at <empty>.Main.run(Main.scala:19)" location=<empty>.Main.run file=Main.scala line=18
```

After:

```
[info] timestamp=2022-11-19T23:24:38.335297Z level=ERROR thread=#zio-fiber-4 message="log with ZIO Cause" cause="Exception in thread "zio-fiber-4" Main$ThirdException: Third exception message
[info]  at Main$.$anonfun$triggerException$3(Main.scala:14)
[info]  at <empty>.Main.triggerException(Main.scala:12)
[info]  at <empty>.Main.triggerException(Main.scala:13)
[info]  at <empty>.Main.triggerException(Main.scala:14)
[info]  at <empty>.Main.run(Main.scala:18)
[info]  at <empty>.Main.run(Main.scala:19)
[info]  Suppressed: Main$SecondException: Second exception message
[info]          at Main$.$anonfun$triggerException$2(Main.scala:13)
[info]          Suppressed: Main$FirstException: First Exception message
[info]                  at Main$.$anonfun$triggerException$1(Main.scala:12)" location=<empty>.Main.run file=Main.scala line=18
```