### PR TITLE
Add missing assertion params to withCode

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
@@ -15,6 +15,10 @@ object AssertionRenderSpec extends ZIOBaseSpec {
       assertionShouldRenderTo(isSome(equalTo(40)))("isSome(equalTo(40))") &&
       assertionShouldRenderTo(isSome(equalTo(40) && contains("a")))("isSome(equalTo(40) and contains(a))")
     }),
+    test("not assertions")({
+      assertionShouldRenderTo(!equalTo(50))("not equalTo(50)") &&
+      assertionShouldRenderTo(equalTo(30) && !isGreaterThan(50))("equalTo(30) and not isGreaterThan(50)")
+    }),
     test("class names render")({
       assertionShouldRenderTo(isSubtype[Duration.Infinite](Assertion.anything))("isSubtype(Infinite)(anything)")
     }),

--- a/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
@@ -86,6 +86,14 @@ object AssertionRenderSpec extends ZIOBaseSpec {
       assertionShouldRenderTo(isSome)("isSome(anything)") &&
       assertionShouldRenderTo(isSome(equalTo(1)))("isSome(equalTo(1))")
 
+    }),
+    test("isLeft")({
+      assertionShouldRenderTo(isLeft)("isLeft(anything)") &&
+      assertionShouldRenderTo(isLeft(equalTo(30)))("isLeft(equalTo(30))")
+    }),
+    test("isRight")({
+      assertionShouldRenderTo(isRight)("isRight(anything)") &&
+      assertionShouldRenderTo(isRight(equalTo(30)))("isRight(equalTo(30))")
     })
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
@@ -34,7 +34,7 @@ object AssertionRenderSpec extends ZIOBaseSpec {
       )
     }),
     test("map keys render")({
-      assertionShouldRenderTo(hasKey(equalTo("bar")))("hasKey(equalTo(bar))")
+      assertionShouldRenderTo(hasKey(exists(equalTo("bar"))))("hasKey(exists(equalTo(bar)))")
     }),
     test("map has keys render")({
       assertionShouldRenderTo(hasKeys[String, Int](equalTo(List("key1", "key2"))))("hasKeys(equalTo(List(key1, key2)))")
@@ -62,6 +62,30 @@ object AssertionRenderSpec extends ZIOBaseSpec {
     }),
     test("diesWithA")({
       assertionShouldRenderTo(diesWithA[RuntimeException])("diesWithA(RuntimeException)")
+    }),
+    test("dies")({
+      val exception = new RuntimeException("boom")
+      assertionShouldRenderTo(dies(equalTo(exception)))("dies(equalTo(java.lang.RuntimeException: boom))")
+    }),
+    test("containsString")({
+      assertionShouldRenderTo(containsString("a string"))("containsString(a string)")
+    }),
+    test("endsWithString")({
+      assertionShouldRenderTo(endsWithString("a string"))("endsWithString(a string)")
+    }),
+    test("startsWithString")({
+      assertionShouldRenderTo(startsWithString("a string"))("startsWithString(a string)")
+    }),
+    test("endsWith")({
+      assertionShouldRenderTo(endsWith(List(1, 2, 3)))("endsWith(List(1, 2, 3))")
+    }),
+    test("equalsIgnoreCase")({
+      assertionShouldRenderTo(equalsIgnoreCase("a String"))("equalsIgnoreCase(a String)")
+    }),
+    test("isSome")({
+      assertionShouldRenderTo(isSome)("isSome(anything)") &&
+      assertionShouldRenderTo(isSome(equalTo(1)))("isSome(equalTo(1))")
+
     })
   )
 

