### PR TITLE
Use Chunk.single rather than Chunk.apply [series/2.0.x]

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1102,7 +1102,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    * Returns a chunk from a number of values.
    */
   override def apply[A](as: A*): Chunk[A] =
-    fromIterable(as)
+    if (as.size == 1) single(as.head) else fromIterable(as)
 
   /*
    * Performs bitwise operations on boolean chunks returning a Chunk.BitChunk

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1251,10 +1251,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
-      case chunk: Chunk[A]                          => chunk
-      case iterable if iterable.isEmpty             => Empty
-      case iterable if iterable.sizeCompare(1) == 0 => single(iterable.head)
-      case vector: Vector[A]                        => VectorChunk(vector)
+      case chunk: Chunk[A]                     => chunk
+      case iterable if iterable.isEmpty        => Empty
+      case iterable if iterable.sizeCompare(1) => single(iterable.head)
+      case vector: Vector[A]                   => VectorChunk(vector)
       case iterable =>
         val builder = ChunkBuilder.make[A]()
         builder.sizeHint(iterable)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1251,9 +1251,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
-      case chunk: Chunk[A]              => chunk
-      case iterable if iterable.isEmpty => Empty
-      case vector: Vector[A]            => VectorChunk(vector)
+      case chunk: Chunk[A]                     => chunk
+      case iterable if iterable.isEmpty        => Empty
+      case iterable if iterable.sizeCompare(1) => single(iterable.head)
+      case vector: Vector[A]                   => VectorChunk(vector)
       case iterable =>
         val builder = ChunkBuilder.make[A]()
         builder.sizeHint(iterable)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1251,10 +1251,9 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
-      case chunk: Chunk[A]                     => chunk
-      case iterable if iterable.isEmpty        => Empty
-      case iterable if iterable.sizeCompare(1) => single(iterable.head)
-      case vector: Vector[A]                   => VectorChunk(vector)
+      case chunk: Chunk[A]              => chunk
+      case iterable if iterable.isEmpty => Empty
+      case vector: Vector[A]            => VectorChunk(vector)
       case iterable =>
         val builder = ChunkBuilder.make[A]()
         builder.sizeHint(iterable)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1251,10 +1251,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
    */
   def fromIterable[A](it: Iterable[A]): Chunk[A] =
     it match {
-      case chunk: Chunk[A]                     => chunk
-      case iterable if iterable.isEmpty        => Empty
-      case iterable if iterable.sizeCompare(1) => single(iterable.head)
-      case vector: Vector[A]                   => VectorChunk(vector)
+      case chunk: Chunk[A]                          => chunk
+      case iterable if iterable.isEmpty             => Empty
+      case iterable if iterable.sizeCompare(1) == 0 => single(iterable.head)
+      case vector: Vector[A]                        => VectorChunk(vector)
       case iterable =>
         val builder = ChunkBuilder.make[A]()
         builder.sizeHint(iterable)

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -140,7 +140,7 @@ object Hub {
             strategy.unsafeCompleteSubscribers(hub, subscribers)
             ZIO.succeed(true)
           } else {
-            strategy.handleSurplus(hub, subscribers, Chunk(a), shutdownFlag)
+            strategy.handleSurplus(hub, subscribers, Chunk.single(a), shutdownFlag)
           }
         }
       def publishAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -300,7 +300,7 @@ object NonEmptyChunk {
    * Constructs a `NonEmptyChunk` from a single value.
    */
   def single[A](a: A): NonEmptyChunk[A] =
-    NonEmptyChunk(a)
+    nonEmpty(Chunk.single(a))
 
   /**
    * Extracts the elements from a `Chunk`.

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -262,7 +262,7 @@ object NonEmptyChunk {
    * Constructs a `NonEmptyChunk` from one or more values.
    */
   def apply[A](a: A, as: A*): NonEmptyChunk[A] =
-    nonEmpty(Chunk.single(a) ++ Chunk.fromIterable(as))
+    fromIterable(a, as)
 
   /**
    * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
@@ -280,7 +280,15 @@ object NonEmptyChunk {
    * Constructs a `NonEmptyChunk` from an `Iterable`.
    */
   def fromIterable[A](a: A, as: Iterable[A]): NonEmptyChunk[A] =
-    nonEmpty(Chunk.single(a) ++ Chunk.fromIterable(as))
+    if (as.isEmpty) single(a)
+    else
+      nonEmpty {
+        val builder = ChunkBuilder.make[A]()
+        builder.sizeHint(as, 1)
+        builder += a
+        builder ++= as
+        builder.result()
+      }
 
   /**
    * Constructs a `NonEmptyChunk` from an `Iterable` or `None` otherwise.

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -262,7 +262,7 @@ object NonEmptyChunk {
    * Constructs a `NonEmptyChunk` from one or more values.
    */
   def apply[A](a: A, as: A*): NonEmptyChunk[A] =
-    nonEmpty(Chunk(a) ++ Chunk.fromIterable(as))
+    nonEmpty(Chunk.single(a) ++ Chunk.fromIterable(as))
 
   /**
    * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -165,7 +165,7 @@ object Queue {
             if (succeeded)
               ZIO.succeed(true)
             else
-              strategy.handleSurplus(Chunk(a), queue, takers, shutdownFlag)
+              strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
           }
         }
       }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -127,7 +127,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
   def interruptAsFork(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
-      val cause = Cause.interrupt(fiberId).traced(StackTrace(fiberId, Chunk(trace)))
+      val cause = Cause.interrupt(fiberId).traced(StackTrace(fiberId, Chunk.single(trace)))
 
       tell(FiberMessage.InterruptSignal(cause))(Unsafe.unsafe)
     }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2011,10 +2011,10 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           },
           err =>
             if (stringBuilder.isEmpty) ZChannel.refailCause(err)
-            else ZChannel.write(Chunk(stringBuilder.result)) *> ZChannel.refailCause(err),
+            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.refailCause(err),
           done =>
             if (stringBuilder.isEmpty) ZChannel.succeed(done)
-            else ZChannel.write(Chunk(stringBuilder.result)) *> ZChannel.succeed(done)
+            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.succeed(done)
         )
 
       new ZPipeline(loop)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -261,8 +261,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                         consumed      <- consumed.get
                         sinkFiber     <- forkSink
                         scheduleFiber <- timeout(Some(b)).forkIn(scope)
-                        toWrite =
-                          c.fold[Chunk[Either[C, B]]](Chunk.single(Right(b)))(c => Chunk.single(Right(b), Left(c)))
+                        toWrite        = c.fold[Chunk[Either[C, B]]](Chunk.single(Right(b)))(c => Chunk(Right(b), Left(c)))
                       } yield
                         if (consumed)
                           ZChannel
@@ -2992,7 +2991,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             .foldZIO(
               _ =>
                 driver.last.orDie.map { b =>
-                  ZChannel.write(Chunk.single(f(a), g(b))) *> loop(driver, chunkIterator, index + 1)
+                  ZChannel.write(Chunk(f(a), g(b))) *> loop(driver, chunkIterator, index + 1)
                 } <* driver.reset,
               _ => ZIO.succeed(ZChannel.write(Chunk.single(f(a))) *> loop(driver, chunkIterator, index + 1))
             )

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -261,7 +261,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                         consumed      <- consumed.get
                         sinkFiber     <- forkSink
                         scheduleFiber <- timeout(Some(b)).forkIn(scope)
-                        toWrite        = c.fold[Chunk[Either[C, B]]](Chunk(Right(b)))(c => Chunk(Right(b), Left(c)))
+                        toWrite =
+                          c.fold[Chunk[Either[C, B]]](Chunk.single(Right(b)))(c => Chunk.single(Right(b), Left(c)))
                       } yield
                         if (consumed)
                           ZChannel
@@ -271,7 +272,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                   case UpstreamEnd =>
                     ZChannel.unwrap {
                       consumed.get.map { p =>
-                        if (p) ZChannel.write(Chunk(Right(b)))
+                        if (p) ZChannel.write(Chunk.single(Right(b)))
                         else ZChannel.unit
                       }
                     }
@@ -2991,9 +2992,9 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             .foldZIO(
               _ =>
                 driver.last.orDie.map { b =>
-                  ZChannel.write(Chunk(f(a), g(b))) *> loop(driver, chunkIterator, index + 1)
+                  ZChannel.write(Chunk.single(f(a), g(b))) *> loop(driver, chunkIterator, index + 1)
                 } <* driver.reset,
-              _ => ZIO.succeed(ZChannel.write(Chunk(f(a))) *> loop(driver, chunkIterator, index + 1))
+              _ => ZIO.succeed(ZChannel.write(Chunk.single(f(a))) *> loop(driver, chunkIterator, index + 1))
             )
         }
       else
@@ -4650,7 +4651,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
             case Some(e) => ZChannel.fail(e)
             case None    => ZChannel.unit
           },
-          a => ZChannel.write(Chunk(a))
+          a => ZChannel.write(Chunk.single(a))
         )
       )
     )
@@ -5760,7 +5761,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
      * terminates with the specified cause if this `Exit` is a `Failure`.
      */
     def done(exit: Exit[E, A])(implicit trace: Trace): B =
-      apply(ZIO.done(exit.mapBothExit(e => Some(e), a => Chunk(a))))
+      apply(ZIO.done(exit.mapBothExit(e => Some(e), a => Chunk.single(a))))
 
     /**
      * Terminates with an end of stream signal.
@@ -5779,7 +5780,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
      * with the failure value of this effect.
      */
     def fromEffect(zio: ZIO[R, E, A])(implicit trace: Trace): B =
-      apply(zio.mapBoth(e => Some(e), a => Chunk(a)))
+      apply(zio.mapBoth(e => Some(e), a => Chunk.single(a)))
 
     /**
      * Either emits the success value of this effect or terminates the stream
@@ -5798,7 +5799,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
      * Emits a chunk containing the specified value.
      */
     def single(a: A)(implicit trace: Trace): B =
-      apply(ZIO.succeed(Chunk(a)))
+      apply(ZIO.succeed(Chunk.single(a)))
   }
 
   /**


### PR DESCRIPTION
Constructing a `Chunk` of size 1 is faster using `Chunk.single` rather than `Chunk.apply` which uses `Chunk.fromIterable`. Found the one coming from `interruptAsFork` while profiling an app:
<img width="356" alt="Screenshot 2024-04-09 at 3 27 40 PM" src="https://github.com/zio/zio/assets/7413894/dc89f7bc-7159-4c2a-bb19-316b47eb1476">
