### PR TITLE
Handle Differences In Ancestor Values When Joining Fiber Refs

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -441,38 +441,16 @@ object FiberRefSpec extends ZIOBaseSpec {
         value <- promise.await
       } yield assertTrue(value)
     },
-    test("child fiber inherits changes made by parent after fork when joining parent") {
-      def parent(
-        fiberRef: FiberRef[Set[String]],
-        promise: Promise[Nothing, Fiber.Runtime[Any, Any]]
-      ): ZIO[Any, Nothing, Set[String]] =
-        for {
-          parent  <- promise.await
-          promise <- Promise.make[Nothing, Fiber.Runtime[Any, Any]]
-          _       <- fiberRef.update(_ + "parent before")
-          child   <- child(fiberRef, promise).fork
-          _       <- fiberRef.update(_ + "parent after")
-          _       <- promise.succeed(parent)
-          value   <- child.join
-        } yield value
-
-      def child(
-        fiberRef: FiberRef[Set[String]],
-        promise: Promise[Nothing, Fiber.Runtime[Any, Any]]
-      ): ZIO[Any, Nothing, Set[String]] =
-        for {
-          parent <- promise.await
-          _      <- parent.inheritAll
-          value  <- fiberRef.get
-        } yield value
-
+    test("child fiber inherits subsequent changes made by parent when joining sibling") {
       for {
-        fiberRef <- FiberRef.makeSet(Set.empty[String])
+        fiberRef <- FiberRef.make(false)
         promise  <- Promise.make[Nothing, Fiber.Runtime[Any, Any]]
-        parent   <- parent(fiberRef, promise).fork
-        _        <- promise.succeed(parent)
-        value    <- parent.join
-      } yield assertTrue(value == Set("parent before", "parent after"))
+        child1   <- (promise.await.flatMap(_.join) *> fiberRef.get).fork
+        _        <- fiberRef.set(true)
+        child2   <- ZIO.unit.fork
+        _        <- promise.succeed(child2)
+        value    <- child1.join
+      } yield assertTrue(value)
     }
   ) @@ TestAspect.fromLayer(Runtime.enableCurrentFiber) @@ TestAspect.sequential
 }


### PR DESCRIPTION
This addresses a somewhat degenerate situation where a child fiber obtains a reference to its own parent and inherits `FiberRef` values from its parent.

Normally, our logic when inheriting `FiberRef` values is to identify the common ancestor between the "joining" and "joined" fibers and compute the difference between the joined fiber's record of the ancestor value and its current value, reasoning that this represents all the changes that the joined fiber has made that should then be applied to the joining fiber.

This works in all cases but one, which is where the joined fiber is actually the parent of the joining fiber and thus the common ancestor is the joined fiber. Since we only track the current value of a `FiberRef` for each fiber, if the parent made a change to its `FiberRef` value after forking the child and then the child inherits from the parent, the child will not pick up this change.

We can instead handle this case by reasoning that if the joined fiber is the common ancestor, that is if we are inheriting from our parent, then we are inheriting from the parent after the time it forked us and thus any differences between its current `FiberRef` value and the value we have from when we were forked were made by the parent subsequently and thus are ones that we should apply to ourselves.