### PR TITLE
Fix Race Benchmark

### DIFF
--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -32,7 +32,7 @@ class EmptyRaceBenchmark {
 
   private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
+      if (i < size) ZIO.never.raceFirstAwait(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeedNow(i)
 
     Unsafe.unsafe { implicit unsafe =>


### PR DESCRIPTION
The analogous ZIO operator to `race` in Cats Effect is `raceFirstAwait` in ZIO 2.