### PR TITLE
Add hexDecode and hexEncode to ZPipeline

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -1,10 +1,12 @@
 package zio.stream
 
 import zio._
+import zio.stream.encoding.EncodingException
 import zio.test.Assertion.{equalTo, fails}
 import zio.test._
-
 import scala.io.Source
+
+import java.nio.charset.StandardCharsets
 
 object ZPipelineSpec extends ZIOBaseSpec {
   def spec =
@@ -152,6 +154,68 @@ object ZPipelineSpec extends ZIOBaseSpec {
             .runCollect
             .exit
         )(fails(equalTo("failed!!!")))
+      ),
+      suite("hex")(
+        test("Empty input encodes to empty output") {
+          for {
+            result <- ZStream.empty.via(ZPipeline.hexEncode).run(ZSink.collectAll[Byte])
+          } yield assert(result)(equalTo(Chunk.empty[Byte]))
+        },
+        test("Hex for Byte 0 is 0x00") {
+          testHexEncode(0.toByte, "00")
+        },
+        test("Hex for Byte 1 is 0x01") {
+          testHexEncode(1.toByte, "01")
+        },
+        test("Hex for Byte 127 is 0x7f") {
+          testHexEncode(127.toByte, "7f")
+        },
+        test("Hex for Byte -128 is 0x80") {
+          testHexEncode(-128.toByte, "80")
+        },
+        test("Hex for Byte -1 is 0xff") {
+          testHexEncode(-1.toByte, "ff")
+        },
+        test("Byte for hex 0x00 is 0") {
+          testHexDecode("00", 0.toByte)
+        },
+        test("Byte for hex 0x01 is 1") {
+          testHexDecode("01", 1.toByte)
+        },
+        test("Byte for hex 0x7f is 127") {
+          testHexDecode("7f", 127.toByte)
+        },
+        test("Byte for hex 0x80 is -128") {
+          testHexDecode("80", -128.toByte)
+        },
+        test("Byte for hex 0xff is -1") {
+          testHexDecode("ff", -1.toByte)
+        },
+        test("Empty input decodes to empty output") {
+          for {
+            result <- ZStream.empty.via(ZPipeline.hexDecode).run(ZSink.collectAll[Byte])
+          } yield assert(result)(equalTo(Chunk.empty[Byte]))
+        },
+        test("Odd number of hex digits causes error on decode") {
+          for {
+            result <-
+              ZStream
+                .fromIterable("abc".getBytes(StandardCharsets.UTF_8))
+                .via(ZPipeline.hexDecode)
+                .run(ZSink.collectAll[Byte])
+                .exit
+          } yield assert(result)(fails(equalTo(EncodingException("Extra input at end after last fully encoded byte"))))
+        },
+        test("Non hex digit causes error on decode") {
+          for {
+            result <-
+              ZStream
+                .fromIterable("ag".getBytes(StandardCharsets.UTF_8))
+                .via(ZPipeline.hexDecode)
+                .run(ZSink.collectAll[Byte])
+                .exit
+          } yield assert(result)(fails(equalTo(EncodingException("Not a valid hex digit: 'g'"))))
+        }
       )
     )
 
@@ -166,4 +230,17 @@ object ZPipelineSpec extends ZIOBaseSpec {
       assertTrue(res == expected)
     }
   }
