### PR TITLE
Allow Either Values To Be Tested

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -61,6 +61,11 @@ object TestSpec extends ZIOBaseSpec {
         message <- STM.succeed("Hello from an STM transaction!")
       } yield assert(message)(anything)
     },
+    test("either values can be tested") {
+      for {
+        message <- Right("Hello from an Either value!")
+      } yield assert(message)(anything)
+    },
     test("fail-fast assertion by automatic lifting to ZIO") {
       for {
         ref <- Ref.make(0)

--- a/test/shared/src/main/scala/zio/test/CheckConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/CheckConstructor.scala
@@ -39,7 +39,7 @@ trait CheckConstructorLowPriority1 extends CheckConstructorLowPriority2 {
     }
 }
 
-trait CheckConstructorLowPriority2 {
+trait CheckConstructorLowPriority2 extends CheckConstructorLowPriority3 {
 
   implicit def AssertZSTMConstructor[R, R1, E, A <: TestResult]
     : CheckConstructor.WithOut[R, ZSTM[R1, E, A], R with R1, E] =
@@ -48,5 +48,16 @@ trait CheckConstructorLowPriority2 {
       type OutError       = E
       def apply(input: => ZSTM[R1, E, A])(implicit trace: Trace): ZIO[OutEnvironment, OutError, TestResult] =
         input.commit
+    }
+}
+
+trait CheckConstructorLowPriority3 {
+
+  implicit def AssertEitherConstructor[R, E, A <: TestResult]: CheckConstructor.WithOut[R, Either[E, A], R, E] =
+    new CheckConstructor[R, Either[E, A]] {
+      type OutEnvironment = R
+      type OutError       = E
+      def apply(input: => Either[E, A])(implicit trace: Trace): ZIO[OutEnvironment, OutError, TestResult] =
+        ZIO.fromEither(input)
     }
 }

--- a/test/shared/src/main/scala/zio/test/TestConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/TestConstructor.scala
@@ -40,7 +40,7 @@ trait TestConstructorLowPriority1 extends TestConstructorLowPriority2 {
     }
 }
 
-trait TestConstructorLowPriority2 {
+trait TestConstructorLowPriority2 extends TestConstructorLowPriority3 {
 
   implicit def AssertZSTMConstructor[R, E, A <: TestResult]: TestConstructor.WithOut[R, ZSTM[R, E, A], Spec[R, E]] =
     new TestConstructor[R, ZSTM[R, E, A]] {
@@ -49,5 +49,17 @@ trait TestConstructorLowPriority2 {
         assertion: => ZSTM[R, E, A]
       )(implicit sourceLocation: SourceLocation, trace: Trace): Spec[R, E] =
         test(label)(assertion.commit)
+    }
+}
+
+trait TestConstructorLowPriority3 extends TestConstructorLowPriority4 {
+
+  implicit def AssertEitherConstructor[E, A <: TestResult]: TestConstructor.WithOut[Any, Either[E, A], Spec[Any, E]] =
+    new TestConstructor[Any, Either[E, A]] {
+      type Out = Spec[Any, E]
+      def apply(label: String)(
+        assertion: => Either[E, A]
+      )(implicit sourceLocation: SourceLocation, trace: Trace): Spec[Any, E] =
+        test(label)(ZIO.fromEither(assertion))
     }
 }

--- a/test/shared/src/main/scala/zio/test/TestConstructor.scala
+++ b/test/shared/src/main/scala/zio/test/TestConstructor.scala
@@ -52,7 +52,7 @@ trait TestConstructorLowPriority2 extends TestConstructorLowPriority3 {
     }
 }
 
-trait TestConstructorLowPriority3 extends TestConstructorLowPriority4 {
+trait TestConstructorLowPriority3 {
 
   implicit def AssertEitherConstructor[E, A <: TestResult]: TestConstructor.WithOut[Any, Either[E, A], Spec[Any, E]] =
     new TestConstructor[Any, Either[E, A]] {


### PR DESCRIPTION
This PR allows `Either` values returning a test result to be used directly in tests. This can be useful in for example testing codecs where it is nice to be able to make assertions about the success case with the failure case being automatically translated into test failure.