### PR TITLE
ZIO Test: Correctly Report Time Of Parallel Tests

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestRunner.scala
+++ b/test/shared/src/main/scala/zio/test/TestRunner.scala
@@ -38,11 +38,10 @@ final case class TestRunner[R, E](executor: TestExecutor[R, E]) { self =>
     implicit trace: Trace
   ): UIO[Summary] =
     for {
-      start    <- ClockLive.currentTime(TimeUnit.MILLISECONDS)
-      summary  <- executor.run(fullyQualifiedName, spec, defExec)
-      finished <- ClockLive.currentTime(TimeUnit.MILLISECONDS)
-      duration  = Duration.fromMillis(finished - start)
-    } yield summary.copy(duration = duration)
+      start   <- ClockLive.instant
+      summary <- executor.run(fullyQualifiedName, spec, defExec)
+      end     <- ClockLive.instant
+    } yield summary.timed(start, end)
 
   trait UnsafeAPI {
     def run(spec: Spec[R, E])(implicit trace: Trace, unsafe: Unsafe): Unit

--- a/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/ConsoleRenderer.scala
@@ -217,7 +217,7 @@ trait ConsoleRenderer extends TestRenderer {
   def renderSummary(summary: Summary): String =
     s"""${summary.success} tests passed. ${summary.fail} tests failed. ${summary.ignore} tests ignored.
        |${summary.failureDetails}
-       |Executed in ${summary.duration.render}
+       |Executed in ${summary.interval.duration.render}
        |""".stripMargin
 
   def render(cause: Cause[_], labels: List[String]): Option[String] =


### PR DESCRIPTION
Resolves #8377.

When we run multiple specs potentially in parallel we should not add their execution times but instead should keep track of when they started and completed and report the total time as the difference between when the first test started and the last test completed.