### PR TITLE
Simplify Race Implementation

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1455,11 +1455,6 @@ sealed trait ZIO[-R, +E, +A]
           },
           leftFiber.id <> rightFiber.id
         )
-        .onInterrupt(
-          leftFiber.interruptAsFork(parentFiber.id) *> rightFiber.interruptAsFork(
-            parentFiber.id
-          ) *> leftFiber.await *> rightFiber.await
-        ) // TODO: .onInterrupt(leftFiber.await *> rightFiber.await)
     }
 
   /**


### PR DESCRIPTION
I don't think we need this anymore with the child fibers being forked in the parent scope.