### PR TITLE
Optimize Chunk.apply with a single element [series/2.0.x]

### DIFF
--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1099,6 +1099,12 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
 object Chunk extends ChunkFactory with ChunkPlatformSpecific {
 
   /**
+   * Returns a chunk from a single value
+   */
+  def apply[A](a: A): Chunk[A] =
+    single(a)
+
+  /**
    * Returns a chunk from a number of values.
    */
   override def apply[A](as: A*): Chunk[A] =

--- a/core/shared/src/main/scala/zio/NonEmptyChunk.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyChunk.scala
@@ -259,10 +259,16 @@ final class NonEmptyChunk[+A] private (private val chunk: Chunk[A]) extends Seri
 object NonEmptyChunk {
 
   /**
+   * Constructs a `NonEmptyChunk` from one value.
+   */
+  def apply[A](a: A): NonEmptyChunk[A] =
+    single(a)
+
+  /**
    * Constructs a `NonEmptyChunk` from one or more values.
    */
   def apply[A](a: A, as: A*): NonEmptyChunk[A] =
-    nonEmpty(Chunk(a) ++ Chunk.fromIterable(as))
+    fromIterable(a, as)
 
   /**
    * Checks if a `chunk` is not empty and constructs a `NonEmptyChunk` from it.
@@ -292,7 +298,7 @@ object NonEmptyChunk {
    * Constructs a `NonEmptyChunk` from a single value.
    */
   def single[A](a: A): NonEmptyChunk[A] =
-    NonEmptyChunk(a)
+    nonEmpty(Chunk(a))
 
   /**
    * Extracts the elements from a `Chunk`.


### PR DESCRIPTION
Constructing a `Chunk` of size 1 is faster using `Chunk.single` rather than `Chunk.fromIterable`. Found the one coming from `interruptAsFork` while profiling an app:
<img width="356" alt="Screenshot 2024-04-09 at 3 27 40 PM" src="https://github.com/zio/zio/assets/7413894/dc89f7bc-7159-4c2a-bb19-316b47eb1476">
