### PR TITLE
Fixed zio-test: assertTrue(someCollection.exists...) super slow #8644

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ExistsInListTestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ExistsInListTestSpec.scala
@@ -1,0 +1,82 @@
+package zio.test
+
+import zio.test.GenUtils.ExistsFaster
+
+object ExistsInListTestSpec extends ZIOSpecDefault {
+
+  case class ComplexObject(id: String)
+
+  object ComplexObject {
+    def of(i: Int): ComplexObject = ComplexObject(id = i.toString)
+  }
+
+  def spec = suite("assert exists/not-exists suite") (
+
+    test("test assert exists in empty list fails") {
+      val emptyList: List[ComplexObject] = List.empty
+      assertTrue(assertTrue(emptyList.existsFast(_.id == "1")).isFailure)
+    },
+
+    test("test assert not exists in empty list succeed") {
+      val emptyList: List[ComplexObject] = List.empty
+      assertTrue(!emptyList.existsFast(_.id == "1"))
+    },
+
+
+    test("test assert exists succeed on single elem list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1))
+      assertTrue(list.existsFast(_.id == "1"))
+    },
+
+    test("test assert not exists succeed on single elem list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1))
+      assertTrue(!list.existsFast(_.id == "0"))
+    },
+
+
+    test("test assert exists fails on single elem list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1))
+      assertTrue(assertTrue(list.existsFast(_.id == "2")).isFailure)
+    },
+
+    test("test assert not exists fails on single elem list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1))
+      assertTrue(assertTrue(!list.existsFast(_.id == "1")).isFailure)
+    },
+
+
+    test("test assert exists succeed on multiple elems list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
+      assertTrue(list.existsFast(_.id == "3"))
+    },
+
+    test("test assert not exists succeed on multiple elems list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
+      assertTrue(!list.existsFast(_.id == "5"))
+    },
+
+
+    test("test assert exists fails on multiple elems list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
+      assertTrue(assertTrue(list.existsFast(_.id == "5")).isFailure)
+    },
+
+    test("test assert not exists fails on multiple elems list") {
+      val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
+      assertTrue(assertTrue(!list.existsFast(_.id == "3")).isFailure)
+    },
+
+
+    test("test assert exists succeed on large 100000 elems list") {
+      val hugeList = (1 to 100000).map(i => ComplexObject.of(i)).toList
+      assertTrue(hugeList.existsFast(_.id == "100000"))
+    },
+
+    test("test assert not exists succeed on large 100000 elems list") {
+      val hugeList = (1 to 100000).map(i => ComplexObject.of(i)).toList
+      assertTrue(!hugeList.existsFast(_.id == "0"))
+    },
+
+  )@@ TestAspect.timed
+
+}

--- a/test-tests/shared/src/test/scala/zio/test/ExistsInListTestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ExistsInListTestSpec.scala
@@ -10,73 +10,55 @@ object ExistsInListTestSpec extends ZIOSpecDefault {
     def of(i: Int): ComplexObject = ComplexObject(id = i.toString)
   }
 
