### PR TITLE
Fair Semaphore

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmark.scala
@@ -21,6 +21,14 @@ class SemaphoreBenchmark {
   var ops: Int = _
 
   @Benchmark
+  def semaphoreContention(): Unit =
+    unsafeRun(for {
+      sem   <- Semaphore.make(fibers / 2L)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(ZIO.succeedNow(1)))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
   def tsemaphoreContention(): Unit =
     unsafeRun(for {
       sem   <- TSemaphore.make(fibers / 2L).commit

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -1,0 +1,37 @@
+package zio
+
+import zio._
+import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.test._
+
+object SemaphoreSpec extends ZIOBaseSpec {
+  override def spec = suite("SemaphoreSpec")(
+    test("withPermit automatically releases the permit if the effect is interrupted") {
+      for {
+        promise   <- Promise.make[Nothing, Unit]
+        semaphore <- Semaphore.make(1)
+        effect     = semaphore.withPermit(promise.succeed(()) *> ZIO.never)
+        fiber     <- effect.fork
+        _         <- promise.await
+        _         <- fiber.interrupt
+        permits   <- semaphore.available
+      } yield assert(permits)(equalTo(1L))
+    } @@ nonFlaky,
+    test("withPermit acquire is interruptible") {
+      for {
+        semaphore <- Semaphore.make(0L)
+        effect     = semaphore.withPermit(ZIO.unit)
+        fiber     <- effect.fork
+        _         <- fiber.interrupt
+      } yield assertCompletes
+    } @@ nonFlaky,
+    test("withPermitsScoped releases same number of permits") {
+      for {
+        semaphore <- Semaphore.make(2L)
+        _         <- ZIO.scoped(semaphore.withPermitsScoped(2))
+        permits   <- semaphore.available
+      } yield assertTrue(permits == 2L)
+    }
+  )
+}

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -19,6 +19,9 @@ package zio
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stm.TSemaphore
 
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores
  * have a certain number of permits, which can be held and released concurrently
@@ -73,20 +76,83 @@ object Semaphore {
     ZIO.succeed(unsafe.make(permits)(Unsafe.unsafe))
 
   object unsafe {
-    def make(permits: Long)(implicit unsafe: Unsafe): Semaphore = {
-      val semaphore = TSemaphore.unsafe.make(permits)
+    def make(permits: Long)(implicit unsafe: Unsafe): Semaphore =
       new Semaphore {
+        val ref = Ref.unsafe.make[Either[Queue[(Promise[Nothing, Unit], Long)], Long]](Right(permits))
+
         def available(implicit trace: Trace): UIO[Long] =
-          semaphore.available.commit
+          ref.get.map {
+            case Left(_)        => 0L
+            case Right(permits) => permits
+          }
+
         def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          semaphore.withPermit(zio)
+          withPermits(1L)(zio)
+
         def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          semaphore.withPermitScoped
+          withPermitsScoped(1L)
+
         def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          semaphore.withPermits(n)(zio)
+          ZIO.acquireReleaseWith(reserve(n))(_.release)(_.acquire *> zio)
+
         def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          semaphore.withPermitsScoped(n)
+          ZIO.acquireRelease(reserve(n))(_.release).flatMap(_.acquire)
+
+        case class Reservation(acquire: UIO[Unit], release: UIO[Any])
+
+        def reserve(n: Long)(implicit trace: Trace): UIO[Reservation] =
+          if (n < 0)
+            ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
+          else if (n == 0L)
+            ZIO.succeedNow(Reservation(ZIO.unit, ZIO.unit))
+          else
+            Promise.make[Nothing, Unit].flatMap { promise =>
+              ref.modify {
+                case Right(permits) if permits >= n =>
+                  Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
+                case Right(permits) =>
+                  Reservation(promise.await, restore(promise, n)) -> Left(Queue(promise -> (n - permits)))
+                case Left(queue) =>
+                  Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
+              }
+            }
+
+        def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =
+          ref.modify {
+            case Left(queue) =>
+              queue
+                .find(_._1 == promise)
+                .fold(releaseN(n) -> Left(queue)) { case (_, permits) =>
+                  releaseN(n - permits) -> Left(queue.filter(_._1 != promise))
+                }
+            case Right(permits) => ZIO.unit -> Right(permits + n)
+          }.flatten
+
+        def releaseN(n: Long)(implicit trace: Trace): UIO[Any] = {
+
+          @tailrec
+          def loop(
+            n: Long,
+            state: Either[Queue[(Promise[Nothing, Unit], Long)], Long],
+            acc: UIO[Any]
+          ): (UIO[Any], Either[Queue[(Promise[Nothing, Unit], Long)], Long]) =
+            state match {
+              case Right(permits) => acc -> Right(permits + n)
+              case Left(queue) =>
+                queue.dequeueOption match {
+                  case None => acc -> Right(permits)
+                  case Some(((promise, permits), queue)) =>
+                    if (n > permits)
+                      loop(n - permits, Left(queue), acc <* promise.succeed(()))
+                    else if (n == permits)
+                      (acc *> promise.succeed(())) -> Left(queue)
+                    else
+                      acc -> Left((promise -> (permits - n)) +: queue)
+                }
+            }
+
+          ref.modify(loop(n, _, ZIO.unit)).flatten
+        }
       }
-    }
   }
 }


### PR DESCRIPTION
One disadvantage of implementing `Semaphore` in terms of `TSemaphore` is that STM transactions may be retried in an arbitrary order, so a `Semaphore` implemented this way does not provide a guarantee that earlier attempts to acquire a permit will succeed before later attempts when a permit becomes available. We can fix this by implementing `Semaphore` directly. In addition, this implementation is faster.

```
[info] Benchmark                                (fibers)  (ops)   Mode  Cnt    Score   Error  Units
[info] SemaphoreBenchmark.semaphoreContention         10   1000  thrpt   15  189.984 ± 0.524  ops/s
[info] SemaphoreBenchmark.tsemaphoreContention        10   1000  thrpt   15   82.308 ± 0.715  ops/s
```