### PR TITLE
Fixed #8051

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -140,6 +140,11 @@ object GenSpec extends ZIOBaseSpec {
       test("offsetDateTime generates OffsetDateTime values") {
         checkSample(Gen.offsetDateTime)(isNonEmpty)
       },
+      test("offsetDateTime generates OffsetDateTime values, when limited to one day range when changing from summer to winter time") {
+        val from = OffsetDateTime.parse("2025-10-29T00:00:00+02:00")
+        val to = OffsetDateTime.parse("2025-10-29T23:59:59.99999999+01:00")
+        checkSample(Gen.offsetDateTime(from, to))(isNonEmpty)
+      },
       test("offsetTime generates java.time.OffsetTime values") {
         checkSample(Gen.offsetTime)(isNonEmpty)
       },

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -140,9 +140,11 @@ object GenSpec extends ZIOBaseSpec {
       test("offsetDateTime generates OffsetDateTime values") {
         checkSample(Gen.offsetDateTime)(isNonEmpty)
       },
-      test("offsetDateTime generates OffsetDateTime values, when limited to one day range when changing from summer to winter time") {
+      test(
+        "offsetDateTime generates OffsetDateTime values, when limited to one day range when changing from summer to winter time"
+      ) {
         val from = OffsetDateTime.parse("2025-10-29T00:00:00+02:00")
-        val to = OffsetDateTime.parse("2025-10-29T23:59:59.99999999+01:00")
+        val to   = OffsetDateTime.parse("2025-10-29T23:59:59.99999999+01:00")
         checkSample(Gen.offsetDateTime(from, to))(isNonEmpty)
       },
       test("offsetTime generates java.time.OffsetTime values") {

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -20,7 +20,7 @@ import com.github.ghik.silencer.silent
 import zio.{Duration, Trace}
 
 import java.time._
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 trait TimeVariants {
 

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -17,11 +17,10 @@
 package zio.test
 
 import com.github.ghik.silencer.silent
-import zio.{Duration, Random, Trace}
-import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.{Duration, Trace}
 
 import java.time._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait TimeVariants {
 
@@ -179,9 +178,19 @@ trait TimeVariants {
       val minLocalDate     = min.atZoneSimilarLocal(utc).toLocalDate
       val maxLocalDate     = max.atZoneSimilarLocal(utc).toLocalDate
       val actualLocalDate  = actual.toLocalDate
-      val minOffsetSeconds = if (minLocalDate == actualLocalDate) min.getOffset.getTotalSeconds else -18 * 3600
-      val maxOffsetSeconds = if (maxLocalDate == actualLocalDate) max.getOffset.getTotalSeconds else 18 * 3600
-      Gen.int(minOffsetSeconds, maxOffsetSeconds).map(ZoneOffset.ofTotalSeconds)
+      val zoneOffsetMin    = -18 * 3600
+      val zoneOffsetMax    = 18 * 3600
+      val minOffsetSeconds = if (minLocalDate == actualLocalDate) min.getOffset.getTotalSeconds else zoneOffsetMin
+      val maxOffsetSeconds = if (maxLocalDate == actualLocalDate) max.getOffset.getTotalSeconds else zoneOffsetMax
+      if (minOffsetSeconds > maxOffsetSeconds) {
+        val secondsAfterMin  = (min.toInstant.toEpochMilli - actual.toInstant(utc).toEpochMilli) / 1000
+        val secondsBeforeMax = (max.toInstant.toEpochMilli - actual.toInstant(utc).toEpochMilli) / 1000
+        Gen
+          .int(Math.max(secondsAfterMin.toInt, zoneOffsetMin), Math.min(secondsBeforeMax.toInt, zoneOffsetMax))
+          .map(ZoneOffset.ofTotalSeconds)
+      } else {
+        Gen.int(minOffsetSeconds, maxOffsetSeconds).map(ZoneOffset.ofTotalSeconds)
+      }
     }
 
     for {


### PR DESCRIPTION
Handle special case where the offset of min is bigger then the offset of max in Gen.offsetDateTime(min, max)