### PR TITLE
Retail If We Do Not Exit In ZIOApp

### DIFF
--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -26,7 +26,8 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
     runtime.unsafe.run {
       for {
         fiberId <- ZIO.fiberId
-        fiber <- workflow.foldCauseZIO(
+        fiber <- workflow
+                   .foldCauseZIO(
                      cause => interruptRootFibers(fiberId) *> exit(ExitCode.failure) *> ZIO.refailCause(cause),
                      _ => interruptRootFibers(fiberId) *> exit(ExitCode.success)
                    )


### PR DESCRIPTION
Resolves #8122.  We can't call `System.exit` if we are running in SBT and not forked because that would exit the SBT session. So if we don't exit we need to fail with the original cause so the application fails with this cause.