-  def spec = suite("assert exists/not-exists suite") (
-
+  def spec = suite("assert exists/not-exists suite")(
     test("test assert exists in empty list fails") {
       val emptyList: List[ComplexObject] = List.empty
       assertTrue(assertTrue(emptyList.existsFast(_.id == "1")).isFailure)
     },
-
     test("test assert not exists in empty list succeed") {
       val emptyList: List[ComplexObject] = List.empty
       assertTrue(!emptyList.existsFast(_.id == "1"))
     },
-
-
     test("test assert exists succeed on single elem list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1))
       assertTrue(list.existsFast(_.id == "1"))
     },
-
     test("test assert not exists succeed on single elem list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1))
       assertTrue(!list.existsFast(_.id == "0"))
     },
-
-
     test("test assert exists fails on single elem list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1))
       assertTrue(assertTrue(list.existsFast(_.id == "2")).isFailure)
     },
-
     test("test assert not exists fails on single elem list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1))
       assertTrue(assertTrue(!list.existsFast(_.id == "1")).isFailure)
     },
-
-
     test("test assert exists succeed on multiple elems list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
       assertTrue(list.existsFast(_.id == "3"))
     },
-
     test("test assert not exists succeed on multiple elems list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
       assertTrue(!list.existsFast(_.id == "5"))
     },
-
-
     test("test assert exists fails on multiple elems list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
       assertTrue(assertTrue(list.existsFast(_.id == "5")).isFailure)
     },
-
     test("test assert not exists fails on multiple elems list") {
       val list: List[ComplexObject] = List(ComplexObject.of(1), ComplexObject.of(2), ComplexObject.of(3))
       assertTrue(assertTrue(!list.existsFast(_.id == "3")).isFailure)
     },
-
-
     test("test assert exists succeed on large 100000 elems list") {
       val hugeList = (1 to 100000).map(i => ComplexObject.of(i)).toList
       assertTrue(hugeList.existsFast(_.id == "100000"))
     },
-
     test("test assert not exists succeed on large 100000 elems list") {
       val hugeList = (1 to 100000).map(i => ComplexObject.of(i)).toList
       assertTrue(!hugeList.existsFast(_.id == "0"))
-    },
-
-  )@@ TestAspect.timed
+    }
+  ) @@ TestAspect.timed
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
@@ -51,7 +51,7 @@ object ExistsTestSlowSpec extends ZIOSpecDefault {
         allShouldNotHave = (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.exists(_.name4 == (-i).toString)))
 
       } yield TestResult.allSuccesses(
-        allShouldNotHave.concat(allShouldHave)
+        allShouldNotHave ++ allShouldHave
       )
     },
     test("testSlowExistsInListFixed") {
@@ -63,7 +63,41 @@ object ExistsTestSlowSpec extends ZIOSpecDefault {
           (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.existsFast(_.name4 == (-i).toString)))
 
       } yield TestResult.allSuccesses(
-        allShouldNotHave.concat(allShouldHave)
+        allShouldNotHave ++ allShouldHave
+      )
+    },
+    test("testSlowFixed") {
+      for {
+        _ <- ZIO.unit
+        // sample of complex objects
+        hugeList = (1 to 1000).map(i => ComplexObject.of(i)).toList
+
+        shouldNotHave20  = assertTrue(!hugeList.existsFast(_.name3 == "-20"))
+        shouldNotHave510 = assertTrue(!hugeList.existsFast(_.name3 == "-510"))
+        shouldNotHave780 = assertTrue(!hugeList.existsFast(_.name3 == "-780"))
+        shouldNotHave999 = assertTrue(!hugeList.existsFast(_.name3 == "-999"))
+      } yield TestResult.allSuccesses(
+        shouldNotHave20,
+        shouldNotHave510,
+        shouldNotHave780,
+        shouldNotHave999
+      )
+    },
+    test("testOrig") {
+      for {
+        _ <- ZIO.unit
+        // sample of complex objects
+        hugeList = (1 to 1000).map(i => ComplexObject.of(i)).toList
+
+        shouldNotHave20  = assertTrue(!hugeList.exists(_.name3 == "-20"))
+        shouldNotHave510 = assertTrue(!hugeList.exists(_.name3 == "-510"))
+        shouldNotHave780 = assertTrue(!hugeList.exists(_.name3 == "-780"))
+        shouldNotHave999 = assertTrue(!hugeList.exists(_.name3 == "-999"))
+      } yield TestResult.allSuccesses(
+        shouldNotHave20,
+        shouldNotHave510,
+        shouldNotHave780,
+        shouldNotHave999
       )
     }
   ) @@ TestAspect.timed

--- a/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
@@ -6,19 +6,19 @@ import zio.test.GenUtils.ExistsFaster
 object ExistsTestSlowSpec extends ZIOSpecDefault {
 
   case class ComplexObject(
-                            id: String,
-                            name: String,
-                            name2: String,
-                            name3: String,
-                            name4: String,
-                            name5: String,
-                            name6: String,
-                            name7: String,
-                            name8: String,
-                            name9: String,
-                            name10: String,
-                            name11: String
-                          )
+    id: String,
+    name: String,
+    name2: String,
+    name3: String,
+    name4: String,
+    name5: String,
+    name6: String,
+    name7: String,
+    name8: String,
+    name9: String,
+    name10: String,
+    name11: String
+  )
 
   object ComplexObject {
     def of(i: Int): ComplexObject = ComplexObject(
@@ -37,37 +37,35 @@ object ExistsTestSlowSpec extends ZIOSpecDefault {
     )
   }
 
-  val toIndex: Int = 10000
+  val toIndex: Int  = 10000
   val numSteps: Int = 100
-  val stepInc: Int = toIndex / numSteps
-  val hugeList = (1 to toIndex).map(i => ComplexObject.of(i)).toList
+  val stepInc: Int  = toIndex / numSteps
+  val hugeList      = (1 to toIndex).map(i => ComplexObject.of(i)).toList
 
   def spec = suite("ExistsTestSlowIssue")(
-
     test("testSlowExistsInList") {
       for {
         _ <- ZIO.unit
 
-        allShouldHave = (1 to toIndex by stepInc).map(i => assertTrue(hugeList.exists(_.name3 == i.toString)))
+        allShouldHave    = (1 to toIndex by stepInc).map(i => assertTrue(hugeList.exists(_.name3 == i.toString)))
         allShouldNotHave = (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.exists(_.name4 == (-i).toString)))
 
       } yield TestResult.allSuccesses(
         allShouldNotHave.concat(allShouldHave)
       )
     },
-
     test("testSlowExistsInListFixed") {
       for {
         _ <- ZIO.unit
 
         allShouldHave = (1 to toIndex by stepInc).map(i => assertTrue(hugeList.existsFast(_.name3 == i.toString)))
-        allShouldNotHave = (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.existsFast(_.name4 == (-i).toString)))
+        allShouldNotHave =
+          (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.existsFast(_.name4 == (-i).toString)))
 
       } yield TestResult.allSuccesses(
         allShouldNotHave.concat(allShouldHave)
       )
