### PR TITLE
Fail in Config#chunkOf If Data Is Missing

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderEnvSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderEnvSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.test.TestSystem
 import zio.test._
+import zio.test.Assertion._
 
 object ConfigProviderEnvSpec extends ZIOBaseSpec {
 
@@ -46,8 +47,8 @@ object ConfigProviderEnvSpec extends ZIOBaseSpec {
       } +
       test("top-level missing list env") {
         for {
-          config <- ConfigProvider.envProvider.load(HostPorts.config)
-        } yield assertTrue(config.hostPorts.length == 0)
+          exit <- ConfigProvider.envProvider.load(HostPorts.config).exit
+        } yield assert(exit)(failsWithA[Config.Error])
       } +
       test("simple map env") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.test._
+import zio.test.Assertion._
 
 object ConfigProviderSpec extends ZIOBaseSpec {
   def provider(map: Map[String, String]): ConfigProvider = ConfigProvider.fromMap(map)
@@ -92,8 +93,8 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         } +
         test("top-level missing list") {
           for {
-            value <- provider(Map()).load(HostPorts.config)
-          } yield assertTrue(value.hostPorts.length == 0)
+            exit <- provider(Map()).load(HostPorts.config).exit
+          } yield assert(exit)(failsWithA[Config.Error])
         } +
         test("simple map") {
           for {
@@ -222,8 +223,8 @@ object ConfigProviderSpec extends ZIOBaseSpec {
       test("top-level missing list") {
         for {
           provider <- propsProvider(Map())
-          result   <- provider.load(HostPorts.config)
-        } yield assertTrue(result.hostPorts.length == 0)
+          exit   <- provider.load(HostPorts.config).exit
+        } yield assert(exit)(failsWithA[Config.Error])
       },
       test("simple map") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -223,7 +223,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
       test("top-level missing list") {
         for {
           provider <- propsProvider(Map())
-          exit   <- provider.load(HostPorts.config).exit
+          exit     <- provider.load(HostPorts.config).exit
         } yield assert(exit)(failsWithA[Config.Error])
       },
       test("simple map") {


### PR DESCRIPTION
At least to me it seems strange that the following code succeeds with an empty chunk.

```scala
object Example extends ZIOAppDefault {

  val configProvider =
    ConfigProvider.fromMap(???)

  val config =
    Config.chunkOf(Config.string)

  val run =
    configProvider.load(config)
```

This code doesn't even really make sense because the `ConfigProvider.fromMap` and in fact any flat `ConfigProvider` consists of key value pairs and the `Config` is attempting to load a value without specifying a key. So there is no conceivable input for `Config.fromMap` in which this would load any information.

Even when we do specify a configuration that makes sense here, we get what I think are somewhat counterintuitive results:

```scala
object Example extends ZIOAppDefault {

  val a = Map.empty[String, String]
  val b = Map("key" -> "")
  val c = Map("key" -> "value")
  val d = Map("key" -> "value1, value2")

  val config =
    Config.chunkOf("key", Config.string)

  val run =
    for {
      _ <- ConfigProvider.fromMap(a).load(config).debug("a")
      _ <- ConfigProvider.fromMap(b).load(config).debug("b")
      _ <- ConfigProvider.fromMap(c).load(config).debug("c")
      _ <- ConfigProvider.fromMap(d).load(config).debug("d")
    } yield ()
}
```

```
[info] a: Chunk()
[info] b: Chunk()
[info] c: Chunk(value)
[info] d: Chunk(value1,value2)
```

This is definitely debatable but it seems questionable whether we should be succeeding with an empty chunk if the key doesn't exist. In particular, it seems inconsistent that attempting to load a chunk in a map where the key doesn't exist succeeds with an empty chunk but attempting to load something else like a string in a map where the key doesn't exist will fail. You could say that the chunk has a natural "empty" element which other types don't but I think we need consistent behavior across data types.

So I would expect `a` to fail with a `Config.Error` instead of succeeding with an empty chunk.

This PR changes this behavior so that the first example and `a` both fail. So you can still have empty sequences but you at least need the key to be present. If you want the current behavior of succeeding with an empty chunk if the key is not present you could do `chunkOf("key", Config.string).withDefault(Chunk.empty)`. 