### PR TITLE
Update chunk.md

### DIFF
--- a/docs/reference/stream/chunk.md
+++ b/docs/reference/stream/chunk.md
@@ -9,7 +9,7 @@ import zio._
 ```
 
 ## Why Chunk?
-Arrays are fast and don’t box primitive values. ZIO Chunk is a wrapper on Java array. So also Chunks have zero boxing for primitives, but due to ClassTag requirements and mutability, arrays are painful to use and don’t integrate well into functional code.
+Arrays are fast and don’t box primitive values but due to `ClassTag` requirements and mutability they are painful to use and don't integrate well info functional code. ZIO chunks are backed by arrays so they also have zero boxing for primitives while providing an immutable interface and avoiding `ClassTag` requirements.
 
 Lets to get more details behind why Chunk invented:
 

--- a/docs/reference/stream/chunk.md
+++ b/docs/reference/stream/chunk.md
@@ -9,7 +9,7 @@ import zio._
 ```
 
 ## Why Chunk?
-Arrays are fast and don’t box primitive values. ZIO Chunk is a wrapper on Java array. So also Chunks have zero boxing for primitives, but due to ClassTag requirements and mutability, they are painful to use and don’t integrate well into functional code.
+Arrays are fast and don’t box primitive values. ZIO Chunk is a wrapper on Java array. So also Chunks have zero boxing for primitives, but due to ClassTag requirements and mutability, arrays are painful to use and don’t integrate well into functional code.
 
 Lets to get more details behind why Chunk invented:
 


### PR DESCRIPTION
Being more explicit. Why? When using the word 'they', it sounded for me that ZIO Chunks were painful to use and don't integrate well into functional code.

I also asked ChatGPT:
Given the following code documentation, I have a question: Which one is painful to use and does not integrate well into functional code, is it ZIO Chunks or Arrays? "Arrays are fast and don’t box primitive values. ZIO Chunk is a wrapper on Java array. So also Chunks have zero boxing for primitives, but due to ClassTag requirements and mutability, they are painful to use and don’t integrate well into functional code."

ChatGPT's answer:
Based on the provided code documentation, it appears that ZIO Chunks are the ones that are considered painful to use and do not integrate well into functional code. Here's the relevant statement:

"Chunks have zero boxing for primitives, but due to ClassTag requirements and mutability, they are painful to use and don’t integrate well into functional code."

This statement suggests that while Chunks have certain performance benefits (zero boxing for primitives), they come with downsides such as ClassTag requirements and mutability, which make them less convenient and less suitable for functional programming compared to Arrays. Arrays, on the other hand, are described as fast and not boxing primitive values, which makes them more suitable for certain use cases.