### PR TITLE
Fix ConfigProvider#nested prefix

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -71,7 +71,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
     )
   }
 
-  final case class Settings(settings:Map[String, String])
+  final case class Settings(settings: Map[String, String])
   object Settings {
     val config: Config[Settings] = (Config.table("settings", Config.string)).map(Settings(_))
 
@@ -334,11 +334,18 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         } yield assertTrue(result1 == "value") && assertTrue(result2 == "value")
       } +
       test("nested with table") {
-        val configProvider = ConfigProvider.fromMap(Map("web.targets" -> "https://zio.dev,https://tak.tak")).nested("web")
-        configProvider.load(WebScrapingTargets.config).map(r => assertTrue(r.targets == Set(new java.net.URI("https://zio.dev"), new java.net.URI("https://tak.tak"))))
+        val configProvider =
+          ConfigProvider.fromMap(Map("web.targets" -> "https://zio.dev,https://tak.tak")).nested("web")
+        configProvider
+          .load(WebScrapingTargets.config)
+          .map(r =>
+            assertTrue(r.targets == Set(new java.net.URI("https://zio.dev"), new java.net.URI("https://tak.tak")))
+          )
       } +
       test("nested with map") {
-        val configProvider = ConfigProvider.fromMap(Map("example.settings.key1" -> "value1", "example.settings.key2" -> "value2")).nested("example")
+        val configProvider = ConfigProvider
+          .fromMap(Map("example.settings.key1" -> "value1", "example.settings.key2" -> "value2"))
+          .nested("example")
         configProvider.load(Settings.config).map(r => assertTrue(r == Settings.default))
       } +
       test("nested with variable arguments") {

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -71,6 +71,13 @@ object ConfigProviderSpec extends ZIOBaseSpec {
     )
   }
 
+  final case class Settings(settings:Map[String, String])
+  object Settings {
+    val config: Config[Settings] = (Config.table("settings", Config.string)).map(Settings(_))
+
+    val default: Settings = Settings(Map("key1" -> "value1", "key2" -> "value2"))
+  }
+
   def spec = suite("ConfigProviderSpec") {
     suite("map")(
       test("flat atoms") {
@@ -325,6 +332,14 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           result1 <- configProvider1.load(config1)
           result2 <- configProvider2.load(config2)
         } yield assertTrue(result1 == "value") && assertTrue(result2 == "value")
+      } +
+      test("nested with table") {
+        val configProvider = ConfigProvider.fromMap(Map("web.targets" -> "https://zio.dev,https://tak.tak")).nested("web")
+        configProvider.load(WebScrapingTargets.config).map(r => assertTrue(r.targets == Set(new java.net.URI("https://zio.dev"), new java.net.URI("https://tak.tak"))))
+      } +
+      test("nested with map") {
+        val configProvider = ConfigProvider.fromMap(Map("example.settings.key1" -> "value1", "example.settings.key2" -> "value2")).nested("example")
+        configProvider.load(Settings.config).map(r => assertTrue(r == Settings.default))
       } +
       test("nested with variable arguments") {
         val configProvider = ConfigProvider.fromMap(Map("parent.child.key" -> "value"))

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -416,8 +416,8 @@ object ConfigProvider {
       override def load[A](path: Chunk[String], primitive: Config.Primitive[A], split: Boolean)(implicit
         trace: Trace
       ): IO[Config.Error, Chunk[A]] = {
-        val pathString  = makePathString(path)
-        val name        = path.lastOption.getOrElse("<unnamed>")
+        val pathString = makePathString(path)
+        val name       = path.lastOption.getOrElse("<unnamed>")
 
         for {
           valueOpt <- zio.System.env(pathString).mapError(sourceUnavailable(path))
@@ -540,8 +540,8 @@ object ConfigProvider {
             import table.valueConfig
             for {
               patchedPrefix <- ZIO.fromEither(flat.patch(prefix))
-              keys   <- flat.enumerateChildren(patchedPrefix)
-              values <- ZIO.foreach(Chunk.fromIterable(keys))(key => loop(prefix ++ Chunk(key), valueConfig, split))
+              keys          <- flat.enumerateChildren(patchedPrefix)
+              values        <- ZIO.foreach(Chunk.fromIterable(keys))(key => loop(prefix ++ Chunk(key), valueConfig, split))
             } yield
               if (values.isEmpty) Chunk(Map.empty[String, valueType])
               else values.transpose.map(values => keys.zip(values).toMap)
@@ -628,9 +628,9 @@ object ConfigProvider {
       override def load[A](path: Chunk[String], primitive: Config.Primitive[A], split: Boolean)(implicit
         trace: Trace
       ): IO[Config.Error, Chunk[A]] = {
-        val pathString  = makePathString(path)
-        val name        = path.lastOption.getOrElse("<unnamed>")
-        val valueOpt    = mapWithIndexSplit.get(pathString)
+        val pathString = makePathString(path)
+        val name       = path.lastOption.getOrElse("<unnamed>")
+        val valueOpt   = mapWithIndexSplit.get(pathString)
 
         for {
           value <- ZIO
@@ -679,8 +679,8 @@ object ConfigProvider {
       override def load[A](path: Chunk[String], primitive: Config.Primitive[A], split: Boolean)(implicit
         trace: Trace
       ): IO[Config.Error, Chunk[A]] = {
-        val pathString  = makePathString(path)
-        val name        = path.lastOption.getOrElse("<unnamed>")
+        val pathString = makePathString(path)
+        val name       = path.lastOption.getOrElse("<unnamed>")
 
         for {
           valueOpt <- zio.System.property(pathString).mapError(sourceUnavailable(path))


### PR DESCRIPTION
`ConfigProvider#nested` doesn't work well with nested maps and sequences.
the issue is the prefix computed by `Flat#patch` is called twice if the configuration is Sequence or Table and this causes an error: `Missing data` with an additional `parent` prefix.

/claim #8661
