### PR TITLE
Race Interruptibly In Channel.mergeAllWith

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1794,7 +1794,9 @@ object ZChannel {
                                  (queueReader >>> channel)
                                    .toPullIn(scope)
                                    .flatMap(
-                                     evaluatePull(_).raceAwait(errorSignal.await.interruptible).raceAwait(canceler.await.interruptible)
+                                     evaluatePull(_)
+                                       .raceAwait(errorSignal.await.interruptible)
+                                       .raceAwait(canceler.await.interruptible)
                                    )
                                }
                              childFiber <- permits


### PR DESCRIPTION
Awaiting the error signal and acquiring the permits should be interruptible.