### PR TITLE
Reduce allocations

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -29,11 +29,11 @@ import java.util.concurrent.locks.LockSupport
  * Lerche. [[https://tokio.rs/blog/2019-10-scheduler]]
  */
 private final class ZScheduler extends Executor {
-  private[this] val poolSize           = java.lang.Runtime.getRuntime.availableProcessors
-  private[this] val cache              = MutableConcurrentQueue.unbounded[ZScheduler.Worker]
-  private[this] val globalQueue        = MutableConcurrentQueue.unbounded[Runnable]
-  private[this] val idle               = MutableConcurrentQueue.bounded[ZScheduler.Worker](poolSize)
-  private[this] val state              = new AtomicInteger(poolSize << 16)
+  private[this] val poolSize    = java.lang.Runtime.getRuntime.availableProcessors
+  private[this] val cache       = MutableConcurrentQueue.unbounded[ZScheduler.Worker]
+  private[this] val globalQueue = MutableConcurrentQueue.unbounded[Runnable]
+  private[this] val idle        = MutableConcurrentQueue.bounded[ZScheduler.Worker](poolSize)
+  private[this] val state       = new AtomicInteger(poolSize << 16)
   // Each value will only ever have one element. The array is merely to prevent boxing each time we mutate the Long.
   private[this] val submittedLocations = new java.util.HashMap[Trace, Array[Long]]
   private[this] val workers            = Array.ofDim[ZScheduler.Worker](poolSize)
@@ -230,8 +230,8 @@ private final class ZScheduler extends Executor {
 
   private[this] def isBlocking(runnable: Runnable): Boolean =
     if (runnable.isInstanceOf[FiberRunnable]) {
-      val fiberRunnable  = runnable.asInstanceOf[FiberRunnable]
-      val location       = fiberRunnable.location
+      val fiberRunnable = runnable.asInstanceOf[FiberRunnable]
+      val location      = fiberRunnable.location
       submittedLocations.compute(
         location,
         (_, submittedCount) =>


### PR DESCRIPTION
This reduces allocations due to not boxing every `Long` in [ZScheduler#submittedLocations](https://github.com/zio/zio/blob/064d1cd7cef7a5814a00f2a76d6ecd32d86eaab9/core/jvm/src/main/scala/zio/internal/ZScheduler.scala#L37). I measured the difference by running `ZIO.unit.forever` and profiling the same way I did at https://github.com/zio/zio/pull/7365.

### benchmarks

before

```
[info] Benchmark                                            Mode  Cnt     Score    Error  Units
[info] ZSchedulerBenchmarks.catsRuntimeChainedFork         thrpt   15  6207.667 ± 65.372  ops/s
[info] ZSchedulerBenchmarks.catsRuntimeForkMany            thrpt   15   670.941 ±  9.549  ops/s
[info] ZSchedulerBenchmarks.catsRuntimePingPong            thrpt   15   986.860 ± 31.994  ops/s
[info] ZSchedulerBenchmarks.catsRuntimeYieldMany           thrpt   15   855.601 ± 18.382  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolChainedFork  thrpt   15  2735.637 ± 34.485  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolForkMany     thrpt   15   389.630 ±  3.819  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolPingPong     thrpt   15   784.109 ±  6.717  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolYieldMany    thrpt   15    14.408 ±  0.143  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerChainedFork        thrpt   15  2609.220 ±  8.991  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerForkMany           thrpt   15   444.072 ±  3.386  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerPingPong           thrpt   15  1886.767 ±  8.340  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerYieldMany          thrpt   15    67.884 ±  0.189  ops/s
```

after
```
[info] Benchmark                                            Mode  Cnt     Score    Error  Units
[info] ZSchedulerBenchmarks.catsRuntimeChainedFork         thrpt   15  6266.270 ±  5.935  ops/s
[info] ZSchedulerBenchmarks.catsRuntimeForkMany            thrpt   15   664.790 ±  1.493  ops/s
[info] ZSchedulerBenchmarks.catsRuntimePingPong            thrpt   15   936.911 ±  9.402  ops/s
[info] ZSchedulerBenchmarks.catsRuntimeYieldMany           thrpt   15   725.193 ±  2.423  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolChainedFork  thrpt   15  2806.162 ±  6.056  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolForkMany     thrpt   15   417.146 ±  1.950  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolPingPong     thrpt   15   715.587 ±  3.365  ops/s
[info] ZSchedulerBenchmarks.zioFixedThreadPoolYieldMany    thrpt   15    14.125 ±  0.080  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerChainedFork        thrpt   15  2917.393 ±  6.393  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerForkMany           thrpt   15   445.130 ±  6.354  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerPingPong           thrpt   15  1863.503 ± 13.140  ops/s
[info] ZSchedulerBenchmarks.zioSchedulerYieldMany          thrpt   15    71.960 ±  0.133  ops/s
```

### allocations

before


![before](https://user-images.githubusercontent.com/1625822/204115143-1993fdb2-cff8-40c8-ae7c-f30ccc72cead.png)

after

Notice that there are many fewer `java.lang.Long` allocations.

![after2](https://user-images.githubusercontent.com/1625822/204118190-d7ef2436-3dbe-4236-9a1e-8a922ffb69f5.png)