--- a/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
@@ -1,0 +1,66 @@
+package zio.test
+
+import zio.test.Assertion._
+
+import scala.concurrent.duration.Duration
+
+object AssertionRenderSpec extends ZIOBaseSpec {
+
+  def spec = suite("Assertion Render Spec")(
+    test("renders ops")({
+      assertionShouldRenderTo(equalTo(30) || equalTo(40))("equalTo(30) or equalTo(40)") &&
+      assertionShouldRenderTo(equalTo(30) && equalTo(40))("equalTo(30) and equalTo(40)")
+    }),
+    test("embedded assertions")({
+      assertionShouldRenderTo(isSome(equalTo(40)))("isSome(equalTo(40))") &&
+      assertionShouldRenderTo(isSome(equalTo(40) && contains("a")))("isSome(equalTo(40) and contains(a))")
+    }),
+    test("class names render")({
+      assertionShouldRenderTo(isSubtype[Duration.Infinite](Assertion.anything))("isSubtype(Infinite)(anything)")
+    }),
+    test("list render")({
+      assertionShouldRenderTo(equalTo(List.fill(9)(10.0)))(
+        "equalTo(List(10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0))"
+      )
+    }),
+    test("fields render")({
+      case class Person(age: Int)
+      assertionShouldRenderTo(hasField("age", (p: Person) => p.age, Assertion.equalTo(10)))(
+        "hasField(_.age)(equalTo(10))"
+      )
+    }),
+    test("map keys render")({
+      assertionShouldRenderTo(hasKey(equalTo("bar")))("hasKey(equalTo(bar))")
+    }),
+    test("map has keys render")({
+      assertionShouldRenderTo(hasKeys[String, Int](equalTo(List("key1", "key2"))))("hasKeys(equalTo(List(key1, key2)))")
+    }),
+    test("has none of")({
+      assertionShouldRenderTo(hasNoneOf(List(123, 234, 32)))("hasNoneOf(List(123, 234, 32))")
+    }),
+    test("isUnit")({
+      assertionShouldRenderTo(isUnit)("isUnit")
+    }),
+    test("hasSameElementsAs")({
+      assertionShouldRenderTo(hasSameElements(List(1, 2, 3)))("hasSameElements(List(1, 2, 3))")
+    }),
+    test("approximately equals")({
+      assertionShouldRenderTo(approximatelyEquals(10, 0.1))("approximatelyEquals(10.0, tolerance=0.1)")
+    }),
+    test("hasAt")({
+      assertionShouldRenderTo(hasAt(1)(equalTo(40)))("hasAt(1)(equalTo(40))")
+    }),
+    test("failsWith")({
+      assertionShouldRenderTo(failsWithA[RuntimeException])("failsWithA(RuntimeException)")
+    }),
+    test("isWithin")({
+      assertionShouldRenderTo(Assertion.isWithin(10, 100))("isWithin(min=10, max=100)")
+    }),
+    test("diesWithA")({
+      assertionShouldRenderTo(diesWithA[RuntimeException])("diesWithA(RuntimeException)")
+    })
+  )
+
+  private def assertionShouldRenderTo[A](assertion: Assertion[A])(expected: String) =
+    assert(assertion.render)(equalTo(expected))
+}

--- a/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionRenderSpec.scala
@@ -19,8 +19,8 @@ object AssertionRenderSpec extends ZIOBaseSpec {
       assertionShouldRenderTo(isSubtype[Duration.Infinite](Assertion.anything))("isSubtype(Infinite)(anything)")
     }),
     test("list render")({
-      assertionShouldRenderTo(equalTo(List.fill(9)(10.0)))(
-        "equalTo(List(10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0))"
+      assertionShouldRenderTo(equalTo(List.fill(9)(10)))(
+        "equalTo(List(10, 10, 10, 10, 10, 10, 10, 10, 10))"
       )
     }),
     test("fields render")({
@@ -45,7 +45,7 @@ object AssertionRenderSpec extends ZIOBaseSpec {
       assertionShouldRenderTo(hasSameElements(List(1, 2, 3)))("hasSameElements(List(1, 2, 3))")
     }),
     test("approximately equals")({
-      assertionShouldRenderTo(approximatelyEquals(10, 0.1))("approximatelyEquals(10.0, tolerance=0.1)")
+      assertionShouldRenderTo(approximatelyEquals(100, 10))("approximatelyEquals(100, tolerance=10)")
     }),
     test("hasAt")({
       assertionShouldRenderTo(hasAt(1)(equalTo(40)))("hasAt(1)(equalTo(40))")

--- a/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
@@ -17,6 +17,7 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.test.Assertion.Arguments.value
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
@@ -34,6 +35,6 @@ trait AssertionVariants {
             M.pretty(actual) + M.equals + M.pretty(expected)
           }
         }
-        .withCode("equalTo")
+        .withCode("equalTo", value(expected))
     )
 }

--- a/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/AssertionVariants.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.test.Assertion.Arguments.value
+import zio.test.Assertion.Arguments.valueArgument
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
@@ -35,6 +35,6 @@ trait AssertionVariants {
             M.pretty(actual) + M.equals + M.pretty(expected)
           }
         }
