### PR TITLE
Remove duplicate test execution furniture

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -27,10 +27,7 @@ import java.util.concurrent.TimeUnit
  * require an environment `R` and may fail with an error `E`. Test runners
  * require a test executor, a runtime configuration, and a reporter.
  */
-final case class TestRunner[R, E](
-  executor: TestExecutor[R, E],
-  bootstrap: ULayer[ExecutionEventSink] = TestRunner.defaultBootstrap
-) { self =>
+final case class TestRunner[R, E](executor: TestExecutor[R, E]) { self =>
 
   val runtime: Runtime[Any] = Runtime.default
 
@@ -61,7 +58,7 @@ final case class TestRunner[R, E](
        */
       def run(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Unit =
         runtime.unsafe
-          .run(self.run("Test Task name unavailable in this context.", spec).provideLayer(bootstrap))
+          .run(self.run("Test Task name unavailable in this context.", spec))
           .getOrThrowFiberFailure()
 
       /**
@@ -69,7 +66,7 @@ final case class TestRunner[R, E](
        */
       def runAsync(spec: Spec[R, E])(k: => Unit)(implicit trace: Trace, unsafe: Unsafe): Unit = {
         val fiber =
-          runtime.unsafe.fork(self.run("Test Task name unavailable in this context.", spec).provideLayer(bootstrap))
+          runtime.unsafe.fork(self.run("Test Task name unavailable in this context.", spec))
         fiber.unsafe.addObserver {
           case Exit.Success(_) => k
           case Exit.Failure(c) => throw FiberFailure(c)
@@ -80,17 +77,6 @@ final case class TestRunner[R, E](
        * An unsafe, synchronous run of the specified spec.
        */
       def runSync(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Exit[Nothing, Unit] =
-        runtime.unsafe.run(self.run("Test Task name unavailable in this context.", spec).unit.provideLayer(bootstrap))
+        runtime.unsafe.run(self.run("Test Task name unavailable in this context.", spec).unit)
     }
-
-  private[test] def buildRuntime(implicit
-    trace: Trace
-  ): ZIO[Scope, Nothing, Runtime[ExecutionEventSink]] =
-    bootstrap.toRuntime
-}
-
-object TestRunner {
-  private lazy val defaultBootstrap: ZLayer[Any, Nothing, ExecutionEventSink] = {
-    ExecutionEventSink.live(Console.ConsoleLive, ConsoleEventRenderer)
-  }
 }


### PR DESCRIPTION
The summary is already provided by the sink while the sink layer is already baked in the executor.