### PR TITLE
ZIO Stream: Optimize ZStream#onExecutor

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4188,6 +4188,16 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     }
 
   /**
+   * Shifts execution to the specified executor and shifts it back to the
+   * previous executor, if any, when the scope is closed.
+   */
+  def onExecutorScoped(executor: => Executor)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+    ZIO.descriptorWith { descriptor =>
+      if (descriptor.isLocked) ZIO.acquireRelease(ZIO.shift(executor))(_ => ZIO.shift(descriptor.executor))
+      else ZIO.acquireRelease(ZIO.shift(executor))(_ => ZIO.unshift)
+    }
+
+  /**
    * Applies the specified changes to the `FiberRef` values for the fiber
    * running this workflow.
    */

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2367,7 +2367,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               ref2      <- Ref.make[Executor](default)
               stream1    = ZStream.fromZIO(ZIO.executor.flatMap(ref1.set)).onExecutor(global)
               stream2    = ZStream.fromZIO(ZIO.executor.flatMap(ref2.set))
-              _         <- (stream1 *> stream2).runDrain.onExecutor(default)
+              _         <- (stream1 ++ stream2).runDrain.onExecutor(default)
               executor1 <- ref1.get
               executor2 <- ref2.get
             } yield assert(executor1)(equalTo(global)) &&
@@ -2382,7 +2382,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               after   <- Ref.make[Thread](default)
               stream1  = ZStream.fromZIO(thread.flatMap(during.set)).onExecutor(global)
               stream2  = ZStream.fromZIO(thread.flatMap(after.set))
-              _       <- (stream1 *> stream2).runDrain
+              _       <- (stream1 ++ stream2).runDrain
               thread1 <- during.get
               thread2 <- after.get
             } yield assert(thread1)(equalTo(thread2))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1856,14 +1856,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * previous executor.
    */
   def onExecutor(executor: => Executor)(implicit trace: Trace): ZStream[R, E, A] =
-    ZStream.fromZIO(ZIO.descriptor).flatMap { descriptor =>
-      ZStream.scoped(ZIO.acquireRelease(ZIO.shift(executor))(_ => ZIO.shift(descriptor.executor))) *>
-        self <*
-        ZStream.fromZIO {
-          if (descriptor.isLocked) ZIO.shift(descriptor.executor)
-          else ZIO.unshift
-        }
-    }
+    ZStream.scoped(ZIO.onExecutorScoped(executor)) *> self
 
   /**
    * Translates any failure into a stream termination, making the stream


### PR DESCRIPTION
Currently this operator shifts execution of the stream to the specified executor but also shifts execution back to the original executor for each element emitted by the stream.

This is inconsistent with the treatment of scopes and other regional operators on streams, which generally open the scope at the beginning of the stream and close it at the end of the stream so any downstream operators are executed within the scope of any acquired resources or other regional changes.

In addition, the current behavior can be extremely inefficient because it means that for each stream element we are bouncing back and forth between two different executors.

If the user does want to run the downstream on a different executor than the upstream they should specify this explicitly by calling `onExecutor` on the downstream, consistent with the principle that inner scopes override outer ones. Or even better they should fork the upstream on a separate fiber and have it offer values to a queue so that the upstream and downstream can each operate on the appropriate executors with no need for either of them to unnecessarily shift, which will be much more efficient.