### PR TITLE
Only Recover In Config#optional When All Errors Are Missing Data

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -75,12 +75,12 @@ object ConfigSpec extends ZIOBaseSpec {
           value <- configProvider.load(config).exit
         } yield assert(value)(failsWithA[Config.Error])
       },
-      test("recovers from missing data or other error") {
+      test("does not recover from missing data or other error") {
         val config         = Config.int("key1").orElse(Config.int("key2")).withDefault(0)
         val configProvider = ConfigProvider.fromMap(Map("key2" -> "value"))
         for {
-          value <- configProvider.load(config)
-        } yield assert(value)(equalTo(0))
+          value <- configProvider.load(config).exit
+        } yield assert(value)(failsWithA[Config.Error])
       }
     )
 
@@ -107,12 +107,12 @@ object ConfigSpec extends ZIOBaseSpec {
           value <- configProvider.load(config).exit
         } yield assert(value)(failsWithA[Config.Error])
       },
-      test("recovers from missing data or other error") {
+      test("does not recover from missing data or other error") {
         val config         = Config.int("key1").orElse(Config.int("key2")).optional
         val configProvider = ConfigProvider.fromMap(Map("key2" -> "value"))
         for {
-          value <- configProvider.load(config)
-        } yield assert(value)(isNone)
+          value <- configProvider.load(config).exit
+        } yield assert(value)(failsWithA[Config.Error])
       }
     )
 

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -434,7 +434,7 @@ object Config {
         def andCase(context: Any, left: Boolean, right: Boolean): Boolean                = left && right
         def invalidDataCase(context: Any, path: Chunk[String], message: String): Boolean = false
         def missingDataCase(context: Any, path: Chunk[String], message: String): Boolean = true
-        def orCase(context: Any, left: Boolean, right: Boolean): Boolean                 = left || right
+        def orCase(context: Any, left: Boolean, right: Boolean): Boolean                 = left && right
         def sourceUnavailableCase(
           context: Any,
           path: Chunk[String],


### PR DESCRIPTION
```scala
test("optional duration does not fail on invalid value") {
  for {
    _      <- TestSystem.putEnv("DURATION", "xxx")
    result <- ZIO.config(Config.duration("duration").optional)
  } yield assertTrue(result == None)
```

Currently the following test will pass. The `optional` operator recovers from missing data errors. The default configuration provides attempts to load the configuration from environment variables or else system properties, so the failure is invalid data or missing data.

Currently we consider this a missing data error because the missing data is a "but for" cause of the error. If configuration information had existed in the system properties then loading the configuration would have succeeded, even though the system properties contained invalid data.

While this has a certain logic to it, another way to conceptualize it is that some error occurred beyond just data being missing. If we think of there being a hierarchy of severity of errors with missing data being the least severe and other errors being more severe, or missing data being "expected" to some extent and other errors being less expected, something happened beyond just data being missing.

This PR changes the semantics of `isMissingDataOnly` to return true only when every error is missing data, or in other words no errors occurred that are not missing data. With this change loading this configuration results in a failure.