### PR TITLE
Improve Tracing

### DIFF
--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -104,7 +104,7 @@ trait ZIOCompanionVersionSpecific {
         case t: Throwable =>
           ZIO.withFiberRuntime[Any, Throwable, A] { (fiberState, _) =>
             if (!fiberState.isFatal(t)(Unsafe.unsafe))
-              throw ZIOError.Traced(Cause.fail(t, StackTrace.fromJava(fiberState.id, t.getStackTrace())))
+              throw ZIOError.Traced(Cause.fail(t))
             else
               throw t
           }

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -107,7 +107,7 @@ trait ZIOCompanionVersionSpecific {
         case t: Throwable =>
           ZIO.withFiberRuntime[Any, Throwable, A] { (fiberState, _) =>
             if (!fiberState.isFatal(t)(Unsafe.unsafe))
-              throw ZIOError.Traced(Cause.fail(t, StackTrace.fromJava(fiberState.id, t.getStackTrace())))
+              throw ZIOError.Traced(Cause.fail(t))
             else
               throw t
           }


### PR DESCRIPTION
Resolves #8148.

We previously added logic in #7106 to capture the stack trace of a throwable in `ZIO.attempt` and include it in the ZIO trace, since we would not otherwise render the trace. However, we subsequently added logic in #7541 to special case the rendering of fail causes containing a throwable, resulting in duplicate traces.