### PR TITLE
Implement TestAspect.withConfigProvider

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -326,7 +326,12 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         _ <- ZIO.sleep(1.nanosecond)
       } yield assertCompletes
-    } @@ withLiveEnvironment
+    } @@ withLiveEnvironment,
+    test("withConfigProvider runs tests with the specified config provider") {
+      for {
+        value <- ZIO.config(Config.string("key"))
+      } yield assertTrue(value == "value")
+    } @@ withConfigProvider(ConfigProvider.fromMap(Map("key" -> "value")))
   )
 
   def diesWithSubtypeOf[E](implicit ct: ClassTag[E]): TestFailure[E] => Boolean =

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1011,6 +1011,15 @@ object TestAspect extends TimeoutVariants {
   val windows: TestAspectPoly = os(_.isWindows)
 
   /**
+   * An aspect that runs tests with the specified config provider.
+   */
+  def withConfigProvider(configProvider: ConfigProvider): TestAspectPoly =
+    new TestAspectPoly {
+      def some[R, E](spec: Spec[R, E])(implicit trace: Trace): Spec[R, E] =
+        spec.provideSomeLayer[R](ZLayer.scoped(ZIO.withConfigProviderScoped(configProvider)))
+    }
+
+  /**
    * An aspect that runs tests with the live clock service.
    */
   lazy val withLiveClock: TestAspectPoly =


### PR DESCRIPTION
A test aspect that runs tests with the specified config provider.