### PR TITLE
Render expectation exactly

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/DefaultTestReporterSpec.scala
@@ -59,6 +59,12 @@ object DefaultTestReporterSpec extends ZIOBaseSpec {
             a && exists(matchesRegex(expectedLine.stripLineEnd))
           }
         )
-      } @@ TestAspect.nonFlaky
+      } @@ TestAspect.nonFlaky,
+      testM("correctly reports mock failure of unmet expectations using 'repeats'") {
+        assertM(runLog(mock6))(equalTo(mock6Expected.mkString + reportStats(0, 0, 1)))
+      },
+      testM("correctly reports mock failure of unmet expectations using 'exactly'") {
+        assertM(runLog(mock7))(equalTo(mock7Expected.mkString + reportStats(0, 0, 1)))
+      }
     ) @@ silent
 }

--- a/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ReportingTestUtils.scala
@@ -267,6 +267,32 @@ object ReportingTestUtils {
     """[\s║]*failed!"""
   )
 
+  val mock6: ZSpec[Any, Nothing] = test("Repeated calls out of range") {
+    throw UnsatisfiedExpectationsException(
+      PureModuleMock.SingleParam(equalTo(2), value("foo")).repeats(1 to 2)
+    )
+  }
+
+  val mock6Expected: Vector[String] = Vector(
+    expectedFailure("Repeated calls out of range"),
+    withOffset(2)(s"${red("- unsatisfied expectations")}\n"),
+    withOffset(4)(s"repeated 0 times not in range 1 to 2 by 1\n"),
+    withOffset(6)(s"""zio.test.mock.module.PureModuleMock.SingleParam with arguments ${cyan("equalTo(2)")}\n""")
+  )
+
+  val mock7: ZSpec[Any, Nothing] = test("Exact repetitions not met") {
+    throw UnsatisfiedExpectationsException(
+      PureModuleMock.SingleParam(equalTo(2), value("foo")).exactly(2)
+    )
+  }
+
+  val mock7Expected: Vector[String] = Vector(
+    expectedFailure("Exact repetitions not met"),
+    withOffset(2)(s"${red("- unsatisfied expectations")}\n"),
+    withOffset(4)(s"exactly 0 times not equal to 2\n"),
+    withOffset(6)(s"""zio.test.mock.module.PureModuleMock.SingleParam with arguments ${cyan("equalTo(2)")}\n""")
+  )
+
   def assertSourceLocation(): String = cyan(s"at $sourceFilePath:XXX")
   implicit class TestOutputOps(output: String) {
     def withNoLineNumbers: String =

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -17,7 +17,7 @@
 package zio.test
 
 import zio.duration._
-import zio.test.ConsoleUtils.{cyan, red, _}
+import zio.test.ConsoleUtils._
 import zio.test.FailureRenderer.FailureMessage.{Fragment, Message}
 import zio.test.RenderedResult.CaseType._
 import zio.test.RenderedResult.Status._
@@ -519,47 +519,65 @@ object FailureRenderer {
         case Nil =>
           lines
 
-        case (ident, Expectation.And(children, state, _, _)) :: tail if state.isFailed =>
-          val title       = Line.fromString("in any order", ident)
-          val unsatisfied = children.filter(_.state.isFailed).map(ident + tabSize -> _)
-          loop(unsatisfied ++ tail, lines :+ title)
+        case (ident, Expectation.And(children, state, _, _)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val title       = Line.fromString("in any order", ident)
+            val unsatisfied = children.filter(_.state.isFailed).map(ident + tabSize -> _)
+            loop(unsatisfied ++ tail, lines :+ title)
+          }
 
-        case (ident, Expectation.Call(method, assertion, _, state, _)) :: tail if state.isFailed =>
-          val rendered =
-            withOffset(ident)(Fragment(s"$method with arguments ") + cyan(assertion.toString))
-          loop(tail, lines :+ rendered)
+        case (ident, Expectation.Call(method, assertion, _, state, _)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val rendered =
+              withOffset(ident)(Fragment(s"$method with arguments ") + cyan(assertion.toString))
+            loop(tail, lines :+ rendered)
+          }
 
-        case (ident, Expectation.Chain(children, state, _, _)) :: tail if state.isFailed =>
-          val title       = Line.fromString("in sequential order", ident)
-          val unsatisfied = children.filter(_.state.isFailed).map(ident + tabSize -> _)
-          loop(unsatisfied ++ tail, lines :+ title)
+        case (ident, Expectation.Chain(children, state, _, _)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val title       = Line.fromString("in sequential order", ident)
+            val unsatisfied = children.filter(_.state.isFailed).map(ident + tabSize -> _)
+            loop(unsatisfied ++ tail, lines :+ title)
+          }
 
-        case (ident, Expectation.Or(children, state, _, _)) :: tail if state.isFailed =>
-          val title       = Line.fromString("one of", ident)
-          val unsatisfied = children.map(ident + tabSize -> _)
-          loop(unsatisfied ++ tail, lines :+ title)
+        case (ident, Expectation.Or(children, state, _, _)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val title       = Line.fromString("one of", ident)
+            val unsatisfied = children.map(ident + tabSize -> _)
+            loop(unsatisfied ++ tail, lines :+ title)
+          }
 
-        case (ident, Expectation.Repeated(child, range, state, _, _, completed)) :: tail if state.isFailed =>
-          val min = Try(range.min.toString).getOrElse("0")
-          val max = Try(range.max.toString).getOrElse("∞")
-          val title =
-            Line.fromString(
-              s"repeated $completed times not in range $min to $max by ${range.step}",
-              ident
-            )
-          val unsatisfied = ident + tabSize -> child
-          loop(unsatisfied :: tail, lines :+ title)
+        case (ident, Expectation.Repeated(child, range, state, _, _, completed)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val min = Try(range.min.toString).getOrElse("0")
+            val max = Try(range.max.toString).getOrElse("∞")
+            val title =
+              Line.fromString(
+                s"repeated $completed times not in range $min to $max by ${range.step}",
+                ident
+              )
+            val unsatisfied = ident + tabSize -> child
+            loop(unsatisfied :: tail, lines :+ title)
+          }
 
-        case (ident, Expectation.Exactly(child, times, state, _, completed)) :: tail if state.isFailed =>
-          val title =
-            Line.fromString(
-              s"exactly $completed times not equal to $times",
-              ident
-            )
-          val unsatisfied = ident + tabSize -> child
-          loop(unsatisfied :: tail, lines :+ title)
+        case (ident, Expectation.Exactly(child, times, state, _, completed)) :: tail =>
+          if (!state.isFailed) loop(tail, lines)
+          else {
+            val title =
+              Line.fromString(
+                s"exactly $completed times not equal to $times",
+                ident
+              )
+            val unsatisfied = ident + tabSize -> child
+            loop(unsatisfied :: tail, lines :+ title)
+          }
 
-        case _ :: tail =>
+        case (_, Expectation.NoCalls(_)) :: tail =>
           loop(tail, lines)
       }
 

--- a/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
+++ b/test/shared/src/main/scala/zio/test/DefaultTestReporter.scala
@@ -550,6 +550,15 @@ object FailureRenderer {
           val unsatisfied = ident + tabSize -> child
           loop(unsatisfied :: tail, lines :+ title)
 
+        case (ident, Expectation.Exactly(child, times, state, _, completed)) :: tail if state.isFailed =>
+          val title =
+            Line.fromString(
+              s"exactly $completed times not equal to $times",
+              ident
+            )
+          val unsatisfied = ident + tabSize -> child
+          loop(unsatisfied :: tail, lines :+ title)
+
         case _ :: tail =>
           loop(tail, lines)
       }


### PR DESCRIPTION
Fixes https://github.com/zio/zio/issues/8007

- Adds a case for Expectation.Exactly to render a message when it has a failure
- Removes the pattern guards and catch-all case to allow the compiler to enforce/prevent future similar omissions
- Adds rendering tests for Expectation.Repeats (previously missing) and Expectation.Exactly