### PR TITLE
Implement ZStream.alphanumeric

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4477,6 +4477,11 @@ object ZStreamSpec extends ZIOBaseSpec {
         )
       ),
       suite("Constructors")(
+        test("alphanumeric") {
+          for {
+            chars <- ZStream.alphanumeric.take(100).runCollect
+          } yield assertTrue(chars.forall(_.isLetterOrDigit))
+        },
         test("rechunk") {
           check(tinyChunkOf(Gen.chunkOf(Gen.int)) <*> (Gen.int(1, 100))) { case (chunk, n) =>
             val expected = Chunk.fromIterable(chunk.flatten.grouped(n).toList)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3843,6 +3843,15 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     scoped[R](ZIO.acquireReleaseExit(acquire)(release))
 
   /**
+   * An infinite stream of random alphanumeric characters.
+   */
+  def alphanumeric(implicit trace: Trace): ZStream[Any, Nothing, Char] =
+    ZStream.repeatZIO {
+      val chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+      Random.nextIntBounded(chars.length).map(chars.charAt)
+    }
+
+  /**
    * Creates a pure stream from a variable list of values
    */
   def apply[A](as: A*)(implicit trace: Trace): ZStream[Any, Nothing, A] = fromIterable(as)


### PR DESCRIPTION
The ZIO equivalent of `Scala.util.Random.alphanumeric`.

There is some danger of encroaching on the domain of `Gen` here but since this functionality is directly exposed by `scala.util.Random` I think it is fair that there should be a ZIO equivalent.