### PR TITLE
Update izumi-reflect to 2.3.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(stdSettings("zio"))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio"))
-  .settings(libraryDependencies += "dev.zio" %%% "izumi-reflect" % "2.2.5")
+  .settings(libraryDependencies += "dev.zio" %%% "izumi-reflect" % "2.3.0")
   .enablePlugins(BuildInfoPlugin)
   .settings(macroDefinitionSettings)
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,12 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(stdSettings("zio"))
   .settings(crossProjectSettings)
   .settings(buildInfoSettings("zio"))
-  .settings(libraryDependencies += "dev.zio" %%% "izumi-reflect" % "2.3.0")
+  .settings(
+    libraryDependencies ++= List(
+      "dev.zio"                %%% "izumi-reflect"           % "2.3.0",
+      "org.scala-lang.modules" %%% "scala-collection-compat" % "2.8.1"
+    )
+  )
   .enablePlugins(BuildInfoPlugin)
   .settings(macroDefinitionSettings)
   .settings(


### PR DESCRIPTION
* Scala 3 version now has feature parity with Scala 2 and is considered stable starting from this version.

https://github.com/zio/izumi-reflect/releases/tag/v2.3.0