-        .withCode("equalTo", value(expected))
+        .withCode("equalTo", valueArgument(expected))
     )
 }

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -18,6 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.{ErrorMessage => M}
+import zio.test.Assertion.Arguments.value
 
 trait AssertionVariants {
 
@@ -29,14 +30,14 @@ trait AssertionVariants {
       TestArrow
         .make[A, Boolean] { actual =>
           val result = (actual, expected) match {
-            case (left: Array[_], right: Array[_]) => left.sameElements[Any](right)
+            case (left: Array[_], right: Array[_])         => left.sameElements[Any](right)
             case (left: CharSequence, right: CharSequence) => left.toString == right.toString
-            case (left, right)                     => left == right
+            case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
             M.pretty(actual) + M.equals + M.pretty(expected)
           }
         }
-        .withCode("equalTo")
+        .withCode("equalTo", value(expected))
     )
 }

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.{ErrorMessage => M}
-import zio.test.Assertion.Arguments.value
+import zio.test.Assertion.Arguments.valueArgument
 
 trait AssertionVariants {
 
@@ -38,6 +38,6 @@ trait AssertionVariants {
             M.pretty(actual) + M.equals + M.pretty(expected)
           }
         }
-        .withCode("equalTo", value(expected))
+        .withCode("equalTo", valueArgument(expected))
     )
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -228,17 +228,17 @@ object Assertion extends AssertionVariants {
    */
   def isLeft[A](assertion: Assertion[A]): Assertion[Either[A, Any]] =
     Assertion[Either[A, Any]](
-      SmartAssertions.asLeft[A].withCode("isLeft") >>> assertion.arrow
-    )
+      SmartAssertions.asLeft[A] >>> assertion.arrow
+    ).withCode("isLeft", assertionArgument(assertion))
 
   /**
    * Makes a new assertion that requires a Right value satisfying a specified
    * assertion.
    */
-  def isRight[A](assertion: Assertion[A]): Assertion[Either[Any, A]] =
-    Assertion[Either[Any, A]](
-      SmartAssertions.asRight[A].withCode("isRight") >>> assertion.arrow
-    )
+  def isRight[A](assertion: Assertion[A]) =
+    (Assertion[Either[Any, A]](
+      SmartAssertions.asRight[A] >>> assertion.arrow
+    )).withCode("isRight", assertionArgument(assertion))
 
   /**
    * Makes a new assertion that requires an Either is Right.
@@ -257,9 +257,9 @@ object Assertion extends AssertionVariants {
    * assertion.
    */
   def isSome[A](assertion: Assertion[A]): Assertion[Option[A]] =
