### PR TITLE
MockableMacro: fix warning on produced code

### DIFF
--- a/test/shared/src/main/scala-2/zio/test/mock/MockableMacro.scala
+++ b/test/shared/src/main/scala-2/zio/test/mock/MockableMacro.scala
@@ -314,6 +314,7 @@ private[mock] object MockableMacro {
                 class $serviceClassName extends $service {
                   ..$mocks
                 }
+                val _ = rts //trick to make rts always used and avoid compilation warn when rts is not used inside mocks
                 new $serviceClassName
               }
             }


### PR DESCRIPTION
Most of the time, code generated by MockableMacro make scalac complain about `rts` not being used.
This is a big problem when `-Xfatal-warnings` is used. One could say that the solution will be to use `-Ywarn-macros:before` but some project need or at least recommand usig `-Wmacros:after`, for example:

https://diffx-scala.readthedocs.io/en/latest/#tips-and-tricks