### PR TITLE
Add a demonstation of the smart assertion failure

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -6,12 +6,18 @@ import zio.{Chunk, Exit, ZIO}
 import scala.collection.immutable.SortedSet
 import scala.util.{Failure, Success}
 
+import java.time.Duration
+import zio.duration2DurationOps
+
 object AssertionSpec extends ZIOBaseSpec {
 
   val failing = TestAspect.failing
 
   def spec: Spec[Any, TestFailure[Any]] =
     suite("AssertionSpec")(
+      test("fail to compile a smart assertion with Duration on Scala 3.3.0") {
+        assertTrue(Duration.ofSeconds(1) > Duration.ofSeconds(0))
+      },
       test("and must succeed when both assertions are satisfied") {
         assert(sampleUser)(nameStartsWithU && ageGreaterThan20)
       },


### PR DESCRIPTION
The PR is just a representation of the issue. There is a compilation failure of the smart assertion with Scala 3.3.0 (Scala 2.13 works fine). The compilation error is:
```
[error] -- Error: /zio/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala:18:8 
[error] 18 |        assertTrue(Duration.ofSeconds(1) > Duration.ofSeconds(0))
[error]    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]    |Exception occurred while executing macro expansion.
[error]    |java.lang.Error: NO
[error]    |    at zio.test.SmartAssertMacros$.transform(Macros.scala:163)
[error]    |    at zio.test.SmartAssertMacros$.smartAssertSingle_impl(Macros.scala:233)
[error]    |    at zio.test.SmartAssertMacros$.smartAssert_impl(Macros.scala:244)
[error]    |    at zio.test.SmartAssertMacros$.smartAssert(Macros.scala:31)
[error]    |
[error]    |----------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from CompileVariants.scala:46
[error] 46 |    ${SmartAssertMacros.smartAssert('exprs, 'sourceLocation)}
[error]    |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     ----------------------------------------------------------------------------
[error] one error found
[error] (Test / compileIncremental) Compilation failed
[error] Total time: 1 s, completed 12.09.2023, 13:59:47
```