### PR TITLE
Test Projects Sequentially

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Test on different JVM versions
-        run: ./sbt root${{ matrix.platform }}/test
+        run: ./sbt test${{ matrix.platform }}
 
       - name: Report Test Death JVM 8
         if: ${{ failure() &&  startsWith(matrix.java, '8') }}
@@ -304,7 +304,7 @@ jobs:
         with:
           swap-size-gb: 9
       - name: Test on different Scala target platforms
-        run: free --si -tmws 10 & ./sbt root${{ matrix.platform }}/test
+        run: free --si -tmws 10 & ./sbt test${{ matrix.platform }}
 
   ci:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,16 +190,16 @@ jobs:
       run: ./sbt ++${{ matrix.scala }}! mimaChecks
     - name: Test 2.11
       if: ${{ startsWith(matrix.scala, '2.11.') }}
-      run: ./sbt ++${{ matrix.scala }}! root${{ matrix.platform }}211/test
+      run: ./sbt ++${{ matrix.scala }}! test${{ matrix.platform }}211
     - name: Test 2.12
       if: ${{ startsWith(matrix.scala, '2.12.') }}
-      run: ./sbt ++${{ matrix.scala }}! root${{ matrix.platform }}212/test
+      run: ./sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
     - name: Test 2.13
       if: ${{ startsWith(matrix.scala, '2.13.') }}
-      run: ./sbt ++${{ matrix.scala }}! root${{ matrix.platform }}213/test
+      run: ./sbt ++${{ matrix.scala }}! test${{ matrix.platform }}
     - name: Test 3
       if: ${{ startsWith(matrix.scala, '3.') }}
-      run: ./sbt ++${{ matrix.scala }}! root${{ matrix.platform }}3/test
+      run: ./sbt ++${{ matrix.scala }}! test${{ matrix.platform }}3
     - name: Upload Test Results 2.11
       if: ${{ startsWith(matrix.scala, '2.11.') }}
       uses: actions/upload-artifact@v3

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ addCommandAlias(
   "check",
   "; scalafmtSbtCheck; scalafmtCheckAll"
 )
-// Legacy command aliases ahead, may be removed in future. Consider using the one of the `root*` projects, like `rootJVM/test` instead of `testJVM`
+
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/test:compile;stacktracerJVM/test:compile;streamsTestsJVM/test:compile;testTestsJVM/test:compile;testMagnoliaTestsJVM/test:compile;testRefinedJVM/test:compile;testRunnerJVM/test:compile;examplesJVM/test:compile;macrosTestsJVM/test:compile;concurrentJVM/test:compile;managedTestsJVM/test:compile"
@@ -48,11 +48,11 @@ addCommandAlias(
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRefinedJVM/test:compile;testRunnerJVM/test:run;examplesJVM/test:compile;concurrentJVM/test;managedTestsJVM/test"
 )
 addCommandAlias(
-  "testJVMDotty",
+  "testJVM3",
   ";coreTestsJVM/test;stacktracerJVM/test:compile;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRefinedJVM/test;testRunnerJVM/test:run;examplesJVM/test:compile;concurrentJVM/test;managedTestsJVM/test"
 )
 addCommandAlias(
-  "testJSDotty",
+  "testJS3",
   ";coreTestsJS/test;stacktracerJS/test;streamsTestsJS/test;testTestsJS/test;testMagnoliaTestsJS/test;testRefinedJS/test;examplesJS/test:compile;concurrentJS/test"
 )
 addCommandAlias(

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -215,7 +215,7 @@ object BuildHelper {
           compilerPlugin("com.github.ghik" % "silencer-plugin" % SilencerVersion cross CrossVersion.full)
         )
     },
-    Test / parallelExecution := { scalaVersion.value != Scala3 },
+    Test / parallelExecution := false,
     incOptions ~= (_.withLogRecompileOnMacro(false)),
     // autoAPIMappings := true,
     unusedCompileDependenciesFilter -= moduleFilter("org.scala-js", "scalajs-library"),


### PR DESCRIPTION
We currently run tests for all projects in parallel. There seems to be little value in doing this as we already have a high degree of parallelism in execution of tests within a project and this creates additional memory pressure, particularly on Scala.js. Running tests sequentially will allow us to address these issues and also fail faster (e.g. if core tests are failing there is no point in running stream tests).