### PR TITLE
Added correct fiberRef inheritance if use effect with timeout

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5282,14 +5282,14 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
               case Exit.Success(a) =>
                 winner.inheritAll *> loser.interruptAs(parentFiberId).as(f(a))
               case Exit.Failure(cause) =>
-                loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
+                winner.inheritAll *> loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
             },
           (winner, loser) =>
             winner.await.flatMap {
               case Exit.Success(_) =>
-                winner.inheritAll *> loser.interruptAs(parentFiberId).as(b())
+                loser.inheritAll *> loser.interruptAs(parentFiberId).as(b())
               case Exit.Failure(cause) =>
-                loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
+                loser.inheritAll *> loser.interruptAs(parentFiberId) *> ZIO.refailCause(cause)
             },
           null,
           FiberScope.global


### PR DESCRIPTION
There is a problem with timeout and FiberRef:
We have FiberRef and effect which update value in FiberRef. We use `timeout` on this effect. If this effect add value to FiberRef and next failed, value not updated, because in realization of `TimeoutTo` we don't use `winner.inheritAll` if winner is Exit.Failure.

I consider it is necessary to add `winner.inheritAll` if winner is failed
And i think need add `loser.inheritAll` in case, when timeout occurred since we need to save the FiberRef context

I added issue about this problem:
link to issue: https://github.com/zio/zio/issues/8700