### PR TITLE
Do Not Filter Traces In ZIO Name Space

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -522,7 +522,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
         def loop(throwable: Throwable, trace: StackTrace, result: List[Unified]): List[Unified] = {
           val extra =
             if (stackless) Chunk.empty
-            else Chunk.fromArray(throwable.getStackTrace.takeWhile(!_.getClassName.startsWith("zio.")))
+            else Chunk.fromArray(throwable.getStackTrace.takeWhile(_.getClassName != "zio.internal.FiberRuntime"))
 
           val unified =
             Unified(trace.fiberId, throwable.getClass.getName(), throwable.getMessage(), extra ++ trace.toJava)

--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -64,7 +64,7 @@ object StackTrace {
     StackTrace(
       fiberId,
       Chunk
-        .fromArray(stackTrace.takeWhile(!_.getClassName.startsWith("zio.")))
+        .fromArray(stackTrace.takeWhile(_.getClassName != "zio.internal.FiberRuntime"))
         .map(Trace.fromJava)
         .takeWhile(!Trace.equalIgnoreLocation(_, trace))
     )


### PR DESCRIPTION
Resolves #7636.

```
[info] timestamp=2022-12-15T14:39:26.301869Z level=ERROR thread=#zio-fiber-0 message="" cause="Exception in thread "zio-fiber-4" java.lang.RuntimeException: bad
[info]  at Test$.badFunction(Example.scala:6)
[info]  at Test$.$anonfun$run$2(Example.scala:11)
[info]  at zio.ZIO.$anonfun$map$1(ZIO.scala:960)
[info]  at <empty>.Test.run(Example.scala:10)"
```