### PR TITLE
Fixed broken symbolic links for CoC, Contributing Guideline

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,1 @@
-docs/about/code-of-conduct.md
+./docs/code-of-conduct.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-docs/about/contributing.md
+./docs/contributor-guidelines.md


### PR DESCRIPTION
The directory structure of `/docs` was changed in `v2.0.11`, but symbolic links for 'Code of Conduct' and 'Contributor Guideline' weren't reflecting those changes. Just fixing those two.