### PR TITLE
fix ambiguity checks in ZLayer#provide macro

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -59,6 +59,7 @@ private[zio] trait LayerMacroUtils {
       providedLayers0 = layers.toList,
       layerToDebug = debugMap,
       sideEffectType = c.weakTypeOf[Unit].dealias,
+      anyType = c.weakTypeOf[Any].dealias,
       typeEquals = _ <:< _,
       foldTree = buildFinalTree,
       method = provideMethod,

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -37,6 +37,7 @@ private [zio] object LayerMacroUtils {
       layerToDebug = layerToDebug,
       typeEquals = _ <:< _,
       sideEffectType = TypeRepr.of[Unit],
+      anyType = TypeRepr.of[Any],
       foldTree = buildFinalTree,
       method = provideMethod,
       exprToNode = getNode,


### PR DESCRIPTION
`Zlayer#provide*` macro family sometimes allows having duplicate layers for the same dependency. Here's an example
```scala
trait Repository {
  def upsert(data: Any): UIO[Unit]
}

case class MongoRepository() extends Repository {
  override def upsert(data: Any): UIO[Unit] = ZIO.unit
}
object MongoRepository {
  val live: ULayer[MongoRepository] = ZLayer.fromFunction(MongoRepository.apply _)
}

case class GreenplumRepository() extends Repository {
  override def upsert(data: Any): UIO[Unit] = ZIO.unit
}
object GreenplumRepository {
  val live: ULayer[GreenplumRepository] = ZLayer.fromFunction(GreenplumRepository.apply _)
}

case class RepositoryLive(mongo: MongoRepository, gp: GreenplumRepository) extends Repository {
  override def upsert(data: Any): UIO[Unit] = mongo.upsert(data) <&> gp.upsert(data)
}
object RepositoryLive {
  val live: URLayer[MongoRepository with GreenplumRepository, RepositoryLive] = ZLayer.fromFunction(RepositoryLive.apply _)
}
```
In the above example we've got three different repository implementations, one of which is a combination of two of them.
If we use them like this
```scala
ZIO.service[Repository].provide(RepositoryLive.live, MongoRepository.live, GreenplumRepository.live)
```
The code will compile fine without any warnings. Though it will do an expected thing (it will actually construct and use `RepositoryLive`), this is quite unexpected since any of three layers could've been used. If we just change their order like this
```scala
ZIO.service[Repository].provide(MongoRepository.live, RepositoryLive.live, GreenplumRepository.live)
```
then it will produce a warning that `RepositoryLive.live` and `GreenplumRepository.live` are unused. But overall I'd say that in this case the behaviour is undefined and should be allowed. That's why this MR exists ¯\_(ツ)_/¯