### PR TITLE
fix type for zio.test.Assertion#diesWithA

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.Assertion._
-import zio.{Chunk, Exit}
+import zio.{Chunk, Exit, ZIO}
 
 import scala.collection.immutable.SortedSet
 import scala.util.{Failure, Success}
@@ -47,6 +47,11 @@ object AssertionSpec extends ZIOBaseSpec {
       } @@ failing,
       test("diesWithA must succeed when given type assertion is correct") {
         assert(Exit.die(customException))(diesWithA[CustomException])
+      },
+      test("diesWithA must be agnostic to failure type") {
+        assertZIO(ZIO.die(customException).flatMap(_ => ZIO.fromEither(Right[String, List[Int]](List(1, 2, 3)))).exit)(
+          diesWithA[CustomException]
+        )
       },
       test("endWith must succeed when the supplied value ends with the specified sequence") {
         assert(List(1, 2, 3, 4, 5))(endsWith(List(3, 4, 5)))

--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -49,9 +49,12 @@ object AssertionSpec extends ZIOBaseSpec {
         assert(Exit.die(customException))(diesWithA[CustomException])
       },
       test("diesWithA must be agnostic to failure type") {
-        assertZIO(ZIO.die(customException).flatMap(_ => ZIO.fromEither(Right[String, List[Int]](List(1, 2, 3)))).exit)(
-          diesWithA[CustomException]
-        )
+        assertZIO(
+          ZIO
+            .die(customException)
+            .flatMap(_ => ZIO.fromEither(Right[String, List[Int]](List(1, 2, 3))))
+            .exit
+        )(diesWithA[CustomException])
       },
       test("endWith must succeed when the supplied value ends with the specified sequence") {
         assert(List(1, 2, 3, 4, 5))(endsWith(List(3, 4, 5)))

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -167,7 +167,7 @@ object Assertion extends AssertionVariants {
    * Makes a new assertion that requires an exit value to die with an instance
    * of given type (or its subtype).
    */
-  def diesWithA[E: ClassTag]: Assertion[Exit[E, Any]] =
+  def diesWithA[E <: Throwable : ClassTag]: Assertion[Exit[Any, Any]] =
     dies(isSubtype[E](anything))
 
   /**

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -167,7 +167,7 @@ object Assertion extends AssertionVariants {
    * Makes a new assertion that requires an exit value to die with an instance
    * of given type (or its subtype).
    */
-  def diesWithA[E <: Throwable : ClassTag]: Assertion[Exit[Any, Any]] =
+  def diesWithA[E: ClassTag]: Assertion[Exit[Any, Any]] =
     dies(isSubtype[E](anything))
 
   /**


### PR DESCRIPTION
make `zio.test.Assertion#diesWithA` method agnostic to failure type. Before the change, it wasn't possible to compile when an effect failure type was other than `Throwable`