### PR TITLE
[ScalaCheck] Provide assertions for `Prop` and `Properties`

### DIFF
--- a/test-scalacheck/shared/src/main/scala/zio/test/scalacheck/package.scala
+++ b/test-scalacheck/shared/src/main/scala/zio/test/scalacheck/package.scala
@@ -2,13 +2,24 @@ package zio.test
 
 import org.scalacheck.rng.Seed
 import org.scalacheck.Gen.Parameters
+import org.scalacheck.{Prop, Properties, Test => CheckTest}
 import zio._
+import zio.test.{ErrorMessage => M}
 
 /**
- * Provides functionality for converting legacy ScalaCheck generators to ZIO
- * Test generators to support upgrading to ZIO Test without having to
- * reimplement existing generators. To use it import this module and then call
- * `toGenZIO` on any existing ScalaCheck generator. For example:
+ * This package provides helpers to integrate *some* ScalaCheck primitives to
+ * their ZIO equivalents. Currently available helpers:
+ *
+ *   - Converting ScalaCheck Generators to ZIO Generators
+ *   - Asserting a ScalaCheck `Prop` with ZIO
+ *   - Asserting a ScalaCheck `Properties` with ZIO
+ *
+ * **Generators**
+ *
+ * This functionality converts legacy ScalaCheck generators to ZIO Test
+ * generators to support upgrading to ZIO Test without having to reimplement
+ * existing generators. To use it import this module and then call `toGenZIO` on
+ * any existing ScalaCheck generator. For example:
  *
  * {{{
  * import org.scalacheck.Arbitrary
@@ -19,6 +30,55 @@ import zio._
  *
  * val anyInt: Gen[Any, Int] =
  *   Arbitrary.arbitrary[Int].toGenZIO
+ * }}}
+ *
+ * **Asserting ScalaCheck `Prop` and `Properties`**
+ *
+ * This functionality generates ZIO Assertions from either ScalaCheck `Prop` or
+ * `Properties`. This helps with integrating other libraries that provide
+ * ScalaCheck properties as helpers, i.e. cats-laws.
+ *
+ * `Prop` example:
+ *
+ * {{{
+ * import org.scalacheck.Prop
+ * import org.scalacheck.Test.{ Parameters => ScalaCheckParameters }
+ *
+ * import zio._
+ * import zio.test._
+ * import zio.test.scalacheck._
+ *
+ * val prop: Prop = Prop.forAll { (n: Int, m: Int) =>
+ *   n + m == m + n
+ * }
+ * val resultDefault: TestResult = prop.assertZIO()
+ *
+ * val resultWithCustomizations: TestResult =
+ *   prop.assertZIO("My Prop Name", ScalaCheckParameters.default.withMaxSize(10))
+ * }}}
+ *
+ * `Properties` example:
+ *
+ * {{{
+ * import org.scalacheck.{ Prop, Properties }
+ * import org.scalacheck.Test.{ Parameters => ScalaCheckParameters }
+ *
+ * import zio._
+ * import zio.test._
+ * import zio.test.scalacheck._
+ *
+ * object MyProperties extends Properties("MyProperties") {
+ *   property("myProp") = Prop.forAll { (n: Int, m: Int) =>
+ *     n + m == m + n
+ *   }
+ * }
+ *
+ * * val resultDefault: TestResult = MyProperties.assertZIO()
+ *
+ * // Beware that we can't provide a custom name here, it will be
+ * // taken from the `Properties` name parameter
+ * val resultWithCustomizations: TestResult =
+ *   MyProperties.assertZIO(ScalaCheckParameters.default.withMaxSize(10))
  * }}}
  */
 package object scalacheck {
@@ -36,5 +96,41 @@ package object scalacheck {
           a    <- ZIO.succeed(self.pureApply(Parameters.default.withSize(size), Seed(long)))
         } yield a
       }
+  }
+
+  implicit final class ScalaCheckPropSyntax(private val self: Prop) extends AnyVal {
+
+    /**
+     * Asserts a ScalaCheck `Prop` and provides a ZIO `TestResult`.
+     */
+    def assertZIO(
+      name: String = "ScalaCheck Prop Assertion",
+      testParams: CheckTest.Parameters = CheckTest.Parameters.default
+    ): TestResult =
+      Assertion.assertion[Prop](name)(prop => CheckTest.check(testParams, prop).passed).run(self)
+  }
+
+  implicit final class ScalaCheckPropertiesSyntax(private val self: Properties) extends AnyVal {
+
+    /**
+     * Asserts ScalaCheck `Properties` and provides a ZIO `TestResult`.
+     */
+    def assertZIO(
+      testParams: CheckTest.Parameters = CheckTest.Parameters.default
+    ): TestResult =
+      Assertion(
+        TestArrow
+          .make[Properties, Boolean] { props =>
+            CheckTest
+              .checkProperties(testParams, props)
+              .map { case (name, result) =>
+                TestTrace.boolean(result.passed) {
+                  M.text(name) + M.choice("succeeded", "failed")
+                }
+              }
+              .reduce(_ && _)
+          }
+          .withCode(self.name)
+      ).run(self)
   }
 }

--- a/test-scalacheck/shared/src/test/scala/zio/test/scalacheck/AssertionSpec.scala
+++ b/test-scalacheck/shared/src/test/scala/zio/test/scalacheck/AssertionSpec.scala
@@ -1,0 +1,23 @@
+package zio.test.scalacheck
+
+import org.scalacheck.{Prop, Properties}
+import zio.Scope
+import zio.test._
+
+object AssertionSpec extends ZIOSpecDefault {
+  object FailingProperties extends Properties("MyProperties") {
+    property("PassingProp") = Prop.propBoolean(false)
+  }
+
+  object PassingProperties extends Properties("MyProperties") {
+    property("FailingProp") = Prop.propBoolean(true)
+  }
+
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("ZIO assertions for ScalaCheck")(
+      test("Prop passing")(Prop.propBoolean(true).assertZIO()),
+      test("Prop failing")(Prop.propBoolean(false).assertZIO()) @@ TestAspect.failing,
+      test("Properties passing")(PassingProperties.assertZIO()),
+      test("Properties failing")(FailingProperties.assertZIO()) @@ TestAspect.failing
+    )
+}


### PR DESCRIPTION
This commit provides implicit methods for both ScalaCheck `Prop` and `Properties`.

This enables beautiful things like the following:

```scala
test("Monoid laws for MyCustomType") {
  import cats.kernel.laws.discipline.MonoidTests

  MonoidTests[MyCustomType].monoid.all.assertZIO()
} @@ TestAspect.debug
```

The assertions are collecting the property names correctly, and show them when using the debug TestAspect.