### PR TITLE
When squashing a Cause, return defect first rather than interruption

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -544,14 +544,12 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    */
   final def squashWith(f: E => Throwable): Throwable =
     failureOption.map(f) orElse
-      (if (isInterrupted)
-         Some(
-           new InterruptedException(
-             "Interrupted by fibers: " + interruptors.flatMap(_.ids).map("#" + _).mkString(", ")
-           )
-         )
-       else None) orElse
-      defects.headOption getOrElse (new InterruptedException)
+      defects.headOption getOrElse
+      new InterruptedException(
+        if (interruptors.nonEmpty)
+          "Interrupted by fibers: " + interruptors.flatMap(_.ids).map("#" + _).mkString(", ")
+        else ""
+      )
 
   /**
    * Squashes a `Cause` down to a single `Throwable`, chosen to be the "most


### PR DESCRIPTION
The current logic for `Cause#squashWith` returns a failure if any, then an interruption if any (at any level, it is using `isInterrupted` and not `isInterruptedOnly`) and finally a defect if any. 

I think a defect is more important that an interruption, and quite often the defect will trigger some interruptions. I always assumed it worked this way so I was quite surprised when I found out 😄 