### PR TITLE
Fix Another Stream Test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -562,7 +562,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                     .range(1, 5)
                     .tap(i => ref.update(i :: _) *> latch.succeed(()).when(i == 4))
                     .buffer(2)
-              l1 <- s.take(2).runCollect
+              l1 <- s.take(2).runScoped(ZSink.collectAll)
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))


### PR DESCRIPTION
There is a race condition in this test. It is trying to assert that the upstream can progress independently of the downstream in `buffer` by having the downstream read two elements and asserting that the upstream writes those two elements plus another two. However, the downstream can close the stream after it has read two elements which will shut down the queue and interrupt the upstream when it writes the third element.

We can prevent this by using `runScoped` to have the downstream read two elements without closing the scope of the stream as we do in some tests for other variants of this operator.