### PR TITLE
use attemptBlocking for Source.fromFile

### DIFF
--- a/docs/reference/di/zlayer-constructor-as-a-value.md
+++ b/docs/reference/di/zlayer-constructor-as-a-value.md
@@ -288,7 +288,7 @@ import scala.io.BufferedSource
 val fileLayer: ZLayer[Any, Throwable, BufferedSource] =
   ZLayer.scoped {
     ZIO.fromAutoCloseable(
-      ZIO.attempt(scala.io.Source.fromFile("file.txt"))
+      ZIO.attemptBlocking(scala.io.Source.fromFile("file.txt"))
     )
   }
 ```


### PR DESCRIPTION
As far as I know `scala.io.Source.fromFile("file.txt")` will cause a blocking IO operations. If I'm correct, it would be better to nest it accordingly in the example.