### PR TITLE
Add isEmpty and clear methods to the ConcurrentMap

### DIFF
--- a/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
+++ b/concurrent/shared/src/main/scala/zio/concurrent/ConcurrentMap.scala
@@ -121,6 +121,12 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
     ZIO.succeed(Option(underlying.putIfAbsent(key, value)))
 
   /**
+   * True if there are no elements in this map.
+   */
+  def isEmpty: UIO[Boolean] =
+    ZIO.succeed(underlying.isEmpty)
+
+  /**
    * Removes the entry for the given key, optionally returning value associated
    * with it.
    */
@@ -160,6 +166,12 @@ final class ConcurrentMap[K, V] private (private val underlying: ConcurrentHashM
         }
       }
     )
+
+  /**
+   * Removes all elements.
+   */
+  def clear: UIO[Unit] =
+    ZIO.succeed(underlying.clear())
 
   /**
    * Replaces the entry for the given key only if it is mapped to some value.

--- a/concurrent/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
+++ b/concurrent/shared/src/test/scala/zio/concurrent/ConcurrentMapSpec.scala
@@ -196,6 +196,27 @@ object ConcurrentMapSpec extends ZIOSpecDefault {
           )
         }
       ),
+      suite("isEmpty")(
+        test("returns true for newly created empty map") {
+          for {
+            map <- ConcurrentMap.empty[Int, String]
+            res <- map.isEmpty
+          } yield assertTrue(res)
+        },
+        test("returns false for a map with entries") {
+          for {
+            map <- ConcurrentMap.make((1, "A"), (2, "B"), (3, "C"))
+            res <- map.isEmpty
+          } yield assertTrue(!res)
+        },
+        test("returns false for a map with all entries removed") {
+          for {
+            map <- ConcurrentMap.make((1, "A"), (2, "B"), (3, "C"))
+            _   <- map.clear
+            res <- map.isEmpty
+          } yield assertTrue(res)
+        }
+      ),
       suite("remove")(
         test("returns the value associated with removed key") {
           for {
@@ -239,6 +260,15 @@ object ConcurrentMapSpec extends ZIOSpecDefault {
             bRes.isEmpty,
             cRes.isEmpty
           )
+        }
+      ),
+      suite("clear")(
+        test("removes all elements") {
+          for {
+            map <- ConcurrentMap.make((1, "A"), (2, "B"), (3, "C"))
+            _   <- map.clear
+            res <- map.toList
+          } yield assertTrue(res == List.empty[(Int, String)])
         }
       ),
       suite("replace")(

--- a/docs/reference/sync/concurrentmap.md
+++ b/docs/reference/sync/concurrentmap.md
@@ -103,6 +103,7 @@ Basic operations are provided to manipulate the values in the `ConcurrentMap`:
 | `remove(key: K, value: V): UIO[Boolean]`    | Removes the entry for the given key if it is mapped to a given value.                                      |                                      
 | `removeIf(p: (K, V) => Boolean): UIO[Unit]` | Removes all elements which do not satisfy the given predicate.                                             |
 | `retainIf(p: (K, V) => Boolean): UIO[Unit]` | Removes all elements which do not satisfy the given predicate.                                             |
+| `clear: UIO[Unit]`                          | Removes all elements.                                                                                      |
 
 ### Replacing values
 
@@ -128,6 +129,7 @@ Basic operations are provided to manipulate the values in the `ConcurrentMap`:
 | `collectFirst[B](pf: PartialFunction[(K, V), B]): UIO[Option[B]]` | Finds the first element of a map for which the partial function is defined and applies the function to it. | 
 | `fold[S](zero: S)(f: (S, (K, V)) => S): UIO[S]`                   | Folds the elements of a map using the given binary operator.                                               |
 | `forall(p: (K, V) => Boolean): UIO[Boolean]`                      | Tests whether a predicate is satisfied by all elements of a map.                                           |
+| `isEmpty: UIO[Boolean]`                                           | True if there are no elements in this map.                                                                 |
 | `toChunk: UIO[Chunk[(K, V)]]`                                     | Collects all entries into a chunk.                                                                         |                                                                         
 | `toList: UIO[List[(K, V)]]`                                       | Collects all entries into a list.                                                                          |                                                                          
 
@@ -169,3 +171,4 @@ for {
 | `mapA.removeIf((k, _) => k != 1).get(2)`                 | None    |
 | `mapA.retainIf((k, _) => k == 1).get(1)`                 | "A"     |
 | `mapA.retainIf((k, _) => k == 1).get(2)`                 | None    |
+| `mapA.clear.isEmpty`                                     | true    |


### PR DESCRIPTION
Adds two more methods (`isEmpty` and `clear`) to the `ConcurrentMap`