### PR TITLE
Default the unhandled error log level to Error

### DIFF
--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -529,7 +529,7 @@ object FiberRef {
     FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor)(Unsafe.unsafe)
 
   private[zio] val unhandledErrorLogLevel: FiberRef[Option[LogLevel]] =
-    FiberRef.unsafe.make[Option[LogLevel]](Some(LogLevel.Debug), identity(_), (_, child) => child)(Unsafe.unsafe)
+    FiberRef.unsafe.make[Option[LogLevel]](Some(LogLevel.Error), identity(_), (_, child) => child)(Unsafe.unsafe)
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]


### PR DESCRIPTION
I recently spent an unnecessary amount of time looking for incorrectly working functionality. That functionality was running on a forked, always-running effect. There was an exception raised, but it turned out, on a DEBUG level.

I think it's reasonable to default the unhandled errors to the ERROR log level and let others avoid looking for an error in the DEBUG logs.