### PR TITLE
Detect defects in JUnit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -565,12 +565,14 @@ lazy val testJunitRunnerTests = crossProject(JVMPlatform) // TODO: make plain pr
       "junit"                   % "junit"     % "4.13.2" % Test,
       "org.scala-lang.modules" %% "scala-xml" % "2.2.0"  % Test,
       // required to run embedded maven in the tests
-      "org.apache.maven"       % "maven-embedder"         % "3.9.4"  % Test,
-      "org.apache.maven"       % "maven-compat"           % "3.9.4"  % Test,
-      "org.apache.maven.wagon" % "wagon-http"             % "3.5.3"  % Test,
-      "org.eclipse.aether"     % "aether-connector-basic" % "1.1.0"  % Test,
-      "org.eclipse.aether"     % "aether-transport-wagon" % "1.1.0"  % Test,
-      "org.slf4j"              % "slf4j-simple"           % "1.7.36" % Test
+      "org.apache.maven"          % "maven-embedder"                 % "3.9.6"  % Test,
+      "org.apache.maven"          % "maven-compat"                   % "3.9.6"  % Test,
+      "com.google.inject"         % "guice"                          % "4.0"    % Test,
+      "org.eclipse.sisu"          % "org.eclipse.sisu.inject"        % "0.3.5"  % Test,
+      "org.apache.maven.resolver" % "maven-resolver-connector-basic" % "1.9.18" % Test,
+      "org.apache.maven.resolver" % "maven-resolver-transport-http"  % "1.9.18" % Test,
+      "org.codehaus.plexus"       % "plexus-component-annotations"   % "2.2.0"  % Test,
+      "org.slf4j"                 % "slf4j-simple"                   % "1.7.36" % Test
     )
   )
   .dependsOn(
@@ -584,6 +586,7 @@ lazy val testJunitRunnerTests = crossProject(JVMPlatform) // TODO: make plain pr
         .dependsOn(testJunitRunner / publishM2)
         .dependsOn(tests.jvm / publishM2)
         .dependsOn(core.jvm / publishM2)
+        .dependsOn(internalMacros.jvm / publishM2)
         .dependsOn(streams.jvm / publishM2)
         .dependsOn(stacktracer.jvm / publishM2)
         .value

--- a/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-tests/jvm/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -1,116 +1,115 @@
-// package zio.test.junit
+package zio.test.junit
 
-// import org.apache.maven.cli.MavenCli
-// import zio.test.Assertion._
-// import zio.test.{DefaultRunnableSpec, Spec, _}
-// import zio.{System => _, _}
+import org.apache.maven.cli.MavenCli
+import zio.test.Assertion._
+import zio.test.{ZIOSpecDefault, _}
+import zio.{System => _, ZIO, Task}
 
-// import java.io.File
-// import scala.collection.immutable
-// import scala.xml.XML
+import java.io.File
+import scala.collection.immutable
+import scala.xml.XML
 
-// /**
-//  * when running from IDE run `sbt publishM2`, copy the snapshot version the
-//  * artifacts were published under (something like:
-//  * `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`) and put this into `VM Parameters`:
-//  * `-Dproject.dir=\$PROJECT_DIR\$/test-junit-tests/jvm
-//  * -Dproject.version=\$snapshotVersion`
-//  */
-// object MavenJunitSpec extends DefaultRunnableSpec {
+/**
+ * when running from IDE run `sbt publishM2`, copy the snapshot version the
+ * artifacts were published under (something like:
+ * `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`) and put this into `VM Parameters`:
+ * `-Dproject.dir=\$PROJECT_DIR\$/test-junit-tests/jvm
+ * -Dproject.version=\$snapshotVersion`
+ */
+object MavenJunitSpec extends ZIOSpecDefault {
 
-//   def spec: Spec[Environment, Any] = suite("MavenJunitSpec")(
-//     test("FailingSpec results are properly reported") {
-//       for {
-//         mvn       <- makeMaven
-//         mvnResult <- mvn.clean() *> mvn.test()
-//         report    <- mvn.parseSurefireReport("zio.test.junit.maven.FailingSpec")
-//       } yield {
-//         assert(mvnResult)(not(equalTo(0))) &&
-//         assert(report)(
-//           containsFailure(
-//             "should fail",
-//             s"""zio.test.junit.TestFailed:
-//                |11 did not satisfy equalTo(12)
-//                |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:10""".stripMargin
-//           ) &&
-//             containsFailure(
-//               "should fail - isSome",
-//               s"""zio.test.junit.TestFailed:
-//                  |11 did not satisfy equalTo(12)
-//                  |Some(11) did not satisfy isSome(equalTo(12))
-//                  |at ${mvn.mvnRoot}/src/test/scala/zio/test/junit/maven/FailingSpec.scala:13""".stripMargin
-//             ) &&
-//             containsSuccess("should succeed")
-//         )
-//       }
-//     }
-//   ) @@ TestAspect.sequential @@
-//     // flaky: sometimes maven fails to download dependencies in CI
-//     TestAspect.flaky(3)
+  def spec = suite("MavenJunitSpec")(
+    test("Spec results are properly reported") {
+      for {
+        mvn          <- makeMaven
+        mvnResult    <- mvn.clean() *> mvn.test()
+        report       <- mvn.parseSurefireReport("zio.test.junit.maven.FailingSpec")
+        reportDefect <- mvn.parseSurefireReport("zio.test.junit.maven.DefectSpec")
+      } yield {
+        assert(mvnResult)(not(equalTo(0))) &&
+        assert(report)(
+          containsFailure(
+            "should fail",
+            "11 was not equal to 12"
+          ) &&
+            containsFailure(
+              "should fail - isSome",
+              "11 was not equal to 12"
+            ) &&
+            containsSuccess("should succeed")
+        ) &&
+        assertTrue(reportDefect.length == 1) // spec with defect is reported
+      }
+    }
+  ) @@ TestAspect.sequential @@
+    // flaky: sometimes maven fails to download dependencies in CI
+    TestAspect.flaky(3)
 
-//   def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
-//     projectDir <-
-//       ZIO
-//         .fromOption(sys.props.get("project.dir"))
-//         .orElseFail(
-//           new AssertionError(
-//             "Missing project.dir system property\n" +
-//               "when running from IDE put this into `VM Parameters`: `-Dproject.dir=$PROJECT_DIR$/test-junit-tests/jvm`"
-//           )
-//         )
-//     projectVer <-
-//       ZIO
-//         .fromOption(sys.props.get("project.version"))
-//         .orElseFail(
-//           new AssertionError(
-//             "Missing project.version system property\n" +
-//               "when running from IDE put this into `VM Parameters`: `-Dproject.version=<current zio version>`"
-//           )
-//         )
-//     scalaVersion       = sys.props.get("scala.version").getOrElse("2.12.10")
-//     scalaCompatVersion = sys.props.get("scala.compat.version").getOrElse("2.12")
-//   } yield new MavenDriver(projectDir, projectVer, scalaVersion, scalaCompatVersion)
+  def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
+    projectDir <-
+      ZIO
+        .fromOption(sys.props.get("project.dir"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.dir system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.dir=$PROJECT_DIR$/test-junit-tests/jvm`"
+          )
+        )
+    projectVer <-
+      ZIO
+        .fromOption(sys.props.get("project.version"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.version system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.version=<current zio version>`"
+          )
+        )
+    scalaVersion       = sys.props.get("scala.version").getOrElse("2.12.10")
+    scalaCompatVersion = sys.props.get("scala.compat.version").getOrElse("2.12")
+  } yield new MavenDriver(projectDir, projectVer, scalaVersion, scalaCompatVersion)
 
-//   class MavenDriver(projectDir: String, projectVersion: String, scalaVersion: String, scalaCompatVersion: String) {
-//     val mvnRoot: String = new File(s"$projectDir/../maven").getCanonicalPath
-//     private val cli     = new MavenCli
-//     java.lang.System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
+  class MavenDriver(projectDir: String, projectVersion: String, scalaVersion: String, scalaCompatVersion: String) {
+    val mvnRoot: String = new File(s"$projectDir/../maven").getCanonicalPath
+    private val cli     = new MavenCli
+    java.lang.System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
 
-//     def clean(): Task[Int] = run("clean")
+    def clean(): Task[Int] = run("clean")
 
-//     def test(): Task[Int] = run(
-//       "test",
-//       s"-Dzio.version=$projectVersion",
-//       s"-Dscala.version=$scalaVersion",
-//       s"-Dscala.compat.version=$scalaCompatVersion",
-//       s"-ssettings.xml"
-//     )
-//     def run(command: String*): Task[Int] = ZIO.attemptBlocking(
-//       cli.doMain(command.toArray, mvnRoot, System.out, System.err)
-//     )
+    def test(): Task[Int] = run(
+      "test",
+      s"-Dzio.version=$projectVersion",
+      s"-Dscala.version=$scalaVersion",
+      s"-Dscala.compat.version=$scalaCompatVersion"
+    )
+    def run(command: String*): Task[Int] = ZIO.attemptBlocking(
+      cli.doMain(command.toArray, mvnRoot, System.out, System.err)
+    )
 
-//     def parseSurefireReport(testFQN: String): Task[immutable.Seq[TestCase]] =
-//       ZIO
-//         .attemptBlocking(
-//           XML.load(scala.xml.Source.fromFile(new File(s"$mvnRoot/target/surefire-reports/TEST-$testFQN.xml")))
-//         )
-//         .map { report =>
-//           (report \ "testcase").map { tcNode =>
-//             TestCase(
-//               tcNode \@ "name",
-//               (tcNode \ "error").headOption
-//                 .map(error => TestError(error.text.linesIterator.map(_.trim).mkString("\n"), error \@ "type"))
-//             )
-//           }
-//         }
+    def parseSurefireReport(testFQN: String): Task[immutable.Seq[TestCase]] =
+      ZIO
+        .attemptBlocking(
+          XML.load(scala.xml.Source.fromFile(new File(s"$mvnRoot/target/surefire-reports/TEST-$testFQN.xml")))
+        )
+        .map { report =>
+          (report \ "testcase").map { tcNode =>
+            TestCase(
+              tcNode \@ "name",
+              (tcNode \ "error").headOption
+                .map(error => TestError(error.text.linesIterator.map(_.trim).mkString("\n"), error \@ "type"))
+            )
+          }
+        }
 
-//   }
+  }
 
-//   def containsSuccess(label: String): Assertion[Iterable[TestCase]]                = containsResult(label, error = None)
-//   def containsFailure(label: String, error: String): Assertion[Iterable[TestCase]] = containsResult(label, Some(error))
-//   def containsResult(label: String, error: Option[String]): Assertion[Iterable[TestCase]] =
-//     contains(TestCase(label, error.map(TestError(_, "zio.test.junit.TestFailed"))))
+  def containsSuccess(label: String): Assertion[Iterable[TestCase]]                = containsResult(label, error = None)
+  def containsFailure(label: String, error: String): Assertion[Iterable[TestCase]] = containsResult(label, Some(error))
+  def containsResult(label: String, error: Option[String]): Assertion[Iterable[TestCase]] =
+    exists(assertion(s"check $label") { testCase =>
+      testCase.name == label &&
+      error.map(err => testCase.error.map(_.message.contains(err)).getOrElse(false)).getOrElse(testCase.error == None)
+    })
 
-//   case class TestCase(name: String, error: Option[TestError])
-//   case class TestError(message: String, `type`: String)
-// }
+  case class TestCase(name: String, error: Option[TestError])
+  case class TestError(message: String, `type`: String)
+}

