### PR TITLE
Use changeOwner in `suiteAll` dotty impl

### DIFF
--- a/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
@@ -46,7 +46,7 @@ object ZIOSpecVersionSpecificMacros {
           val name = "spec" + idx
           idx += 1
           val symbol = Symbol.newVal(Symbol.spliceOwner, name, spec.tpe, Flags.EmptyFlags, Symbol.noSymbol)
-          val valDef = ValDef(symbol, Some(spec))
+          val valDef = ValDef(symbol, Some(spec.changeOwner(symbol)))
           val ref = Ref(symbol)
           loop(rest, valDef :: acc, ref :: refs)
         case Nil =>
@@ -55,7 +55,7 @@ object ZIOSpecVersionSpecificMacros {
               val names = 
                 combinedTypes.asType match {
                   case '[specType] =>
-                    Varargs(refs.map{a => 
+                    Varargs(refs.map{ a => 
                       a.asExprOf[specType]
                     }).asExprOf[Seq[specType]]
                 }


### PR DESCRIPTION
Currently, dotty would emit an error if we used `-Xcheck-macros`. The docs in dotty's `Quotes.scala` for `ValDef` explain that you need to change the owner of the body of a `ValDef` to be its symbol. Not really sure what the downside is to not doing this, but it's probably best to obey the docs. 😄 