### PR TITLE
reduce allocations

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -30,10 +30,10 @@ class StreamBenchmarks {
   implicit val system: ActorSystem          = ActorSystem("benchmarks")
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
-  var akkaChunks: IndexedSeq[Array[Int]] = _
+  var akkaChunks: IndexedSeq[Array[Int]]   = _
   var fs2Chunks: IndexedSeq[FS2Chunk[Int]] = _
-  var zioChunks: IndexedSeq[Chunk[Int]] = _
-  var zioChunkChunk: Chunk[Int] = _
+  var zioChunks: IndexedSeq[Chunk[Int]]    = _
+  var zioChunkChunk: Chunk[Int]            = _
 
   @Setup
   def setup(): Unit = {
@@ -86,15 +86,14 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def zioChunkChunkFilterMapSum: Long = {
+  def zioChunkChunkFilterMapSum: Long =
     zioChunkChunk
       .filter(_ % 2 == 0)
       .map(_.toLong)
       .fold(0L)(_ + _)
-  }
 
   @Benchmark
-  def fs2MapAccum: Option[(Long, Long)] = {
+  def fs2MapAccum: Option[(Long, Long)] =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .mapAccumulate(0L) { case (acc, i) =>
@@ -105,7 +104,6 @@ class StreamBenchmarks {
       .compile
       .last
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioMapAccum: Option[Long] = {
@@ -131,7 +129,7 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def fs2Sliding: Long = {
+  def fs2Sliding: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .sliding(100, 1)
@@ -139,7 +137,6 @@ class StreamBenchmarks {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioSliding: Long = {
@@ -162,7 +159,7 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def fs2TakeWhile: Option[Int] = {
+  def fs2TakeWhile: Option[Int] =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .takeWhile(i => (i < (chunkCount * chunkSize) / 2))
@@ -170,7 +167,6 @@ class StreamBenchmarks {
       .compile
       .last
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioTakeWhile: Option[Int] = {
@@ -193,7 +189,7 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def fs2GroupWithin: Long = {
+  def fs2GroupWithin: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .groupWithin[CatsIO](100, ScalaDuration(1, TimeUnit.SECONDS))
@@ -201,7 +197,6 @@ class StreamBenchmarks {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioGroupWithin: Long = {
@@ -214,7 +209,7 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def fs2GroupAdjecentBy: Long = {
+  def fs2GroupAdjecentBy: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .groupAdjacentBy(_ % 2)
@@ -222,7 +217,6 @@ class StreamBenchmarks {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioGroupAdjecentBy: Long = {

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -12,11 +12,14 @@ import zio.stream._
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration => ScalaDuration}
-import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import scala.concurrent.{Await, ExecutionContextExecutor}
 
-@State(JScope.Thread)
+@State(JScope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(value = 1)
 class StreamBenchmarks {
   @Param(Array("10000"))
   var chunkCount: Int = _
@@ -24,11 +27,21 @@ class StreamBenchmarks {
   @Param(Array("5000"))
   var chunkSize: Int = _
 
-  @Param(Array("50"))
-  var parChunkSize: Int = _
-
   implicit val system: ActorSystem          = ActorSystem("benchmarks")
   implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  var akkaChunks: IndexedSeq[Array[Int]] = _
+  var fs2Chunks: IndexedSeq[FS2Chunk[Int]] = _
+  var zioChunks: IndexedSeq[Chunk[Int]] = _
+  var zioChunkChunk: Chunk[Int] = _
+
+  @Setup
+  def setup(): Unit = {
+    akkaChunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
+    fs2Chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
+    zioChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
+    zioChunkChunk = Chunk.fromArray((1 to chunkCount).toArray).flatMap(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
+  }
 
   @TearDown
   def shutdown(): Unit = {
@@ -38,9 +51,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def akkaChunkFilterMapSum: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
+      .fromIterator(() => akkaChunks.iterator.flatten)
       .filter(_ % 2 == 0)
       .map(_.toLong)
       .toMat(AkkaSink.fold(0L)(_ + _))(Keep.right)
@@ -50,8 +62,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2ChunkFilterMapSum: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    val stream = FS2Stream(chunks: _*)
+    val stream = FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .filter(_ % 2 == 0)
       .map(_.toLong)
@@ -63,9 +74,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioChunkFilterMapSum: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val stream = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .filter(_ % 2 == 0)
       .map(_.toLong)
 
@@ -77,8 +87,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioChunkChunkFilterMapSum: Long = {
-    val chunks = Chunk.fromArray((1 to chunkCount).toArray).flatMap(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
-    chunks
+    zioChunkChunk
       .filter(_ % 2 == 0)
       .map(_.toLong)
       .fold(0L)(_ + _)
@@ -86,8 +95,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2MapAccum: Option[(Long, Long)] = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    FS2Stream(chunks: _*)
+    FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .mapAccumulate(0L) { case (acc, i) =>
         val added = acc + i
@@ -101,9 +109,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioMapAccum: Option[Long] = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .mapAccum(0L) { case (acc, i) =>
         val added = acc + i
         (added, added)
@@ -115,9 +122,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def akkaSliding: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
+      .fromIterator(() => akkaChunks.iterator.flatten)
       .sliding(100, 1)
       .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
 
@@ -126,8 +132,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2Sliding: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    FS2Stream(chunks: _*)
+    FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .sliding(100, 1)
       .covary[CatsIO]
@@ -138,9 +143,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioSliding: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .sliding(100, 1)
       .runCount
 
@@ -149,9 +153,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def akkaTakeWhile: Option[Int] = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
+      .fromIterator(() => akkaChunks.iterator.flatten)
       .takeWhile(i => (i < (chunkCount * chunkSize) / 2))
       .toMat(AkkaSink.lastOption)(Keep.right)
 
@@ -160,8 +163,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2TakeWhile: Option[Int] = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    FS2Stream(chunks: _*)
+    FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .takeWhile(i => (i < (chunkCount * chunkSize) / 2))
       .covary[CatsIO]
@@ -172,9 +174,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioTakeWhile: Option[Int] = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .takeWhile(i => (i < (chunkCount * chunkSize) / 2))
       .runLast
 
@@ -183,9 +184,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def akkaGroupWithin: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
     val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
+      .fromIterator(() => akkaChunks.iterator.flatten)
       .groupedWithin(100, ScalaDuration(1, TimeUnit.SECONDS))
       .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
 
@@ -194,8 +194,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2GroupWithin: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    FS2Stream(chunks: _*)
+    FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .groupWithin[CatsIO](100, ScalaDuration(1, TimeUnit.SECONDS))
       .covary[CatsIO]
@@ -206,9 +205,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioGroupWithin: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .groupedWithin(100, Duration(1, TimeUnit.SECONDS))
       .runCount
 
@@ -217,8 +215,7 @@ class StreamBenchmarks {
 
   @Benchmark
   def fs2GroupAdjecentBy: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    FS2Stream(chunks: _*)
+    FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .groupAdjacentBy(_ % 2)
       .covary[CatsIO]
@@ -229,9 +226,8 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioGroupAdjecentBy: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .groupAdjacentBy(_ % 2)
       .runCount
 
@@ -240,114 +236,12 @@ class StreamBenchmarks {
 
   @Benchmark
   def zioGroupByKey: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
     val result = ZStream
-      .fromChunks(chunks: _*)
+      .fromChunks(zioChunks: _*)
       .groupByKey(_ % 2) { case (k, s) =>
         ZStream.fromZIO(s.runCollect.map(vs => k -> vs))
       }
       .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def akkaMapPar: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(parChunkSize)(i))
-    val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
-      .mapAsync(4)(i => Future.successful(BigDecimal.valueOf(i.toLong).pow(3)))
-      .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
-
-    Await.result(program.run(), ScalaDuration.Inf)
-  }
-
-  @Benchmark
-  def fs2MapPar: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(parChunkSize)(i)))
-    FS2Stream(chunks: _*)
-      .flatMap(FS2Stream.chunk(_))
-      .mapAsync[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
-      .covary[CatsIO]
-      .compile
-      .fold(0L)((c, _) => c + 1L)
-      .unsafeRunSync()
-  }
-
-  @Benchmark
-  def zioMapPar: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(parChunkSize)(i)))
-    val result = ZStream
-      .fromChunks(chunks: _*)
-      .mapZIOPar(4)(i => ZIO.succeed(BigDecimal.valueOf(i.toLong).pow(3)))
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def akkaMapParUnordered: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(parChunkSize)(i))
-    val program = AkkaSource
-      .fromIterator(() => chunks.iterator.flatten)
-      .mapAsyncUnordered(4)(i => Future.successful(BigDecimal.valueOf(i.toLong).pow(3)))
-      .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
-
-    Await.result(program.run(), ScalaDuration.Inf)
-  }
-
-  @Benchmark
-  def fs2MapParUnordered: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(parChunkSize)(i)))
-    FS2Stream(chunks: _*)
-      .flatMap(FS2Stream.chunk(_))
-      .mapAsyncUnordered[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
-      .covary[CatsIO]
-      .compile
-      .fold(0L)((c, _) => c + 1L)
-      .unsafeRunSync()
-  }
-
-  @Benchmark
-  def zioMapParUnordered: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(parChunkSize)(i)))
-    val result = ZStream
-      .fromChunks(chunks: _*)
-      .mapZIOParUnordered(4)(i => ZIO.succeed(BigDecimal.valueOf(i.toLong).pow(3)))
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def akkaZipWith: Long = {
-    val chunks = (1 to chunkCount).map(i => Array.fill(chunkSize)(i))
-    val s1     = AkkaSource.fromIterator(() => chunks.iterator.flatten)
-    val s2     = AkkaSource.fromIterator(() => chunks.iterator.flatten).map(_ * 2L)
-    val program = s1
-      .zipWith(s2)(_ + _)
-      .toMat(AkkaSink.fold(0L)((acc, c) => acc + c))(Keep.right)
-    Await.result(program.run(), ScalaDuration.Inf)
-  }
-
-  @Benchmark
-  def fs2ZipWith: Long = {
-    val chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(chunkSize)(i)))
-    val s1     = FS2Stream(chunks: _*).flatMap(FS2Stream.chunk(_))
-    val s2     = FS2Stream(chunks: _*).flatMap(FS2Stream.chunk(_)).map(_ * 2L)
-    s1.zipWith(s2)(_ + _)
-      .covary[CatsIO]
-      .compile
-      .fold(0L)((acc, c) => acc + c)
-      .unsafeRunSync()
-  }
-
-  @Benchmark
-  def zioZipWith: Long = {
-    val chunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(chunkSize)(i)))
-    val s1     = ZStream.fromChunks(chunks: _*)
-    val s2     = ZStream.fromChunks(chunks: _*).map(_ * 2L)
-    val result = s1.zipWith(s2)(_ + _).runSum
 
     unsafeRun(result)
   }

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -30,12 +30,12 @@ class StreamParBenchmark {
   @Param(Array("50"))
   var parChunkSize: Int = _
 
-  implicit val system: ActorSystem = ActorSystem("benchmarks")
+  implicit val system: ActorSystem          = ActorSystem("benchmarks")
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
-  var akkaChunks: IndexedSeq[Array[Int]] = _
+  var akkaChunks: IndexedSeq[Array[Int]]   = _
   var fs2Chunks: IndexedSeq[FS2Chunk[Int]] = _
-  var zioChunks: IndexedSeq[Chunk[Int]] = _
+  var zioChunks: IndexedSeq[Chunk[Int]]    = _
 
   @Setup
   def setup(): Unit = {
@@ -61,7 +61,7 @@ class StreamParBenchmark {
   }
 
   @Benchmark
-  def fs2MapPar: Long = {
+  def fs2MapPar: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .mapAsync[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
@@ -69,7 +69,6 @@ class StreamParBenchmark {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioMapPar: Long = {
@@ -92,7 +91,7 @@ class StreamParBenchmark {
   }
 
   @Benchmark
-  def fs2MapParUnordered: Long = {
+  def fs2MapParUnordered: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
       .mapAsyncUnordered[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
@@ -100,7 +99,6 @@ class StreamParBenchmark {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
   @Benchmark
   def zioMapParUnordered: Long = {
@@ -111,6 +109,5 @@ class StreamParBenchmark {
 
     unsafeRun(result)
   }
-
 
 }

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -1,0 +1,116 @@
+package zio
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Keep, Sink => AkkaSink, Source => AkkaSource}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO => CatsIO}
+import fs2.{Chunk => FS2Chunk, Stream => FS2Stream}
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+import zio.stream._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Duration => ScalaDuration}
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(value = 1)
+class StreamParBenchmark {
+
+  @Param(Array("10000"))
+  var chunkCount: Int = _
+
+  @Param(Array("5000"))
+  var chunkSize: Int = _
+
+  @Param(Array("50"))
+  var parChunkSize: Int = _
+
+  implicit val system: ActorSystem = ActorSystem("benchmarks")
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  var akkaChunks: IndexedSeq[Array[Int]] = _
+  var fs2Chunks: IndexedSeq[FS2Chunk[Int]] = _
+  var zioChunks: IndexedSeq[Chunk[Int]] = _
+
+  @Setup
+  def setup(): Unit = {
+    akkaChunks = (1 to chunkCount).map(i => Array.fill(parChunkSize)(i))
+    fs2Chunks = (1 to chunkCount).map(i => FS2Chunk.array(Array.fill(parChunkSize)(i)))
+    zioChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(parChunkSize)(i)))
+  }
+
+  @TearDown
+  def shutdown(): Unit = {
+    system.terminate()
+    ()
+  }
+
+  @Benchmark
+  def akkaMapPar: Long = {
+    val program = AkkaSource
+      .fromIterator(() => akkaChunks.iterator.flatten)
+      .mapAsync(4)(i => Future.successful(BigDecimal.valueOf(i.toLong).pow(3)))
+      .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
+
+    Await.result(program.run(), ScalaDuration.Inf)
+  }
+
+  @Benchmark
+  def fs2MapPar: Long = {
+    FS2Stream(fs2Chunks: _*)
+      .flatMap(FS2Stream.chunk(_))
+      .mapAsync[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
+      .covary[CatsIO]
+      .compile
+      .fold(0L)((c, _) => c + 1L)
+      .unsafeRunSync()
+  }
+
+  @Benchmark
+  def zioMapPar: Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .mapZIOPar(4)(i => ZIO.succeed(BigDecimal.valueOf(i.toLong).pow(3)))
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def akkaMapParUnordered: Long = {
+    val program = AkkaSource
+      .fromIterator(() => akkaChunks.iterator.flatten)
+      .mapAsyncUnordered(4)(i => Future.successful(BigDecimal.valueOf(i.toLong).pow(3)))
+      .toMat(AkkaSink.fold(0L)((c, _) => c + 1L))(Keep.right)
+
+    Await.result(program.run(), ScalaDuration.Inf)
+  }
+
+  @Benchmark
+  def fs2MapParUnordered: Long = {
+    FS2Stream(fs2Chunks: _*)
+      .flatMap(FS2Stream.chunk(_))
+      .mapAsyncUnordered[CatsIO, BigDecimal](4)(i => CatsIO(BigDecimal.valueOf(i.toLong).pow(3)))
+      .covary[CatsIO]
+      .compile
+      .fold(0L)((c, _) => c + 1L)
+      .unsafeRunSync()
+  }
+
+  @Benchmark
+  def zioMapParUnordered: Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .mapZIOParUnordered(4)(i => ZIO.succeed(BigDecimal.valueOf(i.toLong).pow(3)))
+      .runCount
+
+    unsafeRun(result)
+  }
+
+
+}

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -314,7 +314,7 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
 
   private[this] var done: Exit[Any, Any] = _
 
-  private[this] var doneStack: Stack[ErasedContinuation[Env]] = Stack.empty
+  private[this] var doneStack: Stack[ErasedContinuation[Env]] = Stack.empty[ErasedContinuation[Env]]
 
   private[this] var emitted: Any = _
 


### PR DESCRIPTION
This reduces allocations by using a `Stack` instead of a `List` for [ChannelExecutor](https://github.com/zio/zio/blob/cad5cafe3448f784092f354713f8b9fe4cb0ed51/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala)'s `doneStack`. I measured the difference by running `ZStream.unit.forever.runDrain` and profiling the same way I did at https://github.com/zio/zio/pull/7365.

### benchmarks

before

```
[info] Benchmark                                   (chunkCount)  (chunkSize)   Mode  Cnt  Score    Error  Units
[info] StreamBenchmarks.zioChunkChunkFilterMapSum         10000         5000  thrpt   15  3.299 ±  0.026  ops/s
[info] StreamBenchmarks.zioChunkFilterMapSum              10000         5000  thrpt   15  2.466 ±  0.055  ops/s
[info] StreamBenchmarks.zioGroupAdjecentBy                10000         5000  thrpt   15  1.083 ±  0.003  ops/s
[info] StreamBenchmarks.zioGroupByKey                     10000         5000  thrpt   15  2.533 ±  0.021  ops/s
[info] StreamBenchmarks.zioGroupWithin                    10000         5000  thrpt   15  0.033 ±  0.001  ops/s
[info] StreamBenchmarks.zioMapAccum                       10000         5000  thrpt   15  2.227 ±  0.020  ops/s
[info] StreamBenchmarks.zioSliding                        10000         5000  thrpt   15  0.117 ±  0.001  ops/s
[info] StreamBenchmarks.zioTakeWhile                      10000         5000  thrpt   15  3.212 ±  0.013  ops/s
```

after
```
[info] Benchmark                                   (chunkCount)  (chunkSize)   Mode  Cnt  Score   Error  Units
[info] StreamBenchmarks.zioChunkChunkFilterMapSum         10000         5000  thrpt   15  3.323 ± 0.042  ops/s
[info] StreamBenchmarks.zioChunkFilterMapSum              10000         5000  thrpt   15  2.512 ± 0.012  ops/s
[info] StreamBenchmarks.zioGroupAdjecentBy                10000         5000  thrpt   15  1.073 ± 0.003  ops/s
[info] StreamBenchmarks.zioGroupByKey                     10000         5000  thrpt   15  2.453 ± 0.187  ops/s
[info] StreamBenchmarks.zioGroupWithin                    10000         5000  thrpt   15  0.032 ± 0.001  ops/s
[info] StreamBenchmarks.zioMapAccum                       10000         5000  thrpt   15  2.194 ± 0.012  ops/s
[info] StreamBenchmarks.zioSliding                        10000         5000  thrpt   15  0.108 ± 0.001  ops/s
[info] StreamBenchmarks.zioTakeWhile                      10000         5000  thrpt   15  3.748 ± 0.025  ops/s
```

### allocations

before

![forever before](https://user-images.githubusercontent.com/1625822/204153455-f9eb9d28-1381-4f87-8bbf-ca7683675d11.png)

after

Notice that the `$colon$colon` allocations disappear, and nothing takes their place.

![forever after](https://user-images.githubusercontent.com/1625822/204153458-a747e5c6-5257-4e4f-8fb3-5b1efd92a59f.png)
