### PR TITLE
Deprecate ZIO#unary_!

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -41,14 +41,6 @@ object ZIOSpec extends ZIOBaseSpec {
         assertZIO(ZIO.succeed(false) && ZIO.fail("fail"))(isFalse)
       }
     ),
-    suite("unary_!")(
-      test("not true is false") {
-        assertZIO(!ZIO.succeed(true))(isFalse)
-      },
-      test("not false is true") {
-        assertZIO(!ZIO.succeed(false))(isTrue)
-      }
-    ),
     suite("||")(
       test("true or true is true") {
         assertZIO(ZIO.succeed(true) || ZIO.succeed(true))(isTrue)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -152,6 +152,7 @@ sealed trait ZIO[-R, +E, +A]
    * Returns the logical negation of the `Boolean` value returned by this
    * effect.
    */
+  @deprecated("use negate", "2.0.6")
   final def unary_![R1 <: R, E1 >: E](implicit ev: A <:< Boolean, trace: Trace): ZIO[R1, E1, Boolean] =
     self.map(a => !ev(a))
 


### PR DESCRIPTION
This is an extremely specialized operator that can be easily replaced with `ZIO#negate` and takes takes up potentially very valuable and extremely limited name space for unary operators.