### PR TITLE
Fix wrong package name in zio-streams installation docs

### DIFF
--- a/docs/reference/stream/installation.md
+++ b/docs/reference/stream/installation.md
@@ -10,7 +10,7 @@ In order to use ZIO Streaming, we need to add the required configuration in our 
 println(s"""```scala""")
 println(
 s"""libraryDependencies += Seq(
-  "dev.zio" %% "zio-core"    % "${zio.BuildInfo.version.split('+').head}" % Test
+  "dev.zio" %% "zio"         % "${zio.BuildInfo.version.split('+').head}" % Test
   "dev.zio" %% "zio-streams" % "${zio.BuildInfo.version.split('+').head}" % Test
 )"""
 )


### PR DESCRIPTION
```
[info] Updating
[info] Resolved  dependencies
[warn]
[warn] 	Note: Unresolved dependencies path:
[error] stack trace is suppressed; run last update for the full output
[error] (update) sbt.librarymanagement.ResolveException: Error downloading dev.zio:zio-core_3:2.0.18
[error]   Not found
[error]   Not found
[error]   not found: /Users/xxx/.ivy2/localdev.zio/zio-core_3/2.0.18/ivys/ivy.xml
[error]   not found: https://repo1.maven.org/maven2/dev/zio/zio-core_3/2.0.18/zio-core_3-2.0.18.pom
[error]   not found: /Users/xxx/.m2/repository/dev/zio/zio-core_3/2.0.18/zio-core_3-2.0.18.pom
[error] Total time: 2 s, completed Oct 22, 2023, 8:56:39 AM
```