### PR TITLE
Make SealedTrait Gen runCollect run exhaustingly

### DIFF
--- a/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
+++ b/test-magnolia-tests/shared/src/test/scala/zio/test/magnolia/DeriveGenSpec.scala
@@ -55,6 +55,9 @@ object DeriveGenSpec extends ZIOBaseSpec {
       test("sealed traits can be derived") {
         checkSample(genColor)(equalTo(3), _.distinct.length)
       },
+      test("runCollect on sealed traits resulting all") {
+        assertZIO(genColor.runCollect)(isDistinct && hasSize(equalTo(3)))
+      },
       test("recursive types can be derived") {
         check(genNonEmptyList[Int])(as => assert(as.length)(isGreaterThan(0)))
       }

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -243,7 +243,7 @@ object DeriveGen {
     instance(Gen.suspend(Gen.collectAll(caseClass.parameters.map(_.typeclass.derive)).map(caseClass.rawConstruct)))
 
   def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
-    instance(Gen.suspend(Gen.collectAll(sealedTrait.subtypes.map(_.typeclass.derive)).flatMap(Gen.fromIterable(_))))
+    instance(Gen.suspend(Gen.concatAll(sealedTrait.subtypes.map(_.typeclass.derive))))
 
   implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
 }

--- a/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-2.12-2.13/zio/test/magnolia/DeriveGen.scala
@@ -243,7 +243,7 @@ object DeriveGen {
     instance(Gen.suspend(Gen.collectAll(caseClass.parameters.map(_.typeclass.derive)).map(caseClass.rawConstruct)))
 
   def split[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
-    instance(Gen.suspend(Gen.oneOf(sealedTrait.subtypes.map(_.typeclass.derive): _*)))
+    instance(Gen.suspend(Gen.collectAll(sealedTrait.subtypes.map(_.typeclass.derive)).flatMap(Gen.fromIterable(_))))
 
   implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
 }

--- a/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
@@ -100,7 +100,7 @@ object DeriveGen {
         gen[T]
 
     def genSum[T](s: Mirror.SumOf[T], instances: => List[DeriveGen[_]]): Gen[Any, T] =
-        Gen.suspend(Gen.oneOf(instances.map(_.asInstanceOf[DeriveGen[T]].derive) : _*))
+        Gen.suspend(Gen.collectAll(instances.map(_.derive)).flatMap(Gen.fromIterable(_)))
 
     def genProduct[T](p: Mirror.ProductOf[T], instances: => List[DeriveGen[_]]): Gen[Any, T] =
         Gen.suspend(

--- a/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
+++ b/test-magnolia/shared/src/main/scala-3/zio/test/magnolia/DeriveGen.scala
@@ -100,7 +100,7 @@ object DeriveGen {
         gen[T]
 
     def genSum[T](s: Mirror.SumOf[T], instances: => List[DeriveGen[_]]): Gen[Any, T] =
-        Gen.suspend(Gen.collectAll(instances.map(_.derive)).flatMap(Gen.fromIterable(_)))
+        Gen.suspend(Gen.concatAll(instances.map(_.derive)))
 
     def genProduct[T](p: Mirror.ProductOf[T], instances: => List[DeriveGen[_]]): Gen[Any, T] =
         Gen.suspend(

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -398,7 +398,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   def either[R, A, B](left: Gen[R, A], right: Gen[R, B])(implicit
     trace: Trace
   ): Gen[R, Either[A, B]] =
-    oneOf(left.map(Left(_)), right.map(Right(_)))
+    left.map(Left(_)) ++ right.map(Right(_))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
     if (as.isEmpty) empty else int(0, as.length - 1).map(as)
@@ -635,7 +635,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of optional values. Shrinks toward `None`.
    */
   def option[R, A](gen: Gen[R, A])(implicit trace: Trace): Gen[R, Option[A]] =
-    oneOf(none, gen.map(Some(_)))
+    none ++ gen.map(Some(_))
 
   def oneOf[R, A](as: Gen[R, A]*)(implicit trace: Trace): Gen[R, A] =
     if (as.isEmpty) empty else int(0, as.length - 1).flatMap(as)


### PR DESCRIPTION
When I working with SealedTrait generators in test I want to test all scenarios exhaustingly

```
sealed trait A
final case object B extends A
final case object C extends A
final case object D extends A

private val gen: Gen[Any, A] = DeriveGen[A]
```
Currently this gen runCollect function only return the a List with 1 element, but it should return a List(B, C, D), which I need to make sure I tested all possible scenarios.
