### PR TITLE
Upgrade Scala 3 Version And Revert ProvideSome Optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scala: ['2.12.17', '2.13.10', '3.2.2']
+        scala: ['2.12.17', '2.13.10', '3.3.0']
         java: ['17']
         platform: ['JVM']
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -258,7 +258,6 @@ lazy val coreTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )
-  .settings(testSettings)
   .enablePlugins(BuildInfoPlugin)
   .jvmConfigure(_.enablePlugins(JCStressPlugin))
   .jvmSettings(replSettings)
@@ -310,7 +309,6 @@ lazy val managedTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat
   )
-  .settings(testSettings)
   .enablePlugins(BuildInfoPlugin)
   .jvmConfigure(_.enablePlugins(JCStressPlugin))
   .jvmSettings(replSettings)
@@ -345,7 +343,6 @@ lazy val macrosTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(macroExpansionSettings)
   .settings(testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"))
   .dependsOn(testRunner)
-  .settings(testSettings)
   .settings(buildInfoSettings("zio"))
   .settings(publish / skip := true)
   .enablePlugins(BuildInfoPlugin)
@@ -395,7 +392,6 @@ lazy val streamsTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars
   )
-  .settings(testSettings)
   .enablePlugins(BuildInfoPlugin)
   .jvmConfigure(_.dependsOn(coreTests.jvm % "test->compile"))
   .jsSettings(
@@ -458,7 +454,6 @@ lazy val testTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(buildInfoSettings("zio.test"))
   .settings(publish / skip := true)
   .settings(macroExpansionSettings)
-  .settings(testSettings)
   .enablePlugins(BuildInfoPlugin)
   .jsSettings(
     jsSettings,
@@ -508,7 +503,6 @@ lazy val testMagnoliaTests = crossProject(JVMPlatform, JSPlatform)
   .settings(
     publish / skip := true
   )
-  .settings(testSettings)
   .jsSettings(jsSettings)
   .enablePlugins(BuildInfoPlugin)
 

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -26,14 +26,14 @@ private[zio] trait LayerMacroUtils {
 
     val builder = LayerBuilder[c.Type, LayerExpr](
       target0 = targetTypes,
-      remainder = List(weakTypeOf[R0]),
+      remainder = remainderTypes,
       providedLayers0 = layers.toList,
       layerToDebug = debugMap,
       sideEffectType = c.weakTypeOf[Unit].dealias,
       typeEquals = _ <:< _,
       foldTree = buildFinalTree,
       method = provideMethod,
-      exprToNode = getNode(remainder = weakTypeOf[R0], remainderTypes = remainderTypes.toSet),
+      exprToNode = getNode,
       typeToNode = tpe => Node(Nil, List(tpe), c.Expr[ZLayer[_, E, _]](q"_root_.zio.ZLayer.environment[$tpe]")),
       showExpr = expr => CleanCodePrinter.show(c)(expr.tree),
       showType = _.toString,
@@ -83,21 +83,12 @@ private[zio] trait LayerMacroUtils {
    * Converts a LayerExpr to a Node annotated by the Layer's input and output
    * types.
    */
-  def getNode(remainder: Type, remainderTypes: Set[Type])(layer: LayerExpr): Node[c.Type, LayerExpr] = {
+  def getNode(layer: LayerExpr): Node[c.Type, LayerExpr] = {
     val typeArgs = layer.actualType.dealias.typeArgs
     // ZIO[in, _, out]
     val in  = typeArgs.head
     val out = typeArgs(2)
-    Node(
-      // If node has a dependency on a part of the remainder, prune the graph
-      // at that point and take a dependency on all of the remainder. This optimizes
-      // layer combination at runtime
-      getRequirements(in)
-        .map(tpe => if (remainderTypes.contains(tpe)) remainder else tpe)
-        .distinct,
-      getRequirements(out),
-      layer
-    )
+    Node(getRequirements(in), getRequirements(out), layer)
   }
 
   def getRequirements[T: c.WeakTypeTag]: List[c.Type] =

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -39,7 +39,7 @@ private [zio] object LayerMacroUtils {
       sideEffectType = TypeRepr.of[Unit],
       foldTree = buildFinalTree,
       method = provideMethod,
-      exprToNode = getNode(TypeRepr.of[R0], Set.from(remainderTypes)),
+      exprToNode = getNode,
       typeToNode = tpe => Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ZLayer.environment[t] } }),
       showExpr = expr => scala.util.Try(expr.asTerm.pos.sourceCode).toOption.flatten.getOrElse(expr.show),
       showType = _.show,
@@ -89,18 +89,13 @@ private [zio] object LayerMacroUtils {
 
   }
 
-  def getNode[E: Type](using ctx: Quotes)(remainder: ctx.reflect.TypeRepr, remainderTypes: Set[ctx.reflect.TypeRepr]): LayerExpr[E] => Node[ctx.reflect.TypeRepr, LayerExpr[E]] = {
-    (layer: LayerExpr[E]) => {
-      import quotes.reflect._
-      layer match {
-        case '{ $layer: ZLayer[in, e, out] } =>
-          // If node has a dependency on a part of the remainder, prune the graph
-          // at that point and take a dependency on all of the remainder. This optimizes
-          // layer combination at runtime
-          val inputs = getRequirements[in].map(tpe => if (remainderTypes.contains(tpe)) remainder else tpe)
-          val outputs = getRequirements[out]
-          Node(inputs, outputs, layer)
-      }
+  def getNode[E: Type](layer: LayerExpr[E])(using ctx: Quotes): Node[ctx.reflect.TypeRepr, LayerExpr[E]] = {
+    import quotes.reflect._
+    layer match {
+      case '{ $layer: ZLayer[in, e, out] } =>
+        val inputs = getRequirements[in]
+        val outputs = getRequirements[out]
+        Node(inputs, outputs, layer)
     }
   }
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -241,13 +241,6 @@ object BuildHelper {
     }
   )
 
-  def testSettings = Seq(
-    scalacOptions ++= {
-      if (scalaVersion.value != Scala3) Seq()
-      else Seq("-Xcheck-macros")
-    }
-  )
-
   def nativeSettings = Seq(
     Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`
   )


### PR DESCRIPTION
Resolves #8164.

It looks like the optimizations to `provideSome` are not working on Scala 3.3.0. I'm not sure if this is an issue with the underlying unsoundness of the implementation or the Scala compiler itself but given the importance of this functionality I think we need to get back to a point where things are working and go from there.