### PR TITLE
Add Timed To Test Aspects For Internal Test Suite

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -6,8 +6,8 @@ import scala.annotation.tailrec
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectPoly] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
-    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential)
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
+    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential, TestAspect.timed)
 
   sealed trait ZIOTag {
     val value: String

--- a/managed-tests/shared/src/test/scala/zio/managed/ZIOBaseSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZIOBaseSpec.scala
@@ -7,8 +7,8 @@ import scala.annotation.tailrec
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectPoly] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
-    else Chunk(TestAspect.timeout(120.seconds))
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
+    else Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
 
   sealed trait ZIOTag {
     val value: String

--- a/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOBaseSpec.scala
@@ -4,6 +4,6 @@ import zio._
 
 trait ZIOBaseSpec extends ZIOSpecDefault {
   override def aspects: Chunk[TestAspectAtLeastR[TestEnvironment]] =
-    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds))
-    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential)
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
+    else Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential, TestAspect.timed)
 }


### PR DESCRIPTION
I think this is a useful test aspect to include in our internal test suite to identify tests that are taking too long to run.