### PR TITLE
Un-inline Mirror in derive for layer

### DIFF
--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -53,7 +53,7 @@ trait ZLayerCompanionVersionSpecific {
    *
    */
    inline def derive[A](
-    using inline m: Mirror.ProductOf[A]
+    using m: Mirror.ProductOf[A]
   ): URLayer[LayerMacroUtils.Env[m.MirroredElemTypes], A] =
     LayerMacroUtils.genLayer[m.MirroredElemTypes, A]
 }


### PR DESCRIPTION
Inline parameters are not stable paths, so they cannot be used in path-dependent types. Up to Scala 3.3.0-RC2, there was a bug in the compiler, and the problem was not reported.

There is one inline parameter used in path-dependent type in the ZIO codebase. It needs to be un-inlined before it is compiled with 3.3.0.

I'm not aware of any potential problems with compatibility, but I still advise merging it into a first version compiled with 3.3.0. 