### PR TITLE
add a ZState constructor with the fork and join parameters

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZStateSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZStateSpec.scala
@@ -13,6 +13,15 @@ object ZStateSpec extends ZIOBaseSpec {
             state <- ZIO.getState[Int]
           } yield assertTrue(state == 1)
         }
+      },
+      test("state can be joined between fibers") {
+        ZIO.statefulWith(0)(fork = identity, join = _ + _) {
+          for {
+            fiber <- ZIO.forkAllDiscard(List.fill(100)(ZIO.updateState[Int](_ + 1)))
+            _     <- fiber.join
+            state <- ZIO.getState[Int]
+          } yield assertTrue(state == 100)
+        }
       }
     )
 }


### PR DESCRIPTION
Adds a small helper to facilitate adding the fork/join parameters on FiberRef constructors for more advanced use cases.