### PR TITLE
Prevent implicit widening to Double

### DIFF
--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -429,13 +429,13 @@ object Metric {
    * A counter, which can be incremented by integers.
    */
   def counterInt(name: String): Counter[Int] =
-    counterDouble(name).contramap[Int](_.toInt)
+    counterDouble(name).contramap[Int](_.toDouble)
 
   /**
    * A counter, which can be incremented by integers.
    */
   def counterInt(name: String, description: String): Counter[Int] =
-    counterDouble(name, description).contramap[Int](_.toInt)
+    counterDouble(name, description).contramap[Int](_.toDouble)
 
   /**
    * A string histogram metric, which keeps track of the counts of different


### PR DESCRIPTION
`Int.toInt` is a no-op, IMHO it makes more sense to convert to double explicitly.