### PR TITLE
Preserve Supervision Relationships In Race

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1428,9 +1428,6 @@ sealed trait ZIO[-R, +E, +A]
       val startLeftFiber  = leftFiber.startSuspended()(Unsafe.unsafe)
       val startRightFiber = rightFiber.startSuspended()(Unsafe.unsafe)
 
-      leftFiber.setFiberRef(FiberRef.forkScopeOverride, Some(parentFiber.scope))(Unsafe.unsafe)
-      rightFiber.setFiberRef(FiberRef.forkScopeOverride, Some(parentFiber.scope))(Unsafe.unsafe)
-
       ZIO
         .async[R1, E2, C](
           { cb =>


### PR DESCRIPTION
When we fork children in race we should not override the fork scope of the child fibers so they maintain their normal supervision relationships.