### PR TITLE
Embed Generated Card List For Ecosystem Section

### DIFF
--- a/docs/ecosystem/community/index.md
+++ b/docs/ecosystem/community/index.md
@@ -1,8 +1,13 @@
 ---
 id: index
-title: "Introduction"
+title: "ZIO Ecosystem Community Libraries"
 ---
 
 In this section we are going to introduce some of the most important libraries that have first-class ZIO support from the community.
 
 If you know a useful library that has first-class ZIO support, please consider [submitting a pull request](https://github.com/zio/zio/pulls) to add it to this list.
+
+
+import DocCardList from '@theme/DocCardList';
+
+<DocCardList />

--- a/docs/ecosystem/index.md
+++ b/docs/ecosystem/index.md
@@ -3,57 +3,7 @@ id: index
 title: "ZIO Ecosystem"
 ---
 
-We have two categories of libraries: official and community.
-
-## Official Libraries
-
-Official libraries are maintained by the ZIO team under the [ZIO Organization](https://github.com/zio).
-
-* [ZIO Actors](officials/zio-actors.md)
-* [ZIO Akka Cluster](officials/zio-akka-cluster.md)
-* [ZIO AWS](officials/zio-aws.md)
-* [ZIO Cache](officials/zio-cache.md)
-* [ZIO Config](officials/zio-config.md)
-* [ZIO FTP](officials/zio-ftp.md)
-* [ZIO JSON](officials/zio-json.md)
-* [ZIO Kafka](officials/zio-kafka.md)
-* [ZIO Logging](officials/zio-logging.md)
-* [ZIO Metrics](officials/zio-metrics.md)
-* [ZIO Mock](officials/zio-mock.md)
-* [ZIO NIO](officials/zio-nio.md)
-* [ZIO Optics](officials/zio-optics.md)
-* [ZIO Prelude](officials/zio-prelude.md)
-* [ZIO Process](officials/zio-process.md)
-* [ZIO Query](officials/zio-query.md)
-* [ZIO Redis](officials/zio-redis.md)
-* [ZIO RocksDB](officials/zio-rocksdb.md)
-* [ZIO S3](officials/zio-s3.md)
-* [ZIO Schema](officials/zio-schema.md)
-* [ZIO SQS](officials/zio-sqs.md)
-* [ZIO Telemetry](officials/zio-telemetry.md)
-* [ZIO ZMX](officials/zio-zmx.md)
-
-## Community Libraries
-
-* [Caliban](community/caliban.md)
-* [Distage](community/distage.md)
-* [LogStage](community/logstage.md)
-* [MUnit ZIO](community/munit-zio.md)
-* [Quill](community/quill.md)
-* [Rezilience](community/rezilience.md)
-* [tamer](community/tamer.md)
-* [TranzactIO](community/tranzactio.md)
-* [ZIO AMQP](community/zio-amqp.md)
-* [ZIO Arrow](community/zio-arrow.md)
-* [ZIO AWS S3](community/zio-aws-s3.md)
-* [ZIO gRPC](community/zio-grpc.md)
-* [ZIO HTTP](community/zio-http.md)
-* [ZIO K8S](community/zio-k8s.md)
-* [ZIO Kinesis](community/zio-kinesis.md)
-* [ZIO Pulsar](community/zio-pulsar.md)
-* [ZIO Saga](community/zio-saga.md)
-* [ZIO Slick Interop](community/zio-slick-interop.md)
-* [ZIO Test Akka HTTP](community/zio-test-akka-http.md)
+We have two categories of libraries: official and community. [Official libraries](officials/index.md) are maintained by the ZIO team under the [ZIO Organization](https://github.com/zio), while [community libraries](community/index.md) are maintained by the ZIO community members.
 
 ## ZIO Compatible Libraries
 
@@ -66,4 +16,3 @@ To learn about tools that are useful for ZIO development, see [this section](too
 ## Project Templates
 
 In this section, we introduce a list of [project templates](templates.md) that can be used to quickly start a new project.
-

--- a/docs/ecosystem/officials/index.md
+++ b/docs/ecosystem/officials/index.md
@@ -1,9 +1,11 @@
 ---
 id: index
-title: "Introduction"
+title: "ZIO Ecosystem Official Libraries"
 ---
 
 Official ZIO libraries are hosted in the [ZIO organization](https://github.com/zio/) on Github, and are generally maintained by core contributors to ZIO.
+
+## Development Status
 
 Each project in the ZIO organization namespace has a _Stage Badge_ which indicates the current status of that project:
 
@@ -18,3 +20,10 @@ Each project in the ZIO organization namespace has a _Stage Badge_ which indicat
 * **Concept** — The project is just an idea, development hasn't started yet.
 
 * **Deprecated** — The project is not maintained anymore, and we don't recommend its usage.
+
+
+## Official Libraries
+
+import DocCardList from '@theme/DocCardList';
+
+ <DocCardList />


### PR DESCRIPTION
This work generate a card list for the ecosystem section like the one below:

![image](https://user-images.githubusercontent.com/235974/205424080-e8e5e7c8-4ded-4637-bb37-541169c723c1.png)
