### PR TITLE
Always Succeed With Constant Configuration Value

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -184,6 +184,11 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           for {
             exit <- provider(Map("k1.k3" -> "v")).load(Config.string("k2").nested("k1")).exit
           } yield assert(exit)(Assertion.failsWithA[Config.Error])
+        } +
+        test("accessing a constant value succeeds") {
+          for {
+            value <- provider(Map()).load(Config.succeed("value"))
+          } yield assertTrue(value == "value")
         }
     ) + suite("props")(
       test("flat atoms") {
@@ -283,6 +288,11 @@ object ConfigProviderSpec extends ZIOBaseSpec {
             )
           )
         )
+      },
+      test("succeed for constant value") {
+        for {
+          value <- propsProvider(Map()).load(Config.succeed("value"))
+        } yield assertTrue(value == "value")
       }
     )
   }

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -291,8 +291,9 @@ object ConfigProviderSpec extends ZIOBaseSpec {
       },
       test("succeed for constant value") {
         for {
-          value <- propsProvider(Map()).load(Config.succeed("value"))
-        } yield assertTrue(value == "value")
+          provider <- propsProvider(Map())
+          result   <- provider.load(Config.succeed("value"))
+        } yield assertTrue(result == "value")
       }
     )
   }

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -260,6 +260,12 @@ object ConfigProvider {
                         }
             } yield result
 
+          case Constant(value) =>
+            ZIO.succeed(Chunk(value))
+
+          case Fail(message) =>
+            ZIO.fail(Config.Error.MissingData(prefix, message))
+
           case primitive: Primitive[A] =>
             for {
               vs <- flat.load(prefix, primitive).catchSome {


### PR DESCRIPTION
If the configuration specifies a constant value we should always succeed with that value regardless of whether it exists in the underlying data source.