### PR TITLE
Implement Runtime#setConfigProvider

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -246,6 +246,9 @@ object Runtime extends RuntimePlatformSpecific {
   def setBlockingExecutor(executor: Executor)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentBlockingExecutor.locallyScoped(executor))
 
+  def setConfigProvider(configProvider: ConfigProvider)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
+    ZLayer.scoped(ZIO.withConfigProviderScoped(configProvider))
+
   def setExecutor(executor: Executor)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.overrideExecutor.locallyScoped(Some(executor)))
 

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -1016,7 +1016,7 @@ object TestAspect extends TimeoutVariants {
   def withConfigProvider(configProvider: ConfigProvider): TestAspectPoly =
     new TestAspectPoly {
       def some[R, E](spec: Spec[R, E])(implicit trace: Trace): Spec[R, E] =
-        spec.provideSomeLayer[R](ZLayer.scoped(ZIO.withConfigProviderScoped(configProvider)))
+        spec.provideSomeLayer[R](Runtime.setConfigProvider(configProvider))
     }
 
   /**


### PR DESCRIPTION
Resolves #7726.

I think this should be `setConfigProvider` instead of `addConfigProvider` because we are just setting a new config provider, not changing some concept of the set of config providers.