### PR TITLE
Improve ZLayer derivation

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
@@ -7,22 +7,22 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
   case class OneDependency(d1: String)
   case class TwoDependencies(d1: String, d2: Int)
 
-  val derivedZero = ZLayer.derive[ZeroDependency] 
+  val derivedZero = ZLayer.derive[ZeroDependency]
   val derivedOne  = ZLayer.derive[OneDependency]
   val derivedTwo  = ZLayer.derive[TwoDependencies]
 
-  override def spec = suite("ZLayerDerivationSpec")(
-    test("ZLayer.derive[ZeroDependency]") {
+  override def spec = suite("ZLayer.derive[A]")(
+    test("Zero dependency") {
       for {
-        d1 <- ZIO.service[ZeroDependency]
-      } yield assertTrue(d1 == ZeroDependency())
+        d0 <- ZIO.service[ZeroDependency]
+      } yield assertTrue(d0 == ZeroDependency())
     },
-    test("ZLayer.derive[OneDependency]") {
+    test("One dependency") {
       for {
         d1 <- ZIO.service[OneDependency]
       } yield assertTrue(d1 == OneDependency("one"))
     },
-    test("ZLayer.derive[TwoDependencies]") {
+    test("Two dependencies") {
       for {
         d1 <- ZIO.service[TwoDependencies]
       } yield assertTrue(d1 == TwoDependencies("one", 2))

--- a/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
@@ -3,13 +3,20 @@ package zio
 import zio.test._
 
 object ZLayerDerivationSpec extends ZIOBaseSpec {
+  case class ZeroDependency()
   case class OneDependency(d1: String)
   case class TwoDependencies(d1: String, d2: Int)
 
-  val derivedOne = ZLayer.derive[OneDependency]
-  val derivedTwo = ZLayer.derive[TwoDependencies]
+  val derivedZero = ZLayer.derive[ZeroDependency] 
+  val derivedOne  = ZLayer.derive[OneDependency]
+  val derivedTwo  = ZLayer.derive[TwoDependencies]
 
   override def spec = suite("ZLayerDerivationSpec")(
+    test("ZLayer.derive[ZeroDependency]") {
+      for {
+        d1 <- ZIO.service[ZeroDependency]
+      } yield assertTrue(d1 == ZeroDependency())
+    },
     test("ZLayer.derive[OneDependency]") {
       for {
         d1 <- ZIO.service[OneDependency]
@@ -21,6 +28,7 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
       } yield assertTrue(d1 == TwoDependencies("one", 2))
     }
   ).provide(
+    derivedZero,
     derivedOne,
     derivedTwo,
     ZLayer.succeed("one"),

--- a/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
@@ -15,10 +15,12 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
   case class ZeroDependencyWithPromise(p1: Promise[Nothing, Int])
   case class OneDependencyWithPromise(d1: String, p1: Promise[Nothing, Int])
   case class OneDependencyWithQueue(d1: String, q1: Queue[Int])
+  case class OneDependencyWithHub(d1: String, q1: Hub[Int])
 
   val derivedZeroWithPromise = ZLayer.derive[ZeroDependencyWithPromise]
   val derivedOneWithPromise  = ZLayer.derive[OneDependencyWithPromise]
   val derivedOneWithQueue    = ZLayer.derive[OneDependencyWithQueue]
+  val derivedOneWithHub      = ZLayer.derive[OneDependencyWithHub]
 
   override def spec = suite("ZLayer.derive[A]")(
     test("Zero dependency") {
@@ -53,6 +55,12 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
         svc       <- ZIO.service[OneDependencyWithQueue]
         queueSize <- svc.q1.size
       } yield assertTrue(svc.d1 == "one", queueSize == 0)
+    },
+    test("One dependency with Hub") {
+      for {
+        svc     <- ZIO.service[OneDependencyWithHub]
+        hubSize <- svc.q1.size
+      } yield assertTrue(svc.d1 == "one", hubSize == 0)
     }
   ).provide(
     derivedZero,
@@ -61,6 +69,7 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
     derivedZeroWithPromise,
     derivedOneWithPromise,
     derivedOneWithQueue,
+    derivedOneWithHub,
     ZLayer.succeed("one"),
     ZLayer.succeed(2)
   )

--- a/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerDerivationSpec.scala
@@ -8,6 +8,7 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
 
   val derivedOne = ZLayer.derive[OneDependency]
   val derivedTwo = ZLayer.derive[TwoDependencies]
+
   override def spec = suite("ZLayerDerivationSpec")(
     test("ZLayer.derive[OneDependency]") {
       for {

--- a/core/shared/src/main/scala-2/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZLayerCompanionVersionSpecific.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.macros.{DummyK, ZLayerMakeMacros}
+import zio.internal.macros.{DummyK, ZLayerDerivationMacros, ZLayerMakeMacros}
 
 private[zio] trait ZLayerCompanionVersionSpecific {
 
@@ -43,6 +43,8 @@ private[zio] trait ZLayerCompanionVersionSpecific {
    */
   def makeSome[R0, R]: MakeSomePartiallyApplied[R0, R] =
     new MakeSomePartiallyApplied[R0, R]
+
+  def derive[A]: ZLayer[Nothing, Any, A] = macro ZLayerDerivationMacros.deriveImpl[A]
 }
 
 final class MakePartiallyApplied[R](val dummy: Boolean = true) extends AnyVal {

--- a/core/shared/src/main/scala-2/zio/internal/macros/ZLayerDerivationMacros.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/ZLayerDerivationMacros.scala
@@ -1,0 +1,40 @@
+package zio.internal.macros
+
+import scala.reflect.macros.whitebox
+
+private[zio] class ZLayerDerivationMacros(val c: whitebox.Context) {
+  import c.universe._
+
+  def deriveImpl[A: WeakTypeTag] = {
+    import c.universe._
+
+    val tpe = weakTypeOf[A]
+    val ctor = tpe.decls.collectFirst {
+      case m: MethodSymbol if m.isPrimaryConstructor => m
+    }.get
+
+    val params = ctor.paramLists.head.map { sym =>
+      val serviceName = sym.typeSignature.typeSymbol.name
+      val serviceCall = q"_root_.zio.ZIO.service[${sym.typeSignature}]"
+      (sym.name.toTermName, serviceCall)
+    }
+
+    val assignments = params.map { case (name, serviceCall) =>
+      fq"$name <- $serviceCall"
+    }
+
+    val constructorArgs = params.map { case (name, _) => q"$name" }
+
+    val envType = ctor.paramLists.head match {
+      case Nil => tq"Any"
+      case ps  => ps.view.map(sym => tq"${sym.typeSignature}").reduce((a, b) => tq"$a with $b")
+    }
+
+    q"""
+      _root_.zio.ZLayer[$envType, Nothing, $tpe] {
+        for (..$assignments) yield new $tpe(..$constructorArgs)
+      }
+    """
+  }
+
+}

--- a/core/shared/src/main/scala-2/zio/internal/macros/ZLayerDerivationMacros.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/ZLayerDerivationMacros.scala
@@ -14,16 +14,17 @@ private[zio] class ZLayerDerivationMacros(val c: whitebox.Context) {
       case m: MethodSymbol if m.isPrimaryConstructor => m
     }.getOrElse(c.abort(c.enclosingPosition, s"Failed to derive a ZLayer: type $tpe does not have any constructor."))
 
-    val params = 
+    val params =
       ctor.paramLists.head.map { sym =>
         val depType = sym.typeSignature
-        val serviceName = depType.typeSymbol.name
 
-        val (serviceCall, envType) = 
+        val (serviceCall, envType) =
           if (depType <:< typeOf[Promise[_, _]])
             (q"_root_.zio.Promise.make[..${depType.typeArgs}]", None)
           else if (depType <:< typeOf[Queue[_]])
             (q"_root_.zio.Queue.unbounded[..${depType.typeArgs}]", None)
+          else if (depType <:< typeOf[Hub[_]])
+            (q"_root_.zio.Hub.unbounded[..${depType.typeArgs}]", None)
           else
             (q"_root_.zio.ZIO.service[$depType]", Some(depType))
 

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -128,6 +128,7 @@ private [zio] object LayerMacroUtils {
       case EmptyTuple => Any
       case Promise[_, _] *: rest => Env[rest]
       case Queue[_] *: rest => Env[rest]
+      case Hub[_] *: rest => Env[rest]
       case t *: EmptyTuple => t
       case t *: rest => t & Env[rest]
     }
@@ -161,6 +162,9 @@ private [zio] object LayerMacroUtils {
 
             case '[Queue[a]] =>
               '{ ${acc}.zipWith(Queue.unbounded[a].map(p => Tuple1(p)))(_ ++ _) }
+
+            case '[Hub[a]] =>
+              '{ ${acc}.zipWith(Hub.unbounded[a].map(p => Tuple1(p)))(_ ++ _) }
 
             case '[t] =>
               '{ ${acc}.zipWith(ZIO.serviceWith[t](dep => Tuple1(dep)))(_ ++ _) }

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -126,9 +126,7 @@ private [zio] object LayerMacroUtils {
   type Env[Elems] =
     Elems match {
       case EmptyTuple => Any
-      case Promise[_, _] *: rest => Env[rest]
-      case Queue[_] *: rest => Env[rest]
-      case Hub[_] *: rest => Env[rest]
+      case (Promise[_, _] | Queue[_] | Hub[_]) *: rest => Env[rest]
       case t *: EmptyTuple => t
       case t *: rest => t & Env[rest]
     }


### PR DESCRIPTION
/claim #8106 

Currently it adds `ZLayer.derive[A]` to Scala 2 which simply forwards all primary constructor parameter to the env type.

Possible additions:
- [x] Support for ZIO datatypes that don't require default values e.g. `Queue`, `Promise`
- [ ] Support for lifecycle hooks like `def initialize` and `def finalize`
- [ ] Support for ZIO datatypes requiring default values e.g. `Ref`, `ScopedRef`

I'll add agreed features one by one upon the further discussions.