### PR TITLE
Create Warning Fiber In Test Clock Scope

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -195,7 +195,7 @@ object ClockSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.unit raceFirst Clock.instant
         } yield assertCompletes
-      }.provideLayer(scopedExecutor)
+      }.provideLayer(scopedExecutor) @@ TestAspect.nonFlaky
     ) @@ TestAspect.fibers
 
   class ScopedExecutor extends Executor {

--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -195,8 +195,8 @@ object ClockSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.unit raceFirst Clock.instant
         } yield assertCompletes
-      }.provideLayer(scopedExecutor) @@ TestAspect.nonFlaky
-    ) @@ TestAspect.fibers
+      }.provideLayer(scopedExecutor) @@ nonFlaky
+    )
 
   class ScopedExecutor extends Executor {
     @volatile private var closed = false

--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -202,7 +202,7 @@ object ClockSpec extends ZIOBaseSpec {
     @volatile private var closed = false
     def close(): Unit =
       closed = true
-    def metrics(implicit unsafe: zio.Unsafe): Option[ExecutionMetrics] =
+    def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] =
       None
     def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
       if (closed) throw new RejectedExecutionException
@@ -213,6 +213,7 @@ object ClockSpec extends ZIOBaseSpec {
     ZLayer.scoped {
       for {
         executor <- ZIO.acquireRelease(ZIO.succeed(new ScopedExecutor))(executor => ZIO.succeed(executor.close()))
+        _        <- ZIO.addFinalizer(ZIO.yieldNow)
         _        <- ZIO.onExecutorScoped(executor)
       } yield ()
     }

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -99,7 +99,7 @@ object TestClock extends Serializable {
     clockState: Ref.Atomic[TestClock.Data],
     live: Live,
     annotations: Annotations,
-    warningState: Ref[TestClock.WarningData],
+    warningState: Ref.Synchronized[TestClock.WarningData],
     suspendedWarningState: Ref.Synchronized[TestClock.SuspendedWarningData]
   ) extends Clock
       with TestClock
@@ -264,12 +264,11 @@ object TestClock extends Serializable {
      * Cancels the warning message that is displayed if a test is using time but
      * is not advancing the `TestClock`.
      */
-    private[TestClock] def warningDone(implicit trace: Trace): UIO[Any] =
-      warningState.modify {
-        case WarningData.Start(fiber, _) => fiber.interrupt -> WarningData.done
-        case WarningData.Pending(fiber)  => fiber.interrupt -> WarningData.done
-        case WarningData.Done            => ZIO.unit        -> WarningData.done
-      }.flatten
+    private[TestClock] def warningDone(implicit trace: Trace): UIO[Unit] =
+      warningState.updateSomeZIO[Any, Nothing] {
+        case WarningData.Start          => ZIO.succeedNow(WarningData.done)
+        case WarningData.Pending(fiber) => fiber.interrupt.as(WarningData.done)
+      }
 
     /**
      * Polls until all descendants of this fiber are done or suspended.
@@ -371,12 +370,12 @@ object TestClock extends Serializable {
      * Forks a fiber that will display a warning message if a test is using time
      * but is not advancing the `TestClock`.
      */
-    private def warningStart(implicit trace: Trace): UIO[Any] =
-      warningState.modify {
-        case WarningData.Start(fiber, promise) => promise.succeed(()) -> WarningData.pending(fiber)
-        case WarningData.Pending(fiber)        => ZIO.unit            -> WarningData.pending(fiber)
-        case WarningData.Done                  => ZIO.unit            -> WarningData.done
-      }.flatten
+    private def warningStart(implicit trace: Trace): UIO[Unit] =
+      warningState.updateSomeZIO { case WarningData.Start =>
+        for {
+          fiber <- live.provide(ZIO.logWarning(warning).delay(5.seconds)).interruptible.fork.onExecutor(Runtime.defaultExecutor)
+        } yield WarningData.pending(fiber)
+      }
 
   }
 
@@ -394,13 +393,11 @@ object TestClock extends Serializable {
         live                  <- ZIO.service[Live]
         annotations           <- ZIO.service[Annotations]
         clockState            <- ZIO.succeedNow(Ref.unsafe.make(data)(Unsafe.unsafe))
-        promise               <- Promise.make[Nothing, Unit]
-        fiber                 <- live.provide(promise.await *> ZIO.logWarning(warning).delay(5.seconds)).interruptible.forkScoped
-        warningState          <- Ref.Synchronized.make(WarningData.start(fiber, promise))
+        warningState          <- Ref.Synchronized.make(WarningData.start)
         suspendedWarningState <- Ref.Synchronized.make(SuspendedWarningData.start)
         test                   = Test(clockState, live, annotations, warningState, suspendedWarningState)
         _                     <- ZIO.withClockScoped(test)
-        _                     <- ZIO.addFinalizer(test.warningDone)
+        _                     <- ZIO.addFinalizer(test.warningDone *> test.suspendedWarningDone)
       } yield test
     }
 
@@ -490,30 +487,27 @@ object TestClock extends Serializable {
 
   object WarningData {
 
-    final case class Start(fiber: Fiber[IOException, Unit], promise: Promise[Nothing, Unit]) extends WarningData
-    final case class Pending(fiber: Fiber[IOException, Unit])                                extends WarningData
-    case object Done                                                                         extends WarningData
+    case object Start                                         extends WarningData
+    final case class Pending(fiber: Fiber[IOException, Unit]) extends WarningData
+    case object Done                                          extends WarningData
 
     /**
      * State indicating that a test has not used time.
      */
-    def start(fiber: Fiber[IOException, Unit], promise: Promise[Nothing, Unit]): WarningData =
-      Start(fiber, promise)
+    val start: WarningData = Start
 
     /**
      * State indicating that a test has used time but has not adjusted the
      * `TestClock` with a reference to the fiber that will display the warning
      * message.
      */
-    def pending(fiber: Fiber[IOException, Unit]): WarningData =
-      Pending(fiber)
+    def pending(fiber: Fiber[IOException, Unit]): WarningData = Pending(fiber)
 
     /**
      * State indicating that a test has used time or the warning message has
      * already been displayed.
      */
-    val done: WarningData =
-      Done
+    val done: WarningData = Done
   }
 
   sealed abstract class SuspendedWarningData

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -373,7 +373,11 @@ object TestClock extends Serializable {
     private def warningStart(implicit trace: Trace): UIO[Unit] =
       warningState.updateSomeZIO { case WarningData.Start =>
         for {
-          fiber <- live.provide(ZIO.logWarning(warning).delay(5.seconds)).interruptible.fork.onExecutor(Runtime.defaultExecutor)
+          fiber <- live
+                     .provide(ZIO.logWarning(warning).delay(5.seconds))
+                     .interruptible
+                     .fork
+                     .onExecutor(Runtime.defaultExecutor)
         } yield WarningData.pending(fiber)
       }
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -343,7 +343,8 @@ package object test extends CompileVariants {
                    .withClock(Clock.ClockLive)
                    .interruptible
                    .forkDaemon
-        _ <- (child.interrupt *> fiber.interrupt).forkDaemon
+                   .onExecutor(Runtime.defaultExecutor)
+        _ <- (child.interrupt *> fiber.interrupt).forkDaemon.onExecutor(Runtime.defaultExecutor)
       } yield result
   }
 


### PR DESCRIPTION
Resolves zio/zio-http#1896.

Currently in the `TestClock` we fork a warning fiber when a caller accesses the time that we interrupt when the caller actually adjusts the time or when the scope of the `TestClock` is closed.

However, this can create an issue if the warning fiber is forked in an inner scope where for example it uses an executor that is not valid outside that scope and the fiber is interrupted when the `TestClock` scope is closed after the inner scope is closed.

We can prevent this by forking the fiber at the time that the `TestClock` layer is constructed and merely completing a promise when we want to "start" the warning.  This way we can ensure that the fiber is forked in a scope that is still valid when the fiber is finalized.