### PR TITLE
Improve performance of ConfigProvider.fromMap

### DIFF
--- a/benchmarks/src/main/scala/zio/ConfigProviderBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ConfigProviderBenchmark.scala
@@ -1,0 +1,51 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+class ConfigProviderBenchmark {
+
+  @Param(Array("10", "1000"))
+  var keyCount: Int = _
+
+  val chunkSize = 10
+
+  var mapForFlatConfig: Map[String, String] = _
+
+  var mapForIndexedConfig: Map[String, String] = _
+
+  @Setup
+  def setup(): Unit = {
+    val flatBuilder = Map.newBuilder[String, String]
+    (0 until keyCount).foreach(i => flatBuilder += (s"k$i" -> s"v$i"))
+    mapForFlatConfig = flatBuilder.result()
+
+    val indexedBuilder = Map.newBuilder[String, String]
+    for (i <- 0 until keyCount; j <- 0 until chunkSize) yield indexedBuilder += (s"k$i.items[$j]" -> s"v$i$j")
+    mapForIndexedConfig = indexedBuilder.result()
+  }
+
+  @Benchmark
+  def loadFlatConfig(): Unit = {
+    val cp = ConfigProvider.fromMap(mapForFlatConfig)
+    unsafeRun(ZIO.foreachDiscard(0 until keyCount)(i => cp.load(Config.string(s"k$i"))))
+  }
+
+  @Benchmark
+  def loadIndexedConfig(): Unit = {
+    val cp = ConfigProvider.fromMap(mapForIndexedConfig)
+    unsafeRun(ZIO.foreachDiscard(0 until keyCount) { i =>
+      cp.load(Config.chunkOf("items", Config.string).nested(s"k$i"))
+        .filterOrFail[Throwable](_.length == chunkSize)(new Exception("Invalid chunk size"))
+    })
+  }
+
+}


### PR DESCRIPTION
Hi, I noticed that `ConfigProvider.fromMap` using indexed data performs badly on large map (close to 1000 keys). In my case it's coming from huge Typesafe config file. This happens because of `enumerateChildren` implementation that loops over whole map every time it is called. To avoid this I used `TreeSet` to cache keys and use O(log n) search for enumeration. I've also provided benchmark, here are results:
```
Before optimisation
[info] Benchmark                                  (keyCount)   Mode  Cnt       Score      Error  Units
[info] ConfigProviderBenchmark.loadFlatConfig             10  thrpt   10  132029.533 ± 1118.191  ops/s
[info] ConfigProviderBenchmark.loadFlatConfig           1000  thrpt   10    1139.194 ±   14.454  ops/s
[info] ConfigProviderBenchmark.loadIndexedConfig          10  thrpt   10    2244.199 ±   12.644  ops/s
[info] ConfigProviderBenchmark.loadIndexedConfig        1000  thrpt   10       0.432 ±    0.008  ops/s

After optimisation
[info] Benchmark                                  (keyCount)   Mode  Cnt       Score      Error  Units
[info] ConfigProviderBenchmark.loadFlatConfig             10  thrpt   10  131404.586 ± 1809.497  ops/s
[info] ConfigProviderBenchmark.loadFlatConfig           1000  thrpt   10    1146.160 ±    8.240  ops/s
[info] ConfigProviderBenchmark.loadIndexedConfig          10  thrpt   10    4606.698 ±   46.079  ops/s
[info] ConfigProviderBenchmark.loadIndexedConfig        1000  thrpt   10      35.104 ±    0.466  ops/s
```
So `loadIndexedConfig` benchmark on 1000 keys performs approximately 80 times faster after my change. Please note that I didn't change  `fromEnv` and `fromProps` - because we cannot cache keys easily there and I doubt that these providers are ever used for large number of keys. 
