### PR TITLE
ZIO Stream: Inherit FiberRefs After Running Channel Finalizers

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -747,6 +747,13 @@ object ZChannelSpec extends ZIOBaseSpec {
                     .runDrain
                     .exit
         } yield assertTrue(exit.isFailure)
+      },
+      test("fiberRef values are restored") {
+        for {
+          fiberRef <- FiberRef.make(true)
+          _        <- ZChannel.scoped(fiberRef.locallyScoped(false)).runDrain
+          value    <- fiberRef.get
+        } yield assertTrue(value)
       }
     )
   )


### PR DESCRIPTION
Resolves #8533.