### PR TITLE
Avoiding Boxing in Chunk

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkFoldBenchmarks.scala
@@ -17,17 +17,28 @@ class ChunkFoldBenchmarks {
   var chunk: Chunk[Int]   = _
   var vector: Vector[Int] = _
   var list: List[Int]     = _
+  var array: Array[Int]   = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
-    val array = (1 to size).toArray
-    chunk = Chunk.fromArray(array)
-    vector = array.toVector
-    list = array.toList
+    val arr = (1 to size).toArray
+    chunk = Chunk.fromArray(arr)
+    vector = arr.toVector
+    list = arr.toList
+    array = arr
   }
 
   @Benchmark
   def foldChunk(): Int = chunk.fold(0)(_ + _)
+
+  @Benchmark
+  def foldArray(): Int = array.fold(0)(_ + _)
+
+  @Benchmark
+  def foldRightChunk(): Int = chunk.foldRight(0)(_ + _)
+
+  @Benchmark
+  def foldRightArray(): Int = array.foldRight(0)(_ + _)
 
   @Benchmark
   def foldVector(): Int = vector.fold(0)(_ + _)

--- a/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
@@ -17,17 +17,22 @@ class ChunkMapBenchmarks {
   var chunk: Chunk[Int]   = _
   var vector: Vector[Int] = _
   var list: List[Int]     = _
+  var array: Array[Int]   = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
-    val array = (1 to size).toArray
-    chunk = Chunk.fromArray(array)
-    vector = array.toVector
-    list = array.toList
+    val arr = (1 to size).toArray
+    chunk = Chunk.fromArray(arr)
+    vector = arr.toVector
+    list = arr.toList
+    array = arr
   }
 
   @Benchmark
   def mapChunk(): Chunk[Int] = chunk.map(_ * 2)
+
+  @Benchmark
+  def mapArray(): Array[Int] = array.map(_ * 2)
 
   @Benchmark
   def mapVector(): Vector[Int] = vector.map(_ * 2)

--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -51,10 +51,22 @@ class MixedChunkBenchmarks {
   }
 
   @Benchmark
+  def foreach(): Unit = chunk.foreach(_ * 2)
+
+  @Benchmark
+  def foreachMaterialized(): Unit = chunkMaterialized.foreach(_ * 2)
+
+  @Benchmark
   def fold(): Int = chunk.foldLeft(0)(_ + _)
 
   @Benchmark
+  def foldRight(): Int = chunk.foldRight(0)(_ + _)
+
+  @Benchmark
   def foldMaterialized(): Int = chunkMaterialized.foldLeft(0)(_ + _)
+
+  @Benchmark
+  def foldRightMaterialized(): Int = chunkMaterialized.foldRight(0)(_ + _)
 
   @Benchmark
   def filterZIO(): Chunk[Int] =
