### PR TITLE
Fixing OOM Error in the build-website Job of the CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,6 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ ((github.event_name != 'repository_dispatch') && (github.event.action != 'update-docs')) }}
     steps:
-      - name: Print Memory Info
-        run: while true; do free -h; sleep 5; done &
-    
       - name: Checkout Current Branch
         uses: actions/checkout@v3
         with:
@@ -128,6 +125,7 @@ jobs:
 
       - name: Compile Docs
         run: |
+          while true; do free -h; sleep 5; done &
           sbt -mem 2048 docs/mdoc -verbose
           sbt -mem 2048 docs/unidoc -verbose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: ${{ ((github.event_name != 'repository_dispatch') && (github.event.action != 'update-docs')) }}
     steps:
-      - name: Checkout series/2.x Branch
+      - name: Print Memory Info
+        run: while true; do free -h; sleep 5; done &
+    
+      - name: Checkout Current Branch
         uses: actions/checkout@v3
         with:
           fetch-depth: '0'
@@ -125,8 +128,8 @@ jobs:
 
       - name: Compile Docs
         run: |
-          sbt docs/mdoc
-          sbt docs/unidoc
+          sbt -mem 2048 docs/mdoc -verbose
+          sbt -mem 2048 docs/unidoc -verbose
 
       - name: Build The Website
         working-directory: ./website


### PR DESCRIPTION
I couldn't determine why the 'build-website' job only fails during the release event. Anyway, I tested this code during the release event and it appears to be working as intended. However, I have left diagnostic memory information to ensure that everything also works on the main repository. Then we can remove extra debug stuff.