### PR TITLE
ZIO Ecosystem Docusaurus: Automate Project Discovery

### DIFF
--- a/website/plugins/zio-ecosystem-docusaurus/index.js
+++ b/website/plugins/zio-ecosystem-docusaurus/index.js
@@ -53,7 +53,7 @@ function zioEcosystemPlugin(context, options) {
                         items: items
                     };
                 }
-                var result = zioProjects
+                var result = oldStyledZioProjects
                     // If the sidebar is simple and doesn't have label
                     .filter(function (e) { return (require("@zio.dev/".concat(e.routeBasePath, "/").concat(e.sidebarPath)).sidebar[0] == "index"); })
                     .map(function (project) {
@@ -61,12 +61,11 @@ function zioEcosystemPlugin(context, options) {
                         .sidebar
                         .filter(function (e) { return e != "index"; })), "".concat(project.routeBasePath, "/"));
                 })
-                    .concat(zioProjects
+                    .concat(zioNpmProjects()
                     // If the sidebar has all the metadata including the label
                     .filter(function (e) {
-                    return require("@zio.dev/".concat(e.routeBasePath, "/").concat(e.sidebarPath)).sidebar[0].label !== undefined;
+                    return require("@zio.dev/".concat(e, "/sidebars.js")).sidebar[0].label !== undefined;
                 })
-                    .map(function (p) { return p.routeBasePath; })
                     .map(function (project) {
                     return mapConfig(require("@zio.dev/".concat(project, "/sidebars.js")).sidebar[0], "".concat(project, "/"));
                 }))
@@ -103,7 +102,7 @@ function copy(srcDir, destDir) {
         console.error(err);
     }
 }
-var zioProjects = [
+var oldStyledZioProjects = [
     {
         name: 'Caliban Deriving',
         routeBasePath: 'caliban-deriving',
@@ -135,33 +134,8 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: "ZIO Cache",
-        routeBasePath: 'zio-cache',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO CLI",
-        routeBasePath: 'zio-cli',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO Config",
-        routeBasePath: 'zio-config',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO Constraintless",
-        routeBasePath: 'zio-constraintless',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: "ZIO Connect",
         routeBasePath: 'zio-connect',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO Crypto",
-        routeBasePath: 'zio-crypto',
         sidebarPath: 'sidebars.js'
     },
     {
@@ -170,23 +144,8 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: "ZIO DynamoDB",
-        routeBasePath: 'zio-dynamodb',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO Flow',
         routeBasePath: 'zio-flow',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO FTP',
-        routeBasePath: 'zio-ftp',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Insight',
-        routeBasePath: 'zio-insight',
         sidebarPath: 'sidebars.js'
     },
     {
@@ -200,28 +159,8 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: 'ZIO Interop Reactivestreams',
-        routeBasePath: 'zio-interop-reactivestreams',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO Interop Twitter',
         routeBasePath: 'zio-interop-twitter',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO JDBC",
-        routeBasePath: 'zio-jdbc',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: "ZIO JSON",
-        routeBasePath: 'zio-json',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Kafka',
-        routeBasePath: 'zio-kafka',
         sidebarPath: 'sidebars.js'
     },
     {
@@ -240,28 +179,8 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: 'ZIO Mock',
-        routeBasePath: 'zio-mock',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO NIO',
         routeBasePath: 'zio-nio',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Optics',
-        routeBasePath: 'zio-optics',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Profiling',
-        routeBasePath: 'zio-profiling',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Lambda',
-        routeBasePath: 'zio-lambda',
         sidebarPath: 'sidebars.js'
     },
     {
@@ -270,43 +189,8 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: 'ZIO Parser',
-        routeBasePath: 'zio-parser',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Prelude',
-        routeBasePath: 'zio-prelude',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Process',
-        routeBasePath: 'zio-process',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Query',
-        routeBasePath: 'zio-query',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Quill',
-        routeBasePath: 'zio-quill',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Redis',
-        routeBasePath: 'zio-redis',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO Rocksdb',
         routeBasePath: 'zio-rocksdb',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Schema',
-        routeBasePath: 'zio-schema',
         sidebarPath: 'sidebars.js'
     },
     {
@@ -315,53 +199,13 @@ var zioProjects = [
         sidebarPath: 'sidebars.js'
     },
     {
-        name: 'ZIO SQL',
-        routeBasePath: 'zio-sql',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO SQS',
         routeBasePath: 'zio-sqs',
         sidebarPath: 'sidebars.js'
     },
     {
-        name: 'ZIO Telemetry',
-        routeBasePath: 'zio-telemetry',
-        sidebarPath: 'sidebars.js'
-    },
-    {
         name: 'ZIO Webhooks',
         routeBasePath: 'zio-webhooks',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO SBT',
-        routeBasePath: 'zio-sbt',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Direct Style',
-        routeBasePath: 'zio-direct',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO Logging',
-        routeBasePath: 'zio-logging',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO 2.x Interop Cats 3.x',
-        routeBasePath: 'zio2-interop-cats3',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO 2.x Interop Cats 2.x',
-        routeBasePath: 'zio2-interop-cats2',
-        sidebarPath: 'sidebars.js'
-    },
-    {
-        name: 'ZIO HTTP',
-        routeBasePath: 'zio-http',
         sidebarPath: 'sidebars.js'
     }
 ];

--- a/website/plugins/zio-ecosystem-docusaurus/index.ts
+++ b/website/plugins/zio-ecosystem-docusaurus/index.ts
@@ -24,7 +24,7 @@ function zioEcosystemPlugin(context: LoadContext, options: PluginOptions) {
           }
 
           const result =
-            zioProjects
+            oldStyledZioProjects
               // If the sidebar is simple and doesn't have label
               .filter(e => (require(`@zio.dev/${e.routeBasePath}/${e.sidebarPath}`).sidebar[0] == "index"))
               .map(project => {
@@ -33,17 +33,16 @@ function zioEcosystemPlugin(context: LoadContext, options: PluginOptions) {
                     project.name,
                     require(`@zio.dev/${project.routeBasePath}/${project.sidebarPath}`)
                       .sidebar
-                      .filter(e => e != "index")),
+                     .filter(e => e != "index")),
                   `${project.routeBasePath}/`
                 )
               })
               .concat(
-                zioProjects
+                zioNpmProjects()
                   // If the sidebar has all the metadata including the label
                   .filter(e => {
-                    return require(`@zio.dev/${e.routeBasePath}/${e.sidebarPath}`).sidebar[0].label !== undefined
+                    return require(`@zio.dev/${e}/sidebars.js`).sidebar[0].label !== undefined;
                   })
-                  .map(p => p.routeBasePath)
                   .map(project =>
                     mapConfig(require(`@zio.dev/${project}/sidebars.js`).sidebar[0], `${project}/`)
                   )
@@ -85,7 +84,7 @@ function copy(srcDir: string, destDir: string) {
   }
 }
 
