### PR TITLE
Fix Another Flaky Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
@@ -41,9 +41,9 @@ object ZPoolSpec extends ZIOBaseSpec {
             get     = ZIO.acquireRelease(count.updateAndGet(_ + 1).flatMap(ZIO.fail(_)))(_ => count.update(_ - 1))
             pool   <- ZPool.make[Scope, Int, Any](get, 10)
             _      <- count.get.repeatUntil(_ == 10)
-            values <- ZIO.collectAll(List.fill(10)(pool.get.flip))
-          } yield assertTrue(values == List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-        } +
+            values <- ZIO.collectAll(List.fill(9)(pool.get.flip))
+          } yield assertTrue(values == List(1, 2, 3, 4, 5, 6, 7, 8, 9))
+        } @@ nonFlaky +
         test("blocks when item not available") {
           for {
             count  <- Ref.make(0)


### PR DESCRIPTION
This test is flaky as written because we repeat until the `acquire` workflow has completed for the first ten items in the pool as a way of waiting for the pool to be fully initialized. However, an item can be acquired momentarily before it is added to the queue of items to be taken from the pool. So it is possible that:

1. The first nine items in the pool are initialized
2. The tenth item in the pool is acquired but has not yet been added to the queue
3. The subsequent calls to `get` are executed, causing new items to be acquired because the original one fails
4. One of these items is added to the internal queue before the original tenth item is added to the queue

We could add further coordination to prevent this from occurring but I don't think this is a problem. The pool is correct to allocate a new item once one of the calls to `get` returns a failure and I don't think there is any guarantee that an in process item from initialization must be returned by the pool before an item allocated after failure of an entry.