### PR TITLE
Improve example for composing ZPipeline with ZSink

### DIFF
--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -232,13 +232,15 @@ val lines: ZStream[Any, Throwable, String] =
 
 ```scala mdoc:silent:nest
 val refine: ZIO[Any, Throwable, Long] = {
-  val stream = ZStream.fromFileName("file.txt")
-  val pipe = ZPipeline.utf8Decode >>> ZPipeline.splitLines >>> ZPipeline.filter[String(_.contains('₿'))
-  val sink = ZSink
+  val stream: ZStream[Any, Throwable, Byte] = ZStream.fromFileName("file.txt")
+  val pipeline: ZPipeline[Any, CharacterCodingException, Byte, String] =
+    ZPipeline.utf8Decode >>> ZPipeline.splitLines >>> ZPipeline.filter[String](_.contains('₿'))
+  val fileSink: ZSink[Any, Throwable, String, Byte, Long] = ZSink
     .fromFileName("file.refined.txt")
     .contramapChunks[String](
       _.flatMap(line => (line + System.lineSeparator()).getBytes())
     )
-  stream >>> pipe >>> sink
+  val pipeSink: ZSink[Any, Any, Byte, Long] = pipeline >>> fileSink
+  stream >>> pipeSink
 }
 ```

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -231,17 +231,14 @@ val lines: ZStream[Any, Throwable, String] =
 2. **Composing ZPipeline with ZSink** — One pipeline can be composed with a sink, resulting in a sink that processes elements by piping them through the pipeline and piping the results into the sink:
 
 ```scala mdoc:silent:nest
-val refine: ZIO[Any, Throwable, Long] =
-  ZStream
-    .fromFileName("file.txt")
-    .via(
-      ZPipeline.utf8Decode >>> ZPipeline.splitLines >>> ZPipeline.filter[String](_.contains('₿'))
+val refine: ZIO[Any, Throwable, Long] = {
+  val stream = ZStream.fromFileName("file.txt")
+  val pipe = ZPipeline.utf8Decode >>> ZPipeline.splitLines >>> ZPipeline.filter[String(_.contains('₿'))
+  val sink = ZSink
+    .fromFileName("file.refined.txt")
+    .contramapChunks[String](
+      _.flatMap(line => (line + System.lineSeparator()).getBytes())
     )
-    .run(
-      ZSink
-        .fromFileName("file.refined.txt")
-        .contramapChunks[String](
-          _.flatMap(line => (line + System.lineSeparator()).getBytes())
-        )
-    )
+  stream >>> pipe >>> sink
+}
 ```

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -231,6 +231,8 @@ val lines: ZStream[Any, Throwable, String] =
 2. **Composing ZPipeline with ZSink** — One pipeline can be composed with a sink, resulting in a sink that processes elements by piping them through the pipeline and piping the results into the sink:
 
 ```scala mdoc:silent:nest
+import java.nio.charset.CharacterCodingException
+
 val refine: ZIO[Any, Throwable, Long] = {
   val stream: ZStream[Any, Throwable, Byte] = ZStream.fromFileName("file.txt")
   val pipeline: ZPipeline[Any, CharacterCodingException, Byte, String] =
@@ -240,7 +242,7 @@ val refine: ZIO[Any, Throwable, Long] = {
     .contramapChunks[String](
       _.flatMap(line => (line + System.lineSeparator()).getBytes())
     )
-  val pipeSink: ZSink[Any, Any, Byte, Long] = pipeline >>> fileSink
+  val pipeSink: ZSink[Any, Throwable, Byte, Byte, Long] = pipeline >>> fileSink
   stream >>> pipeSink
 }
 ```


### PR DESCRIPTION
The previous example didn't actually show composing a pipeline and a sink resulting in a sink. It was instead a stream "via" a pipeline then run into a sink.