### PR TITLE
Optimize fork-join performance

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -34,6 +34,14 @@ object BenchmarkUtil extends Runtime[Any] { self =>
     if (n <= 1) io
     else io.flatMap(_ => catsRepeat(n - 1)(io))
 
-  def unsafeRun[E, A](zio: ZIO[Any, E, A]): A =
-    Unsafe.unsafe(implicit unsafe => self.unsafe.run(zio).getOrThrowFiberFailure())
+  def unsafeRun[E, A](zio: ZIO[Any, E, A], fiberRootsEnabled: Boolean = true): A = {
+    val rt = if (fiberRootsEnabled) self else NoFiberRootsRuntime
+    Unsafe.unsafe(implicit unsafe => rt.unsafe.run(zio).getOrThrowFiberFailure())
+  }
+
+  private object NoFiberRootsRuntime extends Runtime[Any] {
+    val environment  = Runtime.default.environment
+    val fiberRefs    = Runtime.default.fiberRefs
+    val runtimeFlags = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)
+  }
 }

--- a/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
@@ -26,8 +26,8 @@ import java.util.concurrent.TimeUnit
  * JDK 17 (ZScheduler)
  * [info] Benchmark                                    (n)   Mode  Cnt     Score     Error  Units
  * [info] ForkJoinBenchmark.catsForkJoin             10000  thrpt   10  2906.462 ±  14.976  ops/s
