### PR TITLE
Add ZPipeline fail and failCause

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -153,6 +153,11 @@ object ZPipelineSpec extends ZIOBaseSpec {
             .exit
         )(fails(equalTo("failed!!!")))
       ),
+      test("fail")(
+        assertZIO(
+          ZStream(1, 2, 3).via(ZPipeline.fail("error")).runCollect.exit
+        )(fails(equalTo("error")))
+      ),
       suite("hex")(
         test("Empty input encodes to empty output") {
           for {

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1489,6 +1489,18 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     )
 
   /**
+   * Creates a pipeline that fails with the provided error.
+   */
+  def fail[E](e: => E)(implicit trace: Trace): ZPipeline[Any, E, Any, Nothing] =
+    ZPipeline.failCause(Cause.fail(e))
+
+  /**
+   * Creates a pipeline that fails with the provided cause.
+   */
+  def failCause[E](cause: => Cause[E])(implicit trace: Trace): ZPipeline[Any, E, Any, Nothing] =
+    ZPipeline.fromChannel(ZChannel.failCause(cause))
+
+  /**
    * Decode each pair of hex digit input characters (both lower or upper case
    * letters are allowed) as one output byte.
    */


### PR DESCRIPTION
Adds `fail` and `failCause` to `ZPipeline` for consistency with the other stream APIs.