### PR TITLE
logger metrics

### DIFF
--- a/core/shared/src/main/scala/zio/LogLevel.scala
+++ b/core/shared/src/main/scala/zio/LogLevel.scala
@@ -67,4 +67,6 @@ object LogLevel {
   val None: LogLevel    = LogLevel(Int.MaxValue, "OFF", 7)
 
   implicit val orderingLogLevel: Ordering[LogLevel] = Ordering.by(_.ordinal)
+
+  val allLogLevels: List[LogLevel] = List(All, Fatal, Error, Warning, Info, Debug, Trace, None)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -781,6 +781,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val loggers     = getLoggers()
     val contextMap  = getFiberRefs()
 
+    Metric.runtime.loggedTotals.get(logLevel).foreach { counter =>
+      val tags = getFiberRef(FiberRef.currentTags)(Unsafe.unsafe)
+      counter.unsafe.update(1, tags)(Unsafe.unsafe)
+    }
+
     loggers.foreach { logger =>
       logger(trace, fiberId, logLevel, message, cause, contextMap, spans, annotations)
     }

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -401,6 +401,9 @@ object Metric {
     val fiberFailures  = Metric.counter("zio_fiber_failures")
     val fiberLifetimes =
       Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(1.0, 2.0, 100))
+
+    val loggedTotals =
+      LogLevel.allLogLevels.map(level => (level, Metric.counter(s"zio_logger_${level.label.toLowerCase}_total"))).toMap
   }
 
   /**


### PR DESCRIPTION
one of the zio logging related questions was: how to add counter/metric for error logs

in relation to that, looks like a good idea put it directly to zio-core, considering that logger interface is defined there

metrics in form of counter for each log level, metric name:

```scala
zio_logger_${level.label.toLowerCase}_total
```
for example for `LogLevel.Error`: `zio_logger_error_total`

alternative solution for counter definition could be:
* common metric name, for example zio_logger_log_total
* log level in metric tags

another important note: counters will be incremented regardless of whether any logger is defined or underlying logger implementation will implementation logs something