-    Assertion[Option[A]](
-      SmartAssertions.isSome.withCode("isSome") >>> assertion.arrow
-    )
+    (Assertion[Option[A]](
+      SmartAssertions.isSome >>> assertion.arrow
+    )).withCode("isSome", assertionArgument(assertion))
 
   /**
    * Makes a new assertion that requires an Option is Some.

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -119,7 +119,7 @@ object Assertion extends AssertionVariants {
 
   def hasAt[A](pos: Int)(assertion: Assertion[A]): Assertion[Seq[A]] =
     Assertion[Seq[A]](
-      SmartAssertions.hasAt(pos).withCode("hasAt", value(pos)) >>>
+      SmartAssertions.hasAt(pos).withCode("hasAt", valueArgument(pos)) >>>
         assertion.arrow
     )
 
@@ -131,7 +131,7 @@ object Assertion extends AssertionVariants {
     Assertion[A](
       SmartAssertions
         .approximatelyEquals(reference, tolerance)
-        .withCode("approximatelyEquals", value(reference), value(tolerance, name = Some("tolerance")))
+        .withCode("approximatelyEquals", valueArgument(reference), valueArgument(tolerance, name = Some("tolerance")))
     )
 
   /**
@@ -141,7 +141,7 @@ object Assertion extends AssertionVariants {
    */
   def contains[A](element: A): Assertion[Iterable[A]] =
     Assertion[Iterable[A]](
-      SmartAssertions.containsIterable(element).withCode("contains", value(element))
+      SmartAssertions.containsIterable(element).withCode("contains", valueArgument(element))
     )
 
   /**
@@ -149,7 +149,7 @@ object Assertion extends AssertionVariants {
    */
   def containsCause[E](cause: Cause[E]): Assertion[Cause[E]] =
     Assertion[Cause[E]] {
-      SmartAssertions.containsCause(cause).withCode("containsCause", value(cause))
+      SmartAssertions.containsCause(cause).withCode("containsCause", valueArgument(cause))
     }
 
   /**
@@ -157,7 +157,7 @@ object Assertion extends AssertionVariants {
    */
   def containsString(element: String): Assertion[String] =
     Assertion[String](
-      SmartAssertions.containsString(element).withCode("containsString", value(element))
+      SmartAssertions.containsString(element).withCode("containsString", valueArgument(element))
     )
 
   /**
@@ -172,8 +172,8 @@ object Assertion extends AssertionVariants {
    * Makes a new assertion that requires an exit value to die with an instance
    * of given type (or its subtype).
    */
