### PR TITLE
Speed up toQueueOfElements

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2546,20 +2546,12 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Unit] = {
     lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any] =
       ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any](
-        in =>
-          in.foldLeft[ZChannel[R, Any, Any, Any, Nothing, Exit[Option[E], A], Any]](ZChannel.unit) {
-            case (channel, a) =>
-              channel *> ZChannel.write(Exit.succeed(a))
-          } *> writer,
-        err => ZChannel.write(Exit.failCause(err.map(Some(_)))),
-        _ => ZChannel.write(Exit.fail(None))
+        in => ZChannel.fromZIO(queue.offerAll(in.map(Exit.succeed(_)))) *> writer,
+        err => ZChannel.fromZIO(queue.offer(Exit.failCause(err.map(Some(_))))),
+        _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
       )
 
-    (self.channel >>> writer)
-      .mapOutZIO(queue.offer)
-      .drain
-      .runScoped
-      .unit
+    (self.channel >>> writer).drain.runScoped.unit
   }
 
   /**


### PR DESCRIPTION
`toQueueOfElements` is _way_ slower than `toQueue` combined with a workflow on chunks, as in 20x slower on my machine. I guess that is the markup for using a concurrent queue on each element, though I noticed using `offerAll` instead of `offer` reduced the total runtime for my tests by 30%.