### PR TITLE
Add `decodeCharsWithDecoder` to ZPipeline

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -27,6 +27,7 @@ import java.nio.{Buffer, ByteBuffer, CharBuffer}
 import java.nio.charset.{
   CharacterCodingException,
   Charset,
+  CharsetDecoder,
   CoderResult,
   MalformedInputException,
   StandardCharsets,
@@ -918,8 +919,18 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     charset: => Charset,
     bufSize: => Int = 4096
   )(implicit trace: Trace): ZPipeline[Any, CharacterCodingException, Byte, Char] =
+    decodeCharsWithDecoder(charset.newDecoder(), bufSize)
+
+  /**
+   * Creates a pipeline that decodes a stream of bytes into a stream of
+   * characters using the given charset decoder.
+   */
+  def decodeCharsWithDecoder(
+    charsetDecoder: => CharsetDecoder,
+    bufSize: => Int = 4096
+  )(implicit trace: Trace): ZPipeline[Any, CharacterCodingException, Byte, Char] =
     ZPipeline.suspend {
-      val decoder    = charset.newDecoder()
+      val decoder    = charsetDecoder
       val byteBuffer = ByteBuffer.allocate(bufSize)
       val charBuffer = CharBuffer.allocate((bufSize.toFloat * decoder.averageCharsPerByte).round)
 


### PR DESCRIPTION
Given that `decodeCharsWith` takes a `Charset` but only uses it to get a `CharsetDecoder`, add a new method `decodeCharsWithDecoder` that accepts a `CharsetDecoder` directly.

This can be useful as it allows a `CharsetDecoder` to be configured; for example to ignore malformed input.