### PR TITLE
Fix nesting for indexed ConfigProvider

### DIFF
--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -500,13 +500,17 @@ object ConfigProvider {
 
           case Sequence(config) =>
             for {
+              patchedPrefix <- ZIO.fromEither(flat.patch(prefix))
               indices <- flat
-                           .enumerateChildren(prefix)
+                           .enumerateChildren(patchedPrefix)
                            .flatMap(set => indicesFrom(set))
 
               values <-
                 if (indices.isEmpty) {
-                  returnEmptyListIfValueIsNil(prefix = prefix, continue = loop(_, config, split = true).map(Chunk(_)))
+                  returnEmptyListIfValueIsNil(
+                    prefix = patchedPrefix,
+                    continue = loop(_, config, split = true).map(Chunk(_))
+                  )
                 } else
                   ZIO
                     .foreach(Chunk.fromIterable(indices)) { index =>


### PR DESCRIPTION
This PR fixes `ConfigProvider#nest` and  `ConfigProvider#unnest` for indexed data. Currently this doesn't work at all:
```scala
val provider = ConfigProvider.fromMap(Map( "parent.child.employees[0].age" -> "1")).nested("child").nested("parent")
val product = Config.int("age").zip(Config.int("id"))
val config  = Config.listOf("employees", product)

configProvider.load(config) // Fails with exception
```