### PR TITLE
Optimize Histogram.Boundaries.exponential

### DIFF
--- a/benchmarks/src/main/scala/zio/metrics/MetricBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/metrics/MetricBenchmarks.scala
@@ -1,0 +1,30 @@
+package zio.metrics
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+import zio.ZIO
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(value = 3)
+class MetricBenchmarks {
+
+  @Benchmark
+  def exponentialStatic(): Unit = {
+    val metric = Metric.histogram("exponential", MetricKeyType.Histogram.Boundaries.exponential(1.0, 2.0, 64))
+    unsafeRun(ZIO.foreachDiscard(1 to 100000)(i => metric.update(i.toDouble)))
+  }
+
+  @Benchmark
+  def exponentialDynamic(): Unit =
+    unsafeRun {
+      ZIO.foreachDiscard(1 to 100000) { i =>
+        Metric.histogram("exponential", MetricKeyType.Histogram.Boundaries.exponential(1.0, 2.0, 64)).update(i.toDouble)
+      }
+    }
+}

--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -223,6 +223,16 @@ object MetricSpec extends ZIOBaseSpec {
           r1 <- base.tagged(MetricLabel("dyn", "x")).value
           r2 <- base.tagged(MetricLabel("dyn", "xyz")).value
         } yield assertTrue(r0.count == 0L, r1.count == 1L, r2.count == 1L)
+      },
+      test("linear boundaries") {
+        val expected = Chunk(0, 10, 20, 30, 40, 50, 60, 70, 80, 90).map(_.toDouble) :+ Double.MaxValue
+        val actual   = Histogram.Boundaries.linear(0, 10, 10).values
+        assertTrue(actual == expected)
+      },
+      test("exponential boundaries") {
+        val expected = Chunk(1, 2, 4, 8, 16, 32, 64, 128, 256, 512).map(_.toDouble) :+ Double.MaxValue
+        val actual   = Histogram.Boundaries.exponential(1, 2, 10).values
+        assertTrue(actual == expected)
       }
     ),
     suite("Summary")(

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -73,7 +73,7 @@ object MetricKeyType {
        * with exponentially increasing values
        */
       def exponential(start: Double, factor: Double, count: Int): Boundaries =
-        fromChunk(Chunk.fromArray(0.until(count).map(i => start * Math.pow(factor, i.toDouble)).toArray))
+        fromChunk(Chunk.iterate(start, count)(_ * factor))
     }
   }
 


### PR DESCRIPTION
Depending on the amount of required buckets, creation of `Boundaries` might be up to 2-3 times faster. `Metric.timer` will benefit a lot from it.

Here's a benchmark that I used (I doubt it's reasonable to use 1k buckets, it's here just for completeness).
```scala
import org.openjdk.jmh.annotations._
import zio.Chunk

import java.util.concurrent.TimeUnit

@State(Scope.Benchmark)
@BenchmarkMode(Array(Mode.AverageTime))
@OutputTimeUnit(TimeUnit.NANOSECONDS)
@Fork(1)
@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
@Threads(1)
class ZIOMetricBench {

  val start = 1.0

  val factor = 2

  @Param(Array("1", "10", "100", "1000"))
  var count: Int = _

  @Benchmark
  def Current: Unit = Chunk.fromArray(0.until(count).map(i => start * Math.pow(factor, i.toDouble)).toArray)

  @Benchmark
  def Iterate: Unit = Chunk.iterate(start, count)(_ * factor)

}
```

```
[info] Benchmark                (count)  Mode  Cnt      Score     Error  Units
[info] BoundariesBench.Current        1  avgt   10     53.327 ±   3.942  ns/op
[info] BoundariesBench.Current       10  avgt   10    291.636 ±   3.451  ns/op
[info] BoundariesBench.Current      100  avgt   10   3042.538 ±  76.611  ns/op
[info] BoundariesBench.Current     1000  avgt   10  35358.496 ± 510.720  ns/op
[info] BoundariesBench.Iterate        1  avgt   10     44.207 ±   0.927  ns/op
[info] BoundariesBench.Iterate       10  avgt   10    146.497 ±   8.731  ns/op
[info] BoundariesBench.Iterate      100  avgt   10    955.949 ±  20.623  ns/op
[info] BoundariesBench.Iterate     1000  avgt   10   7497.474 ± 143.413  ns/op
```