### PR TITLE
Add TestAspects afterFailure and afterSuccess

### DIFF
--- a/docs/reference/test/aspects/before-after-around.md
+++ b/docs/reference/test/aspects/before-after-around.md
@@ -4,9 +4,11 @@ title: "Before, After, and Around Test Aspects"
 sidebar_label: "Before, After, and Around"
 ---
 
-1. We can run a test _before_, _after_, or _around_ every test:
+1. We can run an effect _before_, _after_, or _around_ every test:
 - `TestAspect.before`
 - `TestAspect.after`
+- `TestAspect.afterFailure`
+- `TestAspect.afterSuccess`
 - `TestAspect.around`
 
 ```scala mdoc:invisible

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -75,6 +75,58 @@ object TestAspectSpec extends ZIOBaseSpec {
         assert(after)(equalTo(-1))
       }
     },
+    test("afterFailure evaluates in case if test IO fails") {
+      for {
+        ref <- Ref.make(0)
+        spec = test("test") {
+                 ZIO.fail("error")
+               } @@ afterFailure(_ => ref.set(-1))
+        result <- succeeded(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isFalse) &&
+        assert(after)(equalTo(-1))
+      }
+    },
+    test("afterFailure does not evaluate in case if test IO succeeds") {
+      for {
+        ref <- Ref.make(0)
+        spec = test("test") {
+                 assertZIO(ref.get)(equalTo(0))
+               } @@ afterFailure(_ => ref.set(-1))
+        result <- succeeded(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isTrue) &&
+        assert(after)(equalTo(0))
+      }
+    },
+    test("afterSuccess evaluates in case if test IO succeeds") {
+      for {
+        ref <- Ref.make(0)
+        spec = test("test") {
+                 assertZIO(ref.get)(equalTo(0))
+               } @@ afterSuccess(ref.set(-1))
+        result <- succeeded(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isTrue) &&
+        assert(after)(equalTo(-1))
+      }
+    },
+    test("afterSuccess does not evaluate in case if test IO fails") {
+      for {
+        ref <- Ref.make(0)
+        spec = test("test") {
+                 ZIO.fail("error")
+               } @@ afterSuccess(ref.set(-1))
+        result <- succeeded(spec)
+        after  <- ref.get
+      } yield {
+        assert(result)(isFalse) &&
+        assert(after)(equalTo(0))
+      }
+    },
     test("exceptJS runs tests on all platforms except ScalaJS") {
       assert(TestPlatform.isJS)(isFalse)
     } @@ exceptJS,


### PR DESCRIPTION
Currently there is no way (that I'm aware of) to react to a test failing or succeeding in zio-test.
I've created TestAspects for this use case that I think might be helpful to others too.

My use case for these is making sure that specification files are only generated once a ZIOSpec has verified that the application indeed adheres to the desired spec, thus avoiding generating a file that does not match application behaviour.

Ideally, there'd also be a similar TestAspect for a Spec instead of single tests to only execute an effect once a set of tests (e.g. all of a ZIOSpec), but I have not found a way to evaluate a Spec and retrieve it's result (or failure) from within an aspect; if there are any I'd look into adding such an aspect as well.