### PR TITLE
Upgrade Docusaurus (v2.2.0)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,9 +12,9 @@
   },
   "dependencies": {
     "@babel/plugin-transform-parameters": "^7.18.8",
-    "@docusaurus/core": "^2.1.0",
-    "@docusaurus/preset-classic": "^2.1.0",
-    "@docusaurus/theme-search-algolia": "^2.1.0",
+    "@docusaurus/core": "^2.2.0",
+    "@docusaurus/preset-classic": "^2.2.0",
+    "@docusaurus/theme-search-algolia": "^2.2.0",
     "@material-ui/core": "4.12.4",
     "@mdx-js/react": "1.6.22",
     "@zio.dev/caliban-deriving": "^0.0.1",


### PR DESCRIPTION
Using Docusaurus v2.2.0, we can use its built-in mermaid feature.
- https://docusaurus.io/blog/releases/2.2
- https://github.com/zio/zio-prelude/pull/1007