-  def diesWithA[E](implicit C: ClassTag[E]): Assertion[Exit[E, Any]] =
-    dies(isSubtype[E](anything)).withCode("diesWithA", `type`)
+  def diesWithA[E: ClassTag]: Assertion[Exit[E, Any]] =
+    dies(isSubtype[E](anything)).withCode("diesWithA", typeArgument)
 
   /**
    * Makes a new assertion that requires a given string to end with the
@@ -181,7 +181,7 @@ object Assertion extends AssertionVariants {
    */
   def endsWith[A](suffix: Seq[A]): Assertion[Seq[A]] =
     Assertion[Seq[A]](
-      SmartAssertions.endsWithSeq(suffix).withCode("endsWith", value(suffix))
+      SmartAssertions.endsWithSeq(suffix).withCode("endsWith", valueArgument(suffix))
     )
 
   /**
@@ -190,7 +190,7 @@ object Assertion extends AssertionVariants {
    */
   def endsWithString(suffix: String): Assertion[String] =
     Assertion[String](
-      SmartAssertions.endsWithString(suffix).withCode("endsWithString", value(suffix))
+      SmartAssertions.endsWithString(suffix).withCode("endsWithString", valueArgument(suffix))
     )
 
   /**
@@ -207,7 +207,7 @@ object Assertion extends AssertionVariants {
             M.pretty(string) + M.equals + M.pretty(other) + "(ignoring case)"
           }
         }
-        .withCode("equalsIgnoreCase", value(other))
+        .withCode("equalsIgnoreCase", valueArgument(other))
     )
 
   /**
@@ -219,7 +219,7 @@ object Assertion extends AssertionVariants {
    */
   def hasField[A, B](name: String, proj: A => B, assertion: Assertion[B]): Assertion[A] =
     Assertion {
-      SmartAssertions.hasField(name, proj).withCode("hasField", value(field(name))) >>> assertion.arrow
+      SmartAssertions.hasField(name, proj).withCode("hasField", valueArgument(field(name))) >>> assertion.arrow
     }
 
   /**
@@ -313,7 +313,7 @@ object Assertion extends AssertionVariants {
    */
   def isSubtype[A](assertion: Assertion[A])(implicit C: ClassTag[A]): Assertion[Any] =
     Assertion[Any](
-      SmartAssertions.as[Any, A].withCode("isSubtype", `type`) >>> assertion.arrow
+      SmartAssertions.as[Any, A].withCode("isSubtype", typeArgument) >>> assertion.arrow
     )
 
   /**
@@ -394,7 +394,7 @@ object Assertion extends AssertionVariants {
             M.value(value) + M.was + M.value(values)
           }
         }
-        .withCode("isOneOf", value(values))
+        .withCode("isOneOf", valueArgument(values))
     }
 
   /**
@@ -475,7 +475,7 @@ object Assertion extends AssertionVariants {
    */
   def isLessThan[A](reference: A)(implicit ord: Ordering[A]): Assertion[A] =
     Assertion[A](
-      SmartAssertions.lessThan(reference).withCode("isLessThan", value(reference))
+      SmartAssertions.lessThan(reference).withCode("isLessThan", valueArgument(reference))
     )
 
   /**
@@ -484,7 +484,7 @@ object Assertion extends AssertionVariants {
    */
   def isLessThanEqualTo[A](reference: A)(implicit ord: Ordering[A]): Assertion[A] =
     Assertion[A](
-      SmartAssertions.lessThanOrEqualTo(reference).withCode("isLessThanEqualTo", value(reference))
+      SmartAssertions.lessThanOrEqualTo(reference).withCode("isLessThanEqualTo", valueArgument(reference))
     )
 
   /**
@@ -493,7 +493,7 @@ object Assertion extends AssertionVariants {
    */
   def isGreaterThan[A](reference: A)(implicit ord: Ordering[A]): Assertion[A] =
     Assertion[A](
-      SmartAssertions.greaterThan(reference).withCode("isGreaterThan", value(reference))
+      SmartAssertions.greaterThan(reference).withCode("isGreaterThan", valueArgument(reference))
     )
 
   /**
@@ -502,7 +502,7 @@ object Assertion extends AssertionVariants {
    */
   def isGreaterThanEqualTo[A](reference: A)(implicit ord: Ordering[A]): Assertion[A] =
     Assertion[A](
-      SmartAssertions.greaterThanOrEqualTo(reference).withCode("isGreaterThanEqualTo", value(reference))
+      SmartAssertions.greaterThanOrEqualTo(reference).withCode("isGreaterThanEqualTo", valueArgument(reference))
     )
 
   /**
@@ -526,7 +526,7 @@ object Assertion extends AssertionVariants {
         .make[A, Boolean] { value =>
           TestTrace.boolean(num.gt(value, num.zero))(M.pretty(value) + M.was + "positive")
         }
-        .withCode("isPositive", value(num))
+        .withCode("isPositive", valueArgument(num))
     )
 
   /**
@@ -551,7 +551,7 @@ object Assertion extends AssertionVariants {
             M.pretty(value) + M.was + "within" + M.pretty(min) + "and" + M.pretty(max)
           )
         }
-        .withCode("isWithin", value(min, name = Some("min")), value(max, name = Some("max")))
+        .withCode("isWithin", valueArgument(min, name = Some("min")), valueArgument(max, name = Some("max")))
     )
 
   /**
@@ -568,7 +568,7 @@ object Assertion extends AssertionVariants {
    */
   def failsWithA[E: ClassTag]: Assertion[Exit[E, Any]] = {
     val assertion = isSubtype[E](anything)
-    fails(assertion).withCode("failsWithA", `type`)
+    fails(assertion).withCode("failsWithA", typeArgument)
   }
 
   /**
@@ -601,7 +601,7 @@ object Assertion extends AssertionVariants {
             M.pretty(value) + M.had + "the same distinct elements as" + M.pretty(other)
           )
         }
-        .withCode("hasSameElementsDistinct", value(other))
+        .withCode("hasSameElementsDistinct", valueArgument(other))
     )
 
   /**
@@ -634,7 +634,7 @@ object Assertion extends AssertionVariants {
     Assertion[Iterable[A]](
       TestArrow
         .fromFunction[Iterable[A], Iterable[A]](value => value.toSeq.intersect(other.toSeq))
-        .withCode("hasIntersection", value(other)) >>> assertion.arrow
+        .withCode("hasIntersection", valueArgument(other)) >>> assertion.arrow
     )
 
   /**
@@ -642,14 +642,14 @@ object Assertion extends AssertionVariants {
    * specified elements.
    */
   def hasAtLeastOneOf[A](other: Iterable[A]): Assertion[Iterable[A]] =
-    hasIntersection(other)(hasSize(isGreaterThanEqualTo(1))).withCode("hasAtLeastOneOf", value(other))
+    hasIntersection(other)(hasSize(isGreaterThanEqualTo(1))).withCode("hasAtLeastOneOf", valueArgument(other))
 
   /**
    * Makes a new assertion that requires an Iterable contain at most one of the
    * specified elements.
    */
   def hasAtMostOneOf[A](other: Iterable[A]): Assertion[Iterable[A]] =
