### PR TITLE
Sbt bump 1.8.0

### DIFF
--- a/docs/guides/tutorials/run-our-first-zio-project-with-vscode.md
+++ b/docs/guides/tutorials/run-our-first-zio-project-with-vscode.md
@@ -51,7 +51,7 @@ touch project/build.properties
 Now, let's add the following lines to the `project/build.properties` file:
 
 ```
-sbt.version = 1.6.2
+sbt.version = 1.8.0
 ```
 
 4. We are ready to open our project in VsCode. We can do this by opening the `my-zio-project` directory from the `File > Open Folder` menu.

--- a/docs/guides/tutorials/run-our-first-zio-project-with-vscode.md
+++ b/docs/guides/tutorials/run-our-first-zio-project-with-vscode.md
@@ -37,7 +37,7 @@ name := "my-zio-project"
 version := "0.0.1"
 
 libraryDependencies ++= Seq(
-  "zio" %% "zio" % "2.0.0-RC6"
+  "zio" %% "zio" % "2.0.5"
 )
 ```
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.8.0

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.7.2"
-declare -r sbt_unreleased_version="1.7.2"
+declare -r sbt_release_version="1.8.0"
+declare -r sbt_unreleased_version="1.8.0"
 
 declare -r latest_213="2.13.10"
 declare -r latest_212="2.12.17"

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.8.0


### PR DESCRIPTION
# SBT changes
- sbt 1.8.0 has been out for 26 days, with no further patches. Compile and scalafix are working locally - hopefully CI is happy too!

---

A couple tangents I thought about when looking around the repo: 

### Dependabot
As a public repo, we should be able to add a Dependabot to `.github/dependabot.yaml`. It could have a few benefits:
- workflows: Keep GitHub Action workflows up-to-date (I suggest regular update frequency, maybe daily). GitHub themselves recommend this - a raised a similar PR for [smithy](https://github.com/awslabs/smithy/pull/1395), which has more details
- node: Keep website dependencies (like Docusaurus) up to date. May lead to fewer [GitHub warnings](https://github.com/zio/zio/pull/7551/files) for example
- sbt: Might be able to keep the sbt versions up to date, at the least 🤞 

I'd be happy to add that in another PR. You could try it, and disable if it's too noisy.

### Windows
I thought at first the GH Action workflows were depending on sbt being baked into Ubuntu 20, and I was looking into using coursier's setup-action (as well as the cache action) to not have that point of weakness (GH's Ubuntu 22 image is missing sbt). I found out that the sbt file in root is sbt-extras, a wrapper around sbt. On Windows it's running compile/check nicely with https://git-scm.com/download/win. Doesn't look like there's a .bat version (thinking of gradlew/gradlew.bat).  There might be docs around this already - I'll have a look another time. If not, this note here may help someone. It's at least good for super basic sbt commands as noted, and I don't seem to have WSL installed.

### GitHub Action cache
I haven't used Coursier's cache action before, but I thought it would cache compilation/scalafix output. 
I can see that code linting takes about 2 minutes:
- https://github.com/zio/zio/actions/runs/3631895597/jobs/6127997092
- https://github.com/zio/zio/actions/runs/3634353094/jobs/6132363011

Locally, my first `./sbt check` takes about 70 seconds, and I'm getting 4 seconds after that.
Might there be some optimisations to compilation times & linting in CI if it can indeed cache the sbt cache of the build? As the tagline notes:
> A GitHub action to save / restore the coursier / sbt / mill / Ammonite caches of your build.