-    },
-
+    }
   ) @@ TestAspect.timed
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ExistsTestSlowSpec.scala
@@ -1,0 +1,73 @@
+package zio.test
+
+import zio.ZIO
+import zio.test.GenUtils.ExistsFaster
+
+object ExistsTestSlowSpec extends ZIOSpecDefault {
+
+  case class ComplexObject(
+                            id: String,
+                            name: String,
+                            name2: String,
+                            name3: String,
+                            name4: String,
+                            name5: String,
+                            name6: String,
+                            name7: String,
+                            name8: String,
+                            name9: String,
+                            name10: String,
+                            name11: String
+                          )
+
+  object ComplexObject {
+    def of(i: Int): ComplexObject = ComplexObject(
+      id = i.toString,
+      name = i.toString,
+      name2 = i.toString,
+      name3 = i.toString,
+      name4 = i.toString,
+      name5 = i.toString,
+      name6 = i.toString,
+      name7 = i.toString,
+      name8 = i.toString,
+      name9 = i.toString,
+      name10 = i.toString,
+      name11 = i.toString
+    )
+  }
+
+  val toIndex: Int = 10000
+  val numSteps: Int = 100
+  val stepInc: Int = toIndex / numSteps
+  val hugeList = (1 to toIndex).map(i => ComplexObject.of(i)).toList
+
+  def spec = suite("ExistsTestSlowIssue")(
+
+    test("testSlowExistsInList") {
+      for {
+        _ <- ZIO.unit
+
+        allShouldHave = (1 to toIndex by stepInc).map(i => assertTrue(hugeList.exists(_.name3 == i.toString)))
+        allShouldNotHave = (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.exists(_.name4 == (-i).toString)))
+
+      } yield TestResult.allSuccesses(
+        allShouldNotHave.concat(allShouldHave)
+      )
+    },
+
+    test("testSlowExistsInListFixed") {
+      for {
+        _ <- ZIO.unit
+
+        allShouldHave = (1 to toIndex by stepInc).map(i => assertTrue(hugeList.existsFast(_.name3 == i.toString)))
+        allShouldNotHave = (1 to toIndex by stepInc).map(i => assertTrue(!hugeList.existsFast(_.name4 == (-i).toString)))
+
+      } yield TestResult.allSuccesses(
+        allShouldNotHave.concat(allShouldHave)
+      )
+    },
+
+  ) @@ TestAspect.timed
+
+}

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -103,4 +103,12 @@ object GenUtils {
     if (n == 0) (n, ZStream.empty)
     else (n, ZStream(n - 1))
   }))
+
+  implicit class ExistsFaster[A](val l: List[A]) {
+    /**
+     * Use optimized List iterator StrictOptimizedLinearSeqOps exists, instead of List.exists.
+     */
+    def existsFast(p: A => Boolean): Boolean = l.iterator.exists(e => p(e))
+  }
+
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -105,8 +105,10 @@ object GenUtils {
   }))
 
   implicit class ExistsFaster[A](val l: List[A]) {
+
     /**
-     * Use optimized List iterator StrictOptimizedLinearSeqOps exists, instead of List.exists.
+     * Use optimized List iterator StrictOptimizedLinearSeqOps exists, instead
+     * of List.exists.
      */
     def existsFast(p: A => Boolean): Boolean = l.iterator.exists(e => p(e))
   }


### PR DESCRIPTION
/claim #8644

Using `List.iterator.exists` instead of `List.exists` improves the slow response, it uses an optimized version of `drop` for the tail that avoids copying.
* An extension method `ExistsFaster.existsFast` was created at `zio.test.GenUtils` using `List.iterator.exists` instead of `List.exists`. 
* Unit tests to check `existsFast` functionality were added at `zio.test.ExistsInListTestSpec`. 
* Comparison unit tests between `List.exists` and created `existsFast` with large size and number of executions were added in `zio.test.ExistsTestSlowSpec`, reducing the execution time by ~6.7 factor:

```
+ ExistsTestSlowIssue
  + testSlowExistsInListFixed - 474 ms
  + testSlowExistsInList - 3 s 196 ms
```