### PR TITLE
Collect Last Output Of Schedule In Schedule#collectAll

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -646,6 +646,12 @@ object ScheduleSpec extends ZIOBaseSpec {
         _       <- TestClock.adjust(2.minutes)
         seconds <- ref.get
       } yield assertTrue(seconds == Chunk(5L, 25L, 30L, 50L, 70L, 90L, 110L))
+    },
+    test("collectAll") {
+      val schedule = Schedule.recurs(5).collectAll
+      for {
+        chunk <- ZIO.unit.repeat(schedule)
+      } yield assertTrue(chunk == Chunk(0L, 1L, 2L, 3L, 4L, 5L))
     }
   )
 


### PR DESCRIPTION
`fold` emits the zero element as the first output but we don't actually want to emit an empty chunk as the first output, we want to emit a chunk with the first output.