### PR TITLE
Return To Default Executor More Eagerly

### DIFF
--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -501,8 +501,8 @@ object FiberRef {
   private[zio] val forkScopeOverride: FiberRef[Option[FiberScope]] =
     FiberRef.unsafe.make[Option[FiberScope]](None, _ => None, (parent, _) => parent)(Unsafe.unsafe)
 
-  private[zio] val overrideExecutor: FiberRef[Either[Executor, Executor]] =
-    FiberRef.unsafe.make[Either[Executor, Executor]](Left(Runtime.defaultExecutor))(Unsafe.unsafe)
+  private[zio] val overrideExecutor: FiberRef[Option[Executor]] =
+    FiberRef.unsafe.make[Option[Executor]](None)(Unsafe.unsafe)
 
   private[zio] val currentEnvironment: FiberRef.WithPatch[ZEnvironment[Any], ZEnvironment.Patch[Any, Any]] =
     FiberRef.unsafe.makeEnvironment(ZEnvironment.empty)(Unsafe.unsafe)

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -250,7 +250,7 @@ object Runtime extends RuntimePlatformSpecific {
     ZLayer.scoped(ZIO.withConfigProviderScoped(configProvider))
 
   def setExecutor(executor: Executor)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
-    ZLayer.scoped(FiberRef.overrideExecutor.locallyScoped(Right(executor)))
+    ZLayer.scoped(FiberRef.overrideExecutor.locallyScoped(Some(executor)))
 
   def setUnhandledErrorLogLevel(logLevel: LogLevel)(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.unhandledErrorLogLevel.locallyScoped(Some(logLevel)))


### PR DESCRIPTION
If the user hasn't specified that we are supposed to run on any executor then after `zio.onExecutor(executor)` completes we continue executing on the current executor for efficiency. 

However, we should return to the default executor the next time we yield since we are incurring the cost of a yield regardless so we don't continue running on a potentially suboptimal executor indefinitely.

This requires keeping track of one more piece of information in the runtime of the executor that is currently running the fiber so we know when we shift to a new executor whether we actually need to yield or whether we happen to already be running on that executor.