### PR TITLE
ZIO Stream: Terminate Zip In Uninterruptible Region

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4155,6 +4155,11 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .runCollect
                 .exit
             )(dies(anything))
+          },
+          test("zip in uninterruptible region") {
+            for {
+              _ <- ZStream(1).zip(ZStream(2)).runDrain.uninterruptible
+            } yield assertCompletes
           }
         ),
         suite("zipAllWith")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -950,7 +950,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
         ZChannel.readWithCause[R1, Err, Chunk[Elem], Any, Nothing, Nothing, Any](
           chunk => ZChannel.fromZIO(handoff.offer(Take.chunk(chunk))) *> producer(handoff, latch),
           cause => ZChannel.fromZIO(handoff.offer(Take.failCause(cause))),
-          _ => ZChannel.fromZIO(handoff.offer(Take.end)) *> producer(handoff, latch)
+          _ => ZChannel.fromZIO(handoff.offer(Take.end))
         )
 
     new ZStream(


### PR DESCRIPTION
We shouldn't read again once we have read a done value.