### PR TITLE
ZIO Test: Convert Rendering Failures to Test Failures

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -20,6 +20,20 @@ object TestSpec extends ZIOBaseSpec {
         result <- ZIO.succeed("succeed")
       } yield assert(result)(equalTo("succeed"))
     } @@ failing,
+    test("rendering error is test failure") {
+      case class Foo(a: Int) {
+        override def productPrefix: String =
+          throw new Exception("Boooom!")
+      }
+      val spec = test("properly report bug") {
+        val foo1 = Foo(2)
+        assertTrue(foo1 == foo1)
+      }
+      for {
+        summary <- execute(spec)
+      } yield assert(summary.fail)(equalTo(1)) &&
+        assert(summary.failureDetails.unstyled)(containsString("Boooom!"))
+    },
     test("test is polymorphic in error type") {
       for {
         _      <- ZIO.attempt(())

--- a/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/render/TestRenderer.scala
@@ -138,15 +138,19 @@ trait TestRenderer {
     )
   }
 
-  def renderAssertionResult(assertionResult: TestTrace[Boolean], offset: Int): Message = {
-    val failures = FailureCase.fromTrace(assertionResult, Chunk.empty)
-    failures
-      .map(fc =>
-        renderGenFailureDetails(assertionResult.getGenFailureDetails, offset) ++
-          Message(renderFailureCase(fc, offset, None))
-      )
-      .foldLeft(Message.empty)(_ ++ _)
-  }
+  def renderAssertionResult(assertionResult: TestTrace[Boolean], offset: Int): Message =
+    try {
+      val failures = FailureCase.fromTrace(assertionResult, Chunk.empty)
+      failures
+        .map(fc =>
+          renderGenFailureDetails(assertionResult.getGenFailureDetails, offset) ++
+            Message(renderFailureCase(fc, offset, None))
+        )
+        .foldLeft(Message.empty)(_ ++ _)
+    } catch {
+      case e: VirtualMachineError => throw e
+      case e: Throwable           => renderCause(Cause.die(e), offset)(Trace.empty)
+    }
 
   def renderFailureCase(failureCase: FailureCase, offset: Int, testLabel: Option[String]): Chunk[Line] =
     failureCase match {


### PR DESCRIPTION
Resolves #8439. /claim #8439 