### PR TITLE
Set exit codes for scala-js + scala-native

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -55,6 +55,8 @@ private[zio] trait PlatformSpecific {
    * Exits the application with the specified exit code.
    */
   final def exit(code: Int)(implicit unsafe: zio.Unsafe): Unit = {
+    // This doesn't exit, but sets the code that will return upon shutdown
+    scala.scalajs.js.Dynamic.global.process.exitCode = code
     val _ = code
   }
 

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -45,7 +45,7 @@ private[zio] trait PlatformSpecific {
    * Exits the application with the specified exit code.
    */
   final def exit(code: Int)(implicit unsafe: zio.Unsafe): Unit =
-    blackhole(code)
+    java.lang.System.exit(code)
 
   /**
    * Returns the name of the thread group to which this thread belongs. This is


### PR DESCRIPTION
When targeting Scala.js and/or Scala Native, it would be nice to have the exit code of the process set correctly, as it is with the JVM.

I believe Scala native already supports using System.exit, java.lang.System is listed here: https://scala-native.org/en/stable/lib/javalib.html , and here is a corresponding test where it is used https://github.com/scala-native/scala-native/blob/main/scripted-tests/run/system-exit/src/main/scala/Exit.scala

For nodejs, and this api https://nodejs.org/api/process.html#processexitcode_1, we can gracefully set an exit code. From the docs:

> A number which will be the process exit code, when the process either exits gracefully, or is exited via process.exit without specifying a code.

I've built + run these changes locally to confirm, but I'd be happy to set up a corresponding test suite with some guidance of similar tests that might already be in place. 