### PR TITLE
Chunk Optimizations

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/MixedChunkBenchmarks.scala
@@ -98,4 +98,10 @@ class MixedChunkBenchmarks {
   def foldZIOMaterialized(): Int =
     BenchmarkUtil.unsafeRun(chunkMaterialized.foldZIO[Any, Nothing, Int](0)((s, a) => ZIO.succeed(s + a)))
 
+  @Benchmark
+  def filter(): Chunk[Int] = chunk.filter(_ % 2 == 0)
+
+  @Benchmark
+  def filterMaterialized(): Chunk[Int] = chunkMaterialized.filter(_ % 2 == 0)
+
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -651,6 +651,11 @@ object ChunkSpec extends ZIOBaseSpec {
         assert(Chunk.fromIterable(as).toList)(equalTo(as))
       }
     },
+    test("chunks can be mapped with heterogeneous functions") {
+      check(Gen.listOf(Gen.int), Gen.function(Gen.oneOf(Gen.int, Gen.string, Gen.none))) { (as, f) =>
+        assert(Chunk.fromIterable(as).map(f).toList)(equalTo(as.map(f)))
+      }
+    },
     test("unfold") {
       assert(
         Chunk.unfold(0)(n => if (n < 10) Some((n, n + 1)) else None)

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -48,9 +48,9 @@ sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]] { self =>
 object ChunkBuilder {
 
   /**
-    * Constructs a specialized `ChunkBuilder` if the type is a value type and a
-    * generic `ChunkBuilder` otherwise.
-    */
+   * Constructs a specialized `ChunkBuilder` if the type is a value type and a
+   * generic `ChunkBuilder` otherwise.
+   */
   def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
     tag match {
       case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -47,6 +47,23 @@ sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]] { self =>
 object ChunkBuilder {
 
   /**
+    * Constructs a specialized `ChunkBuilder` if the type is a value type and a
+    * generic `ChunkBuilder` otherwise.
+    */
+  def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
+    tag match {
+      case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Byte    => (new Byte).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Char    => (new Char).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Double  => (new Double).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Float   => (new Float).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Int     => (new Int).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Long    => (new Long).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Short   => (new Short).asInstanceOf[ChunkBuilder[A]]
+      case _                => make[A]()
+    }
+
+  /**
    * Constructs a generic `ChunkBuilder`.
    */
   def make[A](): ChunkBuilder[A] =
@@ -108,7 +125,7 @@ object ChunkBuilder {
    */
   final class Boolean extends ChunkBuilder[SBoolean] { self =>
 
-    private val arrayBuilder: ArrayBuilder[SByte] = {
+    private val arrayBuilder: ArrayBuilder.ofByte = {
       new ArrayBuilder.ofByte
     }
     private var lastByte: SByte   = 0.toByte
@@ -173,7 +190,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Byte` values.
    */
   final class Byte extends ChunkBuilder[SByte] { self =>
-    private val arrayBuilder: ArrayBuilder[SByte] = {
+    private val arrayBuilder: ArrayBuilder.ofByte = {
       new ArrayBuilder.ofByte
     }
     override def ++=(as: TraversableOnce[SByte]): this.type = {
@@ -187,7 +204,7 @@ object ChunkBuilder {
     override def addAll(as: TraversableOnce[SByte]): this.type =
       self ++= as
     override def addOne(a: SByte): this.type =
-      self += a
+      self.addOne(a)
     def clear(): Unit =
       arrayBuilder.clear()
     override def equals(that: Any): SBoolean =
@@ -207,7 +224,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Char` values.
    */
   final class Char extends ChunkBuilder[SChar] { self =>
-    private val arrayBuilder: ArrayBuilder[SChar] = {
+    private val arrayBuilder: ArrayBuilder.ofChar = {
       new ArrayBuilder.ofChar
     }
     override def ++=(as: TraversableOnce[SChar]): this.type = {
@@ -221,7 +238,7 @@ object ChunkBuilder {
     override def addAll(as: TraversableOnce[SChar]): this.type =
       self ++= as
     override def addOne(a: SChar): this.type =
-      self += a
+      self.addOne(a)
     def clear(): Unit =
       arrayBuilder.clear()
     override def equals(that: Any): SBoolean =
@@ -242,7 +259,7 @@ object ChunkBuilder {
    * values.
    */
   final class Double extends ChunkBuilder[SDouble] { self =>
-    private val arrayBuilder: ArrayBuilder[SDouble] = {
+    private val arrayBuilder: ArrayBuilder.ofDouble = {
       new ArrayBuilder.ofDouble
     }
     override def ++=(as: TraversableOnce[SDouble]): this.type = {
@@ -276,7 +293,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Float` values.
    */
   final class Float extends ChunkBuilder[SFloat] { self =>
-    private val arrayBuilder: ArrayBuilder[SFloat] = {
+    private val arrayBuilder: ArrayBuilder.ofFloat = {
       new ArrayBuilder.ofFloat
     }
     override def ++=(as: TraversableOnce[SFloat]): this.type = {
@@ -310,7 +327,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Int` values.
    */
   final class Int extends ChunkBuilder[SInt] { self =>
-    private val arrayBuilder: ArrayBuilder[SInt] = {
+    private val arrayBuilder: ArrayBuilder.ofInt = {
       new ArrayBuilder.ofInt
     }
     override def ++=(as: TraversableOnce[SInt]): this.type = {
@@ -344,7 +361,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Long` values.
    */
   final class Long extends ChunkBuilder[SLong] { self =>
-    private val arrayBuilder: ArrayBuilder[SLong] = {
+    private val arrayBuilder: ArrayBuilder.ofLong = {
       new ArrayBuilder.ofLong
     }
     override def ++=(as: TraversableOnce[SLong]): this.type = {
@@ -378,7 +395,7 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Short` values.
    */
   final class Short extends ChunkBuilder[SShort] { self =>
-    private val arrayBuilder: ArrayBuilder[SShort] = {
+    private val arrayBuilder: ArrayBuilder.ofShort = {
       new ArrayBuilder.ofShort
     }
     override def ++=(as: TraversableOnce[SShort]): this.type = {

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -48,23 +48,6 @@ sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]] { self =>
 object ChunkBuilder {
 
   /**
-   * Constructs a specialized `ChunkBuilder` if the type is a value type and a
-   * generic `ChunkBuilder` otherwise.
-   */
-  def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
-    tag match {
-      case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Byte    => (new Byte).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Char    => (new Char).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Double  => (new Double).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Float   => (new Float).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Int     => (new Int).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Long    => (new Long).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Short   => (new Short).asInstanceOf[ChunkBuilder[A]]
-      case _                => make[A]()
-    }
-
-  /**
    * Constructs a generic `ChunkBuilder`.
    */
   def make[A](): ChunkBuilder[A] =

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -187,7 +187,7 @@ object ChunkBuilder {
     override def addAll(as: TraversableOnce[SByte]): this.type =
       self ++= as
     override def addOne(a: SByte): this.type =
-      self.addOne(a)
+      self += a
     def clear(): Unit =
       arrayBuilder.clear()
     override def equals(that: Any): SBoolean =
@@ -221,7 +221,7 @@ object ChunkBuilder {
     override def addAll(as: TraversableOnce[SChar]): this.type =
       self ++= as
     override def addOne(a: SChar): this.type =
-      self.addOne(a)
+      self += a
     def clear(): Unit =
       arrayBuilder.clear()
     override def equals(that: Any): SBoolean =

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -20,6 +20,7 @@ import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
+import scala.reflect.ClassTag
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -20,7 +20,6 @@ import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
-import scala.reflect.ClassTag
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -20,6 +20,7 @@ import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
+import scala.reflect.ClassTag
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,
@@ -98,12 +99,29 @@ object ChunkBuilder {
   }
 
   /**
+    * Constructs a specialized `ChunkBuilder` if the type is a value type and a
+    * generic `ChunkBuilder` otherwise.
+    */
+  def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
+    tag match {
+      case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Byte    => (new Byte).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Char    => (new Char).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Double  => (new Double).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Float   => (new Float).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Int     => (new Int).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Long    => (new Long).asInstanceOf[ChunkBuilder[A]]
+      case ClassTag.Short   => (new Short).asInstanceOf[ChunkBuilder[A]]
+      case _                => make[A]()
+    }
+
+  /**
    * A `ChunkBuilder` specialized for building chunks of unboxed `Boolean`
    * values.
    */
   final class Boolean extends ChunkBuilder[SBoolean] { self =>
 
-    private val arrayBuilder: ArrayBuilder[SByte] = {
+    private val arrayBuilder: ArrayBuilder.ofByte = {
       new ArrayBuilder.ofByte
     }
     private var lastByte: SByte   = 0.toByte
@@ -116,7 +134,7 @@ object ChunkBuilder {
     def addOne(b: SBoolean): this.type = {
       if (b) {
         if (maxBitIndex == 8) {
-          arrayBuilder += lastByte
+          arrayBuilder.addOne(lastByte)
           lastByte = (1 << 7).toByte
           maxBitIndex = 1
         } else {
@@ -126,7 +144,7 @@ object ChunkBuilder {
         }
       } else {
         if (maxBitIndex == 8) {
-          arrayBuilder += lastByte
+          arrayBuilder.addOne(lastByte)
           lastByte = 0.toByte
           maxBitIndex = 1
         } else {
@@ -164,15 +182,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Byte` values.
    */
   final class Byte extends ChunkBuilder[SByte] { self =>
-    private val arrayBuilder: ArrayBuilder[SByte] = {
+    private val arrayBuilder: ArrayBuilder.ofByte = {
       new ArrayBuilder.ofByte
     }
     override def addAll(as: IterableOnce[SByte]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SByte): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -194,15 +212,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Char` values.
    */
   final class Char extends ChunkBuilder[SChar] { self =>
-    private val arrayBuilder: ArrayBuilder[SChar] = {
+    private val arrayBuilder: ArrayBuilder.ofChar = {
       new ArrayBuilder.ofChar
     }
     override def addAll(as: IterableOnce[SChar]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SChar): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -225,15 +243,15 @@ object ChunkBuilder {
    * values.
    */
   final class Double extends ChunkBuilder[SDouble] { self =>
-    private val arrayBuilder: ArrayBuilder[SDouble] = {
+    private val arrayBuilder: ArrayBuilder.ofDouble = {
       new ArrayBuilder.ofDouble
     }
     override def addAll(as: IterableOnce[SDouble]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SDouble): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -255,15 +273,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Float` values.
    */
   final class Float extends ChunkBuilder[SFloat] { self =>
-    private val arrayBuilder: ArrayBuilder[SFloat] = {
+    private val arrayBuilder: ArrayBuilder.ofFloat = {
       new ArrayBuilder.ofFloat
     }
     override def addAll(as: IterableOnce[SFloat]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SFloat): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -285,15 +303,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Int` values.
    */
   final class Int extends ChunkBuilder[SInt] { self =>
-    private val arrayBuilder: ArrayBuilder[SInt] = {
+    private val arrayBuilder: ArrayBuilder.ofInt = {
       new ArrayBuilder.ofInt
     }
     override def addAll(as: IterableOnce[SInt]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SInt): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -315,15 +333,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Long` values.
    */
   final class Long extends ChunkBuilder[SLong] { self =>
-    private val arrayBuilder: ArrayBuilder[SLong] = {
+    private val arrayBuilder: ArrayBuilder.ofLong = {
       new ArrayBuilder.ofLong
     }
     override def addAll(as: IterableOnce[SLong]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SLong): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =
@@ -345,15 +363,15 @@ object ChunkBuilder {
    * A `ChunkBuilder` specialized for building chunks of unboxed `Short` values.
    */
   final class Short extends ChunkBuilder[SShort] { self =>
-    private val arrayBuilder: ArrayBuilder[SShort] = {
+    private val arrayBuilder: ArrayBuilder.ofShort = {
       new ArrayBuilder.ofShort
     }
     override def addAll(as: IterableOnce[SShort]): this.type = {
-      arrayBuilder ++= as
+      arrayBuilder.addAll(as)
       this
     }
     def addOne(a: SShort): this.type = {
-      arrayBuilder += a
+      arrayBuilder.addOne(a)
       this
     }
     def clear(): Unit =

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -99,9 +99,9 @@ object ChunkBuilder {
   }
 
   /**
-    * Constructs a specialized `ChunkBuilder` if the type is a value type and a
-    * generic `ChunkBuilder` otherwise.
-    */
+   * Constructs a specialized `ChunkBuilder` if the type is a value type and a
+   * generic `ChunkBuilder` otherwise.
+   */
   def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
     tag match {
       case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -20,7 +20,6 @@ import zio.Chunk.BitChunkByte
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.collection.mutable.{ArrayBuilder, Builder}
-import scala.reflect.ClassTag
 import scala.{
   Boolean => SBoolean,
   Byte => SByte,

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -99,23 +99,6 @@ object ChunkBuilder {
   }
 
   /**
-   * Constructs a specialized `ChunkBuilder` if the type is a value type and a
-   * generic `ChunkBuilder` otherwise.
-   */
-  def make[A](tag: ClassTag[A]): ChunkBuilder[A] =
-    tag match {
-      case ClassTag.Boolean => (new Boolean).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Byte    => (new Byte).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Char    => (new Char).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Double  => (new Double).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Float   => (new Float).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Int     => (new Int).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Long    => (new Long).asInstanceOf[ChunkBuilder[A]]
-      case ClassTag.Short   => (new Short).asInstanceOf[ChunkBuilder[A]]
-      case _                => make[A]()
-    }
-
-  /**
    * A `ChunkBuilder` specialized for building chunks of unboxed `Boolean`
    * values.
    */

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -2618,22 +2618,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def int(index: Int)(implicit ev: Int <:< Int): Int =
       array(index + offset)
     override protected def mapChunk[B](f: Int => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Chunk.empty
-      else if (len == 1) Chunk.single(f(self(0)))
-      else {
-        val tag     = Tags.fromValue(f(self(0)))
-        val builder = ChunkBuilder.make(tag)
-        builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
-        var i = 0
-        while (i < len) {
-          builder += f(self(i))
-          i += 1
-        }
-
-        builder.result()
+      var i = 0
+      while (i < len) {
+        array(i) = f(self(i))
+        i += 1
       }
+
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Int =
       array(index + offset)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -2496,17 +2496,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Byte => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Byte =
       array(index + offset)
@@ -2557,17 +2556,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Char => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Char =
       array(index + offset)
@@ -2678,17 +2676,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def long(index: Int)(implicit ev: Long <:< Long): Long =
       array(index + offset)
     override protected def mapChunk[B](f: Long => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Long =
       array(index + offset)
@@ -2739,17 +2736,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Double => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Double =
       array(index + offset)
@@ -2800,17 +2796,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Float => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Float =
       array(index + offset)
@@ -2859,17 +2854,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Short => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Short =
       array(index + offset)
@@ -2922,17 +2916,16 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Boolean => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
+      val len   = self.length
+      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
 
       var i = 0
       while (i < len) {
-        builder += f(self(i))
+        array(i) = f(self(i))
         i += 1
       }
 
-      builder.result()
+      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Boolean =
       array(index + offset)


### PR DESCRIPTION
## Filter

### Before

```
[info] Benchmark                                (size)  Mode  Cnt      Score     Error  Units
[info] MixedChunkBenchmarks.filterMaterialized    1000  avgt    5   1288.373 ±   2.508  ns/op
```

### After

```
[info] Benchmark                                (size)  Mode  Cnt      Score     Error  Units
[info] MixedChunkBenchmarks.filterMaterialized    1000  avgt    5    708.808 ±  10.336  ns/op
```

## Map

### Before

```
[info] Benchmark                                (size)  Mode  Cnt      Score      Error  Units
[info] MixedChunkBenchmarks.mapMaterialized       1000  avgt    5   4423.072 ±  124.469  ns/op
```

### After

```
[info] Benchmark                                (size)  Mode  Cnt      Score      Error  Units
[info] MixedChunkBenchmarks.mapMaterialized       1000  avgt    5   1787.129 ±   13.842  ns/op
```