### PR TITLE
Handle indexed sequence, and allow more backends for ConfigProvider

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -532,7 +532,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           result           <- configProvider.load(config)
           expectedEmployees = List((0, 10), (1, 11))
           expectedStudents  = List((20, 2), (30, 3))
-        } yield assertTrue(result == (expectedEmployees, expectedStudents))
+        } yield assertTrue(result == expectedEmployees -> expectedStudents)
       } +
       test("map of indexed sequence") {
         val configProvider =

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -424,6 +424,217 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         for {
           result <- configProvider.load(config)
         } yield assertTrue(result == "value")
+      } +
+      test("indexed sequence simple") {
+        val configProvider = ConfigProvider.fromMap(Map("id.[0]" -> "1", "id.[1]" -> "2", "id.[3]" -> "3"))
+        val config         = Config.listOf("id", Config.int)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List(1, 2, 3))
+      } +
+      test("indexed sequence with simple values as list") {
+        val configProvider = ConfigProvider.fromMap(Map("id.[0]" -> "1, 2", "id.[1]" -> "3, 4", "id.[3]" -> "5, 6"))
+        val config         = Config.listOf("id", Config.listOf(Config.int))
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List(List(1, 2), List(3, 4), List(5, 6)))
+      } +
+      test("indexed sequence of 1 element to summon a product") {
+        val configProvider = ConfigProvider.fromMap(Map("employees.[0].age" -> "1", "employees.[0].id" -> "1"))
+        val product        = Config.int("age").zip(Config.int("id"))
+        val config         = Config.listOf("employees", product)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List((1, 1)))
+      } +
+      test("indexed sequence of one product") {
+        val configProvider = ConfigProvider.fromMap(Map("employees.[0].age" -> "1", "employees.[0].id" -> "1"))
+        val product        = Config.int("age").zip(Config.int("id"))
+        val config         = Config.listOf("employees", product)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List((1, 1)))
+      } +
+      test("indexed sequence of one product with missing field") {
+        val configProvider = ConfigProvider.fromMap(Map("employees.[0].age" -> "1"))
+        val product        = Config.int("age").zip(Config.int("id"))
+        val config         = Config.listOf("employees", product)
+
+        for {
+          exit <- configProvider.load(config).exit
+        } yield assert(exit)(failsWithA[Config.Error])
+      } +
+      test("indexed sequence of multiple products") {
+        val configProvider = ConfigProvider.fromMap(
+          Map(
+            "employees.[0].age" -> "1",
+            "employees.[0].id"  -> "2",
+            "employees.[1].age" -> "3",
+            "employees.[1].id"  -> "4"
+          )
+        )
+        val product = Config.int("age").zip(Config.int("id"))
+        val config  = Config.listOf("employees", product)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List((1, 2), (3, 4)))
+      } +
+      test("indexed sequence of multiple products with missing fields") {
+        val configProvider = ConfigProvider.fromMap(
+          Map("employees.[0].age" -> "1", "employees.[0].id" -> "2", "employees.[1].age" -> "3", "employees.[1]" -> "4")
+        )
+        val product = Config.int("age").zip(Config.int("id"))
+        val config  = Config.listOf("employees", product)
+
+        for {
+          exit <- configProvider.load(config).exit
+        } yield assert(exit)(failsWithA[Config.Error])
+      } +
+      test("indexed sequence of multiple products with optional fields") {
+        val configProvider =
+          ConfigProvider.fromMap(Map("employees.[0].age" -> "1", "employees.[0].id" -> "2", "employees.[1].id" -> "4"))
+        val product = Config.int("age").optional.zip(Config.int("id"))
+        val config  = Config.listOf("employees", product)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List((Some(1), 2), (None, 4)))
+      } +
+      test("indexed sequence of multiple products with sequence fields") {
+        val configProvider = ConfigProvider.fromMap(
+          Map(
+            "employees.[0].refunds" -> "1,2,3",
+            "employees.[0].id"      -> "0",
+            "employees.[1].id"      -> "1",
+            "employees.[1].refunds" -> "4, 5, 6"
+          )
+        )
+        val product = Config.listOf("refunds", Config.int).zip(Config.int("id"))
+        val config  = Config.listOf("employees", product)
+
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == List((List(1, 2, 3), 0), (List(4, 5, 6), 1)))
+      } +
+      test("product of indexed sequences with reusable config") {
+        val configProvider = ConfigProvider.fromMap(
+          Map(
+            "employees.[0].id"  -> "0",
+            "employees.[1].id"  -> "1",
+            "employees.[0].age" -> "10",
+            "employees.[1].age" -> "11",
+            "students.[0].id"   -> "20",
+            "students.[1].id"   -> "30",
+            "students.[0].age"  -> "2",
+            "students.[1].age"  -> "3"
+          )
+        )
+        val idAndAge = Config.int("id").zip(Config.int("age"))
+        val config   = Config.listOf("employees", idAndAge).zip(Config.listOf("students", idAndAge))
+
+        for {
+          result           <- configProvider.load(config)
+          expectedEmployees = List((0, 10), (1, 11))
+          expectedStudents  = List((20, 2), (30, 3))
+        } yield assertTrue(result == (expectedEmployees, expectedStudents))
+      } +
+      test("indexed sequence with index in key") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "employees.[0].age" -> "10",
+              "employees.[0].id"  -> "0",
+              "employees.[1].age" -> "20",
+              "employees.[1].id"  -> "1",
+              "students.[0]"      -> "10, 20, 30"
+            )
+          )
+
+        val students = Config.listOf("students.[0]", Config.int)
+        val employee = Config.int("age").zip(Config.int("id"))
+
+        val config = Config.listOf("employees", employee).zip(students)
+
+        for {
+          result           <- configProvider.load(config)
+          expectedEmployees = List((10, 0), (20, 1))
+          expectedStudents  = List(10, 20, 30)
+        } yield assertTrue(result == (expectedEmployees, expectedStudents))
+      } +
+      test("map of indexed sequence") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments.department1.employees.[0].age" -> "10",
+              "departments.department1.employees.[0].id"  -> "0",
+              "departments.department1.employees.[1].age" -> "20",
+              "departments.department1.employees.[1].id"  -> "1",
+              "departments.department2.employees.[0].age" -> "10",
+              "departments.department2.employees.[0].id"  -> "0",
+              "departments.department2.employees.[1].age" -> "20",
+              "departments.department2.employees.[1].id"  -> "1"
+            )
+          )
+
+        val employee = Config.int("age").zip(Config.int("id"))
+
+        val config = Config.table("departments", Config.listOf("employees", employee))
+
+        for {
+          result           <- configProvider.load(config)
+          expectedEmployees = List((10, 0), (20, 1))
+        } yield assertTrue(result == Map("department1" -> expectedEmployees, "department2" -> expectedEmployees))
+      } +
+      test("indexed sequence of map") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "employees.[0].details.age" -> "10",
+              "employees.[0].details.id"  -> "0",
+              "employees.[1].details.age" -> "20",
+              "employees.[1].details.id"  -> "1"
+            )
+          )
+
+        val employee = Config.table("details", Config.int)
+        val config   = Config.listOf("employees", employee)
+
+        for {
+          result           <- configProvider.load(config)
+          expectedEmployees = List(Map("age" -> 10, "id" -> 0), Map("age" -> 20, "id" -> 1))
+        } yield assertTrue(result == expectedEmployees)
+      } +
+      test("indexed sequence of indexed sequence") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments.[0].employees.[0].age" -> "10",
+              "departments.[0].employees.[0].id"  -> "0",
+              "departments.[0].employees.[1].age" -> "20",
+              "departments.[0].employees.[1].id"  -> "1",
+              "departments.[1].employees.[0].age" -> "10",
+              "departments.[1].employees.[0].id"  -> "0",
+              "departments.[1].employees.[1].age" -> "20",
+              "departments.[1].employees.[1].id"  -> "1"
+            )
+          )
+
+        val employee = Config.int("age").zip(Config.int("id"))
+
+        val department = Config.listOf("employees", employee)
+
+        val config = Config.listOf("departments", department)
+
+        for {
+          result             <- configProvider.load(config)
+          expectedEmployees   = List((10, 0), (20, 1))
+          expectedDepartments = List(expectedEmployees, expectedEmployees)
+        } yield assertTrue(result == expectedDepartments)
       }
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -433,22 +433,13 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           result <- configProvider.load(config)
         } yield assertTrue(result == List(1, 2, 3))
       } +
