### PR TITLE
Report the current fiber in `Exception in thread "zio-fiber-X"` instead of the interruptor fiber

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -121,7 +121,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
   def interruptAsFork(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
-      val cause = Cause.interrupt(fiberId).traced(StackTrace(fiberId, Chunk(trace)))
+      val cause = Cause.interrupt(fiberId).traced(StackTrace(self.fiberId, Chunk(trace)))
 
       tell(FiberMessage.InterruptSignal(cause))
     }


### PR DESCRIPTION
Currently the Interrupted Cause only contains the interruptor fiber, not the interrupted fiber, so when 1 interrupts 2, it's reported as:

```
Exception in thread "zio-fiber-1" java.lang.InterruptedException: Interrupted by thread "zio-fiber-1"
```

Should be:

```
Exception in thread "zio-fiber-2" java.lang.InterruptedException: Interrupted by thread "zio-fiber-1"
```