-    hasIntersection(other)(hasSize(isLessThanEqualTo(1))).withCode("hasAtMostOneOf", value(other))
+    hasIntersection(other)(hasSize(isLessThanEqualTo(1))).withCode("hasAtMostOneOf", valueArgument(other))
 
   /**
    * Makes a new assertion that requires an Iterable to contain the first
@@ -691,14 +691,16 @@ object Assertion extends AssertionVariants {
    */
   def hasKey[K, V](key: K, assertion: Assertion[V]): Assertion[Map[K, V]] =
     Assertion[Map[K, V]](
-      SmartAssertions.hasKey[K, V](key).withCode("hasKey", value(key), assertionArgument(assertion)) >>> assertion.arrow
+      SmartAssertions
+        .hasKey[K, V](key)
+        .withCode("hasKey", valueArgument(key), assertionArgument(assertion)) >>> assertion.arrow
     )
 
   /**
    * Makes a new assertion that requires a Map to have the specified key.
    */
   def hasKey[K, V](key: K): Assertion[Map[K, V]] =
-    hasKey(key, anything).withCode("hasKey", value(mapKey(key)))
+    hasKey(key, anything).withCode("hasKey", valueArgument(mapKey(key)))
 
   /**
    * Makes a new assertion that requires a Map have keys satisfying the
@@ -716,14 +718,14 @@ object Assertion extends AssertionVariants {
    * specified elements.
    */
   def hasNoneOf[A](other: Iterable[A]): Assertion[Iterable[A]] =
-    hasIntersection(other)(isEmpty).withCode("hasNoneOf", value(other))
+    hasIntersection(other)(isEmpty).withCode("hasNoneOf", valueArgument(other))
 
   /**
    * Makes a new assertion that requires an Iterable contain exactly one of the
    * specified elements.
    */
   def hasOneOf[A](other: Iterable[A]): Assertion[Iterable[A]] =
-    hasIntersection(other)(hasSize(equalTo(1))).withCode("hasOneOf", value(other))
+    hasIntersection(other)(hasSize(equalTo(1))).withCode("hasOneOf", valueArgument(other))
 
   /**
    * Makes a new assertion that requires an Iterable to have the same elements
@@ -742,7 +744,7 @@ object Assertion extends AssertionVariants {
           }
 
         }
-        .withCode("hasSameElements", value(other))
+        .withCode("hasSameElements", valueArgument(other))
     )
 
   /**
@@ -750,7 +752,7 @@ object Assertion extends AssertionVariants {
    * of the other Iterable.
    */
   def hasSubset[A](other: Iterable[A]): Assertion[Iterable[A]] =
-    hasIntersection(other)(hasSameElements(other)).withCode("hasSubset", value(other))
+    hasIntersection(other)(hasSameElements(other)).withCode("hasSubset", valueArgument(other))
 
   /**
    * Makes a new assertion that requires a Map have values satisfying the
@@ -782,7 +784,7 @@ object Assertion extends AssertionVariants {
             M.pretty(sum) + M.was + "a case of " + termName
           }
         }
-        .withCode("isCase", value(termName), value(unapplyTerm(termName))) >>> assertion.arrow
+        .withCode("isCase", valueArgument(termName), valueArgument(unapplyTerm(termName))) >>> assertion.arrow
     )
 
   /**
@@ -857,20 +859,20 @@ object Assertion extends AssertionVariants {
             M.pretty(s) + M.did + "match" + M.pretty(regex)
           }
         }
-        .withCode("matchesRegex", value(regex))
+        .withCode("matchesRegex", valueArgument(regex))
     )
 
   /**
    * Makes a new assertion that requires a numeric value is non negative.
    */
   def nonNegative[A](implicit num: Numeric[A]): Assertion[A] =
-    isGreaterThanEqualTo(num.zero).withCode("nonNegative", value(num))
+    isGreaterThanEqualTo(num.zero).withCode("nonNegative", valueArgument(num))
 
   /**
    * Makes a new assertion that requires a numeric value is non positive.
    */
   def nonPositive[A](implicit num: Numeric[A]): Assertion[A] =
