### PR TITLE
Show summary when running tests using sbt in Scala 3

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -60,7 +60,7 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
         colored(renderedSummary)
       else if (ignore > 0)
         s"${Console.YELLOW}All eligible tests are currently ignored ${Console.RESET}"
-      else if (total == 0)
+      else
         s"${Console.YELLOW}No tests were executed${Console.RESET}"
 
     // We eagerly print out the info here, rather than returning it


### PR DESCRIPTION
When running tests using sbt in Scala 3, the rendered summary value that is supposed to be printed is actually `()`, as the actual value is discarded due to a missing `else` statement in an if expression. This pull requests aims to solve that by replacing the last `else if` in the expression with `else`.