### PR TITLE
Deprecate Await Race Variants

### DIFF
--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -32,7 +32,7 @@ class EmptyRaceBenchmark {
 
   private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
     def loop(i: Int): UIO[Int] =
-      if (i < size) ZIO.never.raceFirstAwait(ZIO.succeed(i + 1)).flatMap(loop)
+      if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeedNow(i)
 
     Unsafe.unsafe { implicit unsafe =>


### PR DESCRIPTION
Deprecates `raceAwait` and `raceFirstAwait` and changes the semantics of `race` and `raceFirst` to await the interruption of the loser. If you don't want to await the interruption of the loser you can `disconnect` it.

These operators have created inconsistency with other operators derived from `race` and risk a proliferation of variants, creating uncertainty about which version to use. In addition, not waiting for termination can be the source of subtle bugs if resources are not released on a timely basis, whereas waiting for termination when it is not desired typically results in a 'loud" failure that is easily solved by using `disconnect`.