### PR TITLE
Update scalajs documentation to be in line with latest zio2, scalajs

### DIFF
--- a/docs/guides/interop/with-javascript.md
+++ b/docs/guides/interop/with-javascript.md
@@ -16,27 +16,33 @@ println(s"""```""")
 
 ## Example
 
-Your main function can extend `App` as follows.
+Your main function can extend [`ZIOAppDefault`](../../core/zioapp.md) as follows.
+
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.
 
+It assumes you have a `<div id="app">`  somewhere in your HTML, into which the ZIO output is written.
+
 ```scala
-import org.scalajs.dom.{document, raw}
+import java.util.concurrent.TimeUnit
+import org.scalajs.dom.{document,Element}
 import zio._
 import zio.Clock._
 
-object Main extends App {
+object Main extends ZIOAppDefault {
 
-  def run(args: List[String]) = {
+  override def run = {
+    // The node into which we write our ZIO program output
+    val node: Element = dom.document.querySelector("#app")
     for {
       _      <- Console.printLine("Starting progress bar demo.")  // Outputs on browser console log.
+      _      <- IO.succeed(node.appendChild(target)) // "node" might provided in this page by mdoc.
       target <- IO.succeed(document.createElement("pre"))
       _      <- update(target).repeat(Schedule.spaced(1.seconds))
-      _      <- IO.succeed(node.appendChild(target)) // "node" is provided in this page by mdoc.
     } yield ExitCode.success
   }
 
-  def update(target: raw.Element) = {
+  def update(target: Element) = {
       for {
         time   <- currentTime(TimeUnit.SECONDS)
         output <- ZIO.succeed(progress((time % 11).toInt, 10))


### PR DESCRIPTION
It seems the "interop with javascript" page is still using the old "App" trait, which proved confusing. Let's have it use the new ZIOAppDefault instead.

While touching the page, let's also use org.scalajs.dom.Element instead of org.scalajs.dom.raw.Element (which was deprecated).

As for functionality, I found that the code doesn't actually do anything, since it doesn't add "target" to the DOM tree until AFTER all of the calls to update() return; however that's a never-ending repeat. Hence, I also moved adding target() up a little, and created some documentation on how to actually see the output.