### PR TITLE
Read Scala Duration

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -116,10 +116,29 @@ object ConfigSpec extends ZIOBaseSpec {
       }
     )
 
+  def durationSuite =
+    suite("duration")(
+      test("reads a Java duration") {
+        val config         = Config.duration("duration")
+        val configProvider = ConfigProvider.fromMap(Map("duration" -> "PT1H"))
+        for {
+          duration <- configProvider.load(config)
+        } yield assertTrue(duration == 1.hour)
+      },
+      test("reads a Scala duration") {
+        val config         = Config.duration("duration")
+        val configProvider = ConfigProvider.fromMap(Map("duration" -> "1 hour"))
+        for {
+          duration <- configProvider.load(config)
+        } yield assertTrue(duration == 1.hour)
+      }
+    )
+
   def spec =
     suite("ConfigSpec")(
       secretSuite,
       withDefaultSuite,
-      optionalSuite
+      optionalSuite,
+      durationSuite
     )
 }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -209,8 +209,8 @@ object Config {
           case NonFatal(_) => Right(zio.Duration.fromScala(scala.concurrent.duration.Duration(text)))
         }
       } catch {
-      case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
-    }
+        case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
+      }
   }
   final case class Fail(message: String) extends Primitive[Nothing] {
     final def parse(text: String): Either[Config.Error, Nothing] = Left(Config.Error.Unsupported(Chunk.empty, message))

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -203,13 +203,15 @@ object Config {
   case object Duration extends Primitive[zio.Duration] {
     final def parse(text: String): Either[Config.Error, zio.Duration] =
       try {
-        try {
-          Right(java.time.Duration.parse(text))
-        } catch {
-          case NonFatal(_) => Right(zio.Duration.fromScala(scala.concurrent.duration.Duration(text)))
-        }
+        Right(java.time.Duration.parse(text))
       } catch {
-        case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
+        case _: java.time.format.DateTimeParseException =>
+          try {
+            Right(zio.Duration.fromScala(scala.concurrent.duration.Duration(text)))
+          } catch {
+            case _: NumberFormatException =>
+              Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
+          }
       }
   }
   final case class Fail(message: String) extends Primitive[Nothing] {

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -201,8 +201,14 @@ object Config {
     }
   }
   case object Duration extends Primitive[zio.Duration] {
-    final def parse(text: String): Either[Config.Error, zio.Duration] = try Right(java.time.Duration.parse(text))
-    catch {
+    final def parse(text: String): Either[Config.Error, zio.Duration] =
+      try {
+        try {
+          Right(java.time.Duration.parse(text))
+        } catch {
+          case NonFatal(_) => Right(zio.Duration.fromScala(scala.concurrent.duration.Duration(text)))
+        }
+      } catch {
       case NonFatal(e) => Left(Config.Error.InvalidData(Chunk.empty, s"Expected a duration value, but found ${text}"))
     }
   }


### PR DESCRIPTION
In `Config.duration` we currently parse a duration using the Java format. However, ZIO Config previously parsed it using the Scala format. This PR updates the implementation to try to parse it as both a Java and a Scala format. We could potentially have a separate operator for this but I think it is nice for the user to just be able to specify their intention to read a duration and not have to worry about which format a `ConfigProvider` is using.