### PR TITLE
Use Logging For Timeout Warning

### DIFF
--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -60,7 +60,7 @@ trait TimeoutVariants {
     labels: List[String],
     duration: Duration
   ): UIO[Unit] =
-    Live.live(Console.printLine(renderWarning(labels, duration)).orDie)
+    ZIO.logWarning(renderWarning(labels, duration))
 
   private def renderWarning(labels: List[String], duration: Duration): String =
     "Test " + labels.reverse.mkString(" - ") + " has taken more than " + duration.render +


### PR DESCRIPTION
Now that we have integrated logging we can log this warning instead of just printing it to the console.