### PR TITLE
Reduce output for huge lists during pretty printing

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
@@ -45,7 +45,11 @@ Person(
       assertTrue(
         PrettyPrint(Person("Glenda", 123)).unstyled == expected
       )
-    } @@ TestAspect.exceptScala212
+    } @@ TestAspect.exceptScala212,
+    test("Huge list") {
+      val list = (1 to 1000).toList
+      assertTrue(PrettyPrint(list).unstyled == "List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10 + 990 more)")
+    }
   )
 
 }


### PR DESCRIPTION
Fixes #8644 
/claim #8644

I believe the main issue is printing array, not comparison itself. While I also have long tests when using provided example `Executed in 1 s 295 ms` (run using intellij) after using `@@ TestAspect.failing` that removes printing but leaves comparison I get much better `Executed in 547 ms`

Number 10 was selected arbitrary