### PR TITLE
inherit FiberRef's when a failed fiber joins

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -210,7 +210,7 @@ abstract class Fiber[+E, +A] { self =>
    *   `IO[E, A]`
    */
   final def join(implicit trace: Trace): IO[E, A] =
-    await.unexit <* inheritAll
+    (await <* inheritAll).unexit
 
   /**
    * Maps over the value the Fiber computes.


### PR DESCRIPTION
I faced with a problem similar to https://github.com/zio/zio/pull/8721 

`Fiber#join` doesn't inherit FiberRef values if the fiber was failed. 

For example:
```scala
val ref: FiberRef[Set[String]] =
    Unsafe.unsafe(implicit unsafe => FiberRef.unsafe.make[Set[String]](Set.empty, join = _ ++ _))

  def request(system: String, fail: Boolean): Task[Unit] = for {
    _ <- ref.update(_ + system)
    _ <- ZIO.fail(new IllegalStateException("Booom!")).when(fail)
  } yield ()

  override val run =
    for {
      f    <- request("foo", fail = true).fork
      _    <- request("bar", fail = false)
      _ <- f.join.ignore
      data <- ref.get
      _    <- Console.printLine(s"Completed: $data")
    } yield ()
```
prints just `bar`, but

```scala
 for {
      _    <- request("foo", fail = true).ignore
      _    <- request("bar", fail = false)
      data <- ref.get
      _    <- Console.printLine(s"Completed: $data")
    } yield ()
```
prints `foo, bar`.

I expected these snippets to work the same way.
The same expectation is about `ZIO#disconnected`:
```
_ <- request("disconnected", fail = true).disconnect.ignore
```
Now this discards `FiberRef` updates bacause uses `.join` under the hood.

If this behavior must be corrected, I will be glad if my PR is approved