### PR TITLE
Further Refinements to Race Fiber Supervision Semantics

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1422,8 +1422,19 @@ sealed trait ZIO[-R, +E, +A]
 
       val raceIndicator = new AtomicBoolean(true)
 
-      val leftFiber  = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, null)(Unsafe.unsafe)
-      val rightFiber = ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, null)(Unsafe.unsafe)
+      val leftFiber =
+        ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, parentFiber.scope)(Unsafe.unsafe)
+      val rightFiber =
+        ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, parentFiber.scope)(Unsafe.unsafe)
+
+      leftFiber.setFiberRef(
+        FiberRef.forkScopeOverride,
+        parentFiber.getFiberRef(FiberRef.forkScopeOverride)(Unsafe.unsafe)
+      )(Unsafe.unsafe)
+      rightFiber.setFiberRef(
+        FiberRef.forkScopeOverride,
+        parentFiber.getFiberRef(FiberRef.forkScopeOverride)(Unsafe.unsafe)
+      )(Unsafe.unsafe)
 
       val startLeftFiber  = leftFiber.startSuspended()(Unsafe.unsafe)
       val startRightFiber = rightFiber.startSuspended()(Unsafe.unsafe)


### PR DESCRIPTION
The fibers forked internally by race are always forked in the scope of the parent. Any fibers forked by those fibers are forked with the fork scope override of the parent.