### PR TITLE
[Scala 3] Prevent Tag materialization for intersection types in covariant position

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/IntersectionEnvSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/IntersectionEnvSpec.scala
@@ -1,0 +1,70 @@
+package zio
+
+import zio.test._
+import zio.test.Assertion._
+
+object IntersectionEnvSpec extends ZIOBaseSpec {
+  type Curry[A] = [B] =>> [C] =>> A => Set[B] => C
+  val hasNoTag = isLeft(startsWithString("could not find implicit value for izumi.reflect.Tag"))
+
+  def spec = suite("IntersectionEnvSpec")(
+    suite("intersection type")(
+      test("top-level") {
+        assertZIO(typeCheck("ZIO.service[Int & String]"))(hasNoTag)
+      },
+      test("in a list") {
+        assertZIO(typeCheck("ZIO.service[List[Int & String]]"))(hasNoTag)
+      },
+      test("deeply nested in a covariant position") {
+        assertZIO(typeCheck("ZIO.service[Either[Char, Option[List[Int & String]]]]"))(hasNoTag)
+      },
+      test("in twice contravariant position") {
+        assertZIO(typeCheck("ZIO.service[(Int & String => Boolean) => Boolean]"))(hasNoTag)
+      },
+      test("in a set") {
+        assertZIO(typeCheck("ZIO.service[Set[Int & String]]"))(isRight)
+      },
+      test("in a contravariant position") {
+        assertZIO(typeCheck("ZIO.service[Int & String => Boolean]"))(isRight)
+      },
+      test("in a covariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Byte][Char][Int & String]]"))(hasNoTag)
+      },
+      test("in a contravariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Int & String][Byte][Char]]"))(isRight)
+      },
+      test("in an invariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Byte][Int & String][Char]]"))(isRight)
+      }
+    ),
+    suite("union type")(
+      test("top-level") {
+        assertZIO(typeCheck("ZIO.service[Int | String]"))(isRight)
+      },
+      test("in a list") {
+        assertZIO(typeCheck("ZIO.service[List[Int | String]]"))(isRight)
+      },
+      test("deeply nested in a covariant position") {
+        assertZIO(typeCheck("ZIO.service[Either[Char, Option[List[Int | String]]]]"))(isRight)
+      },
+      test("in twice contravariant position") {
+        assertZIO(typeCheck("ZIO.service[(Int | String => Boolean) => Boolean]"))(isRight)
+      },
+      test("in a set") {
+        assertZIO(typeCheck("ZIO.service[Set[Int | String]]"))(isRight)
+      },
+      test("in a contravariant position") {
+        assertZIO(typeCheck("ZIO.service[Int | String => Boolean]"))(hasNoTag)
+      },
+      test("in a covariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Byte][Char][Int | String]]"))(isRight)
+      },
+      test("in a contravariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Int | String][Byte][Char]]"))(hasNoTag)
+      },
+      test("in an invariant position of a type alias") {
+        assertZIO(typeCheck("ZIO.service[Curry[Byte][Int | String][Char]]"))(isRight)
+      }
+    )
+  )
+}

--- a/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
@@ -11,22 +11,29 @@ private object TagMacros {
 
   def materialize[A: Type](using Quotes): Expr[Tag[A]] = {
     import quotes.reflect.*
-    TypeRepr.of[A].dealias match {
-      case tpe if tpe.typeSymbol.isTypeParam || tpe.typeSymbol.isAbstractType =>
-        Expr.summon[Tag[A]] match {
-          case Some(tag) => tag
-          case None => report.errorAndAbort( s"Cannot find implicit Tag[${tpe.show}]" )
-        }
-      case AndType(_, _) =>
-        report.errorAndAbort(s"You must not use an intersection type, yet have provided ${Type.show[A]}")
-      case tpe =>
-        '{
-          val tag0 = EnvironmentTag[A]
-          new Tag[A] {
-            def tag: LightTypeTag =  tag0.tag
-            def closestClass: Class[_] = tag0.closestClass
-          }
-        }
+
+    def isCovariant(typeParam: Symbol) = typeParam.flags.is(Flags.Covariant)
+    def isContravariant(typeParam: Symbol) = typeParam.flags.is(Flags.Contravariant)
+
+    def findIntersectionInCovariantPosition(tpe: TypeRepr, covariant: Boolean = true): Option[TypeRepr] = tpe match {
+      case AndType(_, _) => Option.when(covariant)(tpe)
+      case OrType(_, _) => Option.unless(covariant)(tpe)
+      case AppliedType(constructor, typeArgs) =>
+        val typeParams = constructor.typeSymbol.typeMembers.iterator.filter(_.isTypeParam)
+        typeParams.zip(typeArgs).collectFirst(Function.unlift { (typeParam, typeArg) =>
+          if isContravariant(typeParam) then findIntersectionInCovariantPosition(typeArg, !covariant)
+          else if isCovariant(typeParam) then findIntersectionInCovariantPosition(typeArg, covariant)
+          else None
+        })
+      case _ => None
     }
+
+    // Note: this error message is currently suppressed by the @implicitNotFound annotation on the parent of Tag.
+    def intersectionFound(tpe: TypeRepr) =
+      report.errorAndAbort(s"You must not use an intersection type, yet have provided ${tpe.show}")
+
+    val tpe = TypeRepr.of[A].dealias
+    if tpe.typeSymbol.isTypeParam || tpe.typeSymbol.isAbstractType then '{Tag[A]}
+    else findIntersectionInCovariantPosition(tpe).fold('{Tag[A]})(intersectionFound)
   }
 }

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -102,11 +102,11 @@ trait ZIOCompanionVersionSpecific {
 
         Exit.succeed(code)
       } catch {
-        case t: Throwable =>          
+        case t: Throwable =>
           if (!fiberState.isFatal(t))
             ZIO.failCause(Cause.fail(t))
           else
-            throw t          
+            throw t
       }
     }
 


### PR DESCRIPTION
Unfortunately the custom error message from the macro is suppressed. 
Also return type check errors from `typeCheck` to enable testing.

Closes #8283
/claim #8283