### PR TITLE
add timer with custom boundaries

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -399,9 +399,11 @@ object MetricSpec extends ZIOBaseSpec {
       } yield assertTrue(state == MetricState.Counter(1L))
     },
     test("timer") {
-      val timer = Metric.timer("timer", ChronoUnit.MILLIS)
+      val timer               = Metric.timer("timer", ChronoUnit.MILLIS)
+      val timerWithBoundaries = Metric.timer("timer", ChronoUnit.MILLIS, Chunk(0.1, 0.2, 0.3))
       for {
         _ <- ZIO.unit @@ timer.trackDuration
+        _ <- ZIO.unit @@ timerWithBoundaries.trackDuration
       } yield assertCompletes
     }
   )

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -539,4 +539,18 @@ object Metric {
       duration.toNanos / chronoUnit.getDuration.toNanos
     }
   }
+
+  def timer(
+    name: String,
+    chronoUnit: ChronoUnit,
+    boundaries: Chunk[Double]
+  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
+    val base = Metric
+      .histogram(name, Histogram.Boundaries.fromChunk(boundaries))
+      .tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
+
+    base.contramap[Duration] { (duration: Duration) =>
+      duration.toNanos / chronoUnit.getDuration.toNanos
+    }
+  }
 }


### PR DESCRIPTION
The ability to use custom boundaries for timer metrics. 