-    isLessThanEqualTo(num.zero).withCode("nonPositive", value(num))
+    isLessThanEqualTo(num.zero).withCode("nonPositive", valueArgument(num))
 
   /**
    * Makes a new assertion that negates the specified assertion.
@@ -898,7 +900,7 @@ object Assertion extends AssertionVariants {
     Assertion[Seq[A]](
       SmartAssertions
         .startsWithSeq(prefix)
-        .withCode("startsWith", value(prefix))
+        .withCode("startsWith", valueArgument(prefix))
     )
 
   /**
@@ -907,7 +909,7 @@ object Assertion extends AssertionVariants {
    */
   def startsWithString(prefix: String): Assertion[String] =
     Assertion[String](
-      SmartAssertions.startsWithString(prefix).withCode("startsWithString", value(prefix))
+      SmartAssertions.startsWithString(prefix).withCode("startsWithString", valueArgument(prefix))
     )
 
   /**
@@ -969,10 +971,23 @@ object Assertion extends AssertionVariants {
         .withCode("isJustInterrupted")
     )
 
-  sealed trait Arguments
+  sealed trait Arguments { self =>
+    override final def toString: String = self match {
+      case AssertionArgument(assertion) =>
+        assertion.render
+      case TypeArgument(classTag) =>
+        className(classTag)
+      case ValueArgument(value, name) =>
+        name.map(n => s"$n=$value").getOrElse(value.toString)
+    }
+  }
   object Arguments {
-    def `type`[A](implicit C: ClassTag[A]): Arguments =
-      Type(C)
+
+    /**
+     * Construct a `TypeArgument` from a ClassTag.
+     */
+    def typeArgument[A](implicit C: ClassTag[A]): Arguments =
+      TypeArgument(C)
 
     /**
      * Creates a string representation of a field accessor.
@@ -991,6 +1006,7 @@ object Assertion extends AssertionVariants {
         case t: InternalError if t.getMessage == "Malformed class name" =>
           C.runtimeClass.getName
       }
+
     def mapKey[V](v: V): String =
       v match {
         case assertion: Assertion[_] =>
@@ -999,30 +1015,25 @@ object Assertion extends AssertionVariants {
       }
 
     /**
-     * Construct a `RenderParam` from an `Assertion`.
+     * Construct a `AssertionArgument` from an `Assertion`.
      */
     def assertionArgument[A]: Assertion[A] => Arguments =
       Arguments.AssertionArgument(_)
 
     /**
-     * Construct a `RenderParam` from a value.
+     * Construct a `ValueArgument` from a value.
      */
-    def value[A](a: A, name: Option[String] = None): Arguments =
-      Arguments.Value(a, name)
+    def valueArgument[A](a: A, name: Option[String] = None): Arguments =
+      Arguments.ValueArgument(a, name)
 
     /**
      * Creates a string representation of an unapply method for a term.
      */
     def unapplyTerm(termName: String): String =
       termName + ".unapply"
