### PR TITLE
Separate Interrupting Root Fibers From ZIOApp Exit

### DIFF
--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -69,15 +69,12 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific { self =>
    * A helper function to exit the application with the specified exit code.
    */
   final def exit(code: ExitCode)(implicit trace: Trace): UIO[Unit] =
-    for {
-      fiberId <- ZIO.fiberId
-      roots   <- Fiber.roots
-      _       <- Fiber.interruptAll(roots.filterNot(_.id == fiberId))
-    } yield
+    ZIO.succeed {
       if (!shuttingDown.getAndSet(true)) {
         try Platform.exit(code.code)(Unsafe.unsafe)
         catch { case _: SecurityException => }
       }
+    }
 
   /**
    * Invokes the main app. Designed primarily for testing.


### PR DESCRIPTION
Interrupting root fibers is intended to be done from the main fiber in `ZIOApp` immediately before shutting down but `exit` can technically be called by the user at any time even though this is not recommended so separate out this logic.