### PR TITLE
Fix sequence config with shorter one issue

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -380,18 +380,6 @@ object ConfigProviderSpec extends ZIOBaseSpec {
                   "parent2.child.employees[1].age" -> "31",
                   "parent2.child.employees[1].id"  -> "41"
                 )
-              ) orElse
-              ConfigProvider.fromMap(
-                Map(
-                  "parent1.child.employees[0].age" -> "111",
-                  "parent1.child.employees[0].id"  -> "211",
-                  "parent1.child.employees[1].age" -> "311",
-                  "parent1.child.employees[1].id"  -> "411",
-                  "parent1.child.employees[2].age" -> "511",
-                  "parent1.child.employees[2].id"  -> "611",
-                  "parent1.child.employees[3].age" -> "711",
-                  "parent1.child.employees[3].id"  -> "811"
-                )
               )
 
             val product    = Config.int("age").zip(Config.int("id"))
@@ -402,7 +390,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
             for {
               result1 <- configProvider.load(config1)
               result2 <- configProvider.load(config2)
-            } yield assertTrue(result1 == List((1, 2), (3, 4), (5, 6)), result2 == List((11, 21), (31, 41)))
+            } yield assertTrue(result1 == List((1, 2), (3, 4)), result2 == List((11, 21), (31, 41)))
           } +
           test("with indexed sequences and each provider unnested") {
             val configProvider = ConfigProvider
@@ -464,7 +452,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
 
             for {
               result1 <- configProvider.load(config1)
-            } yield assertTrue(result1 == List((1, 2), (3, 4)))
+            } yield assertTrue(result1 == List((1, 2)))
           }
       } +
       test("values are not split unless a sequence is expected") {

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -380,6 +380,18 @@ object ConfigProviderSpec extends ZIOBaseSpec {
                   "parent2.child.employees[1].age" -> "31",
                   "parent2.child.employees[1].id"  -> "41"
                 )
+              ) orElse
+              ConfigProvider.fromMap(
+                Map(
+                  "parent1.child.employees[0].age" -> "111",
+                  "parent1.child.employees[0].id"  -> "211",
+                  "parent1.child.employees[1].age" -> "311",
+                  "parent1.child.employees[1].id"  -> "411",
+                  "parent1.child.employees[2].age" -> "511",
+                  "parent1.child.employees[2].id"  -> "611",
+                  "parent1.child.employees[3].age" -> "711",
+                  "parent1.child.employees[3].id"  -> "811"
+                )
               )
 
             val product    = Config.int("age").zip(Config.int("id"))

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -209,7 +209,12 @@ object ConfigProvider {
                         case (Left(e1), Left(e2)) => ZIO.fail(e1 && e2)
                         case (Left(_), Right(r))  => ZIO.succeed(r)
                         case (Right(l), Left(_))  => ZIO.succeed(l)
-                        case (Right(l), Right(r)) => ZIO.succeed(l ++ r)
+                        case (Right(l), Right(r)) =>
+                          ZIO.succeed {
+                            val combined = l ++ r
+                            if (combined.size == l.size + r.size) combined
+                            else l // `r` was only partially successful
+                          }
                       }
           } yield result
 

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -209,12 +209,7 @@ object ConfigProvider {
                         case (Left(e1), Left(e2)) => ZIO.fail(e1 && e2)
                         case (Left(_), Right(r))  => ZIO.succeed(r)
                         case (Right(l), Left(_))  => ZIO.succeed(l)
-                        case (Right(l), Right(r)) =>
-                          ZIO.succeed {
-                            val combined = l ++ r
-                            if (combined.size == l.size + r.size) combined
-                            else l // `r` was only partially successful
-                          }
+                        case (Right(l), Right(r)) => ZIO.succeed(if (l.nonEmpty) l else r)
                       }
           } yield result
 


### PR DESCRIPTION
/closes #8604
/claim #8604

Alternatively, we could check if the sequence on the right starts at a higher index than on the left, but this feels more robust. Thoughts?