### PR TITLE
Adding a Description field to ZIO MetricKey

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -537,6 +537,7 @@ object MetricSpec extends ZIOBaseSpec {
         pair1.metricKey.description.isEmpty,
         pair2.metricState == MetricState.Counter(1.0),
         pair2.metricKey.description.contains("description1"),
+        pair2.metricKey.toString == "MetricKey(counterName,Counter,Set(),Some(description1))",
         pair3.metricState == MetricState.Counter(1.0),
         pair3.metricKey.description.contains("description2")
       )

--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -511,43 +511,34 @@ object MetricSpec extends ZIOBaseSpec {
         _ <- ZIO.unit @@ timerWithBoundaries.trackDuration
       } yield assertCompletes
     },
-    test("Metric with description") {
-      val name = "desc_test_gauge"
+    test("metrics with description") {
+      val name = "counterName"
 
-      val gauge1 = Metric.gauge(name, "desc1")
-      val gauge2 = gauge1.tagged("key1", "value1")
-
-      val gauge3 = Metric.gauge(name, "desc2").tagged("key1", "value1")
-      val gauge4 =
-        gauge3
-          .tagged("key2", "value2")
+      val counter1 = Metric.counter(name)
+      val counter2 = Metric.counter(name, "description1")
+      val counter3 = Metric.counter(name, "description2")
 
       for {
-        _        <- gauge1.update(1L)
-        _        <- gauge2.modify(2L)
-        _        <- gauge3.modify(1L)
-        _        <- gauge4.update(2L)
+        _        <- counter1.update(1L)
+        _        <- counter2.update(1L)
+        _        <- counter3.update(1L)
+        r1       <- counter1.value
+        r2       <- counter2.value
+        r3       <- counter3.value
         snapshot <- ZIO.succeed(Unsafe.unsafe(implicit unsafe => metricRegistry.snapshot()))
-        r1       <- gauge1.value
-        r2       <- gauge2.value
-        r3       <- gauge3.value
-        r4       <- gauge4.value
-        pair1    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.gauge(name)))
-        pair2    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.gauge(name).tagged("key1", "value1")))
-        pair3 <- ZIO.fromOption(
-                   snapshot.find(_.metricKey == MetricKey.gauge(name).tagged("key1", "value1").tagged("key2", "value2"))
-                 )
+        pair1    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.counter(name)))
+        pair2    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.counter(name, "description1")))
+        pair3    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.counter(name, "description2")))
       } yield assertTrue(
-        r1 == MetricState.Gauge(1L),
-        r2 == MetricState.Gauge(3L),
-        r3 == MetricState.Gauge(3L),
-        r4 == MetricState.Gauge(2L),
-        pair1.metricState == MetricState.Gauge(1L),
-        pair1.metricKey.description.get == "desc1",
-        pair2.metricState == MetricState.Gauge(3L),
-        pair2.metricKey.description.get == "desc1",
-        pair3.metricState == MetricState.Gauge(2L),
-        pair3.metricKey.description.get == "desc2"
+        r1 == MetricState.Counter(1.0),
+        r2 == MetricState.Counter(1.0),
+        r3 == MetricState.Counter(1.0),
+        pair1.metricState == MetricState.Counter(1.0),
+        pair1.metricKey.description.isEmpty,
+        pair2.metricState == MetricState.Counter(1.0),
+        pair2.metricKey.description.contains("description1"),
+        pair3.metricState == MetricState.Counter(1.0),
+        pair3.metricKey.description.contains("description2")
       )
     }
   )

--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -1,8 +1,9 @@
 package zio
 
 import zio.ZIOAspect._
-import zio.metrics._
+import zio.internal.metrics.metricRegistry
 import zio.metrics.MetricKeyType.Histogram
+import zio.metrics._
 import zio.test._
 
 import java.time.temporal.ChronoUnit
@@ -509,6 +510,45 @@ object MetricSpec extends ZIOBaseSpec {
         _ <- ZIO.unit @@ timer.trackDuration
         _ <- ZIO.unit @@ timerWithBoundaries.trackDuration
       } yield assertCompletes
