### PR TITLE
Delete Flaky Test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -179,31 +179,6 @@ object MetricSpec extends ZIOBaseSpec {
           state <- h.value
         } yield assertTrue(state.count == 2L, state.sum == 4.0, state.min == 1.0, state.max == 3.0)
       },
-      test("observeDurations") {
-        val h =
-          Metric
-            .histogram("h3", Histogram.Boundaries.linear(0, 1.0, 10))
-            .tagged(labels1)
-            .contramap[Duration](_.toMillis.toDouble / 1000.0)
-
-        for {
-          // NOTE: observeDurations always uses real clock
-          start  <- ZIO.attempt(java.lang.System.nanoTime())
-          _      <- (Clock.sleep(1.second) @@ h.trackDuration)
-          _      <- (Clock.sleep(3.seconds) @@ h.trackDuration)
-          end    <- ZIO.attempt(java.lang.System.nanoTime())
-          elapsed = (end - start) / 1e9
-          state  <- h.value
-        } yield assertTrue(
-          state.count == 2L,
-          state.sum > 3.9,
-          state.sum <= elapsed,
-          state.min >= 1.0,
-          state.min < state.max,
-          state.max >= 3.0,
-          state.max < elapsed
-        )
-      } @@ withLiveClock @@ flaky,
       test("observeHistogram") {
         val h = Metric
           .histogram("h4", Histogram.Boundaries.linear(0, 1.0, 10))

--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -4,7 +4,6 @@ import zio.ZIOAspect._
 import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram
 import zio.test._
-import zio.test.TestAspect._
 
 import java.time.temporal.ChronoUnit
 


### PR DESCRIPTION
This test is flaky because it uses the live clock. In addition, `flaky` does not help here because the state of the metric is effected by prior tests causing retries to fail and leading to overall test instability. I think it is better to recognize that we made a conscious choice to use `java.lang.System.nanotime` for efficiency but that makes this method not very testable.