### PR TITLE
Leftover type of `provideSomeLayer` no longer required for Scala 3

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ProvideSomeSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ProvideSomeSpec.scala
@@ -1,0 +1,23 @@
+package zio
+
+import zio.test._
+import zio.test.Assertion._
+
+object ProvideSomeSpec extends ZIOBaseSpec {
+
+  def spec = suite("ProvideSomeSpec")(
+    test("provideSomeLayer") {
+      for {
+        ref    <- Ref.make(0)
+        scope  <- Scope.make
+        scoped  = ZIO.acquireRelease(ref.update(_ + 1))(_ => ref.update(_ - 1))
+        layer   = ZLayer.scoped(scoped)
+        _      <- scope.extend(layer.build.provideSomeLayer(ZLayer.empty))
+        before <- ref.get
+        _      <- scope.close(Exit.unit)
+        after  <- ref.get
+      } yield assertTrue(before == 1) &&
+        assertTrue(after == 0)
+    }
+  )
+}

--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -4,6 +4,17 @@ import zio.ZIO.{Async, asyncInterrupt, blocking}
 
 import java.io.IOException
 
+final class ProvideSomeLayer[R0, -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
+  def apply[E1 >: E, R1](
+    layer: => ZLayer[R0, E1, R1]
+  )(implicit
+    ev: R0 with R1 <:< R,
+    tagged: EnvironmentTag[R1],
+    trace: Trace
+  ): ZIO[R0, E1, A] =
+    self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
+}
+
 trait ZIOCompanionVersionSpecific {
 
   /**
@@ -168,6 +179,9 @@ trait ZIOCompanionVersionSpecific {
           }
       }
     }
+
+  val ProvideSomeLayer = zio.ProvideSomeLayer
+  type ProvideSomeLayer[R0, -R, +E, +A] = zio.ProvideSomeLayer[R0, R, E, A]
 
   /**
    * Returns an effect that models success with the specified value.

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -4,6 +4,17 @@ import zio.ZIO.{Async, asyncInterrupt, blocking}
 
 import java.io.IOException
 
+final class ProvideSomeLayer[R0, -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
+  transparent inline def apply[E1 >: E, R1](
+    layer: => ZLayer[R0, E1, R1]
+  )(implicit
+    ev: R0 with R1 <:< R,
+    tagged: EnvironmentTag[R1],
+    trace: Trace
+  ): ZIO[R0, E1, A] =
+    self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
+}
+
 trait ZIOCompanionVersionSpecific {
 
   /**
@@ -173,6 +184,9 @@ trait ZIOCompanionVersionSpecific {
           }
       }
     }
+
+  val ProvideSomeLayer = zio.ProvideSomeLayer
+  type ProvideSomeLayer[R0, -R, +E, +A] = zio.ProvideSomeLayer[R0, R, E, A]
 
   /**
    * Returns an effect that models success with the specified value.

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5210,17 +5210,6 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       self.refineOrDie { case e: E1 => e }
   }
 
-  final class ProvideSomeLayer[R0, -R, +E, +A](private val self: ZIO[R, E, A]) extends AnyVal {
-    def apply[E1 >: E, R1](
-      layer: => ZLayer[R0, E1, R1]
-    )(implicit
-      ev: R0 with R1 <:< R,
-      tagged: EnvironmentTag[R1],
-      trace: Trace
-    ): ZIO[R0, E1, A] =
-      self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
-  }
-
   final class UpdateService[-R, +E, +A, M](private val self: ZIO[R, E, A]) extends AnyVal {
     def apply[R1 <: R with M](
       f: M => M


### PR DESCRIPTION
The days of `zio.provideSomeLayer[Leftover](layer)` are gone. Say hello to `zio.provideSomeLayer(layer)`. At least for Scala 3 🙂 