### PR TITLE
Implement Config#orElseIf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
     - name: Mima Checks
-      if: ${{ !startsWith(matrix.scala, '3.') }}
+      if: ${{ !startsWith(matrix.scala, '3.') && !startsWith(matrix.scala, '2.11.') }}
       run: ./sbt ++${{ matrix.scala }}! mimaChecks
     - name: Test 2.11
       if: ${{ startsWith(matrix.scala, '2.11.') }}

--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.test._
+import zio.test.Assertion._
 
 import zio.Config.Secret
 
@@ -51,8 +52,41 @@ object ConfigSpec extends ZIOBaseSpec {
         }
     )
 
+  def withDefaultSuite =
+    suite("withDefault")(
+      test("recovers from missing data error") {
+        val config         = Config.int("key").withDefault(0)
+        val configProvider = ConfigProvider.fromMap(Map.empty)
+        for {
+          value <- configProvider.load(config)
+        } yield assert(value)(equalTo(0))
+      },
+      test("does not recover from other errors") {
+        val config         = Config.int("key").withDefault(0)
+        val configProvider = ConfigProvider.fromMap(Map("key" -> "value"))
+        for {
+          value <- configProvider.load(config).exit
+        } yield assert(value)(failsWithA[Config.Error])
+      },
+      test("does not recover from missing data and other error") {
+        val config         = Config.int("key1").zip(Config.int("key2")).withDefault((0, 0))
+        val configProvider = ConfigProvider.fromMap(Map("key2" -> "value"))
+        for {
+          value <- configProvider.load(config).exit
+        } yield assert(value)(failsWithA[Config.Error])
+      },
+      test("recovers from missing data or other error") {
+        val config         = Config.int("key1").orElse(Config.int("key2")).withDefault(0)
+        val configProvider = ConfigProvider.fromMap(Map("key2" -> "value"))
+        for {
+          value <- configProvider.load(config)
+        } yield assert(value)(equalTo(0))
+      }
+    )
+
   def spec =
     suite("ConfigSpec")(
-      secretSuite
+      secretSuite,
+      withDefaultSuite
     )
 }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -312,7 +312,7 @@ object Config {
     def &&(that: Error): Error = And(self, that)
     def ||(that: Error): Error = Or(self, that)
 
-    def fold[Z](
+    final def fold[Z](
       invalidDataCase0: (Chunk[String], String) => Z,
       missingDataCase0: (Chunk[String], String) => Z,
       sourceUnavailableCase0: (Chunk[String], String, Cause[Throwable]) => Z,
@@ -338,7 +338,7 @@ object Config {
         }
       }
 
-    def foldContext[C, Z](context: C)(folder: Folder[C, Z]): Z = {
+    final def foldContext[C, Z](context: C)(folder: Folder[C, Z]): Z = {
       import folder._
       sealed trait ErrorCase
 
@@ -375,7 +375,7 @@ object Config {
       loop(List(self), List.empty).head
     }
 
-    def isMissingDataOnly: Boolean =
+    final def isMissingDataOnly: Boolean =
       foldContext(())(Folder.IsMissingDataOnly)
 
     def prefixed(prefix: Chunk[String]): Error

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -237,7 +237,9 @@ object Config {
     def apply[A](first: Config[A], second: Config[A]): Fallback[A]        = new Fallback(first, second)
     def unapply[A](fallback: Fallback[A]): Option[(Config[A], Config[A])] = Some((fallback.first, fallback.second))
   }
-  final case class Optional[A](config: Config[A]) extends Fallback[Option[A]](config.map(Some(_)), Config.succeed(None))
+  final case class Optional[A](config: Config[A]) extends Fallback[Option[A]](config.map(Some(_)), Config.succeed(None)) {
+    override def condition(error: Config.Error): Boolean = error.isMissingDataOnly
+  }
   final case class FallbackWith[A](
     override val first: Config[A],
     override val second: Config[A],

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -237,7 +237,8 @@ object Config {
     def apply[A](first: Config[A], second: Config[A]): Fallback[A]        = new Fallback(first, second)
     def unapply[A](fallback: Fallback[A]): Option[(Config[A], Config[A])] = Some((fallback.first, fallback.second))
   }
-  final case class Optional[A](config: Config[A]) extends Fallback[Option[A]](config.map(Some(_)), Config.succeed(None)) {
+  final case class Optional[A](config: Config[A])
+      extends Fallback[Option[A]](config.map(Some(_)), Config.succeed(None)) {
     override def condition(error: Config.Error): Boolean = error.isMissingDataOnly
   }
   final case class FallbackWith[A](

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -215,7 +215,8 @@ object ConfigProvider {
         config match {
           case fallback: Fallback[A] =>
             loop(prefix, fallback.first).catchAll(e1 =>
-              loop(prefix, fallback.second).catchAll(e2 => ZIO.fail(e1 || e2))
+              if (fallback.condition(e1)) loop(prefix, fallback.second).catchAll(e2 => ZIO.fail(e1 || e2))
+              else ZIO.fail(e1)
             )
 
           case Described(config, _) => loop(prefix, config)

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -6,7 +6,7 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
 object MimaSettings {
-  lazy val bincompatVersionToCompare = "2.0.3"
+  lazy val bincompatVersionToCompare = "2.0.5"
 
   def mimaSettings(failOnProblem: Boolean) =
     Seq(


### PR DESCRIPTION
Allows the fallback logic for a configuration to depend on how attempting to load the configuration failed. Also changes the behavior of `withDefault` to only recover from missing data errors.