### PR TITLE
Make Redirect Plugin Compatible with Docusaurus Core

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "@babel/plugin-transform-parameters": "^7.18.8",
     "@bytebrain.ai/bytebrain-ui": "0.0.8",
     "@docusaurus/core": "^2.2.0",
-    "@docusaurus/plugin-client-redirects": "3.1.1",
+    "@docusaurus/plugin-client-redirects": "^2.2.0",
     "@docusaurus/preset-classic": "^2.2.0",
     "@docusaurus/theme-mermaid": "^2.2.0",
     "@docusaurus/theme-search-algolia": "^2.2.0",


### PR DESCRIPTION
The redirect plugin is used to redirect deprecated routes to newer ones on zio.dev website.