### PR TITLE
Fix zio-metrics-connectors Version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -48,7 +48,7 @@
     "@zio.dev/zio-logging": "2.1.7",
     "@zio.dev/zio-memberlist": "0.0.0--40-a85dc5a1--20221121-1416-SNAPSHOT",
     "@zio.dev/zio-meta": "0.0.0--21-54bc2e8b-SNAPSHOT",
-    "@zio.dev/zio-metrics-connectors": "^2.0.2",
+    "@zio.dev/zio-metrics-connectors": "2.0.4",
     "@zio.dev/zio-mock": "^1.0.0-RC9",
     "@zio.dev/zio-nio": "^2.0.0",
     "@zio.dev/zio-optics": "^0.2.0",


### PR DESCRIPTION
The new release of `zio-metrics-connectors` has a problem with its documentation. So let's fix the documentation to a specific version.

Note: I'm adding some CI checks on each PR for every project which prevents propagating errors to the zio core project.