### PR TITLE
docs: Clean up some grammar & syntax in core reference

### DIFF
--- a/docs/reference/control-flow/index.md
+++ b/docs/reference/control-flow/index.md
@@ -4,11 +4,11 @@ title: "Introduction to ZIO's Control Flow Operators"
 sidebar_label: "Control Flow"
 ---
 
-Although we have access to built-in scala control flow structures, ZIO has several control flow combinators. In this section, we are going to introduce different ways of controlling flows in ZIO applications.
+Although we have access to built-in Scala control flow structures, ZIO has several control flow combinators. In this section, we are going to introduce different ways of controlling flows in ZIO applications.
 
 ## `if` Expression
 
-When working with ZIO values, we can also work with built-in scala if-then-else expressions:
+When working with ZIO values, we can use built-in Scala if-then-else expressions:
 
 ```scala mdoc:compile-only
 import zio._
@@ -124,7 +124,7 @@ def flipTheCoin: ZIO[Any, IOException, Unit] =
 
 ## Loop Operators
 
-In imperative scala code base, sometime we may use `while(condition) { statement }` or `do { statement } while (condition)` structs to perform loops:
+In imperative Scala code bases, sometimes we may use `while(condition) { statement }` or `do { statement } while (condition)` constructs to perform loops:
 
 ```scala mdoc:compile-only
 object MainApp extends scala.App {
@@ -143,7 +143,7 @@ object MainApp extends scala.App {
 // 3
 ```
 
-But in functional scala, we tend to not use mutable variable. So to have a loop, we would like to use recursions. Let's rewrite the previous example, using recursion:
+But in functional Scala, we tend to avoid mutable variables. So to have a loop, we would like to use recursion. Let's rewrite the previous example using recursion:
 
 ```scala mdoc:compile-only
 import scala.annotation.tailrec
@@ -198,11 +198,11 @@ object MainApp extends ZIOAppDefault {
 }
 ```
 
-After this very short introduction to writing loops in functional scala, now let us go deep into ZIO specific combinators for writing loops:
+After this short introduction to writing loops in functional Scala, now let us go further into ZIO-specific combinators for writing loops:
 
 ### `loop`
 
-The `ZIO.loop` operator takes an initial state, then repeatedly change the state based on the given `inc` function, until the given `cont` function is evaluated to true:
+The `ZIO.loop` operator takes an initial state, then repeatedly changes the state based on the given `inc` function, until the given `cont` function evaluates to true:
 
 ```scala
 object ZIO {
@@ -215,9 +215,9 @@ object ZIO {
   )(cont: S => Boolean, inc: S => S)(body: S => ZIO[R, E, Any]): ZIO[R, E, Unit]
 ```
 
-The `ZIO#loop` collects all intermediate states in a list and returns it finally, while the `ZIO.loopDiscard` discards all results.
+`ZIO.loop` collects all intermediate states in a list and returns it finally, while the `ZIO.loopDiscard` discards all results.
 
-We can think of `ZIO#loop` as a moral equivalent of the following while loop:
+We can think of `ZIO.loop` as a moral equivalent of the following while loop:
 
 ```scala
 var s  = initial
@@ -372,7 +372,7 @@ def getNames: ZIO[Any, IOException, List[String]] =
 
 ### `foreach`
 
-Note that, in several cases, we can avoid these low-level operators and instead use the high-level ones. For example, let's try to rewrite the `r5` with `ZIO.foreach`:
+Note that, in several cases, we can avoid these low-level operators and instead use high-level ones. For example, let's try to rewrite the `r5` with `ZIO.foreach`:
 
 ```scala mdoc:compile-only
 import zio._
@@ -390,13 +390,13 @@ Console.printLine("Please enter three names:") *>
 
 ## try/catch/finally
 
-When working with resources, just like the scala's `try`/`catch`/`finally` construct, in ZIO we have a similar operator called `acquireRelease` and also `ensuring`. We discussed them in more detail in the [resource management section](../resource/index.md). But, for now, we want to focus on their control flow behaviors.
+When working with resources, just like Scala's `try`/`catch`/`finally` construct, in ZIO we have a similar operator called `acquireRelease` and also `ensuring`. We discussed them in more detail in the [resource management section](../resource/index.md). But, for now, we want to focus on their control flow behaviors.
 
 Let's learn about the `ZIO.acquireReleaseWith` operator. This operator takes three effects:
 
-1. **`acquire`** an effect that describes the resource acquisition
-2. **`release`** an effect that describes the release of the resource
-3. **`use`** an effect that describes resource usage
+1. **`acquire`**, an effect that describes the resource acquisition
+2. **`release`**, an effect that describes the release of the resource
+3. **`use`**, an effect that describes resource usage
 
 ```scala mdoc:compile-only
 import zio._
@@ -404,7 +404,7 @@ import zio._
 ZIO.acquireReleaseWith(acquire = ???)(release = ???)(use = ???)
 ```
 
-This operator guarantees us that if the _resource acquisition (acquire)_ the _release_ effect will be executed whether the _use_ effect succeeded or not:
+This operator guarantees us that if the _resource acquisition (acquire)_ succeeds, the _release_ effect will be executed whether the _use_ effect succeeded or not:
 
 ```scala mdoc:compile-only
 import java.io.IOException

--- a/docs/reference/core/runtime.md
+++ b/docs/reference/core/runtime.md
@@ -12,13 +12,13 @@ To run an effect, we need a `Runtime`, which is capable of executing effects. Ru
 
 ## What is a Runtime System?
 
-Whenever we write a ZIO program, we create a ZIO effect from ZIO constructors plus using its combinators. We are building a blueprint. ZIO effect is just a data structure that describes the execution of a concurrent program. So we end up with a tree data structure that contains lots of different data structures combined together to describe what the ZIO effect should do. This data structure doesn't do anything, it is just a description of a concurrent program.
+Whenever we write a ZIO program, we create a ZIO effect from ZIO constructors plus using its combinators. We are building a blueprint. A ZIO effect is just a data structure that describes the execution of a concurrent program. So we end up with a tree data structure that contains lots of different data structures combined together to describe what the ZIO effect should do. This data structure doesn't do anything, it is just a description of a concurrent program.
 
-So the most important thing we should keep in mind when we are working with a functional effect system like ZIO is that when we are writing code, printing a string onto the console, reading a file, querying a database, and so forth; We are just writing a workflow or blueprint of an application. We are just building a data structure.
+So the most important thing we should keep in mind when we are working with a functional effect system like ZIO is that when we are writing code, printing a string onto the console, reading a file, querying a database, and so forth, we are just writing a workflow or blueprint of an application. We are just building a data structure.
 
-So how can ZIO run these workflows? This is where ZIO Runtime System comes into play. Whenever we run an `unsaferun` function, the Runtime System is responsible to step through all the instructions described by the ZIO effect and execute them.
+So how can ZIO run these workflows? This is where the ZIO Runtime System comes into play. Whenever we run an `unsafe.run` function, the Runtime System is responsible for stepping through all the instructions described by the ZIO effect and executing them.
 
-To simplify everything, we can think of a Runtime System like a black box that takes both the ZIO effect (`ZIO[R, E, A]`) and its environment (`R`), it will run this effect and then will return its result as an `Either[E, A]` value.
+To simplify everything, we can think of a Runtime System like a black box that takes both the ZIO effect (`ZIO[R, E, A]`) and its environment (`R`). It will run this effect and return its result as an `Either[E, A]` value.
 
 
 ![ZIO Runtime System](/img/zio-runtime-system.svg)
@@ -31,19 +31,19 @@ Runtime Systems have a lot of responsibilities:
 
 2. **Handle unexpected errors** — They have to handle unexpected errors, not just the expected ones but also the unexpected ones. 
 
-3. **Spawn concurrent fiber** — They are actually responsible for the concurrency that effect systems have. They have to spawn a fiber every time we call `fork` on an effect to spawn off a new fiber.
+3. **Spawn concurrent fibers** — They are actually responsible for the concurrency that effect systems have. They have to spawn a new fiber every time we call `fork` on an effect.
 
 4. **Cooperatively yield to other fibers** — They have to cooperatively yield to other fibers so that fibers that are sort of hogging the spotlight, don't get to monopolize all the CPU resources. They have to make sure that the fibers split the CPU cores among all the fibers that are working.
 
-5. **Capture execution and stack traces** — They have to keep track of where we are in the progress of our own user-land code so the nice detailed execution traces can be captured. 
+5. **Capture execution and stack traces** — They have to keep track of where we are in the progress of our own user-land code, so detailed execution traces can be captured. 
 
-6. **Ensure finalizers are run appropriately** — They have to ensure finalizers are run appropriately at the right point in all circumstances to make sure that resources are closed that clean-up logic is executed. This is the feature that powers Scope and all the other resource-safe constructs in ZIO.
+6. **Ensure finalizers are run appropriately** — They have to ensure finalizers are run appropriately at the right point in all circumstances to make sure that resources are closed and clean-up logic is executed. This is the feature that powers `Scope` and all the other resource-safe constructs in ZIO.
 
-7. **Handle asynchronous callback** — They have to handle this messy job of dealing with asynchronous callbacks. So we don't have to deal with async code. When we are doing ZIO, everything is just async out of the box. 
+7. **Handle asynchronous callbacks** — They have to handle this messy job of dealing with asynchronous callbacks. So we don't have to deal with async code. When we are using ZIO, everything is just async out of the box. 
 
 ## Running a ZIO Effect
 
-There are two common ways to run a ZIO effect. Most of the time, we use the [`ZIOAppDefault`](zioapp.md) trait. There are, however, some advanced use cases for which we need to directly feed a ZIO effect into the runtime system's `unsafeRun` method:
+There are two common ways to run a ZIO effect. Most of the time, we use the [`ZIOAppDefault`](zioapp.md) trait. There are, however, some advanced use cases for which we need to directly feed a ZIO effect into the runtime system's `unsafe.run` method:
 
 ```scala mdoc:compile-only
 import zio._
@@ -63,11 +63,11 @@ object RunZIOEffectUsingUnsafeRun extends scala.App {
 }
 ```
 
-We don't usually use this method to run our effects. One of the use cases of this method is when we are integrating the legacy (non-effectful code) with the ZIO effect. It also helps us to refactor a large legacy code base into a ZIO effect gradually; Assume we have decided to refactor a component in the middle of a legacy code and rewrite that with ZIO. We can start rewriting that component with the ZIO effect and then integrate that component with the existing code base, using the `unsafeRun` function.
+We don't usually use this method to run our effects. One of the use cases of this method is when we are integrating legacy (non-effectful) code with the ZIO effect. It helps us to refactor a large legacy code base into a ZIO effect gradually: assume we have decided to refactor a component in the middle of an application and rewrite that with ZIO. We can start rewriting that component with the ZIO effect and then integrate that component with the existing code base using the `unsafe.run` function.
 
 ## Default Runtime
 
-ZIO contains a default runtime called `Runtime.default` designed to work well for mainstream usage. It is already implemented as below:
+ZIO contains a default runtime called `Runtime.default` designed to work well for mainstream usage. It is implemented as below:
 
 ```scala
 object Runtime {
@@ -76,7 +76,7 @@ object Runtime {
 }
 ```
 
-The default runtime contains minimum capabilities to bootstrap execution of ZIO tasks.
+The default runtime provides the minimum capabilities to bootstrap execution of ZIO tasks.
 
 We can easily access the default `Runtime` to run an effect:
 
@@ -92,7 +92,7 @@ object MainApp extends scala.App {
 }
 ```
 
-## Top-level And Locally Scoped Runtimes
+## Top-level and Locally Scoped Runtimes
 
 In ZIO, we have two types of runtimes:
 
@@ -105,7 +105,7 @@ In ZIO, we have two types of runtimes:
   - In some performance-critical regions, we want to disable logging temporarily.
   - When we want to have a customized executor for running a portion of our code.
 
-ZLayer provides a consistent way to customize and configure runtimes. Using layers to customize the runtime, enables us to use ZIO workflows. So a configuration workflow can be pure, effectful, or resourceful. Let's say we want to customize the runtime based on configuration information from a file or database.
+ZLayer provides a consistent way to customize and configure runtimes. Using layers to customize the runtime enables us to use ZIO workflows. So a configuration workflow can be pure, effectful, or resourceful. Let's say we want to customize the runtime based on configuration information from a file or database.
 
 In most cases, it is sufficient to customize application runtime using the [`bootstrap` layer](#configuring-runtime-using-bootstrap-layer) or [providing a custom configuration](#configuring-runtime-by-providing-configuration-layers) directly to our application. If none of these solutions fit to our problem, we can use [top-level runtime configurations](#top-level-runtime-configuration).
 
@@ -178,7 +178,7 @@ timestamp=2022-08-31T14:28:34.832035Z level=INFO thread=#zio-fiber-6 message="Ap
 
 ### Configuring Runtime Using `bootstrap` Layer
 
-The `bootstrap` layer is a special layer that is mainly used to acquiring and releasing services that are necessary for the application to run. However, it can also be applied to runtime customization as well. This solution requires us to override the `bootstrap` layer from the `ZIOApp` trait.
+The `bootstrap` layer is a special layer that is mainly used to acquire and release services that are necessary for the application to run. However, it can also be applied to runtime customization as well. This solution requires us to override the `bootstrap` layer from the `ZIOApp` trait.
 
 By using this technique, after initialization of the top-level runtime, it will provide the `bootstrap` layer to the ZIO application given through the `run` method.
 
@@ -207,7 +207,7 @@ Application started!
 Application is about to exit!
 ```
 
-Although using this method will apply the configuration layer to the whole ZIO application, it is categorized as local runtime configuration, because the `bootstrap` layer is evaluated and applied after the top-level runtime is initialized. So it will only be applied to the ZIO application given through the `run` method.
+Although using this method will apply the configuration layer to the whole ZIO application, it is categorized as local runtime configuration because the `bootstrap` layer is evaluated and applied after the top-level runtime is initialized. So it will only be applied to the ZIO application given through the `run` method.
 
 To elaborate more on this, let's look at the following example:
 
@@ -232,7 +232,7 @@ object MainApp extends ZIOAppDefault {
 }
 ```
 
-What do we expect to see as the output? We have a `Runtime.removeDefaultLoggers` which removes the default logger from the runtime. So we expect to see log messages only from the simple logger. But that is not the case. We have an effectful configuration layer that is evaluated after the top-level runtime is initialized. So we can see the log message related to the initialization of `effectfulConfiguration` layer from the default logger:
+What do we expect to see as the output? We have `Runtime.removeDefaultLoggers` which removes the default logger from the runtime. So we expect to see log messages only from the simple logger. But that is not the case. We have an effectful configuration layer that is evaluated after the top-level runtime is initialized. So we can see the log message related to the initialization of `effectfulConfiguration` layer from the default logger:
 
 ```scala
 timestamp=2022-09-01T08:07:47.870219Z level=INFO thread=#zio-fiber-6 message="Started effectful workflow to customize runtime configuration" location=<empty>.MainApp.effectfulConfiguration file=ZIOApp.scala line=8
@@ -326,7 +326,7 @@ object MainApp {
 
 The custom runtime can be used to run many different effects that all require the same environment, so we don't have to call `ZIO#provide` on all of them before we run them.
 
-For example, assume we want to create a `Runtime` for services that are for testing purposes, and they don't interact with real external APIs. So we can create a runtime, especially for testing.
+For example, assume we want to create a `Runtime` for services that are for testing purposes, and they don't interact with real external APIs. So we can create a runtime especially for testing.
 
 Let's say we have defined two `LoggingService` and `EmailService` services:
 

--- a/docs/reference/core/zio/io.md
+++ b/docs/reference/core/zio/io.md
@@ -23,12 +23,11 @@ So `IO` is equal to a `ZIO` that doesn't need any requirement.
 
 `ZIO` values of type `IO[E, Nothing]` (where the value type is `Nothing`) are considered _unproductive_, because the `Nothing` type is _uninhabitable_, i.e. there can be no actual values of type `Nothing`. Values of this type may fail with an `E`, but will never produce a value.
 
-:::note Principle of The Least Power
+:::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On other hand, the type aliases are a way of subtyping and specializing the `ZIO` type, specific for a less powerful workflow. 
- 
+The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
-Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
+Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::

--- a/docs/reference/core/zio/rio.md
+++ b/docs/reference/core/zio/rio.md
@@ -22,11 +22,11 @@ type RIO[-R, +A]  = ZIO[R, Throwable, A]
 So `RIO` is equal to a `ZIO` that requires `R`, and whose error channel is `Throwable`. It succeeds with `A`.
 
 
-:::note _Principle of The Least Power_
+:::note _Principle of Least Power_
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On other hand, the type aliases are a way of subtyping and specializing the `ZIO` type, specific for a less powerful workflow. 
+The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
-Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
+Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::

--- a/docs/reference/core/zio/task.md
+++ b/docs/reference/core/zio/task.md
@@ -7,7 +7,7 @@ title: "Task"
 
 :::note
 
-In Scala, the _type alias_ is a way to give a name to another type, to avoid having to repeat the original type again and again. It doesn't affect the type-checking process. It just helps us to have an expressive API design.
+In Scala, a _type alias_ is a way to give a name to another type, to avoid having to repeat the original type again and again. It doesn't affect results of the type-checking process. It just helps us to have an expressive API design.
 :::
 
 Let's see how the `Task` type alias is defined:
@@ -20,17 +20,17 @@ import zio.ZIO
 type Task[+A] = ZIO[Any, Throwable, A]
 ```
 
-So a `Task` is equal to a `ZIO` that doesn't need any requirement, and may fail with a `Throwable`, or succeed with an `A` value.
+So a `Task` is equivalent to a `ZIO` that doesn't need any requirement, and may fail with a `Throwable`, or succeed with an `A` value.
 
-Sometimes, we know that our effect may fail, but we don't care about the type of that exception. This is where we can use `Task`. The type signature of this type-alias is similar to the `Future[T]` and Cats `IO`.
+Sometimes we know that our effect may fail, but we don't care about the type of that exception. This is where we can use `Task`. The signature of this type alias is similar to `Future[T]` and Cats `IO`.
 
-If we want to be less precise and want to eliminate the need to think about requirements and error types, we can use `Task`. This type-alias is a good start point for anyone who wants to refactor the current code base which is written in Cats `IO` or Monix `Task`. 
+If we want to be less precise and eliminate the need to think about requirements and error types, we can use `Task`. This type alias is a good starting point for anyone who wants to refactor an existing code base which is written with Cats `IO` or Monix `Task`. 
 
-:::note Principle of The Least Power
+:::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On other hand, the type aliases are a way of subtyping and specializing the `ZIO` type, specific for a less powerful workflow. 
+The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
-Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
+Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::

--- a/docs/reference/core/zio/uio.md
+++ b/docs/reference/core/zio/uio.md
@@ -42,11 +42,11 @@ def fib(n: Int): UIO[Int] =
   }
 ```
 
-:::note Principle of The Least Power
+:::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On other hand, the type aliases are a way of subtyping and specializing the `ZIO` type, specific for a less powerful workflow. 
+The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
-Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
+Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::

--- a/docs/reference/core/zio/urio.md
+++ b/docs/reference/core/zio/urio.md
@@ -22,11 +22,11 @@ type URIO[-R, +A] = ZIO[R, Nothing, A]
 
 So `URIO` is equal to a `ZIO` that requires `R` and cannot fail (because in Scala the `Nothing` type has no inhabitant, so we can't create an instance of type `Nothing`). It succeeds with `A`.
 
-:::note Principle of The Least Power
+:::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On other hand, the type aliases are a way of subtyping and specializing the `ZIO` type, specific for a less powerful workflow. 
+The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
-Lot of the time, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the proper specialized type alias.
+Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::

--- a/docs/reference/core/zio/zio.md
+++ b/docs/reference/core/zio/zio.md
@@ -163,9 +163,9 @@ val r3: ZIO[Any, NumberFormatException, Int] =
 
 4. **`ZIO.nonOrFail`**— It lifts an option into a ZIO value. If the option is empty it succeeds with `Unit` and if the option is defined it fails with a proper error type:
 
-- `ZIO.nonOrFail` fails with the content of the optional value.
-- `ZIO.nonOrFailUnit` fails with the `Unit` error type.
-- `ZIO.nonOrFailWith` fails with custom error type.
+- `ZIO.noneOrFail` fails with the content of the optional value.
+- `ZIO.noneOrFailUnit` fails with the `Unit` error type.
+- `ZIO.noneOrFailWith` fails with custom error type.
 
 ```scala mdoc:compile-only
 import zio._
@@ -353,7 +353,7 @@ ZIO has a separate **blocking thread pool** specially designed for **Blocking I/
 ZIO has an auto-blocking mechanism that detects blocking operations and runs them on a separate blocking thread pool. However, if you know that some code is blocking you can use the `ZIO.blocking` constructor to give a "hint" of this to the ZIO runtime.
 :::
 
-The `blocking` operator takes a ZIO effect and return another effect that is going to run on a blocking thread pool:
+The `blocking` operator takes a ZIO effect and returns another effect that is going to run on a blocking thread pool:
 
 ```scala mdoc:invisible
 import zio._
@@ -361,7 +361,7 @@ import zio._
 def blockingTask(i: Int): ZIO[Any, Throwable, Unit] = ???
 ```
 
-```scala mdoc:nest
+```scala mdoc:nest:silent
 val program = ZIO.foreachPar((1 to 100).toArray)(t => ZIO.blocking(blockingTask(t)))
 ```
 
@@ -881,9 +881,9 @@ io.ensuring(f1)
  .ensuring(f3)
 ```
 
-### AcquireRelease
+### Acquire Release
 
-In Scala the `try` / `finally` is often used to manage resources. A common use for `try` / `finally` is safely acquiring and releasing resources, such as new socket connections or opened files:
+In Scala `try` / `finally` is often used to manage resources. A common use for `try` / `finally` is safely acquiring and releasing resources, such as new socket connections or opened files:
 
 ```scala
 val handle = openFile(name)
@@ -973,7 +973,7 @@ So they don't affect the return type of our workflows, but they add some new asp
 
 To increase the modularity of our applications, we can separate cross-cutting concerns from the main logic of our programs. ZIO supports this programming paradigm, which is called _ aspect-oriented programming_.
 
-The `ZIO` effect has a data type called `ZIOAspect`, which allows modifying a `ZIO` effect and convert it into a specialized `ZIO` effect. We can add a new aspect to a `ZIO` effect with `@@` syntax like this:
+The `ZIO` effect has a data type called `ZIOAspect`, which allows modifying a `ZIO` effect and converting it into a specialized `ZIO` effect. We can add a new aspect to a `ZIO` effect with `@@` syntax like this:
 
 ```scala mdoc:compile-only
 import zio._

--- a/docs/reference/core/zioapp.md
+++ b/docs/reference/core/zioapp.md
@@ -45,7 +45,7 @@ object HelloApp extends ZIOAppDefault {
 
 ## Customized Runtime
 
-In the ZIO app, by overriding its `runtime` value, we can map the current runtime to a customized one. Let's customize it by introducing our own executor:
+In the ZIO app, by overriding its `bootstrap` value, we can map the current runtime to a customized one. Let's customize it by introducing our own executor:
 
 ```scala mdoc:invisible
 import zio._


### PR DESCRIPTION
Greetings ZIO community,

I've been making a close-reading pass through ZIO core docs, with my text editor close at hand. I find them to be in good shape "in the large"—comprehensive coverage, organization—but to have a lot of speed bumps in the small that I could improve as I go. Style and phrasing are subjective, grammar & syntax are more objective, so I will try to separate these types of changes into PRs that are likely to warrant more or less discussion, respectively.

If still smaller patches would be preferred, let me know.

This one is a first pass of a few sections/chapters on the objective front. Some minor rephrasing may creep in if it fell on the same line as a grammar fix, usually attempting to be more concise, reducing wordiness or repetition.

Disclaimer: I am not a credentialed technical writer, I sometimes might not be able to give better rationale than "it just sounds odd to me as a native English speaker…" 😅

Also, friendly reminder that GitHub has the "rich diffs" toggle that can be useful for reviewing lots of prose changes.