+
+  def testHexDecode(s: String, b: Byte): ZIO[Any, EncodingException, TestResult] =
+    ZStream
+      .fromIterable(s.getBytes(StandardCharsets.UTF_8))
+      .via(ZPipeline.hexDecode)
+      .run(ZSink.head)
+      .map(v => assertTrue(v.get == b))
+
+  def testHexEncode(b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
+    ZStream(b).via(ZPipeline.hexEncode).run(ZSink.collectAll).map { v =>
+      val t = new String(v.toArray)
+      assertTrue(t == s)
+    }
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -6,8 +6,6 @@ import zio.test.Assertion.{equalTo, fails}
 import zio.test._
 import scala.io.Source
 
-import java.nio.charset.StandardCharsets
-
 object ZPipelineSpec extends ZIOBaseSpec {
   def spec =
     suite("ZPipelineSpec")(
@@ -158,8 +156,8 @@ object ZPipelineSpec extends ZIOBaseSpec {
       suite("hex")(
         test("Empty input encodes to empty output") {
           for {
-            result <- ZStream.empty.via(ZPipeline.hexEncode).run(ZSink.collectAll[Byte])
-          } yield assert(result)(equalTo(Chunk.empty[Byte]))
+            result <- ZStream.empty.via(ZPipeline.hexEncode).run(ZSink.collectAll[Char])
+          } yield assert(result)(equalTo(Chunk.empty[Char]))
         },
         test("Hex for Byte 0 is 0x00") {
           testHexEncode(0.toByte, "00")
@@ -200,7 +198,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
           for {
             result <-
               ZStream
-                .fromIterable("abc".getBytes(StandardCharsets.UTF_8))
+                .fromIterable("abc")
                 .via(ZPipeline.hexDecode)
                 .run(ZSink.collectAll[Byte])
                 .exit
@@ -210,7 +208,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
           for {
             result <-
               ZStream
-                .fromIterable("ag".getBytes(StandardCharsets.UTF_8))
+                .fromIterable("ag")
                 .via(ZPipeline.hexDecode)
                 .run(ZSink.collectAll[Byte])
                 .exit
@@ -233,14 +231,14 @@ object ZPipelineSpec extends ZIOBaseSpec {
 
   def testHexDecode(s: String, b: Byte): ZIO[Any, EncodingException, TestResult] =
     ZStream
-      .fromIterable(s.getBytes(StandardCharsets.UTF_8))
+      .fromIterable(s)
       .via(ZPipeline.hexDecode)
       .run(ZSink.head)
       .map(v => assertTrue(v.get == b))
 
   def testHexEncode(b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
-    ZStream(b).via(ZPipeline.hexEncode).run(ZSink.collectAll).map { v =>
-      val t = new String(v.toArray)
+    ZStream(b).via(ZPipeline.hexEncode).run(ZSink.collectAll).map { cs =>
+      val t = new String(cs.toArray)
       assertTrue(t == s)
     }
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -156,23 +156,38 @@ object ZPipelineSpec extends ZIOBaseSpec {
       suite("hex")(
         test("Empty input encodes to empty output") {
           for {
-            result <- ZStream.empty.via(ZPipeline.hexEncode).run(ZSink.collectAll[Char])
+            result <- ZStream.empty.via(ZPipeline.hexEncode()).run(ZSink.collectAll[Char])
           } yield assert(result)(equalTo(Chunk.empty[Char]))
         },
         test("Hex for Byte 0 is 0x00") {
-          testHexEncode(0.toByte, "00")
+          testHexEncode(false, 0.toByte, "00")
+        },
+        test("Hex (upper case) for Byte 0 is 0x00") {
+          testHexEncode(true, 0.toByte, "00")
         },
         test("Hex for Byte 1 is 0x01") {
-          testHexEncode(1.toByte, "01")
+          testHexEncode(false, 1.toByte, "01")
+        },
+        test("Hex (upper case) for Byte 1 is 0x01") {
+          testHexEncode(true, 1.toByte, "01")
         },
         test("Hex for Byte 127 is 0x7f") {
-          testHexEncode(127.toByte, "7f")
+          testHexEncode(false, 127.toByte, "7f")
+        },
+        test("Hex (upper case) for Byte 127 is 0x7F") {
+          testHexEncode(true, 127.toByte, "7F")
         },
         test("Hex for Byte -128 is 0x80") {
-          testHexEncode(-128.toByte, "80")
+          testHexEncode(false, -128.toByte, "80")
+        },
+        test("Hex (upper case) for Byte -128 is 0x80") {
+          testHexEncode(true, -128.toByte, "80")
         },
         test("Hex for Byte -1 is 0xff") {
-          testHexEncode(-1.toByte, "ff")
+          testHexEncode(false, -1.toByte, "ff")
+        },
+        test("Hex for Byte -1 is 0xFF") {
+          testHexEncode(true, -1.toByte, "FF")
         },
         test("Byte for hex 0x00 is 0") {
           testHexDecode("00", 0.toByte)
@@ -236,8 +251,8 @@ object ZPipelineSpec extends ZIOBaseSpec {
       .run(ZSink.head)
       .map(v => assertTrue(v.get == b))
 
-  def testHexEncode(b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
-    ZStream(b).via(ZPipeline.hexEncode).run(ZSink.collectAll).map { cs =>
+  def testHexEncode(uc: Boolean, b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
+    ZStream(b).via(ZPipeline.hexEncode(uc)).run(ZSink.collectAll).map { cs =>
       val t = new String(cs.toArray)
       assertTrue(t == s)
     }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -156,38 +156,23 @@ object ZPipelineSpec extends ZIOBaseSpec {
       suite("hex")(
         test("Empty input encodes to empty output") {
           for {
-            result <- ZStream.empty.via(ZPipeline.hexEncode()).run(ZSink.collectAll[Char])
+            result <- ZStream.empty.via(ZPipeline.hexEncode).run(ZSink.collectAll[Char])
           } yield assert(result)(equalTo(Chunk.empty[Char]))
         },
         test("Hex for Byte 0 is 0x00") {
-          testHexEncode(false, 0.toByte, "00")
-        },
-        test("Hex (upper case) for Byte 0 is 0x00") {
-          testHexEncode(true, 0.toByte, "00")
+          testHexEncode(0.toByte, "00")
         },
         test("Hex for Byte 1 is 0x01") {
-          testHexEncode(false, 1.toByte, "01")
-        },
-        test("Hex (upper case) for Byte 1 is 0x01") {
-          testHexEncode(true, 1.toByte, "01")
+          testHexEncode(1.toByte, "01")
         },
         test("Hex for Byte 127 is 0x7f") {
-          testHexEncode(false, 127.toByte, "7f")
-        },
-        test("Hex (upper case) for Byte 127 is 0x7F") {
-          testHexEncode(true, 127.toByte, "7F")
+          testHexEncode(127.toByte, "7f")
         },
         test("Hex for Byte -128 is 0x80") {
-          testHexEncode(false, -128.toByte, "80")
-        },
-        test("Hex (upper case) for Byte -128 is 0x80") {
-          testHexEncode(true, -128.toByte, "80")
+          testHexEncode(-128.toByte, "80")
         },
         test("Hex for Byte -1 is 0xff") {
-          testHexEncode(false, -1.toByte, "ff")
-        },
-        test("Hex for Byte -1 is 0xFF") {
-          testHexEncode(true, -1.toByte, "FF")
+          testHexEncode(-1.toByte, "ff")
         },
         test("Byte for hex 0x00 is 0") {
           testHexDecode("00", 0.toByte)
@@ -251,8 +236,8 @@ object ZPipelineSpec extends ZIOBaseSpec {
       .run(ZSink.head)
       .map(v => assertTrue(v.get == b))
 
-  def testHexEncode(uc: Boolean, b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
-    ZStream(b).via(ZPipeline.hexEncode(uc)).run(ZSink.collectAll).map { cs =>
+  def testHexEncode(b: Byte, s: String): ZIO[Any, Nothing, TestResult] =
+    ZStream(b).via(ZPipeline.hexEncode).run(ZSink.collectAll).map { cs =>
       val t = new String(cs.toArray)
       assertTrue(t == s)
     }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1489,41 +1489,43 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     )
 
   /**
-   * Decode each pair of hex digit input bytes (both lower or upper case letters
-   * are allowed) as one output byte.
+   * Decode each pair of hex digit input characters (both lower or upper case
+   * letters are allowed) as one output byte.
    */
-  def hexDecode(implicit trace: Trace): ZPipeline[Any, EncodingException, Byte, Byte] = {
-    def digitValue(b: Byte): Int = b match {
+  def hexDecode(implicit trace: Trace): ZPipeline[Any, EncodingException, Char, Byte] = {
+    def digitValue(c: Char): Int = c match {
       case d if d >= '0' && d <= '9' => d - '0'
       case l if l >= 'a' && l <= 'f' => 10 + l - 'a'
       case u if u >= 'A' && u <= 'F' => 10 + u - 'A'
       case _                         => -1
     }
     def decodeChannel(
-      spare: Chunk[Byte]
-    ): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] = {
-      def in(in: Chunk[Byte]): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] = {
+      spare: Chunk[Char]
+    ): ZChannel[Any, Any, Chunk[Char], Any, EncodingException, Chunk[Byte], Unit] = {
+      def in(in: Chunk[Char]): ZChannel[Any, Any, Chunk[Char], Any, EncodingException, Chunk[Byte], Unit] = {
         val toProcess = spare ++ in
         if (toProcess.isEmpty) {
           ZChannel.unit
         } else {
           val l = toProcess.size
-          val (bs, newSpare) = if (l % 2 == 0) {
-            (toProcess, Chunk.empty[Byte])
+          val (cs, newSpare) = if (l % 2 == 0) {
+            (toProcess, Chunk.empty[Char])
           } else {
             toProcess.splitAt(l - 1)
           }
           val temp: ChunkBuilder[Byte] = ChunkBuilder.make[Byte](l / 2)
-          var bad: Option[Byte]        = None
-          for (i <- 0 until bs.size by 2) {
+          var bad: Option[Char]        = None
+          for (i <- 0 until cs.size by 2) {
             if (bad.isEmpty) {
-              val h = digitValue(bs(i))
+              val ch = cs(i)
+              val h  = digitValue(ch)
               if (h < 0) {
-                bad = Some(bs(i))
+                bad = Some(ch)
               } else {
-                val l = digitValue(bs(i + 1))
+                val cl = cs(i + 1)
+                val l  = digitValue(cl)
                 if (l < 0) {
-                  bad = Some(bs(i + 1))
+                  bad = Some(cl)
                 } else {
                   val v = (h << 4) | l
                   val b = v.toByte
@@ -1534,60 +1536,45 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           }
           bad match {
             case None    => ZChannel.write(temp.result()) *> decodeChannel(newSpare)
-            case Some(e) => ZChannel.fail(EncodingException(s"Not a valid hex digit: '${e.toChar}'"))
+            case Some(e) => ZChannel.fail(EncodingException(s"Not a valid hex digit: '$e'"))
           }
         }
       }
-      def err(z: Any): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] =
+      def err(z: Any): ZChannel[Any, Any, Chunk[Char], Any, EncodingException, Chunk[Byte], Unit] =
         ZChannel.fail(EncodingException("Input stream should be infallible"))
 
-      def done(u: Any): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] =
+      def done(u: Any): ZChannel[Any, Any, Chunk[Char], Any, EncodingException, Chunk[Byte], Unit] =
         if (spare.isEmpty) {
           ZChannel.succeed(())
         } else {
           ZChannel.fail(EncodingException("Extra input at end after last fully encoded byte"))
         }
 
-      ZChannel.readWith[Any, Any, zio.Chunk[Byte], Any, EncodingException, zio.Chunk[Byte], Unit](
+      ZChannel.readWith[Any, Any, zio.Chunk[Char], Any, EncodingException, zio.Chunk[Byte], Unit](
         in,
         err,
         done
       )
     }
 
-    ZPipeline.fromChannel(decodeChannel(Chunk.empty[Byte]))
+    ZPipeline.fromChannel(decodeChannel(Chunk.empty[Char]))
   }
 
   /**
    * Encode each input byte as two output bytes as the hex representation of the
    * input byte.
    */
-  def hexEncode(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] = {
-    val DIGITS: Array[Byte] = Array(
-      '0'.toByte,
-      '1'.toByte,
-      '2'.toByte,
-      '3'.toByte,
-      '4'.toByte,
-      '5'.toByte,
-      '6'.toByte,
-      '7'.toByte,
-      '8'.toByte,
-      '9'.toByte,
-      'a'.toByte,
-      'b'.toByte,
-      'c'.toByte,
-      'd'.toByte,
-      'e'.toByte,
-      'f'.toByte
+  def hexEncode(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Char] = {
+    val DIGITS: Array[Char] = Array(
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
     )
-    ZPipeline.fromPush[Any, Nothing, Byte, Byte](
+    ZPipeline.fromPush[Any, Nothing, Byte, Char](
       ZIO.succeed((inChunkOpt: Option[Chunk[Byte]]) =>
         inChunkOpt match {
-          case None => ZIO.succeed(Chunk.empty[Byte])
+          case None => ZIO.succeed(Chunk.empty[Char])
           case Some(bs) =>
             ZIO.succeed {
-              val out = ChunkBuilder.make[Byte](bs.size * 2)
+              val out = ChunkBuilder.make[Char](bs.size * 2)
               for (b <- bs) {
                 out += DIGITS((b >>> 4) & 0x0f)
                 out += DIGITS((b >>> 0) & 0x0f)

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1564,12 +1564,9 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    * Encode each input byte as two output bytes as the hex representation of the
    * input byte.
    */
-  def hexEncode(upperCase: Boolean = false)(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Char] = {
-    val DIGITS_LC: Array[Char] = Array(
+  def hexEncode(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Char] = {
+    val DIGITS: Array[Char] = Array(
       '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
-    )
-    val DIGITS_UC: Array[Char] = Array(
-      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
     )
     ZPipeline.fromPush[Any, Nothing, Byte, Char](
       ZIO.succeed((inChunkOpt: Option[Chunk[Byte]]) =>
@@ -1577,11 +1574,10 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           case None => ZIO.succeed(Chunk.empty[Char])
           case Some(bs) =>
             ZIO.succeed {
-              val digits = if (upperCase) DIGITS_UC else DIGITS_LC
-              val out    = ChunkBuilder.make[Char](bs.size * 2)
+              val out = ChunkBuilder.make[Char](bs.size * 2)
               for (b <- bs) {
-                out += digits((b >>> 4) & 0x0f)
-                out += digits((b >>> 0) & 0x0f)
+                out += DIGITS((b >>> 4) & 0x0f)
+                out += DIGITS((b >>> 0) & 0x0f)
               }
               out.result()
             }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1564,9 +1564,12 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    * Encode each input byte as two output bytes as the hex representation of the
    * input byte.
    */
-  def hexEncode(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Char] = {
-    val DIGITS: Array[Char] = Array(
+  def hexEncode(upperCase: Boolean = false)(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Char] = {
+    val DIGITS_LC: Array[Char] = Array(
       '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+    )
+    val DIGITS_UC: Array[Char] = Array(
+      '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
     )
     ZPipeline.fromPush[Any, Nothing, Byte, Char](
       ZIO.succeed((inChunkOpt: Option[Chunk[Byte]]) =>
@@ -1574,10 +1577,11 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           case None => ZIO.succeed(Chunk.empty[Char])
           case Some(bs) =>
             ZIO.succeed {
-              val out = ChunkBuilder.make[Char](bs.size * 2)
+              val digits = if (upperCase) DIGITS_UC else DIGITS_LC
+              val out    = ChunkBuilder.make[Char](bs.size * 2)
               for (b <- bs) {
-                out += DIGITS((b >>> 4) & 0x0f)
-                out += DIGITS((b >>> 0) & 0x0f)
+                out += digits((b >>> 4) & 0x0f)
+                out += digits((b >>> 0) & 0x0f)
               }
               out.result()
             }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -19,6 +19,7 @@ package zio.stream
 import zio._
 import zio.internal.SingleThreadedRingBuffer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.stream.encoding.EncodingException
 import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import zio.stream.internal.SingleProducerAsyncInput
 
@@ -1486,6 +1487,117 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         upstream pipeToOrFail transducer
       }
     )
+
+  /**
+   * Decode each pair of hex digit input bytes (both lower or upper case letters
+   * are allowed) as one output byte.
+   */
+  def hexDecode(implicit trace: Trace): ZPipeline[Any, EncodingException, Byte, Byte] = {
+    def digitValue(b: Byte): Int = b match {
+      case d if d >= '0' && d <= '9' => d - '0'
+      case l if l >= 'a' && l <= 'f' => 10 + l - 'a'
+      case u if u >= 'A' && u <= 'F' => 10 + u - 'A'
+      case _                         => -1
+    }
+    def decodeChannel(
+      spare: Chunk[Byte]
+    ): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] = {
+      def in(in: Chunk[Byte]): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] = {
+        val toProcess = spare ++ in
+        if (toProcess.isEmpty) {
+          ZChannel.unit
+        } else {
+          val l = toProcess.size
+          val (bs, newSpare) = if (l % 2 == 0) {
+            (toProcess, Chunk.empty[Byte])
+          } else {
+            toProcess.splitAt(l - 1)
+          }
+          val temp: ChunkBuilder[Byte] = ChunkBuilder.make[Byte](l / 2)
+          var bad: Option[Byte]        = None
+          for (i <- 0 until bs.size by 2) {
+            if (bad.isEmpty) {
+              val h = digitValue(bs(i))
+              if (h < 0) {
+                bad = Some(bs(i))
+              } else {
+                val l = digitValue(bs(i + 1))
+                if (l < 0) {
+                  bad = Some(bs(i + 1))
+                } else {
+                  val v = (h << 4) | l
+                  val b = v.toByte
+                  temp += b
+                }
+              }
+            }
+          }
+          bad match {
+            case None    => ZChannel.write(temp.result()) *> decodeChannel(newSpare)
+            case Some(e) => ZChannel.fail(EncodingException(s"Not a valid hex digit: '${e.toChar}'"))
+          }
+        }
+      }
+      def err(z: Any): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] =
+        ZChannel.fail(EncodingException("Input stream should be infallible"))
+
+      def done(u: Any): ZChannel[Any, Any, Chunk[Byte], Any, EncodingException, Chunk[Byte], Unit] =
+        if (spare.isEmpty) {
+          ZChannel.succeed(())
+        } else {
+          ZChannel.fail(EncodingException("Extra input at end after last fully encoded byte"))
+        }
+
+      ZChannel.readWith[Any, Any, zio.Chunk[Byte], Any, EncodingException, zio.Chunk[Byte], Unit](
+        in,
+        err,
+        done
+      )
+    }
+
+    ZPipeline.fromChannel(decodeChannel(Chunk.empty[Byte]))
+  }
+
+  /**
+   * Encode each input byte as two output bytes as the hex representation of the
+   * input byte.
+   */
+  def hexEncode(implicit trace: Trace): ZPipeline[Any, Nothing, Byte, Byte] = {
+    val DIGITS: Array[Byte] = Array(
+      '0'.toByte,
+      '1'.toByte,
+      '2'.toByte,
+      '3'.toByte,
+      '4'.toByte,
+      '5'.toByte,
+      '6'.toByte,
+      '7'.toByte,
+      '8'.toByte,
+      '9'.toByte,
+      'a'.toByte,
+      'b'.toByte,
+      'c'.toByte,
+      'd'.toByte,
+      'e'.toByte,
+      'f'.toByte
+    )
+    ZPipeline.fromPush[Any, Nothing, Byte, Byte](
+      ZIO.succeed((inChunkOpt: Option[Chunk[Byte]]) =>
+        inChunkOpt match {
+          case None => ZIO.succeed(Chunk.empty[Byte])
+          case Some(bs) =>
+            ZIO.succeed {
+              val out = ChunkBuilder.make[Byte](bs.size * 2)
+              for (b <- bs) {
+                out += DIGITS((b >>> 4) & 0x0f)
+                out += DIGITS((b >>> 0) & 0x0f)
+              }
+              out.result()
+            }
+        }
+      )
+    )
+  }
 
   /**
    * The identity pipeline, which does not modify streams in any way.

--- a/streams/shared/src/main/scala/zio/stream/encoding/EncodingException.scala
+++ b/streams/shared/src/main/scala/zio/stream/encoding/EncodingException.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020-2023 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.stream.encoding
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+/** Signals that exception occurred in encoding/decoding */
+case class EncodingException private (message: String, cause: Exception) extends Exception(message, cause)
+
+object EncodingException {
+  def apply(message: String, cause: Option[Exception] = None) = new EncodingException(message, cause.getOrElse(null))
+
+  def apply(cause: Exception) = new EncodingException(cause.getMessage(), cause)
+}


### PR DESCRIPTION
Convenient pipelines for encoding bytes to hex and decoding hex to bytes.