### PR TITLE
Optimise `_IdentityFn`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5026,7 +5026,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   )(implicit trace: Trace): ZIO[R, E, A] =
     Stateful(trace, onState)
 
-  private lazy val _IdentityFn: Any => Any = (a: Any) => a
+  private val _IdentityFn: Any => Any = (a: Any) => a
 
   private[zio] def identityFn[A]: A => A = _IdentityFn.asInstanceOf[A => A]
 


### PR DESCRIPTION
Here's how I see this (and I can be wrong):
The probability that someone using ZIO doesn't use this `_IdentityFn` lazy val is IMO close to 0. Each time you flatten a ZIO, you probably use it.
AFAIR, using a `lazy val` over a `val` adds several instructions in the bytecode to make the `lazy` mechanism work.

Because this probably is low, the memory impact of this `val` not being lazy is extremelly low, and the additional bytecode instructions needed for the `lazy` mechanism, I think we can just remove the `lazy` part

WDYT?