--- a/test-junit-tests/maven/pom.xml
+++ b/test-junit-tests/maven/pom.xml
@@ -9,12 +9,10 @@
     <inceptionYear>2020</inceptionYear>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.version>2.13.8</scala.version>
+        <scala.version>2.13.12</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
-        <zio.version>2.0.0</zio.version>
+        <zio.version>2.0.21</zio.version>
     </properties>
 
     <dependencies>
@@ -49,14 +47,13 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M5</version>
+            <version>3.2.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.surefire</groupId>
             <artifactId>surefire-junit47</artifactId>
-            <version>3.0.0-M5</version>
+            <version>3.2.5</version>
         </dependency>
-
     </dependencies>
 
 
@@ -66,7 +63,7 @@
                 <!-- see http://davidb.github.com/scala-maven-plugin -->
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>4.5.6</version>
+                <version>4.8.1</version>
                 <executions>
                     <execution>
                         <goals>
@@ -88,7 +85,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.2.5</version>
                 <configuration>
                     <goal>test</goal>
                     <parallel>methods</parallel>

--- a/test-junit-tests/maven/src/test/scala/zio/test/junit/maven/DefectSpec.scala
+++ b/test-junit-tests/maven/src/test/scala/zio/test/junit/maven/DefectSpec.scala
@@ -1,0 +1,39 @@
+package zio.test.junit.maven
+
+import zio.test.Assertion.equalTo
+import zio.test.junit.JUnitRunnableSpec
+import zio.test.{Spec, TestEnvironment, assert}
+import zio.{Scope, Task, ZIO, ZLayer}
+
+trait Ops {
+ def targetHost: String
+}
+
+object OpsTest extends Ops {
+  override def targetHost: String = null
+}
+
+trait MyService {
+  def readData : Task[List[String]]
+}
+
+class MyServiceTest(targetHostName: String) extends MyService {
+
+  val url = s"https://${targetHostName.toLowerCase}/ws" // <- null pointer exception here
+
+  override def readData: Task[List[String]] = {
+    ZIO.succeed(List("a","b"))
+  }
+}
+
+class DefectSpec extends JUnitRunnableSpec{
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("nul test")(
+    test("test with defect") {
+      for {
+        ms <- ZIO.service[MyService]
+        result <- ms.readData
+      }
+      yield assert(result.size)(equalTo(2))
+    }.provideLayer(ZLayer.succeed(new MyServiceTest(OpsTest.targetHost)))
+  )
+}

