### PR TITLE
Filtered out zero value Boundaries in ZIO Metrics Core.

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -345,13 +345,18 @@ object MetricSpec extends ZIOBaseSpec {
         } yield assertTrue(r0.count == 0L, r1.count == 1L, r2.count == 1L)
       },
       test("linear boundaries") {
-        val expected = Chunk(0, 10, 20, 30, 40, 50, 60, 70, 80, 90).map(_.toDouble) :+ Double.MaxValue
+        val expected = Chunk(10, 20, 30, 40, 50, 60, 70, 80, 90).map(_.toDouble) :+ Double.MaxValue
         val actual   = Histogram.Boundaries.linear(0, 10, 10).values
         assertTrue(actual == expected)
       },
       test("exponential boundaries") {
         val expected = Chunk(1, 2, 4, 8, 16, 32, 64, 128, 256, 512).map(_.toDouble) :+ Double.MaxValue
         val actual   = Histogram.Boundaries.exponential(1, 2, 10).values
+        assertTrue(actual == expected)
+      },
+      test("custom boundaries without zero and negative values") {
+        val expected = Chunk(10, 20).map(_.toDouble) :+ Double.MaxValue
+        val actual   = Histogram.Boundaries.fromChunk(Chunk(-10, 0, 10, 20)).values
         assertTrue(actual == expected)
       }
     ),

--- a/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKeyType.scala
@@ -59,7 +59,8 @@ object MetricKeyType {
 
     object Boundaries {
 
-      def fromChunk(chunk: Chunk[Double]): Boundaries = Boundaries((chunk ++ Chunk(Double.MaxValue)).distinct)
+      def fromChunk(chunk: Chunk[Double]): Boundaries =
+        Boundaries((chunk.filter(_ > 0) ++ Chunk(Double.MaxValue)).distinct)
 
       /**
        * A helper method to create histogram bucket boundaries for a histogram


### PR DESCRIPTION
This enhancement aims to improve the accuracy and reliability of metrics reporting by removing meaningless zero value boundaries that can potentially cause failures in backend metrics systems.

The motivation behind this merge request is to address the issue with what I faced in project `zio-metrics-connectors` (`InstrumentedSample`) where zero value boundaries, such as zero duration or zero count, may be inadvertently captured and reported as metrics. In certain backend metrics systems, zero values can lead to unexpected behavior or errors during ingestion or processing. By filtering out these zero value boundaries at the core level, we ensure that only meaningful and relevant metrics are reported, reducing the likelihood of failures or inconsistencies in the monitoring infrastructure, amount of the whole traffic and metrics size.

Now it is very easy to create Boundaries with unuseful zero upper bound. For example:

`Histogram.Boundaries.linear(0.0d, 10.0d, 11)`