### PR TITLE
scala 3 smart assertions macro fix for class with same named field an…

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -513,6 +513,44 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       test("equalTo on java.lang.Boolean works") {
         val jBool = java.lang.Boolean.FALSE
         assertTrue(jBool == false)
+      }, {
+        final case class Bar(valid: Boolean = true)
+        final case class Foo(bar: Bar, otherField: Boolean) {
+          def bar(b: Bar): Foo = copy(bar = b)
+        }
+        object Foo {
+          def apply(v: Boolean): Foo = Foo(Bar(v), v)
+
+          def sameName(v: Boolean): Foo = Foo(Bar(v), v)
+        }
+        suite("test complex class with same name for method and field")(
+          test("one line default apply field check") {
+            assertTrue(Foo(Bar(), true).otherField)
+          },
+          test("one line default apply nested same name check") {
+            assertTrue(Foo(Bar(), true).bar.valid)
+          },
+          test("one line companion apply field check") {
+            assertTrue(Foo(true).otherField)
+          },
+          test("one line companion apply nested same name check") {
+            assertTrue(Foo(true).bar.valid)
+          },
+          test("one line other create method field check") {
+            assertTrue(Foo.sameName(true).otherField)
+          },
+          test("one line other create method nested same name check") {
+            assertTrue(Foo.sameName(true).bar.valid)
+          },
+          test("external assigned object nested same name check") {
+            val externalFoo = Foo(true)
+            assertTrue(externalFoo.bar.valid)
+          },
+          test("external assigned object nested same name field") {
+            val externalBar = Foo(true).bar
+            assertTrue(externalBar.valid)
+          }
+        )
       }
     )
   )

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -197,10 +197,18 @@ object SmartAssertMacros {
               try Select.unique(param, name)
               catch {
                 case _: AssertionError =>
-                  // Tries to find directly the referenced method on lhs's type
-                  lhs.symbol.declaredMethods.filter(_.name == name).headOption match {
-                    case Some(method) => Select(param, method)
-                    case None => throw new Error(s"Could not resolve $name on $lhs")
+                  // Tries to find directly the referenced method on lhs's type (or if lhs is method, on lhs's returned type)
+                  lhs.symbol.tree match {
+                    case DefDef(_, _, tpt, _) =>
+                      tpt.symbol.declaredFields.find(_.name == name).orElse(tpt.symbol.declaredMethods.find(_.name == name)) match {
+                        case Some(fieldOrMethod) => Select(param, fieldOrMethod)
+                        case None => throw new Error(s"Could not resolve $name on $tpt")
+                      }
+                    case _ =>
+                      lhs.symbol.declaredFields.find(_.name == name).orElse(lhs.symbol.declaredMethods.find(_.name == name)) match {
+                        case Some(fieldOrMethod) => Select(param, fieldOrMethod)
+                        case None => throw new Error(s"Could not resolve $name on $lhs")
+                      }
                   }
               }
             case (tpeArgs, Some(args)) => Select.overloaded(param, name, tpeArgs, args)


### PR DESCRIPTION
Added distinguishing between fields and method in processing smart assertions macro, prioritizing fields over methods. Additionaly, for method expressions, trying to find specific field or method on resulting type, not on function type

Closes https://github.com/zio/zio/issues/8518