--- a/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/jvm/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -147,22 +147,27 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
   ): Spec[R, E] = {
     type ZSpecCase = Spec.SpecCase[R, E, Spec[R, E]]
     def instrumentTest(label: String, path: Vector[String], test: ZIO[R, TestFailure[E], TestSuccess]) =
-      test.tapBoth(
-        {
-          case Assertion(result, _) =>
-            notifier.fireTestStarted(label, path) *>
-              reportAssertionFailure(notifier, path, label, result)
-          case Runtime(cause, _) =>
-            notifier.fireTestStarted(label, path) *>
-              reportRuntimeFailure(notifier, path, label, cause)
-        },
-        {
-          case Succeeded(_) =>
-            notifier.fireTestStarted(label, path) *>
-              notifier.fireTestFinished(label, path)
-          case Ignored(_) => notifier.fireTestIgnored(label, path)
+      test
+        .tapBoth(
+          {
+            case Assertion(result, _) =>
+              notifier.fireTestStarted(label, path) *>
+                reportAssertionFailure(notifier, path, label, result)
+            case Runtime(cause, _) =>
+              notifier.fireTestStarted(label, path) *>
+                reportRuntimeFailure(notifier, path, label, cause)
+          },
+          {
+            case Succeeded(_) =>
+              notifier.fireTestStarted(label, path) *>
+                notifier.fireTestFinished(label, path)
+            case Ignored(_) => notifier.fireTestIgnored(label, path)
+          }
+        )
+        .tapDefect { e =>
+          notifier.fireTestStarted(label, path) *>
+            reportRuntimeFailure(notifier, path, label, e)
         }
-      )
     def loop(specCase: ZSpecCase, path: Vector[String] = Vector.empty): ZSpecCase =
       specCase match {
         case Spec.ExecCase(exec, spec) =>


### PR DESCRIPTION
/claim #8565
The JUnit Runner didn't detect tests with defects. Also the `test-junit` test is now restored. 

@loicdescotte However, it's better in your example to leverage ZIO's error management when constructing the `ZLayer` using for example `ZLayer.fromZIO(ZIO.attempt(_))` instead of `ZLayer.succeed` (ignore this if it was used just for the minimal example and doesn't apply to your use case).