### PR TITLE
Remove `CrossVersion.for2_13Use3` usage on `refined` dependency in `test-refined` module as refined 0.10 is avaiable for Scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -544,10 +544,7 @@ lazy val testRefined = crossProject(JVMPlatform, JSPlatform)
   .settings(macroDefinitionSettings)
   .settings(
     crossScalaVersions --= Seq(Scala211),
-    libraryDependencies ++=
-      Seq(
-        ("eu.timepit" %% "refined" % "0.10.1").cross(CrossVersion.for3Use2_13)
-      )
+    libraryDependencies += ("eu.timepit" %% "refined" % "0.10.1")
   )
   .jsSettings(jsSettings)
 


### PR DESCRIPTION
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/1193670/211456217-d6e2f0da-35a9-4828-8033-c5264900ee56.png">
