### PR TITLE
Handle Empty Sequence In Config

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -425,6 +425,13 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           result <- configProvider.load(config)
         } yield assertTrue(result == "value")
       } +
+      test("empty list") {
+        val configProvider = ConfigProvider.fromMap(Map("key" -> ""))
+        val config         = Config.chunkOf(Config.string).nested("key")
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == Chunk.empty)
+      } +
       test("indexed sequence simple") {
         val configProvider = ConfigProvider.fromMap(Map("id[0]" -> "1", "id[1]" -> "2", "id[2]" -> "3"))
         val config         = Config.listOf("id", Config.int)

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -296,7 +296,8 @@ object ConfigProvider {
 
     object util {
       def splitPathString(text: String, escapedDelim: String): Chunk[String] =
-        Chunk.fromArray(text.split("\\s*" + escapedDelim + "\\s*"))
+        if (text.isEmpty) Chunk.empty
+        else Chunk.fromArray(text.split("\\s*" + escapedDelim + "\\s*"))
 
       def parsePrimitive[A](
         text: String,
@@ -564,7 +565,7 @@ object ConfigProvider {
             for {
               prefix <- ZIO.fromEither(flat.patch(prefix))
               vs     <- flat.load(prefix, primitive, split)
-              result <- if (vs.isEmpty)
+              result <- if (vs.isEmpty && !split)
                           ZIO.fail(primitive.missingError(prefix.lastOption.getOrElse("<n/a>")))
                         else ZIO.succeed(vs)
             } yield result


### PR DESCRIPTION
If we have a `ConfigProvider` like `Map("key" -> "")` and the `Config` is `Config.chunkOf(Config.string).nested("key")` currently we return a chunk with a single element containing the empty string. This PR changes that behavior to instead return an empty chunk.

One disadvantage of this change is that it makes loading a configuration with a sequence containing a single empty string unrepresentable, but that seems much better than the current behavior where an empty sequence is unrepresentable. Unfortunately it does not seem possible to support both without introducing an additional operator which seems potentially excessive for a somewhat degenerate case.