### PR TITLE
Fix overview doc link from basic-concurrency to running-effects

### DIFF
--- a/docs/overview/basic-concurrency.md
+++ b/docs/overview/basic-concurrency.md
@@ -198,4 +198,4 @@ If an effect times out, then instead of continuing to execute in the background,
 
 ## Next Steps
 
-If you are comfortable with basic concurrency, the next step is to learn about [running effects](running_effects.md).
+If you are comfortable with basic concurrency, the next step is to learn about [running effects](running-effects.md).


### PR DESCRIPTION
Fixes a broken link on `basic-concurrency.md` that was erroneously pointing to `running_effects.md` instead of `running-effects.md`