### PR TITLE
Fix ScheduleSpec when run on last day of year

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -379,7 +379,7 @@ object ScheduleSpec extends ZIOBaseSpec {
 
         assertZIO(runManually(Schedule.hourOfDay(1), input).map(toOffsetDateTime)) {
           val expected          = originOffset.withHour(1)
-          val afterTimeExpected = expected.withDayOfYear(expected.getDayOfYear + 1)
+          val afterTimeExpected = expected.plusDays(1)
           equalTo(List(expected, afterTimeExpected, expected, afterTimeExpected))
         }
       },


### PR DESCRIPTION
The expression `dateTime.withDayOfYear(dateTime.getDayOfYear + 1)` fails with `java.time.DateTimeException: Invalid date 'DayOfYear 366' as '2023' is not a leap year` when run on the last day of the year (unless the next year is a leap year).