### PR TITLE
Reduce Number Of Buckets For Metric.timer

### DIFF
--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -533,7 +533,7 @@ object Metric {
     name: String,
     chronoUnit: ChronoUnit
   ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
-    val boundaries = Histogram.Boundaries.exponential(1.0, 2.0, 100)
+    val boundaries = Histogram.Boundaries.exponential(1.0, 2.0, 64)
     val base       = histogram(name, boundaries).tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
 
     base.contramap[Duration] { (duration: Duration) =>


### PR DESCRIPTION
64 buckets with a power of two is already sufficient to represent `Long.MaxValue` which is the largest value we could get by dividing a `Long` number of nanoseconds by a nanosecond time unit. Using a power of two will also be slightly more efficient.