-const zioProjects =
+const oldStyledZioProjects =
   [
     {
       name: 'Caliban Deriving',
@@ -118,33 +117,8 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: "ZIO Cache",
-      routeBasePath: 'zio-cache',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO CLI",
-      routeBasePath: 'zio-cli',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO Config",
-      routeBasePath: 'zio-config',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO Constraintless",
-      routeBasePath: 'zio-constraintless',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: "ZIO Connect",
       routeBasePath: 'zio-connect',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO Crypto",
-      routeBasePath: 'zio-crypto',
       sidebarPath: 'sidebars.js',
     },
     {
@@ -153,23 +127,8 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: "ZIO DynamoDB",
-      routeBasePath: 'zio-dynamodb',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO Flow',
       routeBasePath: 'zio-flow',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO FTP',
-      routeBasePath: 'zio-ftp',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Insight',
-      routeBasePath: 'zio-insight',
       sidebarPath: 'sidebars.js',
     },
     {
@@ -183,28 +142,8 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: 'ZIO Interop Reactivestreams',
-      routeBasePath: 'zio-interop-reactivestreams',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO Interop Twitter',
       routeBasePath: 'zio-interop-twitter',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO JDBC",
-      routeBasePath: 'zio-jdbc',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: "ZIO JSON",
-      routeBasePath: 'zio-json',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Kafka',
-      routeBasePath: 'zio-kafka',
       sidebarPath: 'sidebars.js',
     },
     {
@@ -223,28 +162,8 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: 'ZIO Mock',
-      routeBasePath: 'zio-mock',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO NIO',
       routeBasePath: 'zio-nio',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Optics',
-      routeBasePath: 'zio-optics',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Profiling',
-      routeBasePath: 'zio-profiling',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Lambda',
-      routeBasePath: 'zio-lambda',
       sidebarPath: 'sidebars.js',
     },
     {
@@ -253,43 +172,8 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: 'ZIO Parser',
-      routeBasePath: 'zio-parser',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Prelude',
-      routeBasePath: 'zio-prelude',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Process',
-      routeBasePath: 'zio-process',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Query',
-      routeBasePath: 'zio-query',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Quill',
-      routeBasePath: 'zio-quill',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Redis',
-      routeBasePath: 'zio-redis',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO Rocksdb',
       routeBasePath: 'zio-rocksdb',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Schema',
-      routeBasePath: 'zio-schema',
       sidebarPath: 'sidebars.js',
     },
     {
@@ -298,53 +182,13 @@ const zioProjects =
       sidebarPath: 'sidebars.js',
     },
     {
-      name: 'ZIO SQL',
-      routeBasePath: 'zio-sql',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO SQS',
       routeBasePath: 'zio-sqs',
       sidebarPath: 'sidebars.js',
     },
     {
-      name: 'ZIO Telemetry',
-      routeBasePath: 'zio-telemetry',
-      sidebarPath: 'sidebars.js',
-    },
-    {
       name: 'ZIO Webhooks',
       routeBasePath: 'zio-webhooks',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO SBT',
-      routeBasePath: 'zio-sbt',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Direct Style',
-      routeBasePath: 'zio-direct',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO Logging',
-      routeBasePath: 'zio-logging',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO 2.x Interop Cats 3.x',
-      routeBasePath: 'zio2-interop-cats3',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO 2.x Interop Cats 2.x',
-      routeBasePath: 'zio2-interop-cats2',
-      sidebarPath: 'sidebars.js',
-    },
-    {
-      name: 'ZIO HTTP',
-      routeBasePath: 'zio-http',
       sidebarPath: 'sidebars.js',
     }
   ]


### PR DESCRIPTION
resolves #8631 

Through this work new projects that have been added recently to the ZIO ecosystem become available on zio.dev website.

From now on, whenever a new project is introduced to the ZIO ecosystem, we need only add its corresponding documentation project to the `website/package.json` file. e.g.:

```shell
yarn add @zio.dev/zio-xyz:<version>
```