### PR TITLE
Correct example in Scaladoc for ZLayer.derive

### DIFF
--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -45,7 +45,7 @@ trait ZLayerCompanionVersionSpecific {
    * Derives a simple layer for a case class given as a type parameter.
    * {{{
    * case class Car(engine: Engine, wheels: Wheels)
-   * val derivedLayer: ZLayer[Engine & Wheels, Nothing, Car] = ZLayer.deriveLayer[Car]
+   * val derivedLayer: ZLayer[Engine & Wheels, Nothing, Car] = ZLayer.derive[Car]
    * // equivalent to:
    * val manualLayer: ZLayer[Engine & Wheels, Nothing, Car] =
    *   ZLayer.fromFunction(Car(_, _))


### PR DESCRIPTION
Apparently the example was overlooked when the [method name was changed](https://github.com/zio/zio/pull/7300#discussion_r961749550).
