### PR TITLE
Smart assertions equalTo explicitly providing optional diff

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -109,6 +109,7 @@ object BuildHelper {
         Seq(
           "-language:implicitConversions",
           "-Xignore-scala2-macros",
+          "-Xmax-inlines:64",
           "-noindent"
         )
       case Some((2, 13)) =>


### PR DESCRIPTION
There was a problem with finding implicit for `Diff` - we were getting rid of specific types, so in `SmartAssertions.equalTo` it was looking for `implicit diff: OptionalImplicit[Diff[Any]]`. 
Only way I get it working was specifying this implicit explicitly - similarly like in "greater than" `Ordering` few lines above.

Closes https://github.com/zio/zio/issues/8389