### PR TITLE
ZIO Config: Don't Split Values Unless A Sequence Is Expected

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -319,6 +319,12 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           _      <- TestSystem.putProperty("key", "value")
           result <- ZIO.config(Config.string("key").optional)
         } yield assertTrue(result == Some("value"))
+      } +
+      test("values are not split unless a sequence is expected") {
+        for {
+          _      <- TestSystem.putProperty("greeting", "Hello, World!")
+          result <- ZIO.config(Config.string("greeting"))
+        } yield assertTrue(result == "Hello, World!")
       }
   }
 }

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -173,7 +173,6 @@ object ConfigProvider {
             "There was a problem reading configuration from the console",
             Cause.fail(e)
           )
-        val isText = primitive == Config.Text || primitive == Config.Secret
 
         for {
           _       <- Console.printLine(s"Please enter ${description} for property ${name}:").mapError(sourceError)


### PR DESCRIPTION
Resolves #7716.

Currently if we have a config like `Config.string("greeting")` and a config provider like `ConfigProvider.fromMap("greeting" -> "Hello, World!")` the result of loading this config will be `Hello`.

While this has some internal logic to it since the `,` is a sequence delimiter and if a sequence isn't requested the first value will be returned, this also seems somewhat unexpected to me. Not only is the additional information in the value silently dropped but I also said I wanted to just load a string and not a sequence of strings.

This PR changes that behavior so that now we only split a string if a sequence is requested. So loading `Config.chunkOf(Config.string("greeting"))` would return `Chunk("Hello", "World!")` whereas loading `Config.string("greeting")` would just load `"Hello, World!"`.

Unfortunately, this does require significant contortions in the implementation of `Flat` to support this while preserving binary compatibility since the current signature of `Flat#load` does not give the implementation enough information to know whether it is being requested to load a single value or a collection of values.