### PR TITLE
Fallback for assertTrue method resolution

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -501,12 +501,16 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         assertTrue(Foo(null, 1) == Foo("a", 1))
       } @@ failing
     ),
-    suite("miscellaneous issues") {
+    suite("miscellaneous issues")(
       test("implicit Diff between Option[Nothing] and None is resolved") {
         val option: Option[Nothing] = Option.empty
         assertTrue(option == None)
+      },
+      test("isSuccess on Exit[_, _] works") {
+        val exit: Exit[String, Int] = Exit.succeed(1)
+        assertTrue(exit.isSuccess)
       }
-    }
+    )
   )
 
   // The implicit trace will be used by assertTrue to report the


### PR DESCRIPTION
The following assertion currently does not work with Scala 3:

```scala
val exit = Exit.success(1)
assertTrue(exit.isSuccess)
```

Fails because `Select.unique` cannot decide between `def isSuccess: Boolean` on `Exit` and `def isSuccess(implicit trace: Trace): Boolean` on `ZIO`.

Tried `Select.overloaded` instead but that also fails saying the method has no overloads. 

So the proposed workaround in case `unique` does not work tries to find the method in the direct type of the LHS and selects that.