+    },
+    test("Metric with description") {
+      val name = "desc_test_gauge"
+
+      val gauge1 = Metric.gauge(name, "desc1")
+      val gauge2 = gauge1.tagged("key1", "value1")
+
+      val gauge3 = Metric.gauge(name, "desc2").tagged("key1", "value1")
+      val gauge4 =
+        gauge3
+          .tagged("key2", "value2")
+
+      for {
+        _        <- gauge1.update(1L)
+        _        <- gauge2.modify(2L)
+        _        <- gauge3.modify(1L)
+        _        <- gauge4.update(2L)
+        snapshot <- ZIO.succeed(Unsafe.unsafe(implicit unsafe => metricRegistry.snapshot()))
+        r1       <- gauge1.value
+        r2       <- gauge2.value
+        r3       <- gauge3.value
+        r4       <- gauge4.value
+        pair1    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.gauge(name)))
+        pair2    <- ZIO.fromOption(snapshot.find(_.metricKey == MetricKey.gauge(name).tagged("key1", "value1")))
+        pair3 <- ZIO.fromOption(
+                   snapshot.find(_.metricKey == MetricKey.gauge(name).tagged("key1", "value1").tagged("key2", "value2"))
+                 )
+      } yield assertTrue(
+        r1 == MetricState.Gauge(1L),
+        r2 == MetricState.Gauge(3L),
+        r3 == MetricState.Gauge(3L),
+        r4 == MetricState.Gauge(2L),
+        pair1.metricState == MetricState.Gauge(1L),
+        pair1.metricKey.description.get == "desc1",
+        pair2.metricState == MetricState.Gauge(3L),
+        pair2.metricKey.description.get == "desc1",
+        pair3.metricState == MetricState.Gauge(2L),
+        pair3.metricKey.description.get == "desc2"
+      )
     }
   )
 }

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -591,14 +591,8 @@ object Metric {
   def timer(
     name: String,
     chronoUnit: ChronoUnit
-  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
-    val boundaries = Histogram.Boundaries.exponential(1.0, 2.0, 64)
-    val base       = histogram(name, boundaries).tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
-
-    base.contramap[Duration] { (duration: Duration) =>
-      duration.toNanos / chronoUnit.getDuration.toNanos
-    }
-  }
+  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] =
+    timer(name, chronoUnit, Chunk.iterate(1.0, 64)(_ * 2.0))
 
   /**
    * Creates a timer metric, based on a histogram, which keeps track of
@@ -610,15 +604,8 @@ object Metric {
     name: String,
     description: String,
     chronoUnit: ChronoUnit
-  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
-    val boundaries = Histogram.Boundaries.exponential(1.0, 2.0, 64)
-    val base =
-      histogram(name, description, boundaries).tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
-
-    base.contramap[Duration] { (duration: Duration) =>
-      duration.toNanos / chronoUnit.getDuration.toNanos
-    }
-  }
+  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] =
+    timer(name, description, chronoUnit, Chunk.iterate(1.0, 64)(_ * 2.0))
 
   def timer(
     name: String,

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -17,11 +17,9 @@
 package zio.metrics
 
 import zio._
-import zio.metrics.MetricKey
+import zio.internal.metrics._
 import zio.metrics.MetricKeyType.Histogram
 
-import zio.internal.metrics._
-import java.util.concurrent.TimeUnit
 import java.time.temporal.ChronoUnit
 
 /**
@@ -410,16 +408,34 @@ object Metric {
     counterDouble(name).contramap[Long](_.toDouble)
 
   /**
+   * A counter, which can be incremented by longs.
+   */
+  def counter(name: String, description: String): Counter[Long] =
+    counterDouble(name, description).contramap[Long](_.toDouble)
+
+  /**
    * A counter, which can be incremented by doubles.
    */
   def counterDouble(name: String): Counter[Double] =
     fromMetricKey(MetricKey.counter(name))
 
   /**
+   * A counter, which can be incremented by doubles.
+   */
+  def counterDouble(name: String, description: String): Counter[Double] =
+    fromMetricKey(MetricKey.counter(name).described(description))
+
+  /**
    * A counter, which can be incremented by integers.
    */
   def counterInt(name: String): Counter[Int] =
     counterDouble(name).contramap[Int](_.toInt)
