### PR TITLE
Handle empty list keeping backward compatibility

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -603,6 +603,114 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           expectedEmployees   = List((10, 0), (20, 1))
           expectedDepartments = List(expectedEmployees, expectedEmployees)
         } yield assertTrue(result == expectedDepartments)
+      } +
+    test("empty list") {
+      val configProvider =
+        ConfigProvider.fromMap(
+          Map(
+            "departments" -> "",
+          )
+        )
+
+      val config = Config.listOf("departments", Config.int)
+
+      for {
+        result             <- configProvider.load(config)
+      } yield assertTrue(result == Nil)
+    } +
+      test("empty list optional") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> "",
+            )
+          )
+
+        val config = Config.listOf("departments", Config.int.optional)
+
+        for {
+          result             <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
+      test("empty list with description") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> "",
+            )
+          )
+
+        val config = Config.listOf("departments", Config.int ?? "Integer")
+
+        for {
+          result             <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
+      test("empty list with product") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> "",
+            )
+          )
+
+        val member = Config.int("age").zip(Config.string("name"))
+
+        val config = Config.listOf("departments", member)
+
+        for {
+          result             <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
+      test("empty list with product optional") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> "",
+            )
+          )
+
+        val member = Config.int("age").zip(Config.string("name"))
+
+        val config = Config.listOf("departments", member.optional)
+
+        for {
+          result             <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
+      test("empty list with product with description") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> "",
+            )
+          )
+
+        val member = Config.int("age").zip(Config.string("name"))
+
+        val config = Config.listOf("departments", member ?? "Member")
+
+        for {
+          result             <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
+      //FIXME: Failing test
+      test("empty list within indexed list") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments[0].ids" -> "",
+              "departments[1].ids" -> "1",
+              "departments[2].ids" -> "1, 2",
+            )
+          )
+
+        val config = Config.listOf("departments", Config.listOf("ids", Config.int))
+
+        for {
+          result             <- configProvider.load(config)
+          _ = println(result)
+        } yield assertTrue(result == List(Nil, List(1), List(1, 2)))
       }
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -604,53 +604,53 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           expectedDepartments = List(expectedEmployees, expectedEmployees)
         } yield assertTrue(result == expectedDepartments)
       } +
-    test("empty list") {
-      val configProvider =
-        ConfigProvider.fromMap(
-          Map(
-            "departments" -> "",
+      test("empty list") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "departments" -> ""
+            )
           )
-        )
 
-      val config = Config.listOf("departments", Config.int)
+        val config = Config.listOf("departments", Config.int)
 
-      for {
-        result             <- configProvider.load(config)
-      } yield assertTrue(result == Nil)
-    } +
+        for {
+          result <- configProvider.load(config)
+        } yield assertTrue(result == Nil)
+      } +
       test("empty list optional") {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> "",
+              "departments" -> ""
             )
           )
 
         val config = Config.listOf("departments", Config.int.optional)
 
         for {
-          result             <- configProvider.load(config)
+          result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
       test("empty list with description") {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> "",
+              "departments" -> ""
             )
           )
 
         val config = Config.listOf("departments", Config.int ?? "Integer")
 
         for {
-          result             <- configProvider.load(config)
+          result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
       test("empty list with product") {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> "",
+              "departments" -> ""
             )
           )
 
@@ -659,14 +659,14 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val config = Config.listOf("departments", member)
 
         for {
-          result             <- configProvider.load(config)
+          result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
       test("empty list with product optional") {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> "",
+              "departments" -> ""
             )
           )
 
@@ -675,14 +675,14 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val config = Config.listOf("departments", member.optional)
 
         for {
-          result             <- configProvider.load(config)
+          result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
       test("empty list with product with description") {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> "",
+              "departments" -> ""
             )
           )
 
@@ -691,7 +691,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val config = Config.listOf("departments", member ?? "Member")
 
         for {
-          result             <- configProvider.load(config)
+          result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
       //FIXME: Failing test
@@ -701,15 +701,15 @@ object ConfigProviderSpec extends ZIOBaseSpec {
             Map(
               "departments[0].ids" -> "",
               "departments[1].ids" -> "1",
-              "departments[2].ids" -> "1, 2",
+              "departments[2].ids" -> "1, 2"
             )
           )
 
         val config = Config.listOf("departments", Config.listOf("ids", Config.int))
 
         for {
-          result             <- configProvider.load(config)
-          _ = println(result)
+          result <- configProvider.load(config)
+          _       = println(result)
         } yield assertTrue(result == List(Nil, List(1), List(1, 2)))
       }
   }

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -608,7 +608,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -622,7 +622,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -636,7 +636,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -650,7 +650,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -666,7 +666,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -682,7 +682,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments" -> ""
+              "departments" -> "<nil>"
             )
           )
 
@@ -699,7 +699,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider =
           ConfigProvider.fromMap(
             Map(
-              "departments[0].ids" -> "",
+              "departments[0].ids" -> "<nil>",
               "departments[1].ids" -> "1",
               "departments[2].ids" -> "1, 2"
             )

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -315,9 +315,9 @@ object ConfigProvider {
             .mapError(_.prefixed(path))
         else {
 
-            ZIO
-              .foreach(splitPathString(text, escapedDelim))(s => ZIO.fromEither(primitive.parse(s.trim)))
-              .mapError(_.prefixed(path))
+          ZIO
+            .foreach(splitPathString(text, escapedDelim))(s => ZIO.fromEither(primitive.parse(s.trim)))
+            .mapError(_.prefixed(path))
         }
       }
 


### PR DESCRIPTION
`<nil>` is another way (along with empty string) to encode empty list when the config is actually indexed. Usually only libraries like zio-config (or advanced users) would ever need to encode emptiness using as a String `<nil>`

Users who prefer to write flat-structure hardly end up doing this and can use "" as before. This implies, as test cases indicate, we keep all the existing behaviour of ConfigProvider as it is.

We can remove this pre-requisite in zio-3.x, where ConfigPath is the default behaviour