### PR TITLE
Do Not Allow Interruption To Be Observed In Uninterruptible Region In ZIO#timeout

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2386,6 +2386,16 @@ object ZIOSpec extends ZIOBaseSpec {
           _     <- end.await
         } yield assertCompletes
       },
+      test("timeout does not allow interruption to be observed in uninterruptible region") {
+        ZIO.uninterruptible {
+          for {
+            promise <- Promise.make[Nothing, Unit]
+            fiber   <- (promise.succeed(()) *> ZIO.sleep(2.second).timeout(1.seconds)).fork
+            _       <- promise.await
+            exit    <- fiber.interrupt
+          } yield assert(exit)(not(isInterrupted))
+        }
+      } @@ TestAspect.withLiveClock,
       test("catchAllCause") {
         val io =
           for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5214,7 +5214,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       trace: Trace
     ): ZIO[R, E, B1] =
       ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith(ZIO.sleep(duration).interruptible)(
+        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
           (winner, loser) =>
             winner.await.flatMap {
               case Exit.Success(a) =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1398,7 +1398,9 @@ sealed trait ZIO[-R, +E, +A]
    */
   private final def raceFibersWith[R1 <: R, ER, E2, B, C](right: ZIO[R1, ER, B])(
     leftWins: (Fiber.Runtime[E, A], Fiber.Runtime[ER, B]) => ZIO[R1, E2, C],
-    rightWins: (Fiber.Runtime[ER, B], Fiber.Runtime[E, A]) => ZIO[R1, E2, C]
+    rightWins: (Fiber.Runtime[ER, B], Fiber.Runtime[E, A]) => ZIO[R1, E2, C],
+    leftScope: FiberScope = null,
+    rightScope: FiberScope = null
   )(implicit trace: Trace): ZIO[R1, E2, C] =
     ZIO.withFiberRuntime[R1, E2, C] { (parentFiber, parentStatus) =>
       import java.util.concurrent.atomic.AtomicBoolean
@@ -1418,8 +1420,9 @@ sealed trait ZIO[-R, +E, +A]
 
       val raceIndicator = new AtomicBoolean(true)
 
-      val leftFiber  = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, null)(Unsafe.unsafe)
-      val rightFiber = ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, null)(Unsafe.unsafe)
+      val leftFiber = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)(Unsafe.unsafe)
+      val rightFiber =
+        ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)(Unsafe.unsafe)
 
       val startLeftFiber  = leftFiber.startSuspended()(Unsafe.unsafe)
       val startRightFiber = rightFiber.startSuspended()(Unsafe.unsafe)
@@ -5210,7 +5213,26 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      (self map f) raceFirstAwait (ZIO.sleep(duration).interruptible as b())
+      ZIO.fiberIdWith { parentFiberId =>
+        self.raceFibersWith(ZIO.sleep(duration).interruptible)(
+          (winner, loser) =>
+            winner.await.flatMap {
+              case Exit.Success(a) =>
+                winner.inheritAll *> loser.interruptAs(parentFiberId).as(f(a))
+              case Exit.Failure(cause) =>
+                loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
+            },
+          (winner, loser) =>
+            winner.await.flatMap {
+              case Exit.Success(_) =>
+                winner.inheritAll *> loser.interruptAs(parentFiberId).as(b())
+              case Exit.Failure(cause) =>
+                loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
+            },
+          null,
+          FiberScope.global
+        )
+      }
   }
 
   final class Acquire[-R, +E, +A](private val acquire: () => ZIO[R, E, A]) extends AnyVal {


### PR DESCRIPTION
This test raises the issue of how `timeout` should behave in an uninterruptible region. The current behavior is if the program is externally interrupted the timeout fiber will be interrupted because interruption is propagated from parent to child and the timeout fiber is interruptible. This means the timeout fiber "wins" the race by terminating first and causes the timeout to fail with an interrupted cause, which seems clearly incorrect.

I think the correct behavior is that the timeout should get the full time to execute and essentially should behave as if no external interruption had occurred since it is in an uninterruptible region. To achieve this we fork the timeout fiber in the global scope instead of the parent scope so the only way it will be interrupted is if the workflow being timed out terminates and interrupts it.

```scala
test("timeout does not allow interruption to be observed in uninterruptible region") {
  ZIO.uninterruptible {
    for {
      promise <- Promise.make[Nothing, Unit]
      fiber   <- (promise.succeed(()) *> ZIO.sleep(2.second).timeout(1.seconds)).fork
      _       <- promise.await
      exit    <- fiber.interrupt
    } yield assert(exit)(not(isInterrupted))
  }
} @@ TestAspect.withLiveClock
```