### PR TITLE
Fix FileNotFoundException: debug.txt in zio-test

### DIFF
--- a/test/jvm-native/src/main/scala/zio/test/TestDebug.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestDebug.scala
@@ -66,15 +66,18 @@ private[test] object TestDebug {
   private def removeLine(fullyQualifiedTaskName: String, searchString: String, lock: TestDebugFileLock) =
     lock.updateFile {
       ZIO.succeed {
-        val source = Source.fromFile(outputFileForTask(fullyQualifiedTaskName))
+        val file = new File(outputFileForTask(fullyQualifiedTaskName))
+        if (file.exists()) {
+          val source = Source.fromFile(file)
 
-        val remainingLines =
-          source.getLines.filterNot(_.contains(searchString)).toList
+          val remainingLines =
+            source.getLines.filterNot(_.contains(searchString)).toList
 
-        val pw = new PrintWriter(outputFileForTask(fullyQualifiedTaskName))
-        pw.write(remainingLines.mkString("\n") + "\n")
-        pw.close()
-        source.close()
+          val pw = new PrintWriter(outputFileForTask(fullyQualifiedTaskName))
+          pw.write(remainingLines.mkString("\n") + "\n")
+          pw.close()
+          source.close()
+        }
       }
     }
 }


### PR DESCRIPTION
We get this error in our tests with ZIO 2.0.15 (it's flaky):

```
Exception in thread "zio-fiber-29" java.io.FileNotFoundException: target/test-reports-zio/spec.FQDN_debug.txt (No such file or directory)
    at java.base/java.io.FileInputStream.open0(Native Method)
    at java.base/java.io.FileInputStream.open(FileInputStream.java:216)
    at java.base/java.io.FileInputStream.<init>(FileInputStream.java:157)
    at scala.io.Source$.fromFile(Source.scala:94)
    at scala.io.Source$.fromFile(Source.scala:79)
    at scala.io.Source$.fromFile(Source.scala:57)
    at zio.test.TestDebug$.$anonfun$removeLine$1(TestDebug.scala:69)
    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    at zio.test.TestDebug.removeLine(TestDebug.scala:68)
    at zio.test.TestDebugFileLock.updateFile(TestDebugFileLock.scala:12)
    at zio.test.TestOutput.TestOutputLive.printOrQueue(TestOutput.scala:116)
```

Should the debug.txt file even be created in user projects? Could you suggest a better way to fix this error?

Relevant issue: #8079

@adamgfraser @swoogles 