- * [info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10  1439.081 ±  47.475  ops/s
- * [info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10  3919.496 ± 218.537  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10  1931.372 ±  19.676  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10  4812.394 ± 114.765  ops/s
  *
  * JDK 21 (Loom)
  * [info] Benchmark                                    (n)   Mode  Cnt     Score    Error  Units

--- a/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
@@ -42,7 +42,7 @@ class ForkJoinBenchmark {
   @Benchmark
   def zioForkJoin(): Unit = {
     val forkFiber     = ZIO.unit.forkDaemon
-    val forkAllFibers = ZIO.foreach(range)(_ => forkFiber)
+    val forkAllFibers = ZIO.yieldNow *> ZIO.foreach(range)(_ => forkFiber)
 
     val _ =
       unsafeRun(

--- a/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
@@ -19,6 +19,22 @@ import java.util.concurrent.TimeUnit
  * [info] ForkJoinBenchmark.zioForkJoin  10000  thrpt    5  99.841 ∩┐╜  1.353  ops/s
  * [info] ForkJoinBenchmark.zioForkJoin  10000  thrpt    5  105.782 ∩┐╜ 1.599  ops/s
  * }}}
+ *
+ * {{{
+ * 13/04/2024
+ *
+ * JDK 17 (ZScheduler)
+ * [info] Benchmark                                    (n)   Mode  Cnt     Score     Error  Units
+ * [info] ForkJoinBenchmark.catsForkJoin             10000  thrpt   10  2906.462 ±  14.976  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10  1439.081 ±  47.475  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10  3919.496 ± 218.537  ops/s
+ *
+ * JDK 21 (Loom)
+ * [info] Benchmark                                    (n)   Mode  Cnt     Score    Error  Units
+ * [info] ForkJoinBenchmark.catsForkJoin             10000  thrpt   10  2913.651 ± 28.332  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10   613.202 ±  5.053  ops/s
+ * [info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10   764.049 ±  7.925  ops/s
+ * }}}
  */
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -39,16 +55,19 @@ class ForkJoinBenchmark {
   def setup(): Unit =
     range = (0 to n).toList
 
-  @Benchmark
-  def zioForkJoin(): Unit = {
+  private val zioEffect = {
     val forkFiber     = ZIO.unit.forkDaemon
     val forkAllFibers = ZIO.yieldNow *> ZIO.foreach(range)(_ => forkFiber)
-
-    val _ =
-      unsafeRun(
-        forkAllFibers.flatMap(fibers => ZIO.foreach(fibers)(_.await))
-      )
+    forkAllFibers.flatMap(fibers => ZIO.foreach(fibers)(_.await))
   }
+
+  @Benchmark
+  def zioForkJoin(): Unit =
+    unsafeRun(zioEffect)
+
+  @Benchmark
+  def zioForkJoinNoFiberRoots(): Unit =
+    unsafeRun(zioEffect, fiberRootsEnabled = false)
 
   @Benchmark
   def catsForkJoin(): Unit = {

--- a/benchmarks/src/main/scala/zio/internal/WeakConcurrentBagBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/WeakConcurrentBagBenchmark.scala
@@ -5,13 +5,14 @@ import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import java.util.concurrent.{TimeUnit, ThreadLocalRandom}
 import java.util.concurrent.atomic.AtomicLong
 
-@BenchmarkMode(Array(Mode.Throughput))
 @State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
-@Fork(1)
-private[zio] class WeakConcurrentBagBenchmark {
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Threads(16)
+class WeakConcurrentBagBenchmark {
 
   @Param(Array("1000"))
   var capacity: Int = _
@@ -43,6 +44,7 @@ private[zio] class WeakConcurrentBagBenchmark {
     println(s"aliveness: ${alive.toDouble / (alive.toDouble + dead.toDouble)}")
   }
 }
+
 object WeakConcurrentBagBenchmark {
   val alive: AtomicLong = new AtomicLong(0L)
   val dead: AtomicLong  = new AtomicLong(0L)

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -25,6 +25,54 @@ object FiberRefsSpec extends ZIOBaseSpec {
         val newParentFiberRefs = parentFiberRefs.joinAs(parent)(childFiberRefs)
 
         assertTrue(newParentFiberRefs.get(FiberRef.interruptedCause) == Some(Cause.empty))
+      } +
+      /*
+        If any of the following tests fail, it is likely that the optimizations in FiberRefs are broken.
+        Either ensure that the optimizations are no longer needed (and delete the tests) or fix the issue that
+        is causing the underlying maps to return a different instance of `FiberRefs`
+       */
+      suite("optimizations") {
+        implicit val unsafe: Unsafe = Unsafe.unsafe
+        val fiberId                 = FiberId.make(implicitly)
+
+        val fiberRefs = List(
+          FiberRef.unsafe.make[Int](0, join = (a, b) => a + b),
+          FiberRef.unsafe.make(1),
+          FiberRef.unsafe.make(3),
+          FiberRef.unsafe.make(4),
+          FiberRef.unsafe.make[Int](5, fork = _ + 1)
+        )
+
+        def makeFiberRefs(f: List[FiberRef[Int]]) =
+          f.foldLeft(FiberRefs.empty)((refs, ref) => refs.updatedAs(fiberId)(ref, 5))
+
+        test("`delete` returns the same instance if the map was unchanged") {
+          val fr   = makeFiberRefs(fiberRefs)
+          val isEq = fr.delete(FiberRef.unsafe.make(6)) eq fr
+          assertTrue(isEq)
+        } +
+          test("forkAs returns the same map if no fibers are modified during fork") {
+            val fr   = makeFiberRefs(fiberRefs.take(4))
+            val isEq = fr.forkAs(FiberId.make(implicitly)) eq fr
+            assertTrue(isEq)
+          } +
+          test("joinAs returns the same map when fiber refs are unchanged after joining") {
+            val fr1  = makeFiberRefs(fiberRefs.drop(1))
+            val fr2  = makeFiberRefs(fiberRefs.drop(2))
+            val isEq = fr1.joinAs(FiberId.make(implicitly))(fr2) eq fr1
+            assertTrue(isEq)
+          } +
+          // Sanity checks
+          test("forkAs returns a different map if forked fibers are modified") {
+            val fr   = makeFiberRefs(fiberRefs)
+            val isEq = fr.forkAs(FiberId.make(implicitly)) ne fr
+            assertTrue(isEq)
+          } +
+          test("joinAs returns a different map when fiber refs are changed after joining") {
+            val fr1, fr2 = makeFiberRefs(fiberRefs)
+            val isEq     = fr1.joinAs(FiberId.make(implicitly))(fr2) ne fr1
+            assertTrue(isEq)
+          }
       }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
@@ -53,6 +53,15 @@ object MutableConcurrentQueueSpec extends ZIOBaseSpec {
         && assert(q.poll(-1))(equalTo(-1))
         && assert(q.isEmpty())(isTrue))
       }
+    ),
+    suite("Partitioned queues")(
+      test("partitioned queues have n * 4 rounded to the next power of 2 capacity") {
+        val q1       = MutableConcurrentQueue.unboundedPartitioned().nPartitions()
+        val q2       = MutableConcurrentQueue.boundedPartitioned(100).nPartitions()
+        val expected = RingBuffer.nextPow2(java.lang.Runtime.getRuntime.availableProcessors() * 4)
+
+        assertTrue(q1 == expected, q2 == expected)
+      }
     )
   )
 }

--- a/core-tests/shared/src/test/scala/zio/internal/PartitionedLinkedQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/PartitionedLinkedQueueSpec.scala
@@ -1,0 +1,69 @@
+package zio.internal
+
+import zio.ZIOBaseSpec
+import zio.test._
+
+object PartitionedLinkedQueueSpec extends ZIOBaseSpec {
+
+  def spec = suite("PartitionedLinkedQueueSpec")(
+    test("partitions round to nearest power of 2") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      assertTrue(q.nPartitions() == 16)
+    },
+    test("addMetrics = true") {
+      val q = new PartitionedLinkedQueue[String](9, true)
+
+      q.offer("1")
+      q.offerAll(List("2", "3", "4"))
+      q.poll(null)
+      q.pollUpTo(2)
+      val enq  = q.enqueuedCount()
+      val deq1 = q.dequeuedCount()
+      q.pollUpTo(10)
+      val deq2 = q.dequeuedCount()
+
+      assertTrue(enq == 4, deq1 == 3, deq2 == 4)
+    },
+    test("addMetrics = false") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      q.offer("1")
+      q.poll(null)
+
+      assertTrue(q.enqueuedCount() == 0, q.dequeuedCount() == 0)
+    },
+    test("addMetrics = false") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      q.offer("1")
+      q.poll(null)
+
+      assertTrue(q.enqueuedCount() == 0, q.dequeuedCount() == 0)
+    },
+    test("offerAll and pollUpTo items") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      val oneToHundred = (1 to 100).map(_.toString)
+      q.offerAll(oneToHundred)
+      val polled = q.pollUpTo(100)
+
+      assertTrue(polled.toSet == oneToHundred.toSet)
+    } @@ TestAspect.nonFlaky,
+    test("offer and poll items") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      val oneToHundred = (1 to 100).map(_.toString)
+      oneToHundred.foreach(q.offer)
+      val polled = (1 to 100).map(_ => q.poll(null)).toSet
+
+      assertTrue(polled == oneToHundred.toSet)
+    } @@ TestAspect.nonFlaky,
+    test("queue size") {
+      val q = new PartitionedLinkedQueue[String](9, false)
+
+      q.offerAll((1 to 3).map(_.toString))
+      assertTrue(q.size() == 3)
+    }
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/internal/PartitionedRingBufferSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/PartitionedRingBufferSpec.scala
@@ -1,0 +1,77 @@
+package zio.internal
+
+import zio.ZIOBaseSpec
+import zio.test._
+
+object PartitionedRingBufferSpec extends ZIOBaseSpec {
+
+  def spec = suite("PartitionedRingBufferSpec")(
+    test("capacity is the specified when divisible by the number of partitions") {
+      val q = new PartitionedRingBuffer[String](4, 8, roundToPow2 = false)
+
+      assertTrue(q.capacity == 8)
+    },
+    test("capacity rounds up when not divisible by the number of partitions") {
+      val q = new PartitionedRingBuffer[String](4, 9, roundToPow2 = false)
+
+      assertTrue(q.capacity == 12)
+    },
+    test("partitions round to nearest power of 2") {
+      val q = new PartitionedRingBuffer[String](3, 9, roundToPow2 = false)
+
+      assertTrue(q.nPartitions() == 4)
+    },
+    test("capacity of each partition rounds up to nearest power of 2 when specified") {
+      val q = new PartitionedRingBuffer[String](3, 9, roundToPow2 = true)
+
+      assertTrue(q.capacity == 16)
+    },
+    test("offered items are accepted up to capacity") {
+      val q = new PartitionedRingBuffer[String](2, 2, roundToPow2 = true)
+
+      assertTrue(
+        q.offer("1"),
+        q.offer("2"),
+        q.offer("3"),
+        q.offer("4"),
+        !q.offer("5")
+      )
+    } @@ TestAspect.nonFlaky,
+    test("polling items") {
+      val q = new PartitionedRingBuffer[String](2, 2, roundToPow2 = true)
+
+      (1 to 4).foreach(i => q.offer(i.toString))
+      assertTrue(q.pollUpTo(4).toSet == Set("1", "2", "3", "4"))
+    } @@ TestAspect.nonFlaky,
+    test("iterating partitions") {
+      val q = new PartitionedRingBuffer[String](2, 2, roundToPow2 = true)
+
+      (1 to 4).foreach(i => q.offer(i.toString))
+      val p = q.partitionIterator.toList
+      assertTrue(p.size == 2, p.forall(_.size() == 2))
+    },
+    test("returns the default value when the queue is empty") {
+      val q = new PartitionedRingBuffer[String](2, 2, roundToPow2 = true)
+
+      assertTrue(q.poll("default") == "default")
+    },
+    test("returns the correct size") {
+      val q = new PartitionedRingBuffer[String](2, 2, roundToPow2 = true)
+
+      q.offerAll((1 to 3).map(_.toString))
+      assertTrue(q.size() == 3)
+    },
+    test("underlying partitions can be RingBufferPowArb when roundToPow2 = false") {
+      val q = new PartitionedRingBuffer[String](3, 9, roundToPow2 = false)
+
+      val result = q.partitionIterator.toList.forall(_.isInstanceOf[RingBufferArb[_]])
+      assertTrue(result)
+    },
+    test("underlying partitions are forced to RingBuggerPow2 when roundToPow2 = true") {
+      val q = new PartitionedRingBuffer[String](3, 9, roundToPow2 = true)
+
+      val result = q.partitionIterator.toList.forall(_.isInstanceOf[RingBufferPow2[_]])
+      assertTrue(result)
+    }
+  )
+}

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -86,6 +86,7 @@ private[zio] trait PlatformSpecific {
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -85,8 +85,9 @@ private[zio] trait PlatformSpecific {
 
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
-  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A]                     = new HashSet[A]()
-  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
+    new HashSet[A](initialCapacity)
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -85,7 +85,7 @@ private[zio] trait PlatformSpecific {
 
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
-  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A]                     = new HashSet[A]()
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()

--- a/core/js/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/js/src/main/scala/zio/internal/RingBuffer.scala
@@ -24,7 +24,7 @@ private[zio] object RingBuffer {
    * @note
    *   minimum supported capacity is 2
    */
-  def apply[A](requestedCapacity: Int): MutableConcurrentQueue[A] = {
+  def apply[A](requestedCapacity: Int): RingBuffer[A] = {
     assert(requestedCapacity >= 2)
 
     if (nextPow2(requestedCapacity) == requestedCapacity) RingBufferPow2(requestedCapacity)

--- a/core/js/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
+++ b/core/js/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
@@ -1,0 +1,7 @@
+package zio.internal
+
+import zio.Duration
+
+private object WeakConcurrentBagGc {
+  def start[A <: AnyRef](bag: WeakConcurrentBag[A], every: Duration): Unit = ()
+}

--- a/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
+++ b/core/jvm/src/main/scala/zio/internal/DefaultExecutors.scala
@@ -23,7 +23,7 @@ import java.util.concurrent.{RejectedExecutionException, ThreadPoolExecutor}
 
 private[zio] abstract class DefaultExecutors {
   final def makeDefault(): zio.Executor =
-    makeDefault(true)
+    makeDefault(false)
 
   final def makeDefault(autoBlocking: Boolean): zio.Executor =
     new ZScheduler(autoBlocking)

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -111,7 +111,11 @@ private[zio] trait PlatformSpecific {
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
-  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = ConcurrentHashMap.newKeySet[A]()
+  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
+    ConcurrentHashMap.newKeySet[A]()
+
+  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
+    ConcurrentHashMap.newKeySet[A](initialCapacity)
 
   final def newWeakReference[A](value: A)(implicit unsafe: zio.Unsafe): () => A = {
     val ref = new WeakReference[A](value)

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -331,8 +331,7 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
       }
     }
     // If there was no space in the queue we return the remainder of the iterator
-    if (as.hasNext) Chunk.fromIterator(as)
-    else Chunk.empty
+    Chunk.fromIterator(as)
   }
 
   override final def poll(default: A): A = {

--- a/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/jvm/src/main/scala/zio/internal/RingBuffer.scala
@@ -480,7 +480,7 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
       // We have successfully reserved space in the queue and have exclusive
       // ownership of each space until we publish our changes. Dequeue the
       // elements sequentially and publish our changes as we go.
-      val builder = ChunkBuilder.make[A]()
+      val builder = ChunkBuilder.make[A](n.min(aCapacity))
       builder.sizeHint((deqTail - deqHead).toInt)
       while (deqHead < deqTail) {
         curIdx = posToIdx(deqHead, aCapacity)

--- a/core/jvm/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
+++ b/core/jvm/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
@@ -1,0 +1,34 @@
+package zio.internal
+
+import zio.Duration
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+private final class WeakConcurrentBagGc[A <: AnyRef] private (
+  bag: WeakConcurrentBag[A],
+  sleepFor: Duration
+) extends Thread {
+  override def run(): Unit = {
+    val sleepForNanos = sleepFor.toNanos
+    while (!isInterrupted) {
+      LockSupport.parkNanos(sleepForNanos)
+      bag.gc(false)
+    }
+  }
+}
+
+private object WeakConcurrentBagGc {
+  private val i = new AtomicInteger(0)
+
+  def start[A <: AnyRef](bag: WeakConcurrentBag[A], every: Duration): Unit = {
+    assert(every.toMillis >= 1000, "Auto-gc interval must be >= 1 second")
+
+    val thread = new WeakConcurrentBagGc(bag, every)
+    thread.setName(s"zio.internal.WeakConcurrentBag.GcThread-${i.getAndIncrement()}")
+    thread.setPriority(4)
+    thread.setDaemon(true)
+    thread.start()
+  }
+
+}

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -19,24 +19,29 @@ package zio.internal
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ThreadLocalRandom
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{ConcurrentHashMap, ThreadLocalRandom}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.locks.LockSupport
+import scala.collection.mutable
 
 /**
  * A `ZScheduler` is an `Executor` that is optimized for running ZIO
  * applications. Inspired by "Making the Tokio Scheduler 10X Faster" by Carl
  * Lerche. [[https://tokio.rs/blog/2019-10-scheduler]]
  */
-private final class ZScheduler(autoBlocking: Boolean) extends Executor {
-  private[this] val poolSize           = java.lang.Runtime.getRuntime.availableProcessors
-  private[this] val cache              = MutableConcurrentQueue.unbounded[ZScheduler.Worker]
-  private[this] val globalQueue        = MutableConcurrentQueue.unbounded[Runnable]
-  private[this] val idle               = MutableConcurrentQueue.unbounded[ZScheduler.Worker]
-  private[this] val state              = new AtomicInteger(poolSize << 16)
-  private[this] val submittedLocations = makeLocations()
-  private[this] val workers            = Array.ofDim[ZScheduler.Worker](poolSize)
+private final class ZScheduler(autoBlocking: Boolean, trackBlockedLocations: Boolean = true) extends Executor {
 
+  private[this] val poolSize = java.lang.Runtime.getRuntime.availableProcessors
+  private[this] val cache    = MutableConcurrentQueue.unbounded[ZScheduler.Worker](addMetrics = false)
+  private[this] val globalQueue = {
+    val nPartitions = if (poolSize == 1) poolSize else poolSize << 1
+    MutableConcurrentQueue.unboundedPartitioned[Runnable](nPartitions, addMetrics = false)
+  }
+  private[this] val idle                                    = MutableConcurrentQueue.unbounded[ZScheduler.Worker](addMetrics = false)
+  private[this] val globalLocations                         = makeLocations()
+  private[this] val state                                   = new AtomicInteger(poolSize << 16)
+  private[this] val workers                                 = Array.ofDim[ZScheduler.Worker](poolSize)
+  private[this] val emptyTrace                              = Trace.empty
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
 
   (0 until poolSize).foreach { workerId =>
@@ -104,9 +109,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
   }
 
   override def stealWork(depth: Int): Boolean = {
-    val currentThread = Thread.currentThread
-    if (currentThread.isInstanceOf[ZScheduler.Worker]) {
-      val worker   = currentThread.asInstanceOf[ZScheduler.Worker]
+    val worker = getWorkerOrNull
+    if (worker ne null) {
       var runnable = null.asInstanceOf[Runnable]
       if (worker.nextRunnable ne null) {
         runnable = worker.nextRunnable
@@ -136,13 +140,22 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
     }
   }
 
-  def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
-    if (isBlocking(runnable)) {
+  /**
+   * If the current thread is a [[ZScheduler.Worker]] then it is returned,
+   * otherwise returns null
+   */
+  private def getWorkerOrNull: ZScheduler.Worker =
+    Thread.currentThread() match {
+      case w: ZScheduler.Worker => w
+      case _                    => null
+    }
+
+  def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+    val worker = getWorkerOrNull
+    if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      val currentThread = Thread.currentThread
-      if (currentThread.isInstanceOf[ZScheduler.Worker]) {
-        val worker = currentThread.asInstanceOf[ZScheduler.Worker]
+      if (worker ne null) {
         if (worker.blocking) {
           globalQueue.offer(runnable)
         } else if (worker.localQueue.offer(runnable)) {
@@ -153,39 +166,26 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
             }
           }
         } else {
-          globalQueue.offerAll(worker.localQueue.pollUpTo(128) :+ runnable)
+          val rnd = ThreadLocalRandom.current()
+          globalQueue.offerAll(worker.localQueue.pollUpTo(128), rnd)
+          globalQueue.offer(runnable, rnd)
         }
       } else {
         globalQueue.offer(runnable)
       }
-      val currentState     = state.get
-      val currentActive    = (currentState & 0xffff0000) >> 16
-      val currentSearching = currentState & 0xffff
-      if (currentActive != poolSize && currentSearching == 0) {
-        var loop = true
-        while (loop) {
-          val worker = idle.poll(null)
-          if (worker eq null) {
-            loop = false
-          } else {
-            state.getAndAdd(0x10001)
-            worker.active = true
-            LockSupport.unpark(worker)
-            loop = false
-          }
-        }
-      }
+      val currentState = state.get
+      maybeUnparkWorker(currentState)
       true
     }
+  }
 
-  override def submitAndYield(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
-    if (isBlocking(runnable)) {
+  override def submitAndYield(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+    val worker = getWorkerOrNull
+    if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      val currentThread = Thread.currentThread
-      var notify        = false
-      if (currentThread.isInstanceOf[ZScheduler.Worker]) {
-        val worker = currentThread.asInstanceOf[ZScheduler.Worker]
+      var notify = false
+      if (worker ne null) {
         if (worker.blocking) {
           globalQueue.offer(runnable)
           notify = true
@@ -200,7 +200,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
           }
           notify = true
         } else {
-          globalQueue.offerAll(worker.localQueue.pollUpTo(128) :+ runnable)
+          val rnd = ThreadLocalRandom.current()
+          globalQueue.offerAll(worker.localQueue.pollUpTo(128), rnd)
+          globalQueue.offer(runnable, rnd)
           notify = true
         }
       } else {
@@ -208,59 +210,42 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
         notify = true
       }
       if (notify) {
-        val currentState     = state.get
-        val currentActive    = (currentState & 0xffff0000) >> 16
-        val currentSearching = currentState & 0xffff
-        if (currentActive != poolSize && currentSearching == 0) {
-          var loop = true
-          while (loop) {
-            val worker = idle.poll(null)
-            if (worker eq null) {
-              loop = false
-            } else {
-              state.getAndAdd(0x10001)
-              worker.active = true
-              LockSupport.unpark(worker)
-              loop = false
-            }
-          }
-        }
+        val currentState = state.get
+        maybeUnparkWorker(currentState)
       }
       true
     }
+  }
 
-  private[this] def isBlocking(runnable: Runnable): Boolean =
-    if (runnable.isInstanceOf[FiberRunnable]) {
+  private[this] def isBlocking(worker: ZScheduler.Worker, runnable: Runnable): Boolean =
+    if (autoBlocking && runnable.isInstanceOf[FiberRunnable]) {
       val fiberRunnable = runnable.asInstanceOf[FiberRunnable]
       val location      = fiberRunnable.location
-      submittedLocations.put(location)
-      blockingLocations.contains(location)
-    } else {
-      false
-    }
+      if ((location ne null) && (location ne emptyTrace)) {
+        if (worker eq null) globalLocations.put(location)
+        else worker.submittedLocations.put(location)
+        blockingLocations.contains(location)
+      } else false
+    } else false
 
   private[this] def makeLocations(): ZScheduler.Locations =
-    new ZScheduler.Locations {
-      private[this] val locations = new java.util.HashMap[Trace, Array[Long]]
-      def get(trace: Trace): Long = {
-        val array = locations.get(trace)
-        if (array eq null) 0L else array(0)
-      }
-      def put(trace: Trace): Long = {
-        val array = locations.get(trace)
-        if (array eq null) {
-          locations.put(trace, Array(1L))
-          0L
-        } else {
-          val value = array(0)
-          array(0) += 1
-          value
-        }
-      }
-    }
+    if (autoBlocking && trackBlockedLocations) new ZScheduler.Locations.Enabled
+    else ZScheduler.Locations.Disabled
 
   private[this] def makeSupervisor(): ZScheduler.Supervisor =
     new ZScheduler.Supervisor {
+
+      private def countSubmittedAt(location: Trace): Long = {
+        var count = globalLocations.get(location)
+        var i     = 0
+        while (i < poolSize) {
+          val workerCount = workers(i).submittedLocations.get(location)
+          count += workerCount
+          i += 1
+        }
+        count
+      }
+
       override def run(): Unit = {
         var currentTime         = java.lang.System.currentTimeMillis()
         val identifiedLocations = makeLocations()
@@ -279,7 +264,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                   val location      = fiberRunnable.location
                   if (location ne Trace.empty) {
                     val identifiedCount = identifiedLocations.put(location)
-                    val submittedCount  = submittedLocations.get(location)
+                    val submittedCount  = countSubmittedAt(location)
                     if (submittedCount > 64 && identifiedCount >= submittedCount / 2) {
                       blockingLocations += location
                     }
@@ -326,6 +311,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
 
   private[this] def makeWorker(): ZScheduler.Worker =
     new ZScheduler.Worker { self =>
+      val submittedLocations = makeLocations()
+
       override def run(): Unit = {
         var currentBlocking = false
         var currentOpCount  = 0L
@@ -341,7 +328,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
             }
           } else {
             if ((currentOpCount & 63) == 0) {
-              runnable = globalQueue.poll(null)
+              runnable = globalQueue.poll(null, random)
               if (runnable eq null) {
                 if (nextRunnable ne null) {
                   runnable = nextRunnable
@@ -357,7 +344,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
               } else {
                 runnable = localQueue.poll(null)
                 if (runnable eq null) {
-                  runnable = globalQueue.poll(null)
+                  runnable = globalQueue.poll(null, random)
                 }
               }
             }
@@ -382,15 +369,19 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                     if (size > 0) {
                       val runnables = worker.localQueue.pollUpTo(size - size / 2)
                       if (runnables.nonEmpty) {
-                        runnable = runnables.head
-                        if (runnables.tail.nonEmpty) {
-                          localQueue.offerAll(runnables.tail)
+                        var i    = 1
+                        val iter = runnables.chunkIterator
+                        runnable = iter.nextAt(0)
+                        while (iter.hasNextAt(i)) {
+                          val next1 = iter.nextAt(i)
+                          localQueue.offer(next1)
+                          i += 1
                         }
                         currentBlocking = blocking
                         if (currentBlocking) {
                           val runnables = localQueue.pollUpTo(256)
                           if (runnables.nonEmpty) {
-                            globalQueue.offerAll(runnables)
+                            globalQueue.offerAll(runnables, random)
                           }
                         }
                         loop = false
@@ -400,7 +391,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                   i += 1
                 }
                 if (runnable eq null) {
-                  runnable = globalQueue.poll(null)
+                  runnable = globalQueue.poll(null, random)
                 }
               }
             }
@@ -430,23 +421,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                 notify = !globalQueue.isEmpty()
               }
               if (notify) {
-                val currentState     = state.get
-                val currentActive    = (currentState & 0xffff0000) >> 16
-                val currentSearching = currentState & 0xffff
-                if (currentActive != poolSize && currentSearching == 0) {
-                  var loop = true
-                  while (loop) {
-                    val worker = idle.poll(null)
-                    if (worker eq null) {
-                      loop = false
-                    } else {
-                      state.getAndAdd(0x10001)
-                      worker.active = true
-                      LockSupport.unpark(worker)
-                      loop = false
-                    }
-                  }
-                }
+                val currentState = state.get
+                maybeUnparkWorker(currentState)
               }
             }
             while (!active && !isInterrupted) {
@@ -456,23 +432,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
           } else {
             if (searching) {
               searching = false
-              val currentState     = state.decrementAndGet()
-              val currentSearching = currentState & 0xffff
-              val currentActive    = (currentState & 0xffff0000) >> 16
-              if (currentActive != poolSize && currentSearching == 0) {
-                var loop = true
-                while (loop) {
-                  val worker = idle.poll(null)
-                  if (worker eq null) {
-                    loop = false
-                  } else {
-                    state.getAndAdd(0x10001)
-                    worker.active = true
-                    LockSupport.unpark(worker)
-                    loop = false
-                  }
-                }
-              }
+              val currentState = state.decrementAndGet()
+              maybeUnparkWorker(currentState)
             }
             currentRunnable = runnable
             runnable.run()
@@ -484,6 +445,19 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
         }
       }
     }
+
+  private def maybeUnparkWorker(currentState: Int): Unit = {
+    val currentSearching = currentState & 0xffff
+    val currentActive    = (currentState & 0xffff0000) >> 16
+    if (currentActive != poolSize && currentSearching == 0) {
+      val worker = idle.poll(null)
+      if (worker ne null) {
+        state.getAndAdd(0x10001)
+        worker.active = true
+        LockSupport.unpark(worker)
+      }
+    }
+  }
 
   private[this] def submitBlocking(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
     Blocking.blockingExecutor.submit(runnable)
@@ -511,6 +485,29 @@ private[zio] object ZScheduler {
     def put(trace: Trace): Long
   }
 
+  private object Locations {
+
+    final class Enabled(initialSize: Int = 64) extends Locations {
+      private[this] val locations = mutable.HashMap.empty[Trace, AtomicLong]
+      locations.sizeHint((initialSize / 0.75d).toInt)
+
+      def get(trace: Trace): Long = {
+        val v = locations.getOrElse(trace, null)
+        if (v eq null) 0L else v.get()
+      }
+
+      def put(trace: Trace): Long =
+        locations
+          .getOrElseUpdate(trace, new AtomicLong(0L))
+          .getAndIncrement()
+    }
+
+    object Disabled extends Locations {
+      def get(trace: Trace): Long = 0L
+      def put(trace: Trace): Long = 0L
+    }
+  }
+
   /**
    * A `Supervisor` is a `Thread` that is responsible for monitoring workers and
    * shifting tasks from workers that are blocking to new workers.
@@ -522,6 +519,8 @@ private[zio] object ZScheduler {
    * submitted to the scheduler.
    */
   private sealed abstract class Worker extends Thread {
+
+    val submittedLocations: Locations
 
     /**
      * Whether this worker is currently active.
@@ -563,5 +562,6 @@ private[zio] object ZScheduler {
     @volatile
     var opCount: Long =
       0L
+
   }
 }

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -307,7 +307,6 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
             LockSupport.parkUntil(deadline)
             loop = java.lang.System.currentTimeMillis() < deadline
           }
-          Fiber._roots.graduate()
         }
       }
     }

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -370,12 +370,12 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                   if ((worker ne self) && !worker.blocking) {
                     val size = worker.localQueue.size()
                     if (size > 0) {
-                      val chunk     = worker.localQueue.pollUpTo(size - size / 2)
-                      val chunkSize = chunk.size
-                      val iter      = chunk.iterator
-                      if (chunkSize != 0) {
+                      val runnables  = worker.localQueue.pollUpTo(size - size / 2)
+                      val nRunnables = runnables.size
+                      if (nRunnables > 0) {
+                        val iter = runnables.iterator
                         runnable = iter.next()
-                        if (chunkSize != 1) localQueue.offerAll(iter, chunkSize - 1)
+                        if (nRunnables > 1) localQueue.offerAll(iter, nRunnables - 1)
                         currentBlocking = blocking
                         if (currentBlocking) {
                           val runnables = localQueue.pollUpTo(256)
@@ -496,7 +496,7 @@ private[zio] object ZScheduler {
       }
 
       def put(trace: Trace): Long =
-        locations.getOrElseUpdate(trace, new AtomicLong()).getAndIncrement()
+        locations.getOrElseUpdate(trace, new AtomicLong(0L)).getAndIncrement()
     }
 
     object Disabled extends Locations {

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -370,9 +370,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
                   if ((worker ne self) && !worker.blocking) {
                     val size = worker.localQueue.size()
                     if (size > 0) {
-                      val chunk = worker.localQueue.pollUpTo(size - size / 2)
+                      val chunk     = worker.localQueue.pollUpTo(size - size / 2)
                       val chunkSize = chunk.size
-                      val iter  = chunk.iterator
+                      val iter      = chunk.iterator
                       if (chunkSize != 0) {
                         runnable = iter.next()
                         if (chunkSize != 1) localQueue.offerAll(iter, chunkSize - 1)

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -72,8 +72,9 @@ private[zio] trait PlatformSpecific {
 
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
-  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A]                     = new HashSet[A]()
-  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
+    new HashSet[A](initialCapacity)
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -72,7 +72,8 @@ private[zio] trait PlatformSpecific {
 
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
-  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
+  final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A]                     = new HashSet[A]()
+  final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 

--- a/core/native/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/RingBuffer.scala
@@ -24,7 +24,7 @@ private[zio] object RingBuffer {
    * @note
    *   minimum supported capacity is 2
    */
-  def apply[A](requestedCapacity: Int): MutableConcurrentQueue[A] = {
+  def apply[A](requestedCapacity: Int): RingBuffer[A] = {
     assert(requestedCapacity >= 2)
 
     if (nextPow2(requestedCapacity) == requestedCapacity) RingBufferPow2(requestedCapacity)

--- a/core/native/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
+++ b/core/native/src/main/scala/zio/internal/WeakConcurrentBagGc.scala
@@ -1,0 +1,7 @@
+package zio.internal
+
+import zio.Duration
+
+private object WeakConcurrentBagGc {
+  def start[A <: AnyRef](bag: WeakConcurrentBag[A], every: Duration): Unit = ()
+}

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1279,11 +1279,12 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
   /**
    * Creates a chunk from an iterator.
    */
-  def fromIterator[A](iterator: Iterator[A]): Chunk[A] = {
-    val builder = ChunkBuilder.make[A]()
-    builder ++= iterator
-    builder.result()
-  }
+  def fromIterator[A](iterator: Iterator[A]): Chunk[A] =
+    if (iterator.hasNext) {
+      val builder = ChunkBuilder.make[A]()
+      builder ++= iterator
+      builder.result()
+    } else Empty
 
   /**
    * Returns a chunk backed by a Java iterable.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -1007,5 +1007,6 @@ object Fiber extends FiberPlatformSpecific {
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
   private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
-    WeakConcurrentBag(10000, _.isAlive())
+    WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
+      .withAutoGc(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -477,6 +477,8 @@ object Fiber extends FiberPlatformSpecific {
    */
   sealed abstract class Runtime[+E, +A] extends Fiber.Internal[E, A] { self =>
 
+    private[zio] def shouldYieldBeforeFork(): Boolean
+
     /**
      * The location the fiber was forked from.
      */
@@ -627,7 +629,7 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] object Runtime {
 
     implicit def fiberOrdering[E, A]: Ordering[Fiber.Runtime[E, A]] =
-      Ordering.by[Fiber.Runtime[E, A], (Long, Long)](fiber => (fiber.id.startTimeMillis, fiber.id.id))
+      Ordering.by[Fiber.Runtime[E, A], Long](_.id.startTimeMillis)
 
     abstract class Internal[+E, +A] extends Runtime[E, A]
   }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -628,8 +628,8 @@ object Fiber extends FiberPlatformSpecific {
 
   private[zio] object Runtime {
 
-    implicit def fiberOrdering[E, A]: Ordering[Fiber.Runtime[E, A]] =
-      Ordering.by[Fiber.Runtime[E, A], Long](_.id.startTimeMillis)
+    implicit val fiberOrdering: Ordering[Fiber.Runtime[?, ?]] =
+      Ordering.by[Fiber.Runtime[?, ?], Long](_.id.startTimeMillis)
 
     abstract class Internal[+E, +A] extends Runtime[E, A]
   }

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.annotation.tailrec
+import java.util.concurrent.ThreadLocalRandom
 
 /**
  * The identity of a Fiber, described by the time it began life, and a
@@ -63,10 +63,10 @@ object FiberId {
   def apply(id: Int, startTimeSeconds: Int, location: Trace): FiberId =
     Runtime(id, startTimeSeconds * 1000L, location)
 
-  private[zio] def make(location: Trace)(implicit unsafe: Unsafe): FiberId.Runtime =
-    FiberId.Runtime(_fiberCounter.getAndIncrement(), java.lang.System.currentTimeMillis(), location)
-
-  private[zio] val _fiberCounter = new java.util.concurrent.atomic.AtomicInteger(0)
+  private[zio] def make(location: Trace)(implicit unsafe: Unsafe): FiberId.Runtime = {
+    val id = ThreadLocalRandom.current().nextInt(Int.MaxValue)
+    FiberId.Runtime(id, java.lang.System.currentTimeMillis(), location)
+  }
 
   case object None                                                          extends FiberId
   final case class Runtime(id: Int, startTimeMillis: Long, location: Trace) extends FiberId

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -151,7 +151,7 @@ trait Runtime[+R] { self =>
 
       val supervisor = fiber.getSupervisor()
 
-      if (supervisor != Supervisor.none) {
+      if (supervisor ne Supervisor.none) {
         supervisor.onStart(environment, zio, None, fiber)
 
         fiber.addObserver(exit => supervisor.onEnd(exit, fiber))

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -281,7 +281,7 @@ object Supervisor {
   }
 
   private def removeSupervisor(self: Supervisor[Any], that: Supervisor[Any]): Supervisor[Any] =
-    if (self == that) Supervisor.none
+    if (self eq that) Supervisor.none
     else
       self match {
         case Zip(left, right) => removeSupervisor(left, that) ++ removeSupervisor(right, that)
@@ -289,7 +289,7 @@ object Supervisor {
       }
 
   private[zio] def toSet(supervisor: Supervisor[Any]): Set[Supervisor[Any]] =
-    if (supervisor == Supervisor.none) Set.empty
+    if (supervisor eq Supervisor.none) Set.empty
     else
       supervisor match {
         case Zip(left, right) => toSet(left) ++ toSet(right)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -811,9 +811,10 @@ sealed trait ZIO[-R, +E, +A]
     scopeOverride: FiberScope
   )(implicit trace: Trace): URIO[R, Fiber.Runtime[E, A]] =
     ZIO.withFiberRuntime[R, Nothing, Fiber.Runtime[E, A]] { (parentFiber, parentStatus) =>
-      ZIO.succeed(
+      val f = ZIO.succeed(
         ZIO.unsafe.fork(trace, self, parentFiber, parentStatus.runtimeFlags, scopeOverride)(Unsafe.unsafe)
       )
+      if (parentFiber.shouldYieldBeforeFork()) ZIO.yieldNow *> f else f
     }
 
   /**

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -19,15 +19,15 @@ package zio.internal
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.tailrec
-
 import java.util.{Set => JavaSet}
-import java.util.concurrent.atomic.AtomicBoolean
-
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import zio._
 import zio.metrics.{Metric, MetricLabel}
+
 import java.nio.channels.ClosedByInterruptException
 import zio.Exit.Failure
 import zio.Exit.Success
+import zio.internal.SpecializationHelpers.SpecializeInt
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
     extends Fiber.Runtime.Internal[E, A]
@@ -38,19 +38,24 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   import ZIO._
   import FiberRuntime.EvaluationSignal
 
-  private var _lastTrace      = fiberId.location
-  private var _fiberRefs      = fiberRefs0
-  private var _runtimeFlags   = runtimeFlags0
-  private var _blockingOn     = FiberRuntime.notBlockingOn
-  private var _asyncContWith  = null.asInstanceOf[ZIO.Erased => Any]
-  private val running         = new AtomicBoolean(false)
-  private val inbox           = new java.util.concurrent.ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
-  private var observers       = Nil: List[Exit[E, A] => Unit]
-  private var runningExecutor = null.asInstanceOf[Executor]
-  private var _stack          = null.asInstanceOf[Array[Continuation]]
-  private var _stackSize      = 0
-  private val emptyTrace      = Trace.empty
+  private var _lastTrace       = fiberId.location
+  private var _fiberRefs       = fiberRefs0
+  private var _runtimeFlags    = runtimeFlags0
+  private var _runtimeFlagsOld = new AtomicInteger(Int.MinValue)
+  private var _blockingOn      = FiberRuntime.notBlockingOn
+  private var _asyncContWith   = null.asInstanceOf[ZIO.Erased => Any]
+  private val running          = new AtomicBoolean(false)
+  private val inbox            = new java.util.concurrent.ConcurrentLinkedQueue[FiberMessage]()
+  private var _children        = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var observers        = Nil: List[Exit[E, A] => Unit]
+  private var runningExecutor  = null.asInstanceOf[Executor]
+  private var _stack           = null.asInstanceOf[Array[Continuation]]
+  private var _stackSize       = 0
+  private val emptyTrace       = Trace.empty
+  private val _forkedChildren  = new AtomicInteger(0)
+
+  private[zio] def shouldYieldBeforeFork(): Boolean =
+    (_forkedChildren.incrementAndGet() % FiberRuntime.MaxForksBeforeYield) == 0
 
   if (RuntimeFlags.runtimeMetrics(_runtimeFlags)) {
     val tags = getFiberRef(FiberRef.currentTags)
@@ -196,10 +201,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     assert(running.get)
 
     var evaluationSignal: EvaluationSignal = EvaluationSignal.Continue
-    var previousFiber                      = null.asInstanceOf[FiberRuntime[_, _]]
     try {
       if (RuntimeFlags.currentFiber(_runtimeFlags)) {
-        val previousFiber = Fiber._currentFiber.get()
         Fiber._currentFiber.set(self)
       }
 
@@ -212,8 +215,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       }
     } finally {
       running.set(false)
-
-      if ((previousFiber ne null) || RuntimeFlags.currentFiber(_runtimeFlags)) Fiber._currentFiber.set(previousFiber)
     }
 
     // Maybe someone added something to the inbox between us checking, and us
@@ -363,9 +364,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     if (supervisor ne Supervisor.none) supervisor.onResume(self)(Unsafe.unsafe)
 
     try {
-      var effect      = effect0
-      var trampolines = 0
-      var finalExit   = null.asInstanceOf[Exit[E, A]]
+      var effect    = effect0
+      var finalExit = null.asInstanceOf[Exit[E, A]]
 
       while (effect ne null) {
         try {
@@ -517,7 +517,10 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * Retrieves the state of the fiber ref, or else the specified value.
    */
   private[zio] def getFiberRefOrElse[A](fiberRef: FiberRef[A], orElse: => A): A =
-    _fiberRefs.get(fiberRef).getOrElse(orElse)
+    _fiberRefs.getOrNull(fiberRef) match {
+      case null => orElse
+      case a    => a
+    }
 
   /**
    * Retrieves the value of the specified fiber ref, or `None` if this fiber is
@@ -1223,7 +1226,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     reportExitValue(e)
 
     // ensure we notify observers in the same order they subscribed to us
-    val iterator = observers.reverse.iterator
+    val iterator = observers.reverseIterator
 
     while (iterator.hasNext) {
       val observer = iterator.next()
@@ -1233,7 +1236,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     observers = Nil
   }
 
-  private[zio] def setFiberRef[A](fiberRef: FiberRef[A], value: A): Unit =
+  private[zio] def setFiberRef[@specialized(SpecializeInt) A](fiberRef: FiberRef[A], value: A): Unit =
     _fiberRefs = _fiberRefs.updatedAs(fiberId)(fiberRef, value)
 
   private[zio] def setFiberRefs(fiberRefs0: FiberRefs): Unit =
@@ -1377,6 +1380,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
 object FiberRuntime {
   private[zio] final val MaxTrampolinesBeforeYield = 5
+  private[zio] final val MaxForksBeforeYield       = 100
   private[zio] final val MaxOperationsBeforeYield  = 1024 * 10
   private[zio] final val MaxDepthBeforeTrampoline  = 300
   private[zio] final val MaxWorkStealingDepth      = 150
@@ -1384,11 +1388,11 @@ object FiberRuntime {
 
   private[zio] final val IgnoreContinuation: Any => Unit = _ => ()
 
-  private[zio] sealed trait EvaluationSignal
+  private[zio] type EvaluationSignal = Int
   private[zio] object EvaluationSignal {
-    case object Continue extends EvaluationSignal
-    case object YieldNow extends EvaluationSignal
-    case object Done     extends EvaluationSignal
+    final val Continue = 1
+    final val YieldNow = 2
+    final val Done     = 3
   }
   import java.util.concurrent.atomic.AtomicBoolean
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -38,24 +38,23 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   import ZIO._
   import FiberRuntime.EvaluationSignal
 
-  private var _lastTrace       = fiberId.location
-  private var _fiberRefs       = fiberRefs0
-  private var _runtimeFlags    = runtimeFlags0
-  private var _runtimeFlagsOld = new AtomicInteger(Int.MinValue)
-  private var _blockingOn      = FiberRuntime.notBlockingOn
-  private var _asyncContWith   = null.asInstanceOf[ZIO.Erased => Any]
-  private val running          = new AtomicBoolean(false)
-  private val inbox            = new java.util.concurrent.ConcurrentLinkedQueue[FiberMessage]()
-  private var _children        = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
-  private var observers        = Nil: List[Exit[E, A] => Unit]
-  private var runningExecutor  = null.asInstanceOf[Executor]
-  private var _stack           = null.asInstanceOf[Array[Continuation]]
-  private var _stackSize       = 0
-  private val emptyTrace       = Trace.empty
-  private val _forkedChildren  = new AtomicInteger(0)
+  private var _lastTrace      = fiberId.location
+  private var _fiberRefs      = fiberRefs0
+  private var _runtimeFlags   = runtimeFlags0
+  private var _blockingOn     = FiberRuntime.notBlockingOn
+  private var _asyncContWith  = null.asInstanceOf[ZIO.Erased => Any]
+  private val running         = new AtomicBoolean(false)
+  private val inbox           = new java.util.concurrent.ConcurrentLinkedQueue[FiberMessage]()
+  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var observers       = Nil: List[Exit[E, A] => Unit]
+  private var runningExecutor = null.asInstanceOf[Executor]
+  private var _stack          = null.asInstanceOf[Array[Continuation]]
+  private var _stackSize      = 0
+  private val emptyTrace      = Trace.empty
+  private val nForkedFibers   = new AtomicInteger(0)
 
   private[zio] def shouldYieldBeforeFork(): Boolean =
-    (_forkedChildren.incrementAndGet() % FiberRuntime.MaxForksBeforeYield) == 0
+    (nForkedFibers.incrementAndGet() % FiberRuntime.MaxForksBeforeYield) == 0
 
   if (RuntimeFlags.runtimeMetrics(_runtimeFlags)) {
     val tags = getFiberRef(FiberRef.currentTags)

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -31,23 +31,29 @@ private[zio] object MutableConcurrentQueue {
     if (capacity == 1) new OneElementConcurrentQueue()
     else RingBuffer[A](capacity)
 
+  /**
+   * @param preferredCapacity
+   *   The preferred total capacity of the queue. The actual capacity of each
+   *   partition will vary depending on the number of partition and whether
+   *   `roundToPow2` is set to true.
+   * @param roundToPow2
+   *   whether to round the capacity of each partition to the nearest power of
+   *   2.
+   */
+  def boundedPartitioned[A <: AnyRef](preferredCapacity: Int, roundToPow2: Boolean = true): PartitionedRingBuffer[A] =
+    new PartitionedRingBuffer[A](defaultPartitions, preferredCapacity, roundToPow2)
+
   def unbounded[A]: LinkedQueue[A] =
     unbounded[A](addMetrics = true)
 
   def unbounded[A](addMetrics: Boolean = true): LinkedQueue[A] =
     new LinkedQueue[A](addMetrics)
 
-  def unboundedPartitioned[A <: AnyRef](
-    preferredPartitions: Int,
-    addMetrics: Boolean = true
-  ): PartitionedLinkedQueue[A] =
-    new PartitionedLinkedQueue[A](preferredPartitions, addMetrics)
+  def unboundedPartitioned[A <: AnyRef](addMetrics: Boolean = true): PartitionedLinkedQueue[A] =
+    new PartitionedLinkedQueue[A](defaultPartitions, addMetrics)
 
-  def unboundedPartitioned[A <: AnyRef](
-    preferredPartitions: Int,
-    capacity: Int
-  ): PartitionedRingBuffer[A] =
-    new PartitionedRingBuffer[A](preferredPartitions, capacity)
+  private val defaultPartitions =
+    java.lang.Runtime.getRuntime.availableProcessors() << 2
 
   /**
    * Rounds up to the nearest power of 2 and subtracts 1. e.g.,

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -103,7 +103,7 @@ private[zio] abstract class MutableConcurrentQueue[A] {
    * A non-blocking enqueue of multiple elements.
    */
   def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
-    val builder  = ChunkBuilder.make[A1](as.size)
+    val builder  = ChunkBuilder.make[A1]()
     val iterator = as.iterator
     var loop     = true
     while (loop && iterator.hasNext) {
@@ -134,7 +134,7 @@ private[zio] abstract class MutableConcurrentQueue[A] {
    * A non-blocking dequeue of multiple elements.
    */
   def pollUpTo(n: Int): Chunk[A] = {
-    val builder = ChunkBuilder.make[A](n)
+    val builder = ChunkBuilder.make[A]()
     val default = null.asInstanceOf[A]
     var i       = n
     while (i > 0) {

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -59,12 +59,12 @@ private[zio] object MutableConcurrentQueue {
    * Rounds up to the nearest power of 2 and subtracts 1. e.g.,
    *
    * {{{
-   * maskFor(3) // 3
-   * maskFor(4) // 3
-   * maskFor(5) // 7
+   * roundToPow2MinusOne(3) // 3
+   * roundToPow2MinusOne(4) // 3
+   * roundToPow2MinusOne(5) // 7
    * }}}
    */
-  def maskFor(n: Int): Int = {
+  def roundToPow2MinusOne(n: Int): Int = {
     var value = n - 1
     value |= value >> 1
     value |= value >> 2

--- a/core/shared/src/main/scala/zio/internal/SpecializationHelpers.scala
+++ b/core/shared/src/main/scala/zio/internal/SpecializationHelpers.scala
@@ -1,0 +1,5 @@
+package zio.internal
+
+private[zio] object SpecializationHelpers {
+  final val SpecializeInt: Specializable.Group[Tuple1[Int]] = null
+}

--- a/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
+++ b/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
@@ -40,7 +40,7 @@ private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsA
 
   def withAutoGc(every: Duration): WeakConcurrentBag[A] = {
     if (autoGc.compareAndSet(false, true)) {
-      assert(every.toSeconds >= 1, "Auto-gc interval must be >= 1 second")
+      assert(every.toMillis >= 1000, "Auto-gc interval must be >= 1 second")
 
       val thread = new GcThread(every)
       thread.setName(s"zio.internal.WeakConcurrentBag.GcThread")

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -23,7 +23,9 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 import scala.annotation.nowarn
 
-private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+private[zio] final class LinkedQueue[A](addMetrics: Boolean = true)
+    extends MutableConcurrentQueue[A]
+    with Serializable {
   override final val capacity = Int.MaxValue
 
   private[this] val jucConcurrentQueue = new ConcurrentLinkedQueue[A]()
@@ -33,32 +35,32 @@ private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with S
    * performance implications. Having a better solution would be
    * desirable.
    */
-  private[this] val enqueuedCounter = new AtomicLong(0)
-  private[this] val dequeuedCounter = new AtomicLong(0)
+  private[this] val enqueuedCounter = if (addMetrics) new AtomicLong(0) else null
+  private[this] val dequeuedCounter = if (addMetrics) new AtomicLong(0) else null
 
   override def size(): Int = jucConcurrentQueue.size()
 
-  override def enqueuedCount(): Long = enqueuedCounter.get()
+  override def enqueuedCount(): Long = if (enqueuedCounter ne null) enqueuedCounter.get() else 0L
 
-  override def dequeuedCount(): Long = dequeuedCounter.get()
+  override def dequeuedCount(): Long = if (dequeuedCounter ne null) dequeuedCounter.get() else 0L
 
   override def offer(a: A): Boolean = {
     val success = jucConcurrentQueue.offer(a)
-    if (success) enqueuedCounter.incrementAndGet()
+    if (success && (enqueuedCounter ne null)) enqueuedCounter.incrementAndGet()
     success
   }
 
   override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     import collection.JavaConverters._
     jucConcurrentQueue.addAll(as.asJavaCollection): @nowarn("msg=JavaConverters")
-    enqueuedCounter.addAndGet(as.size.toLong)
+    if (enqueuedCounter ne null) enqueuedCounter.addAndGet(as.size.toLong)
     Chunk.empty
   }
 
   override def poll(default: A): A = {
     val polled = jucConcurrentQueue.poll()
     if (polled != null) {
-      dequeuedCounter.incrementAndGet()
+      if (dequeuedCounter ne null) dequeuedCounter.incrementAndGet()
       polled
     } else default
   }

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.Chunk
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.ThreadLocalRandom
+
+private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
+  preferredPartitions: Int,
+  addMetrics: Boolean
+) extends MutableConcurrentQueue[A]
+    with Serializable {
+
+  override final val capacity = Int.MaxValue
+
+  private[this] val mask    = MutableConcurrentQueue.maskFor(preferredPartitions)
+  private[this] val nQueues = mask + 1
+  private[this] val queues  = Array.fill(nQueues)(new LinkedQueue[A](addMetrics = addMetrics))
+
+  def size(random: ThreadLocalRandom): Int = {
+    val nq   = nQueues
+    val from = random.nextInt(nQueues)
+    var i    = 0
+    var size = 0
+    while (i < nq) {
+      val idx = (from + i) & mask
+      size += queues(idx).size()
+      i += 1
+    }
+    size
+  }
+  override def size(): Int = {
+    val nq   = nQueues
+    var i    = 0
+    var size = 0
+    while (i < nq) {
+      size += queues(i).size()
+      i += 1
+    }
+    size
+  }
+
+  override def enqueuedCount(): Long =
+    if (addMetrics) {
+      val nq   = nQueues
+      var i    = 0
+      var size = 0L
+      while (i < nq) {
+        size += queues(i).enqueuedCount()
+        i += 1
+      }
+      size
+    } else 0
+
+  override def dequeuedCount(): Long =
+    if (addMetrics) {
+      val nq   = nQueues
+      var i    = 0
+      var size = 0L
+      while (i < nq) {
+        size += queues(i).dequeuedCount()
+        i += 1
+      }
+      size
+    } else 0
+
+  def offer(a: A, random: ThreadLocalRandom): Boolean = {
+    val idx = random.nextInt(nQueues)
+    queues(idx).offer(a)
+  }
+
+  override def offer(a: A): Boolean =
+    offer(a, ThreadLocalRandom.current())
+
+  def offerAll[A1 <: A](as: Iterable[A1], random: ThreadLocalRandom): Chunk[A1] = {
+    val from = random.nextInt(nQueues)
+    var i    = 0
+    val iter = as.iterator
+    while (iter.hasNext) {
+      val value = iter.next()
+      val idx   = (from + i) & mask
+      queues(idx).offer(value)
+      i += 1
+    }
+    Chunk.empty
+  }
+  override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] =
+    offerAll(as, ThreadLocalRandom.current())
+
+  def poll(default: A, random: ThreadLocalRandom): A = {
+    val nq     = nQueues
+    val from   = random.nextInt(nQueues)
+    var i      = 0
+    var result = null.asInstanceOf[A]
+    while ((result eq null) && i < nq) {
+      val idx = (from + i) & mask
+      result = queues(idx).poll(default)
+      i += 1
+    }
+    result
+  }
+
+  override def poll(default: A): A =
+    poll(default, ThreadLocalRandom.current())
+
+  def isEmpty(random: ThreadLocalRandom): Boolean = {
+    val nq   = nQueues
+    val from = random.nextInt(nQueues)
+    var i    = 0
+    while (i < nq) {
+      val idx = (from + i) & mask
+      if (!queues(idx).isEmpty) return false
+      i += 1
+    }
+    true
+  }
+
+  override def isEmpty(): Boolean =
+    isEmpty(ThreadLocalRandom.current())
+
+  override def isFull(): Boolean = false
+}

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
@@ -125,7 +125,7 @@ private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
     var i    = 0
     while (i < nq) {
       val idx = (from + i) & mask
-      if (!queues(idx).isEmpty) return false
+      if (!queues(idx).isEmpty()) return false
       i += 1
     }
     true

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
@@ -29,7 +29,7 @@ private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
 
   override final val capacity = Int.MaxValue
 
-  private[this] val mask    = MutableConcurrentQueue.maskFor(preferredPartitions)
+  private[this] val mask    = MutableConcurrentQueue.roundToPow2MinusOne(preferredPartitions)
   private[this] val nQueues = mask + 1
   private[this] val queues  = Array.fill(nQueues)(new LinkedQueue[A](addMetrics = addMetrics))
 

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
@@ -33,6 +33,8 @@ private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
   private[this] val nQueues = mask + 1
   private[this] val queues  = Array.fill(nQueues)(new LinkedQueue[A](addMetrics = addMetrics))
 
+  def nPartitions(): Int = nQueues
+
   override def size(): Int = {
     val from = ThreadLocalRandom.current().nextInt(nQueues)
     var i    = 0

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedLinkedQueue.scala
@@ -72,15 +72,17 @@ private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
       size
     } else 0L
 
-  def offer(a: A, random: ThreadLocalRandom): Boolean = {
+  def offer(a: A, random: ThreadLocalRandom): Unit = {
     val idx = random.nextInt(nQueues)
     queues(idx).offer(a)
   }
 
-  override def offer(a: A): Boolean =
+  override def offer(a: A): Boolean = {
     offer(a, ThreadLocalRandom.current())
+    true
+  }
 
-  def offerAll[A1 <: A](as: Iterable[A1], random: ThreadLocalRandom): Chunk[A1] = {
+  def offerAll[A1 <: A](as: Iterable[A1], random: ThreadLocalRandom): Unit = {
     val from = random.nextInt(nQueues)
     var i    = 0
     val iter = as.iterator
@@ -90,10 +92,12 @@ private[zio] final class PartitionedLinkedQueue[A <: AnyRef](
       queues(idx).offer(value)
       i += 1
     }
+  }
+
+  override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
+    offerAll(as, ThreadLocalRandom.current())
     Chunk.empty
   }
-  override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] =
-    offerAll(as, ThreadLocalRandom.current())
 
   def poll(default: A, random: ThreadLocalRandom): A = {
     val from   = random.nextInt(nQueues)

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
@@ -16,7 +16,6 @@
 
 package zio.internal
 
-import zio.{Chunk, ChunkBuilder}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ThreadLocalRandom
@@ -118,7 +117,7 @@ private[zio] final class PartitionedRingBuffer[A <: AnyRef](
     val nq = nQueues
     var i  = 0
     while (i < nq) {
-      if (!queues(i).isEmpty) return false
+      if (!queues(i).isEmpty()) return false
       i += 1
     }
     true

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
@@ -16,7 +16,6 @@
 
 package zio.internal
 
-import zio.Chunk
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ThreadLocalRandom
@@ -28,7 +27,7 @@ private[zio] final class PartitionedRingBuffer[A <: AnyRef](
 ) extends MutableConcurrentQueue[A]
     with Serializable {
 
-  private[this] val mask: Int    = MutableConcurrentQueue.maskFor(preferredPartitions)
+  private[this] val mask: Int    = MutableConcurrentQueue.roundToPow2MinusOne(preferredPartitions)
   private[this] val nQueues: Int = mask + 1
 
   private[this] val partitionSize: Int = {

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.{Chunk, ChunkBuilder}
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.ThreadLocalRandom
+
+private[zio] final class PartitionedRingBuffer[A <: AnyRef](
+  preferredPartitions: Int,
+  preferredCapacity: Int
+) extends MutableConcurrentQueue[A]
+    with Serializable {
+
+  private[this] val mask: Int          = MutableConcurrentQueue.maskFor(preferredPartitions)
+  private[this] val nQueues: Int       = mask + 1
+  private[this] val ringBufferCapacity = (preferredCapacity / nQueues).max(2)
+  private[this] val queues             = Array.fill(nQueues)(RingBuffer[A](ringBufferCapacity))
+
+  override final val capacity = nQueues * ringBufferCapacity
+
+  override def size(): Int = {
+    val nq   = nQueues
+    var i    = 0
+    var size = 0
+    while (i < nq) {
+      size += queues(i).size()
+      i += 1
+    }
+    size
+  }
+
+  override def enqueuedCount(): Long = {
+    val nq   = nQueues
+    var i    = 0
+    var size = 0L
+    while (i < nq) {
+      size += queues(i).enqueuedCount()
+      i += 1
+    }
+    size
+  }
+
+  override def dequeuedCount(): Long = {
+    val nq   = nQueues
+    var i    = 0
+    var size = 0L
+    while (i < nq) {
+      size += queues(i).dequeuedCount()
+      i += 1
+    }
+    size
+  }
+
+  /**
+   * Offers an element to the queue, returning whether the offer was successful.
+   *
+   * @param maxMisses
+   *   How many partitions to try before giving up
+   */
+  def offer(a: A, random: ThreadLocalRandom, maxMisses: Int): Boolean = {
+    val maxI = nQueues.min(maxMisses + 1)
+    val from = random.nextInt(nQueues)
+    var i    = 0
+    while (i < maxI) {
+      val idx = (from + i) & mask
+      if (queues(idx).offer(a)) return true
+      i += 1
+    }
+    false
+  }
+
+  override def offer(a: A): Boolean =
+    offer(a, ThreadLocalRandom.current(), nQueues)
+
+  /**
+   * Polls an element to the queue, returning the element or `default` if the
+   * queue is empty.
+   *
+   * @param maxMisses
+   *   How many partitions to try polling from before giving up
+   */
+  def poll(default: A, random: ThreadLocalRandom, maxMisses: Int): A = {
+    val nq     = nQueues
+    val from   = random.nextInt(nQueues)
+    var i      = 0
+    var result = null.asInstanceOf[A]
+    var misses = 0
+    while ((result eq null) && i < nq && misses <= maxMisses) {
+      val idx   = (from + i) & mask
+      val queue = queues(idx)
+      result = queue.poll(default)
+      if (result eq null) misses += 1
+      i += 1
+    }
+    result
+  }
+
+  override def poll(default: A): A =
+    poll(default, ThreadLocalRandom.current(), nQueues)
+
+  override def isEmpty(): Boolean = {
+    val nq = nQueues
+    var i  = 0
+    while (i < nq) {
+      if (!queues(i).isEmpty) return false
+      i += 1
+    }
+    true
+  }
+
+  override def isFull(): Boolean = false
+}

--- a/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/PartitionedRingBuffer.scala
@@ -28,7 +28,7 @@ private[zio] final class PartitionedRingBuffer[A <: AnyRef](
 
   private[this] val mask: Int          = MutableConcurrentQueue.maskFor(preferredPartitions)
   private[this] val nQueues: Int       = mask + 1
-  private[this] val ringBufferCapacity = (preferredCapacity / nQueues).max(2)
+  private[this] val ringBufferCapacity = Math.ceil(preferredCapacity.toDouble / nQueues).toInt.max(2)
   private[this] val queues             = Array.fill(nQueues)(RingBuffer[A](ringBufferCapacity))
 
   override final val capacity = nQueues * ringBufferCapacity

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkZioSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestFrameworkZioSpec.scala
@@ -199,7 +199,7 @@ object ZTestFrameworkZioSpec extends ZIOSpecDefault {
       testC <- testConsole
       tasksZ <-
         ZIO
-          .attempt(
+          .attemptBlocking(
             new ZTestFramework()
               .runner(testArgs, Array(), getClass.getClassLoader)
               .tasksZ(tasks, testC)


### PR DESCRIPTION
_Leaving this as draft for the time being as I want to add tests for the newly added queues and until we decide whether the approach for generating `FiberId`s is solid (more below)_

/claim #8611
/fixes #8611
/split @ghostdogpr 

@jdegoes assuming you're happy to reward the bounty for this PR, I'd like to share it with @ghostdogpr as we worked on this together. Is there something I need to do to indicate to the Algora bot to split the payment?


Now, let's dig into the changes in this PR

### Avoiding global resource contention

Anyone that gave it a go at resolving this issue (myself included) probably kept running into loops where optimizing something didn't show any improvement in the benchmarks. The reason for this is that there are multiple points where threads are attempting to read/write from the same globally initialised resource, effectively limiting the overall throughput of the ZIO runtime to the throughput of that individual object. So unless all of the places of contention are resolved, the benchmark wouldn't show any improvement - even if the individual optimization was solid. The biggest culprits:

1. `ZScheduler#globalQueue`
2. `WeakConcurrentBag#nursery`
3. `FiberRef.make`
4. `ZScheduler#submittedLocations`

For (1) and (2), the solution I came up with was to use a "partitioned" queue consisting of multiple sub-queues, so when threads are offering / polling from them the chance of contention is reduced. Interestingly, when I first thought of this approach and shared an initial implementation with @ghostdogpr, he pointed out it was scarily similar to the [cats-effect global queue](https://github.com/typelevel/cats-effect/blob/series/3.x/core/jvm/src/main/scala/cats/effect/unsafe/ScalQueue.scala). At this point we knew we were on the right track and did what any software engineer worth their buck would do; "ported" (i.e., stole) any improvement we could see in their implementation into ours.

Now (3), this is something I'm very conflicted about, and would appreciate feedback on. The current implementation uses an `AtomicInteger` and increments it whenever a new `FiberId` is created. The problem with this approach is that when multiple threads are creating fibers, there is contention on updating the `AtomicInteger`. This acts up as a big bottleneck that limits the overall scalability of the ZIO runtime. The solution in this PR is to allocate a random `Int` instead, but there are 2 issues with this approach:

1. it's extremely unlikely but technically possible that 2 fibers created with the same `startTimeMilli` and `location` will have the same `id`. One way to reduce the chances even more is to use a random `Long` as the `id`.
2. Previously, `Fiber.Runtime` objects were ordered based on `(startTimeMilli, id)` and with these changes we lose the ability to order based on `id` in case of a `startTimeMilli` collision. _Having said that_, the ordering is only used in `zio.test` macros, so this might not be a big issue?

Finally, (4) was a bit easier to solve. Instead of having a globally-defined map to store the `submittedLocations`, the way to avoid the single resource contention was by having each `ZScheduler.Worker` submit its own locations in its own Map. Then the `ZScheduler.Supervisor` (the only place that reads from `submittedLocations`), aggregates the submitted locations from all workers. Since the supervisor only needs to read these locations when it suspects a worker thread is blocking unnecessarily (which is _never_ if users properly wrap blocking code in `ZIO.blocking`), it's much cheaper than having all workers write to the same globally shared Map.

### Improved thread scheduling(?)

Now this is an interesting one. When a thread is spawning multiple child fibers (e.g., in the case of `ZIO.foreachPar` or when using `.fork` in a loop), we found that it's much more performant if the thread yields after every X number of forks. This brings a huge improvement because the main thread occasionally yields from enqueueing more runnables into the global queues, giving a chance for the newly spawned workers to complete tasks in their local queues work prior to yielding themselves (in the case of async jobs). We found that yielding every ~100 forks is a good enough tradeoff between the added overhead of yielding and improved thread scheduling.

### CPU hot-path optimizations

Besides resolving global resource-contention and thread-scheduling this PR also optimizes the following which were found to improve this fairly substantially

1. The values added to `WeakConcurrentBag` are now wrapped in `WeakReference`. This means that fibers can be GC'd much earlier
2. Only a single thread is allowed to perform GC in `WeakConcurrentBag` under "auto gc" conditions
3. Made multiple optimizations to `FiberRefs` to avoid boxing of `Int`s as much as possible and avoid calling `transform` on the Map if we know it won't transform any of the entries

### Benchmarking results

TLDR: 

- `ZScheduler`-based runtime is ~x6.5 faster with `FiberRoots` enabled
- `ZScheduler`-based runtime is ~x15 faster without `FiberRoots` enabled
- Loom-based runtime ~x2 faster. The bottleneck at this point is the Loom executor scheduler and unfortunately we can't optimize it

cats-effect (baseline)
```
[info] Benchmark                        (n)   Mode  Cnt    Score   Error  Units
[info] ForkJoinBenchmark.catsForkJoin             10000  thrpt   10  2906.462 ±  14.976  ops/s
```

series/2.x (Note: this is the same with / without `FiberRoots` enabled)
```
JDK 17 - ZScheduler
[info] Benchmark                        (n)   Mode  Cnt    Score   Error  Units
[info] ForkJoinBenchmark.zioForkJoin  10000  thrpt   10  299.090 ± 5.982  ops/s

JDK21 - Loom
[info] Benchmark                        (n)   Mode  Cnt    Score    Error  Units
[info] ForkJoinBenchmark.zioForkJoin  10000  thrpt   10  448.071 ± 28.781  ops/s
```

PR
```
JDK 17 - ZScheduler
[info] Benchmark                                    (n)   Mode  Cnt     Score     Error  Units
[info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10  1931.372 ±  31.926  ops/s
[info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10  4812.394 ± 282.183  ops/s

JDK 21 - Loom
[info] Benchmark                                    (n)   Mode  Cnt    Score   Error  Units
[info] ForkJoinBenchmark.zioForkJoin              10000  thrpt   10  660.001 ± 5.386  ops/s
[info] ForkJoinBenchmark.zioForkJoinNoFiberRoots  10000  thrpt   10  758.261 ± 6.501  ops/s
```
