### PR TITLE
Do not emit non-0 exit code for failing tests when running with IntelliJ

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -30,9 +30,16 @@ private[test] final case class TestArgs(
 ) {
   val testEventRenderer: ReporterEventRenderer =
     testRenderer match {
-      case renderer: ConsoleRenderer  => ConsoleEventRenderer
-      case renderer: IntelliJRenderer => IntelliJEventRenderer
-      case _                          => ???
+      case _: ConsoleRenderer  => ConsoleEventRenderer
+      case _: IntelliJRenderer => IntelliJEventRenderer
+    }
+
+  def ignoreFailures: Boolean =
+    // When calling from IntelliJ, we want to ignore emitting a non-0 exit code.
+    // Test running and termination is entirely handled by IntelliJ.
+    testRenderer match {
+      case _: IntelliJRenderer => true
+      case _                   => false
     }
 }
 

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -75,9 +75,11 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       _ <- ZIO.when(testArgs.printSummary) {
              console.printLine(testArgs.testRenderer.renderSummary(summary)).orDie
            }
-      _ <- ZIO.when(summary.status == Summary.Failure) {
-             ZIO.fail(new RuntimeException("Tests failed."))
-           }
+      _ <- ZIO
+             .when(summary.status == Summary.Failure) {
+               ZIO.fail(new RuntimeException("Tests failed."))
+             }
+             .unless(testArgs.ignoreFailures)
     } yield summary
 
   /*


### PR DESCRIPTION
At some point, there was an exception added to force the runner to quit with exit code 1 whenever there's a test failure, however this causes the following exception text to be printed every time the tests are run in IntelliJ:

```
Testing started at 19:58 ...
timestamp=2023-12-23T17:58:46.109282Z level=ERROR thread=#zio-fiber-1 message="" cause="Exception in thread "zio-fiber-35" java.lang.RuntimeException: null
	at zio.test.ZIOSpecAbstract.$anonfun$runSpec$11(ZIOSpecAbstract.scala:79)
	at zio.ZIO$.$anonfun$fail$1(ZIO.scala:3149)
	at zio.ZIO$.$anonfun$failCause$3(ZIO.scala:3158)"
```

This PR replaces the exception with a call to `exit` with ExitCode.failure. This terminates the runner cleanly while reporting the required exit code 1.