-    final case class AssertionArgument[A](assertion: Assertion[A]) extends Arguments {
-      override def toString: String = assertion.render
-    }
-    final case class Type[A](classTag: ClassTag[A]) extends Arguments {
-      override def toString: String = className(classTag)
-    }
-    final case class Value[A](value: A, name: Option[String] = None) extends Arguments {
-      override def toString: String = name.map(n => s"$n=$value").getOrElse(value.toString)
-    }
+
+    final case class AssertionArgument[A](assertion: Assertion[A])           extends Arguments
+    final case class TypeArgument[A](classTag: ClassTag[A])                  extends Arguments
+    final case class ValueArgument[A](value: A, name: Option[String] = None) extends Arguments
   }
 }

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -257,9 +257,9 @@ object Assertion extends AssertionVariants {
    * assertion.
    */
   def isSome[A](assertion: Assertion[A]): Assertion[Option[A]] =
-    (Assertion[Option[A]](
-      SmartAssertions.isSome >>> assertion.arrow
-    )).withCode("isSome", assertionArgument(assertion))
+    Assertion[Option[A]](
+      SmartAssertions.isSome.withCode("isSome") >>> assertion.arrow
+    )
 
   /**
    * Makes a new assertion that requires an Option is Some.

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -139,7 +139,7 @@ sealed trait TestArrow[-A, +B] { self =>
     meta(span = Some(Span(span._1, span._2)))
 
   def withCode(code: String, arguments: Arguments*): TestArrow[A, B] =
-    meta(code = if (arguments.nonEmpty) Some(s"$code(${arguments.map(_.toString).mkString(", ")})") else Some(code))
+    meta(code = if (arguments.nonEmpty) Some(s"$code(${arguments.mkString(", ")})") else Some(code))
 
   def withCompleteCode(completeCode: String): TestArrow[A, B] =
     meta(completeCode = Some(completeCode))

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -72,7 +72,7 @@ sealed trait TestArrow[-A, +B] { self =>
           case Right(TestArrow.Or(left, right)) =>
             loop(Right(left) :: Left(" or ") :: Right(right) :: arrows.tail)
           case Right(TestArrow.Not(arrow)) =>
-            loop(Right(arrow) :: Left(" not ") :: arrows.tail)
+            loop(Left("not ") :: Right(arrow) :: arrows.tail)
           case Right(TestArrow.AndThen(left, right)) =>
             loop(Right(left) :: Left("(") :: Right(right) :: Left(")") :: arrows.tail)
           case Right(arrow: TestArrow.Meta[_, _]) =>

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -3,9 +3,11 @@ package zio.test
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.language.implicitConversions
-import zio.{Trace, ZIO}
+import zio.{ChunkBuilder, Trace, ZIO}
 import zio.internal.stacktracer.SourceLocation
+import zio.test.Assertion.Arguments
 
+import scala.annotation.tailrec
 import scala.util.control.NonFatal
 
 case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
@@ -57,6 +59,41 @@ object TestResult {
 }
 
 sealed trait TestArrow[-A, +B] { self =>
+
+  def render: String = {
+    val builder = ChunkBuilder.make[String]()
+
+    @tailrec
+    def loop(arrows: List[Either[String, TestArrow[_, _]]]): Unit =
+      if (arrows.nonEmpty) {
+        arrows.head match {
+          case Right(TestArrow.And(left, right)) =>
+            loop(Right(left) :: Left(" and ") :: Right(right) :: arrows.tail)
+          case Right(TestArrow.Or(left, right)) =>
+            loop(Right(left) :: Left(" or ") :: Right(right) :: arrows.tail)
+          case Right(TestArrow.Not(arrow)) =>
+            loop(Right(arrow) :: Left(" not ") :: arrows.tail)
+          case Right(TestArrow.AndThen(left, right)) =>
+            loop(Right(left) :: Left("(") :: Right(right) :: Left(")") :: arrows.tail)
+          case Right(arrow: TestArrow.Meta[_, _]) =>
+            builder += arrow.code.mkString
+            loop(arrows.tail)
+          case Right(arrow @ TestArrow.TestArrowF(_)) =>
+            builder += arrow.toString
+            loop(arrows.tail)
+          case Right(arrow @ TestArrow.Suspend(_)) =>
+            builder += arrow.toString
+            loop(arrows.tail)
+          case Left(str) =>
+            builder += str
+            loop(arrows.tail)
+        }
+      }
+
+    loop(List(Right(self)))
+    builder.result.mkString
+  }
+
   def ??(message: String): TestArrow[A, B] = self.label(message)
 
   def label(message: String): TestArrow[A, B] = self.meta(customLabel = Some(message))
@@ -101,8 +138,8 @@ sealed trait TestArrow[-A, +B] { self =>
   def span(span: (Int, Int)): TestArrow[A, B] =
     meta(span = Some(Span(span._1, span._2)))
 
-  def withCode(code: String): TestArrow[A, B] =
-    meta(code = Some(code))
+  def withCode(code: String, arguments: Arguments*): TestArrow[A, B] =
+    meta(code = if (arguments.nonEmpty) Some(s"$code(${arguments.map(_.toString).mkString(", ")})") else Some(code))
 
   def withCompleteCode(completeCode: String): TestArrow[A, B] =
     meta(completeCode = Some(completeCode))


### PR DESCRIPTION
Adds additional RenderParams to the with code method for  rendering test assertions. Forward ported what was needed from the Render trait in the zio 1 branch. 
Closes #7602 