### PR TITLE
Expose Unsafe Operators On Default Services

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -47,7 +47,7 @@ trait Clock extends Serializable { self =>
 
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit]
 
-  private[zio] trait UnsafeAPI {
+  trait UnsafeAPI {
     def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long
     def currentTime(unit: ChronoUnit)(implicit unsafe: Unsafe): Long
     def currentDateTime()(implicit unsafe: Unsafe): OffsetDateTime
@@ -56,7 +56,7 @@ trait Clock extends Serializable { self =>
     def nanoTime()(implicit unsafe: Unsafe): Long
   }
 
-  private[zio] def unsafe: UnsafeAPI =
+  def unsafe: UnsafeAPI =
     new UnsafeAPI {
       def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
         Runtime.default.unsafe.run(self.currentTime(unit)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
@@ -110,7 +110,7 @@ object Clock extends ClockPlatformSpecific with Serializable {
     def scheduler(implicit trace: Trace): UIO[Scheduler] =
       ZIO.succeed(globalScheduler)
 
-    @transient override private[zio] val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long = {
           val inst = instant()
@@ -182,7 +182,7 @@ object Clock extends ClockPlatformSpecific with Serializable {
       ZIO.succeed(JavaClock(ZoneId.systemDefault))
     }
 
-    @transient override private[zio] val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long = {
           val inst = instant()

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -38,7 +38,7 @@ trait Console extends Serializable { self =>
   def readLine(prompt: String)(implicit trace: Trace): IO[IOException, String] =
     print(prompt) *> readLine
 
-  private[zio] trait UnsafeAPI {
+  trait UnsafeAPI {
     def print(line: Any)(implicit unsafe: Unsafe): Unit
     def printError(line: Any)(implicit unsafe: Unsafe): Unit
     def printLine(line: Any)(implicit unsafe: Unsafe): Unit
@@ -46,7 +46,7 @@ trait Console extends Serializable { self =>
     def readLine()(implicit unsafe: Unsafe): String
   }
 
-  private[zio] def unsafe: UnsafeAPI =
+  def unsafe: UnsafeAPI =
     new UnsafeAPI {
       def print(line: Any)(implicit unsafe: Unsafe): Unit =
         Runtime.default.unsafe.run(self.print(line)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
@@ -86,7 +86,7 @@ object Console extends Serializable {
     def readLine(implicit trace: Trace): IO[IOException, String] =
       ZIO.attemptBlockingInterrupt(unsafe.readLine()(Unsafe.unsafe)).refineToOrDie[IOException]
 
-    @transient override private[zio] val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def print(line: Any)(implicit unsafe: Unsafe): Unit =
           print(SConsole.out)(line)

--- a/core/shared/src/main/scala/zio/Random.scala
+++ b/core/shared/src/main/scala/zio/Random.scala
@@ -68,7 +68,7 @@ trait Random extends Serializable { self =>
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], unsafe: Unsafe): Collection[A]
   }
 
-  private[zio] def unsafe: UnsafeAPI =
+  def unsafe: UnsafeAPI =
     new UnsafeAPI {
       def nextBoolean()(implicit unsafe: Unsafe): Boolean =
         Runtime.default.unsafe.run(self.nextBoolean(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
@@ -207,7 +207,7 @@ object Random extends Serializable {
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
       ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient private[zio] override val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
           scala.util.Random.nextBoolean()
@@ -335,7 +335,7 @@ object Random extends Serializable {
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
       ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient private[zio] override val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
           random.nextBoolean()

--- a/core/shared/src/main/scala/zio/System.scala
+++ b/core/shared/src/main/scala/zio/System.scala
@@ -47,7 +47,7 @@ trait System extends Serializable { self =>
     trace: Trace
   ): IO[Throwable, Option[String]]
 
-  private[zio] trait UnsafeAPI {
+  trait UnsafeAPI {
     def env(variable: String)(implicit unsafe: Unsafe): Option[String]
     def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String
     def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String]
@@ -59,7 +59,7 @@ trait System extends Serializable { self =>
     def propertyOrOption(prop: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String]
   }
 
-  private[zio] def unsafe: UnsafeAPI =
+  def unsafe: UnsafeAPI =
     new UnsafeAPI {
       def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
         Runtime.default.unsafe.run(self.env(variable)(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
@@ -138,7 +138,7 @@ object System extends Serializable {
     ): IO[Throwable, Option[String]] =
       ZIO.attempt(unsafe.propertyOrOption(prop, alt)(Unsafe.unsafe))
 
-    @transient override private[zio] val unsafe: UnsafeAPI =
+    @transient override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
           Option(JSystem.getenv(variable))

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -226,7 +226,7 @@ object TestClock extends Serializable {
     def timeZone(implicit trace: Trace): UIO[ZoneId] =
       clockState.get.map(_.timeZone)
 
-    override private[zio] val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
           unit.convert(clockState.unsafe.get.instant.toEpochMilli, TimeUnit.MILLISECONDS)

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -185,7 +185,7 @@ object TestConsole extends Serializable {
     def silent[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
       debugState.locally(false)(zio)
 
-    override private[zio] val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def print(line: Any)(implicit unsafe: Unsafe): Unit =
           consoleState.unsafe.update { data =>

--- a/test/shared/src/main/scala/zio/test/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/TestRandom.scala
@@ -373,7 +373,7 @@ object TestRandom extends Serializable {
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
       ZIO.succeed(unsafe.shuffle(list)(bf, Unsafe.unsafe))
 
-    override private[zio] val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
           getOrElse(bufferedBoolean)(randomBoolean)

--- a/test/shared/src/main/scala/zio/test/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/TestSystem.scala
@@ -147,7 +147,7 @@ object TestSystem extends Serializable {
         systemData <- systemState.get
       } yield systemState.set(systemData)
 
-    override private[zio] val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
           systemState.unsafe.get.envs.get(variable)


### PR DESCRIPTION
I think we need to expose the unsafe operators on the default ZIO services. Part of the reason for creating the `UnsafeAPI` pattern was to allow sophisticated users in the ZIO ecosystem to take advantage of these operators when necessary. Particularly for the default services, this is important for users implementing their own versions of the default services to be able to implement their own versions of these unsafe operators.