@@ -65,16 +77,25 @@ class MixedChunkBenchmarks {
     BenchmarkUtil.unsafeRun(chunkMaterialized.filterZIO[Any, Nothing](n => ZIO.succeed(n % 2 == 0)))
 
   @Benchmark
-  def map(): Chunk[Int] = chunk.map(_ * 2)
+  def map(): Chunk[Int] =
+    chunk.map(_ * 2)
 
   @Benchmark
-  def mapMaterialized(): Chunk[Int] = chunkMaterialized.map(_ * 2)
+  def mapMaterialized(): Chunk[Int] =
+    chunkMaterialized.map(_ * 2)
+
+  @Benchmark
+  def mapToLongMaterialized(): Chunk[Long] =
+    chunkMaterialized.map(_ * 2L)
 
   @Benchmark
   def flatMap(): Chunk[Int] = chunk.flatMap(n => Chunk(n + 2))
 
   @Benchmark
   def flatMapMaterialized(): Chunk[Int] = chunkMaterialized.flatMap(n => Chunk(n + 2))
+
+  @Benchmark
+  def flatMap2Materialized(): Chunk[Int] = chunkMaterialized.flatMap(n => Chunk(n, n + 1, n + 2))
 
   @Benchmark
   def find(): Option[Int] = chunk.find(_ > 2)
@@ -89,6 +110,10 @@ class MixedChunkBenchmarks {
   @Benchmark
   def mapZIOMaterialized(): Unit =
     BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIODiscard(_ => ZIO.unit))
+
+  @Benchmark
+  def realMapZIOMaterialized(): Unit =
+    BenchmarkUtil.unsafeRun(chunkMaterialized.mapZIO(i => ZIO.succeed(i * 2)).flatMap(_ => ZIO.unit))
 
   @Benchmark
   def foldZIO(): Int =

--- a/core/shared/src/main/scala-2.12/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkLike.scala
@@ -93,7 +93,7 @@ private[zio] trait ChunkLike[+A]
    * Returns a chunk with the elements mapped by the specified function.
    */
   override final def map[B, That](f: A => B)(implicit bf: CanBuildFrom[Chunk[A], B, That]): That =
-    if (isChunkCanBuildFrom[A, B, That](bf)) mapChunk(f).asInstanceOf[That]
+    if (isChunkCanBuildFrom[A, B, That](bf)) map(f).asInstanceOf[That]
     else super.map(f)
 
   /**

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -19,7 +19,7 @@ package zio
 import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.collection.mutable.{ArrayBuilder, Builder}
+import scala.collection.mutable.{ArrayBuilder, Buffer, Builder}
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,
@@ -37,7 +37,16 @@ import scala.{
  * build chunks of unboxed primitives and for compatibility with the Scala
  * collection library.
  */
-sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]]
+sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]] {
+
+  override def addAll(xs: IterableOnce[A]): this.type = {
+    val it = xs.iterator
+    while (it.hasNext) {
+      addOne(it.next())
+    }
+    this
+  }
+}
 
 object ChunkBuilder {
 
@@ -103,9 +112,7 @@ object ChunkBuilder {
    */
   final class Boolean extends ChunkBuilder[SBoolean] { self =>
 
-    private val arrayBuilder: ArrayBuilder[SByte] = {
-      new ArrayBuilder.ofByte
-    }
+    private val arrayBuilder      = new ArrayBuilder.ofByte
     private var lastByte: SByte   = 0.toByte
     private var maxBitIndex: SInt = 0
 
@@ -164,15 +171,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Byte` values.
    */
   final class Byte extends ChunkBuilder[SByte] { self =>
-    private val arrayBuilder: ArrayBuilder[SByte] = {
-      new ArrayBuilder.ofByte
-    }
+    private val arrayBuilder = new ArrayBuilder.ofByte
     override def addAll(as: IterableOnce[SByte]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SByte): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -194,15 +199,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Char` values.
    */
   final class Char extends ChunkBuilder[SChar] { self =>
-    private val arrayBuilder: ArrayBuilder[SChar] = {
-      new ArrayBuilder.ofChar
-    }
+    private val arrayBuilder = new ArrayBuilder.ofChar
     override def addAll(as: IterableOnce[SChar]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SChar): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -225,15 +228,13 @@ object ChunkBuilder {
    * values.
    */
   final class Double extends ChunkBuilder[SDouble] { self =>
-    private val arrayBuilder: ArrayBuilder[SDouble] = {
-      new ArrayBuilder.ofDouble
-    }
+    private val arrayBuilder = new ArrayBuilder.ofDouble
     override def addAll(as: IterableOnce[SDouble]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SDouble): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -255,15 +256,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Float` values.
    */
   final class Float extends ChunkBuilder[SFloat] { self =>
-    private val arrayBuilder: ArrayBuilder[SFloat] = {
-      new ArrayBuilder.ofFloat
-    }
+    private val arrayBuilder = new ArrayBuilder.ofFloat
     override def addAll(as: IterableOnce[SFloat]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SFloat): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -285,15 +284,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Int` values.
    */
   final class Int extends ChunkBuilder[SInt] { self =>
-    private val arrayBuilder: ArrayBuilder[SInt] = {
-      new ArrayBuilder.ofInt
-    }
+    private val arrayBuilder = new ArrayBuilder.ofInt
     override def addAll(as: IterableOnce[SInt]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SInt): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -315,15 +312,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Long` values.
    */
   final class Long extends ChunkBuilder[SLong] { self =>
-    private val arrayBuilder: ArrayBuilder[SLong] = {
-      new ArrayBuilder.ofLong
-    }
+    private val arrayBuilder = new ArrayBuilder.ofLong
     override def addAll(as: IterableOnce[SLong]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SLong): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -345,15 +340,13 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Short` values.
    */
   final class Short extends ChunkBuilder[SShort] { self =>
-    private val arrayBuilder: ArrayBuilder[SShort] = {
-      new ArrayBuilder.ofShort
-    }
+    private val arrayBuilder = new ArrayBuilder.ofShort
     override def addAll(as: IterableOnce[SShort]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SShort): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -88,7 +88,7 @@ trait ChunkLike[+A]
     if (B0 == null) Chunk.empty
     else {
       implicit val B: ClassTag[B] = B0
-      val dest: Array[B]          = Array.ofDim(total)
+      val dest: Array[B]          = B.newArray(total)
       val it                      = chunks.iterator
       var n                       = total
       while (it.hasNext) {
@@ -117,8 +117,7 @@ trait ChunkLike[+A]
   /**
    * Returns a chunk with the elements mapped by the specified function.
    */
-  override final def map[B](f: A => B): Chunk[B] =
-    mapChunk(f)
+  def map[B](f: A => B): Chunk[B]
 
   override def sorted[A1 >: A](implicit ord: Ordering[A1]): Chunk[A] = {
     implicit val classTag = Chunk.classTagOf(self)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1554,7 +1554,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
     override def flatMap[B](f: A => IterableOnce[B]): Chunk[B]
 
-    def array: Array[A]
+    val array: Array[A]
 
     implicit val classTag: ClassTag[A] =
       ClassTag(array.getClass.getComponentType)
@@ -1688,7 +1688,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       val len = length
       var i   = 0
       while (i < len) {
-        f(apply(i))
+        f(self(i))
         i += 1
       }
     }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -469,7 +469,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] with Serializable { self =>
   /**
    * Folds over the elements in this chunk from the left.
    */
-  final override def foldLeft[S](s0: S)(f: (S, A) => S): S = {
+  override def foldLeft[S](s0: S)(f: (S, A) => S): S = {
     val iterator = self.chunkIterator
     var index    = 0
     var s        = s0
@@ -484,13 +484,13 @@ sealed trait Chunk[+A] extends ChunkLike[A] with Serializable { self =>
   /**
    * Effectfully folds over the elements in this chunk from the left.
    */
-  def foldZIO[R, E, S](s: S)(f: (S, A) => ZIO[R, E, S])(implicit trace: Trace): ZIO[R, E, S] =
+  final def foldZIO[R, E, S](s: S)(f: (S, A) => ZIO[R, E, S])(implicit trace: Trace): ZIO[R, E, S] =
     ZIO.foldLeft(self)(s)(f)
 
   /**
    * Folds over the elements in this chunk from the right.
    */
-  final override def foldRight[S](s0: S)(f: (A, S) => S): S = {
+  override def foldRight[S](s0: S)(f: (A, S) => S): S = {
     val len = self.length
     val it  = self.chunkIterator
     var s   = s0
@@ -670,7 +670,7 @@ sealed trait Chunk[+A] extends ChunkLike[A] with Serializable { self =>
   /**
    * Effectfully maps the elements of this chunk purely for the effects.
    */
-  def mapZIODiscard[R, E](f: A => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
+  final def mapZIODiscard[R, E](f: A => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
     ZIO.foreachDiscard(self)(f)
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -28,7 +28,6 @@ import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 import izumi.reflect.macrortti.LightTypeTag
-import zio.Chunk.ChunkIteratorWithState
 
 /**
  * A `ZIO[R, E, A]` value is an immutable value (called an "effect") that
@@ -3343,18 +3342,6 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       val builder  = bf.newBuilder(in)
 
       ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
-    }
-
-  def chunkForeach[R, E, A, B](ch: Chunk[A])(
-    f: A => ZIO[R, E, B]
-  )(implicit trace: Trace): ZIO[R, E, Chunk[B]] =
-    ZIO.suspendSucceed {
-      val builder  = ChunkBuilder.make[B](ch.length)
-      val iterator = new ChunkIteratorWithState(ch)
-
-      ZIO
-        .whileLoop(iterator.hasNext)(f(iterator.next()))(builder.addOne _)
-        .as(builder.result())
     }
 
   /**


### PR DESCRIPTION
There I add some changes which improve the `Chunk` performance mostly by avoiding boxing for primitive types.

Firstly, now we can map chunk on one primitive type to another without boxing! This makes map operations faster in 4.5-7 times. Even faster then `Array[Int].map(_.toLong)`

Secondly, I fix some boxing in ChunkBuilder. 

I run benchmarks by command 
```benchmarks/jmh:run  .*MixedChunkBenchmarks -i 2 -wi 2 -f 3 -t 1``` 
`3 x (10s + 10s)` there can be a large spread of results 
and have such results
```
Benchmark               (size)  Mode  Cnt  Score_Before      Error  Units      Score_After      Error  Units   SpeedUp (approx.)

map                       1000  avgt    6   58885.718 ±   2730.727  ns/op       8360.755 ±   6748.954  ns/op     ~7
mapMaterialized           1000  avgt    6    4926.876 ±    797.178  ns/op       1098.353 ±   1403.662  ns/op     ~4.5
mapToLongMaterialized     1000  avgt    6    6293.551 ±    576.242  ns/op       1436.974 ±    405.055  ns/op     ~4.5

flatMap                   1000  avgt    6  104640.639 ±  13652.667  ns/op      67335.231 ±   6201.908  ns/op     ~1.5
flatMap2Materialized      1000  avgt    6                           ns/op      53864.543 ±   1413.425  ns/op
flatMapMaterialized       1000  avgt    6   54544.530 ±   5287.720  ns/op      18080.761 ±   1270.506  ns/op     ~3
```

(full results will be added soon)


**UPD**: I didn't expect binary compatibility problems. It seems I cannot fix them and save the performance. I can create the new PR with only safe changes but before it interesting to me, what do you think about all of there changes?