### PR TITLE
Specialized `Cause::foldLeft` to `Boolean` as the usage of this method in `Cause::isEmpty` introduces boxing

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -251,7 +251,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
   /**
    * Folds over the cause to statefully compute a value.
    */
-  final def foldLeft[Z](z: Z)(f: PartialFunction[(Z, Cause[E]), Z]): Z = {
+  final def foldLeft[@specialized(Boolean) Z](z: Z)(f: PartialFunction[(Z, Cause[E]), Z]): Z = {
     @tailrec
     def loop(z: Z, cause: Cause[E], stack: List[Cause[E]]): Z =
       (f.applyOrElse[(Z, Cause[E]), Z](z -> cause, _ => z), cause) match {


### PR DESCRIPTION
I'm not an expert on this `@specialized` annotation. So I'm a 100% sure about this change

Seen in a profiling session on zio-kafka:
```scala
--- 20000000 ns (0.08%), 2 samples
  [ 0] scala.runtime.BoxesRunTime.boxToBoolean
  [ 1] zio.Cause.isEmpty
  [ 2] zio.internal.FiberRuntime.isInterrupted
  [ 3] zio.internal.FiberRuntime.runLoop
  [ 4] zio.internal.FiberRuntime.evaluateEffect
  [ 5] zio.internal.FiberRuntime.evaluateMessageWhileSuspended
  [ 6] zio.internal.FiberRuntime.drainQueueOnCurrentThread
  [ 7] zio.internal.FiberRuntime.run
  [ 8] zio.internal.ZScheduler$$anon$4.run
```