### PR TITLE
Optimize PinchableArray#pinch

### DIFF
--- a/core/shared/src/main/scala/zio/internal/PinchableArray.scala
+++ b/core/shared/src/main/scala/zio/internal/PinchableArray.scala
@@ -77,7 +77,7 @@ private[zio] final class PinchableArray[A: ClassTag](hint: Int) extends Iterable
   def pinch(): Chunk[A] = {
     val size = self._size
 
-    if ((array eq null) || size == 0) Chunk.empty
+    if (size == 0) Chunk.empty
     else {
       ensurePinchCapacity(size)
 


### PR DESCRIPTION
If the size is not equal to zero then we know that the array must not be `null`.