### PR TITLE
Switch head from AtomicInteger to AtomicLong

### DIFF
--- a/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
@@ -174,7 +174,7 @@ private[zio] class ConcurrentMetricHooksPlatformSpecific extends ConcurrentMetri
     // While Observing we cut off the first sample if we have already maxSize samples
     def observe(tuple: (Double, java.time.Instant)): Unit = {
       if (maxSize > 0) {
-        val target = head.incrementAndGet() % maxSize
+        val target = (head.incrementAndGet() % maxSize).toInt
         values.set(target, tuple)
       }
 

--- a/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
@@ -125,7 +125,7 @@ private[zio] class ConcurrentMetricHooksPlatformSpecific extends ConcurrentMetri
     import key.keyType.{maxSize, maxAge, error, quantiles}
 
     val values = new AtomicReferenceArray[(Double, java.time.Instant)](maxSize)
-    val head   = new AtomicInteger(0)
+    val head   = new AtomicLong(0)
     val count  = new LongAdder
     val sum    = new DoubleAdder
     val min    = AtomicDouble.make(Double.MaxValue)
@@ -174,7 +174,7 @@ private[zio] class ConcurrentMetricHooksPlatformSpecific extends ConcurrentMetri
     // While Observing we cut off the first sample if we have already maxSize samples
     def observe(tuple: (Double, java.time.Instant)): Unit = {
       if (maxSize > 0) {
-        val target = head.updateAndGet(index => (index + 1) % maxSize)
+        val target = head.incrementAndGet() % maxSize
         values.set(target, tuple)
       }
 

--- a/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/metrics/ConcurrentMetricHooksPlatformSpecific.scala
@@ -174,7 +174,7 @@ private[zio] class ConcurrentMetricHooksPlatformSpecific extends ConcurrentMetri
     // While Observing we cut off the first sample if we have already maxSize samples
     def observe(tuple: (Double, java.time.Instant)): Unit = {
       if (maxSize > 0) {
-        val target = head.incrementAndGet() % maxSize
+        val target = head.updateAndGet(index => (index + 1) % maxSize)
         values.set(target, tuple)
       }
 


### PR DESCRIPTION
Problem: If we call `update` on a `Summary` metric a lot, it will increase the `head` index past the maximum integer, at which point we will get negative values for the index. Once we `%` that index we will still get a negative number, and then we will get an `ArrayIndexOutOfBoundsException ` when we try to set the value in the values array appropriately.

Solution: Use an `AtomicLong` rather than an `AtomicInteger` 