### PR TITLE
Expose Unsafe FiberRef Constructors

### DIFF
--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -384,7 +384,7 @@ object FiberRef {
   ): ZIO[Scope, Nothing, FiberRef.WithPatch[Set[A], SetPatch[A]]] =
     makeWith(unsafe.makeSet(initial)(Unsafe.unsafe))
 
-  private[zio] object unsafe {
+  object unsafe {
     def make[A](
       initial: A,
       fork: A => A = ZIO.identityFn[A],


### PR DESCRIPTION
These can be useful to users who want to implement their own top level `FiberRef` values.