### PR TITLE
chore: remove diff rendering from the assertion

### DIFF
--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -8,6 +8,7 @@ import zio.test.internal.SmartAssertions
 import zio.test.{ErrorMessage => M}
 import zio.{Cause, Exit, Trace, ZIO}
 
+import zio.test.IntDiffRender
 import scala.reflect.ClassTag
 import scala.util.Try
 

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -23,6 +23,7 @@ import zio.test.ReporterEventRenderer.ConsoleEventRenderer
 import zio.test.Spec.LabeledCase
 
 import scala.language.implicitConversions
+import zio.test.BooleanDiffRender
 
 /**
  * _ZIO Test_ is a featherweight testing library for effectful programs.


### PR DESCRIPTION
Hi @jdegoes, I have managed to separate the diff rendering from the assertion, and I made sure that the SmartAseertions and AssertionVariants are using the Diff pattern. 

But, I think I'm heading in the wrong direction here. I've imported the necessary diff render types in `Assertion.scala` and `package.scala` but the error below keeps showing when I run my tests.
 
```shell
[error]: Assertion.scala:725:43: could not find implicit value for parameter diffRender: zio.test.DiffRender[Int] [error]     hasIntersection(other)(hasSize(equalTo(1))).withCode("hasOneOf", valueArgument(other)) [error]                                           ^ 

[error] zio/test/shared/src/main/scala/zio/test/package.scala:387:39: could not find implicit value for parameter diffRender: zio.test.DiffRender[Boolean] [error]     assertImpl(true)(Assertion.equalTo(false)) ?? message
```

Kindly take a look when you see this. Thanks!

/claim #8664 