### PR TITLE
Allow releasing 2.0.x branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
     branches:
-      - 'series/2.x'
+      - 'series/2.0.x'
   release:
     types:
       - published


### PR DESCRIPTION
I'd like to do a 2.0.x release with the performance improvements that have been pushed to that branch. I *think* that change is all we need to do that.

Independent question: what's the plan for 2.1? Are there more things to be included? Are the runtime changes complete/stable? 