### PR TITLE
Fix: Enable `ZLayer.derive` to handle arity 0 case classes (#8236)

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ZLayerDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ZLayerDerivationSpec.scala
@@ -3,12 +3,19 @@ package zio
 import zio.test._
 
 object ZLayerDerivationSpec extends ZIOBaseSpec {
+  case class ZeroDependencies()
   case class OneDependency(d1: String)
   case class TwoDependencies(d1: String, d2: Int)
 
+  val derivedZero = ZLayer.derive[ZeroDependencies]
   val derivedOne = ZLayer.derive[OneDependency]
   val derivedTwo = ZLayer.derive[TwoDependencies]
   override def spec = suite("ZLayerDerivationSpec")(
+    test("ZLayer.derive[ZeroDependencies]") {
+      for {
+        d1 <- ZIO.service[ZeroDependencies]
+      } yield assertTrue(d1 == ZeroDependencies())
+    },
     test("ZLayer.derive[OneDependency]") {
       for {
         d1 <- ZIO.service[OneDependency]
@@ -20,6 +27,7 @@ object ZLayerDerivationSpec extends ZIOBaseSpec {
       } yield assertTrue(d1 == TwoDependencies("one", 2))
     }
   ).provide(
+    derivedZero,
     derivedOne,
     derivedTwo,
     ZLayer.succeed("one"),

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -125,6 +125,7 @@ private [zio] object LayerMacroUtils {
 
   type Env[Elems] =
     Elems match {
+    case EmptyTuple => Any
     case t *: EmptyTuple => t
     case t *: rest => t & Env[rest]
   }
@@ -164,8 +165,9 @@ private [zio] object LayerMacroUtils {
       }
 
     def genLayer(fields: List[Tree]): Expr[URIO[Env[T], A]] =
-      if fields.size == 1
-
+      if fields.size == 0
+    then '{ZIO.succeed(${caseClassApply(Nil).asExprOf[A]})}
+      else if fields.size == 1
     then'{ZIO.serviceWith(dep => ${caseClassApply('{dep}.asTerm :: Nil).asExprOf[A]})}
     else
     '{${genDeps(fields)}.map(deps => ${depsDefs('{deps.asInstanceOf[T]}).asExprOf[A]})}


### PR DESCRIPTION
fixes #8236 