-      test("indexed sequence with simple values as list") {
+      test("indexed sequence simple with list values") {
         val configProvider = ConfigProvider.fromMap(Map("id.[0]" -> "1, 2", "id.[1]" -> "3, 4", "id.[3]" -> "5, 6"))
         val config         = Config.listOf("id", Config.listOf(Config.int))
 
         for {
           result <- configProvider.load(config)
         } yield assertTrue(result == List(List(1, 2), List(3, 4), List(5, 6)))
-      } +
-      test("indexed sequence of 1 element to summon a product") {
-        val configProvider = ConfigProvider.fromMap(Map("employees.[0].age" -> "1", "employees.[0].id" -> "1"))
-        val product        = Config.int("age").zip(Config.int("id"))
-        val config         = Config.listOf("employees", product)
-
-        for {
-          result <- configProvider.load(config)
-        } yield assertTrue(result == List((1, 1)))
       } +
       test("indexed sequence of one product") {
         val configProvider = ConfigProvider.fromMap(Map("employees.[0].age" -> "1", "employees.[0].id" -> "1"))

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -464,7 +464,7 @@ object ConfigProvider {
             for {
               indices <- flat
                            .enumerateChildren(prefix)
-                           .map(set => if (set.forall(isIndex)) set else Set.empty)
+                           .map(set => if (set.forall(isIndex)) Chunk.fromIterable(set).sorted else Chunk.empty)
 
               values <-
                 if (indices.isEmpty) loop(prefix, config, split = true).map(Chunk(_))

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -288,10 +288,10 @@ object ConfigProvider {
         Empty
 
       private final case class AndThen(first: PathPatch, second: PathPatch) extends PathPatch
-      private case object Empty extends PathPatch
-      private final case class MapName(f: String => String) extends PathPatch
-      private final case class Nested(name: String) extends PathPatch
-      private final case class Unnested(name: String) extends PathPatch
+      private case object Empty                                             extends PathPatch
+      private final case class MapName(f: String => String)                 extends PathPatch
+      private final case class Nested(name: String)                         extends PathPatch
+      private final case class Unnested(name: String)                       extends PathPatch
     }
 
     object util {

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -750,7 +750,7 @@ object ConfigProvider {
         val optionalIndex: Option[Int] = Option(regexMatched.group(3))
           .flatMap(s => if (s.isEmpty) None else Try(s.toInt).toOption)
 
-        optionalString.zip(optionalIndex)
+        optionalString.flatMap(str => optionalIndex.map(ind => (str, ind)))
       }
 
 }

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by aplicable law or agreed to in writing, software
+ * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -288,13 +288,9 @@ object ConfigProvider {
         Empty
 
       private final case class AndThen(first: PathPatch, second: PathPatch) extends PathPatch
-
       private case object Empty extends PathPatch
-
       private final case class MapName(f: String => String) extends PathPatch
-
       private final case class Nested(name: String) extends PathPatch
-
       private final case class Unnested(name: String) extends PathPatch
     }
 


### PR DESCRIPTION
Handling indexed sequence as given in the below example code, will allow more backends for` ConfigProvider` in `zio-config`.

The implementation is a simplified version of https://github.com/zio/zio/pull/7798, and it keeps backward compatibility.

```scala

object Hello extends App {

  val map =
    Map(
      "employees[0].age" -> "1",
      "employees[0].id" -> "1",
      "employees[1].age" -> "2",
      "employees[1].id" -> "2",
      "employees[2].id" -> "3",

    )

  val provider =
    ConfigProvider.fromMap(map)

  case class Employee(age: Option[Int], id: Int)

    val employee: Config[Employee] =
      Config.int("age").optional.zip(Config.int("id")).map(Employee.tupled)

  case class AppConfig(list1: List[Employee], dummyIds: List[Int])

  val config: Config[AppConfig] =
    Config.listOf("employees", employee).zip(Config.listOf("dummyIds.[0]", Config.int)).map(AppConfig.tupled)

  val pgm =
    provider.load(config)

  val result =
    Unsafe.unsafe(implicit u => zio.Runtime.default.unsafe.run(pgm.either).getOrThrowFiberFailure())

  assert(result == Right(AppConfig(List(Employee(Some(1),1), Employee(Some(2),2), Employee(None,3)),List(4, 6, 6))))

}

```