+
+  /**
+   * A counter, which can be incremented by integers.
+   */
+  def counterInt(name: String, description: String): Counter[Int] =
+    counterDouble(name, description).contramap[Int](_.toInt)
 
   /**
    * A string histogram metric, which keeps track of the counts of different
@@ -429,8 +445,15 @@ object Metric {
     fromMetricKey(MetricKey.frequency(name))
 
   /**
+   * A string histogram metric, which keeps track of the counts of different
+   * strings.
+   */
+  def frequency(name: String, description: String): Frequency[String] =
+    fromMetricKey(MetricKey.frequency(name).described(description))
+
+  /**
    * Creates a metric from a metric key. This is the primary constructor for
-   * [[zio.Metric]].
+   * [[zio.metrics.Metric]].
    */
   def fromMetricKey[Type <: MetricKeyType](
     key: MetricKey[Type]
@@ -474,11 +497,24 @@ object Metric {
     fromMetricKey(MetricKey.gauge(name))
 
   /**
+   * A gauge, which can be set to a value.
+   */
+  def gauge(name: String, description: String): Gauge[Double] =
+    fromMetricKey(MetricKey.gauge(name).described(description))
+
+  /**
    * A numeric histogram metric, which keeps track of the count of numbers that
    * fall in bins with the specified boundaries.
    */
   def histogram(name: String, boundaries: Histogram.Boundaries): Histogram[Double] =
     fromMetricKey(MetricKey.histogram(name, boundaries))
+
+  /**
+   * A numeric histogram metric, which keeps track of the count of numbers that
+   * fall in bins with the specified boundaries.
+   */
+  def histogram(name: String, description: String, boundaries: Histogram.Boundaries): Histogram[Double] =
+    fromMetricKey(MetricKey.histogram(name, boundaries).described(description))
 
   /**
    * Creates a metric that ignores input and produces constant output.
@@ -514,6 +550,19 @@ object Metric {
   ): Summary[Double] =
     summaryInstant(name, maxAge, maxSize, error, quantiles).withNow[Double]
 
+  /**
+   * A summary metric.
+   */
+  def summary(
+    name: String,
+    description: String,
+    maxAge: Duration,
+    maxSize: Int,
+    error: Double,
+    quantiles: Chunk[Double]
+  ): Summary[Double] =
+    summaryInstant(name, description, maxAge, maxSize, error, quantiles).withNow[Double]
+
   def summaryInstant(
     name: String,
     maxAge: Duration,
@@ -522,6 +571,16 @@ object Metric {
     quantiles: Chunk[Double]
   ): Summary[(Double, java.time.Instant)] =
     fromMetricKey(MetricKey.summary(name, maxAge, maxSize, error, quantiles))
+
+  def summaryInstant(
+    name: String,
+    description: String,
+    maxAge: Duration,
+    maxSize: Int,
+    error: Double,
+    quantiles: Chunk[Double]
+  ): Summary[(Double, java.time.Instant)] =
+    fromMetricKey(MetricKey.summary(name, maxAge, maxSize, error, quantiles).described(description))
 
   /**
    * Creates a timer metric, based on a histogram, which keeps track of
@@ -541,6 +600,26 @@ object Metric {
     }
   }
 
+  /**
+   * Creates a timer metric, based on a histogram, which keeps track of
+   * durations in the specified unit of time (milliseconds, seconds, etc.). The
+   * unit of time will automatically be added to the metric as a tag
+   * ("time_unit: milliseconds").
+   */
+  def timer(
+    name: String,
+    description: String,
+    chronoUnit: ChronoUnit
+  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
+    val boundaries = Histogram.Boundaries.exponential(1.0, 2.0, 64)
+    val base =
+      histogram(name, description, boundaries).tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
+
+    base.contramap[Duration] { (duration: Duration) =>
+      duration.toNanos / chronoUnit.getDuration.toNanos
+    }
+  }
+
   def timer(
     name: String,
     chronoUnit: ChronoUnit,
@@ -548,6 +627,21 @@ object Metric {
   ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
     val base = Metric
       .histogram(name, Histogram.Boundaries.fromChunk(boundaries))
+      .tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
+
+    base.contramap[Duration] { (duration: Duration) =>
+      duration.toNanos / chronoUnit.getDuration.toNanos
+    }
+  }
+
+  def timer(
+    name: String,
+    description: String,
+    chronoUnit: ChronoUnit,
+    boundaries: Chunk[Double]
+  ): Metric[MetricKeyType.Histogram, Duration, MetricState.Histogram] = {
+    val base = Metric
+      .histogram(name, description, Histogram.Boundaries.fromChunk(boundaries))
       .tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
 
     base.contramap[Duration] { (duration: Duration) =>

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -423,7 +423,7 @@ object Metric {
    * A counter, which can be incremented by doubles.
    */
   def counterDouble(name: String, description: String): Counter[Double] =
-    fromMetricKey(MetricKey.counter(name).described(description))
+    fromMetricKey(MetricKey.counter(name, description))
 
   /**
    * A counter, which can be incremented by integers.
@@ -449,7 +449,7 @@ object Metric {
    * strings.
    */
   def frequency(name: String, description: String): Frequency[String] =
-    fromMetricKey(MetricKey.frequency(name).described(description))
+    fromMetricKey(MetricKey.frequency(name, description))
 
   /**
    * Creates a metric from a metric key. This is the primary constructor for
@@ -500,7 +500,7 @@ object Metric {
    * A gauge, which can be set to a value.
    */
   def gauge(name: String, description: String): Gauge[Double] =
-    fromMetricKey(MetricKey.gauge(name).described(description))
+    fromMetricKey(MetricKey.gauge(name, description))
 
   /**
    * A numeric histogram metric, which keeps track of the count of numbers that
@@ -514,7 +514,7 @@ object Metric {
    * fall in bins with the specified boundaries.
    */
   def histogram(name: String, description: String, boundaries: Histogram.Boundaries): Histogram[Double] =
-    fromMetricKey(MetricKey.histogram(name, boundaries).described(description))
+    fromMetricKey(MetricKey.histogram(name, description, boundaries))
 
   /**
    * Creates a metric that ignores input and produces constant output.
@@ -580,7 +580,7 @@ object Metric {
     error: Double,
     quantiles: Chunk[Double]
   ): Summary[(Double, java.time.Instant)] =
-    fromMetricKey(MetricKey.summary(name, maxAge, maxSize, error, quantiles).described(description))
+    fromMetricKey(MetricKey.summary(name, description, maxAge, maxSize, error, quantiles))
 
   /**
    * Creates a timer metric, based on a histogram, which keeps track of

--- a/core/shared/src/main/scala/zio/metrics/MetricKey.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKey.scala
@@ -40,14 +40,6 @@ sealed case class MetricKey[+Type] private (
     }
 
   /**
-   * Returns a new `MetricKey` with the specified description.
-   */
-  def described(description0: String): MetricKey[Type] =
-    new MetricKey[Type](self.name, self.keyType, self.tags) {
-      override def description: Option[String] = Some(description0)
-    }
-
-  /**
    * Returns a new `MetricKey` with the specified tag appended.
    */
   def tagged(key: String, value: String): MetricKey[Type] =
@@ -83,6 +75,15 @@ object MetricKey {
     MetricKey(name, MetricKeyType.Counter)
 
   /**
+   * Creates a metric key for a counter, with the specified name and
+   * description.
+   */
+  def counter(name: String, description0: String): Counter =
+    new MetricKey(name, MetricKeyType.Counter) {
+      override def description: Option[String] = Some(description0)
+    }
+
+  /**
    * Creates a metric key for a categorical frequency table, with the specified
    * name.
    */
@@ -90,10 +91,27 @@ object MetricKey {
     MetricKey(name, MetricKeyType.Frequency)
 
   /**
+   * Creates a metric key for a categorical frequency table, with the specified
+   * name and description.
+   */
+  def frequency(name: String, description0: String): Frequency =
+    new MetricKey(name, MetricKeyType.Frequency) {
+      override def description: Option[String] = Some(description0)
+    }
+
+  /**
    * Creates a metric key for a gauge, with the specified name.
    */
   def gauge(name: String): Gauge =
     MetricKey(name, MetricKeyType.Gauge)
+
+  /**
+   * Creates a metric key for a gauge, with the specified name and description.
+   */
+  def gauge(name: String, description0: String): Gauge =
+    new MetricKey(name, MetricKeyType.Gauge) {
+      override def description: Option[String] = Some(description0)
+    }
 
   /**
    * Creates a metric key for a histogram, with the specified name.
@@ -103,6 +121,19 @@ object MetricKey {
     boundaries: Boundaries
   ): Histogram =
     MetricKey(name, MetricKeyType.Histogram(boundaries))
+
+  /**
+   * Creates a metric key for a histogram, with the specified name and
+   * description.
+   */
+  def histogram(
+    name: String,
+    description0: String,
+    boundaries: Boundaries
+  ): Histogram =
+    new MetricKey(name, MetricKeyType.Histogram(boundaries)) {
+      override def description: Option[String] = Some(description0)
+    }
 
   /**
    * Creates a metric key for a summary, with the specified name.
@@ -115,4 +146,20 @@ object MetricKey {
     quantiles: Chunk[Double]
   ): Summary =
     MetricKey(name, MetricKeyType.Summary(maxAge, maxSize, error, quantiles))
+
+  /**
+   * Creates a metric key for a summary, with the specified name and
+   * description.
+   */
+  def summary(
+    name: String,
+    description0: String,
+    maxAge: Duration,
+    maxSize: Int,
+    error: Double,
+    quantiles: Chunk[Double]
+  ): Summary =
+    new MetricKey(name, MetricKeyType.Summary(maxAge, maxSize, error, quantiles)) {
+      override def description: Option[String] = Some(description0)
+    }
 }

--- a/core/shared/src/main/scala/zio/metrics/MetricKey.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKey.scala
@@ -53,6 +53,9 @@ sealed case class MetricKey[+Type] private (
       case _ => false
     }
 
+  override def toString: String =
+    s"${self.productPrefix}($name,$keyType,$tags,$description)"
+
   /**
    * Returns a new `MetricKey` with the specified tag appended.
    */

--- a/core/shared/src/main/scala/zio/metrics/MetricKey.scala
+++ b/core/shared/src/main/scala/zio/metrics/MetricKey.scala
@@ -26,11 +26,26 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * boundaries of a histogram. In this way, it is impossible to ever create
  * different metrics with conflicting keys.
  */
-final case class MetricKey[+Type] private (
+sealed case class MetricKey[+Type] private (
   name: String,
   keyType: Type,
   tags: Set[MetricLabel] = Set.empty
 ) { self =>
+
+  def description: Option[String] = None
+
+  def copy[Type2](name: String = name, keyType: Type2 = keyType, tags: Set[MetricLabel] = tags): MetricKey[Type2] =
+    new MetricKey(name, keyType, tags) {
+      override def description: Option[String] = self.description
+    }
+
+  /**
+   * Returns a new `MetricKey` with the specified description.
+   */
+  def described(description0: String): MetricKey[Type] =
+    new MetricKey[Type](self.name, self.keyType, self.tags) {
+      override def description: Option[String] = Some(description0)
+    }
 
   /**
    * Returns a new `MetricKey` with the specified tag appended.


### PR DESCRIPTION
The MetricKey describes metric with its name and tags.
With this MR, the MetricKey is extended to include a "description" field, allowing developers to provide meaningful descriptions for each metric.

## Problem
While working on new metric connector (https://github.com/zio/zio-metrics-connectors/pull/42) I was faced with the need to extract the description of the metric.
Similar issue (https://github.com/zio/zio-metrics-connectors/issues/23) was solved via throwing description through metrics tags set (https://github.com/zio/zio-metrics-connectors/pull/32/files#diff-fcbe5916f5b460e7cca68e385fbb00d736fcb533e5b2867ee09a7a3e38be17b9R35). IMO this is not very clean approach because tags is not a storage for metadata at all. 
We need to have a separate typed field (optional) in MetricKey to be able to operate with metric description without any non clear workarounds. 

## Additional motivation
- enhances the self-documentation aspect of ZIO metric development. By adding descriptive metadata to metrics, developers can clearly communicate the purpose, usage, and context of individual metrics.
- aligns ZIO more closely with vendor-specific metrics systems like Prometheus. These systems often rely on metric metadata to generate insightful visualizations, dashboards, and analytics. With the "description" field supported by MetricKey, ZIO facilitates seamless integration with Prometheus and other similar vendors, ensuring a smooth flow of metric data for monitoring and analysis

If MR is accepted I would be able to fix description extraction in zio-metrics-connector module. 