### PR TITLE
Add ZIOAspect.identity

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -193,4 +193,12 @@ object ZIOAspect {
       def apply[R, E >: E1, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         zio.timeoutFail(e)(d)
     }
+
+  /**
+   * An aspect that does nothing.
+   */
+  val noop: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] = zio
+    }
 }

--- a/core/shared/src/main/scala/zio/ZIOAspect.scala
+++ b/core/shared/src/main/scala/zio/ZIOAspect.scala
@@ -195,9 +195,9 @@ object ZIOAspect {
     }
 
   /**
-   * An aspect that does nothing.
+   * An aspect that returns effects unchanged.
    */
-  val noop: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
+  val identity: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] =
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] = zio
     }


### PR DESCRIPTION
I calculate OpenTracing tags in library code, and sometimes it's more convenient to return a noop object from a condition rather than dealing with an Option/List. Empty/noop objects like this are often useful.