### PR TITLE
Fix timer metric

### DIFF
--- a/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/metrics/MetricSpec.scala
@@ -516,6 +516,13 @@ object MetricSpec extends ZIOBaseSpec {
         _ <- ZIO.unit @@ timerWithBoundaries.trackDuration
       } yield assertCompletes
     },
+    test("timer with duration smaller than the unit") {
+      val timer = Metric.timer("timer", ChronoUnit.SECONDS)
+      for {
+        _         <- TestClock.adjust(1.milliseconds) @@ timer.trackDuration
+        histogram <- timer.value
+      } yield assertTrue(histogram.sum > 0d)
+    },
     test("metrics with description") {
       val name = "counterName"
 

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -617,7 +617,7 @@ object Metric {
       .tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
 
     base.contramap[Duration] { (duration: Duration) =>
-      duration.toNanos / chronoUnit.getDuration.toNanos
+      duration.toNanos.toDouble / chronoUnit.getDuration.toNanos
     }
   }
 
@@ -632,7 +632,7 @@ object Metric {
       .tagged(MetricLabel("time_unit", chronoUnit.toString.toLowerCase()))
 
     base.contramap[Duration] { (duration: Duration) =>
-      duration.toNanos / chronoUnit.getDuration.toNanos
+      duration.toNanos.toDouble / chronoUnit.getDuration.toNanos
     }
   }
 }


### PR DESCRIPTION
There was a division between `Long`, and the result was then converted to `Double`.
Instead, we should do a `Double` division to not lose any precision.

This bug was particularly visible when using `ChronoUnit.SECONDS` with times that are under a second: they all ended up to be zero.