### PR TITLE
Avoid allocation in ZEnvironment.get [series/2.0.x]

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -164,9 +164,8 @@ final class ZEnvironment[+R] private (
         getOrElse(tag, throw new Error(s"Defect in zio.ZEnvironment: Could not find ${tag} inside ${self}"))
 
       private[ZEnvironment] def getOrElse[A](tag: LightTypeTag, default: => A)(implicit unsafe: Unsafe): A =
-        self.cache.get(tag) match {
-          case Some(a) => a.asInstanceOf[A]
-          case None =>
+        self.cache.getOrElse(tag, null) match {
+          case null =>
             var index      = -1
             val iterator   = self.map.iterator
             var service: A = null.asInstanceOf[A]
@@ -182,6 +181,7 @@ final class ZEnvironment[+R] private (
               self.cache = self.cache.updated(tag, service)
               service
             }
+          case a => a.asInstanceOf[A]
         }
 
       private[ZEnvironment] def update[A >: R](tag: LightTypeTag, f: A => A)(implicit


### PR DESCRIPTION
This PR implements a micro-optimization in `ZEnvironment` to prevent the allocation of a `Some` every time we lookup for something. This will benefit not only ZIO but also ZPure. I actually noticed this allocation in a CPU-intensive ZPure usage at work:
<img width="856" alt="Screenshot 2024-04-08 at 2 37 06 PM" src="https://github.com/zio/zio/assets/7413894/cd91c0d2-d1f1-4bcb-ae48-3e52927c7eaa">

Since I am not sure what is the state of 2.1, I am opening this PR against `series/2.0.x`, hoping to get a release soon with also https://github.com/zio/zio/pull/8672. I will open another PR for `series/2.x`.