### PR TITLE
Allow `contains` in an assertion to be passed a subtype when there's …

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -490,6 +490,14 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         assertTrue(someParent.contains(someChild))
       } @@ failing
     ),
+    suite("subtype seq")(
+      test("contains") {
+        assertTrue(Seq(Seq[Any](1)).contains(Seq[Int](1)))
+      },
+      test("contains failure") {
+        assertTrue(Seq(Seq[Any]()).contains(Seq[Int](1)))
+      } @@ failing
+    ),
     suite("custom assertions")(
       test("reports source location of actual usage") {
         customAssertion("hello")

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -438,7 +438,7 @@ $TestResult($ast.withCode($codeString).withLocation)
     val containsSeq: ASTConverter =
       ASTConverter.make {
         case AST.Method(_, lhsTpe, _, "contains", _, Some(args), _) if lhsTpe <:< weakTypeOf[Seq[_]] =>
-          AssertAST("containsSeq", args = args)
+          AssertAST("containsSeq", args = args, tpes = List(args.head.tpe.dealias, lhsTpe.typeArgs.head.dealias))
       }
 
     val containsOption: ASTConverter =

--- a/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
+++ b/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
@@ -140,9 +140,9 @@ object SmartAssertions {
         )
       }
 
-  def containsSeq[A](value: A): TestArrow[Seq[A], Boolean] =
+  def containsSeq[A, B >: A](value: A): TestArrow[Seq[B], Boolean] =
     TestArrow
-      .make[Seq[A], Boolean] { seq =>
+      .make[Seq[B], Boolean] { seq =>
         TestTrace.boolean(seq.contains(value)) {
           className(seq) + M.did + "contain" + M.pretty(value)
         }


### PR DESCRIPTION
…an inner Seq. (#8539)