### PR TITLE
Maintain bin compatibility with `v2.0.x` for methods used in `zio/interop-cats`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1402,6 +1402,8 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.withFiberRuntime[R1, E2, C] { (parentFiber, parentStatus) =>
       import java.util.concurrent.atomic.AtomicBoolean
 
+      implicit val unsafe: Unsafe = Unsafe.unsafe
+
       val parentRuntimeFlags = parentStatus.runtimeFlags
 
       @inline def complete[E0, E1, A, B](
@@ -1417,9 +1419,9 @@ sealed trait ZIO[-R, +E, +A]
 
       val raceIndicator = new AtomicBoolean(true)
 
-      val leftFiber = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)(Unsafe.unsafe)
+      val leftFiber = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)
       val rightFiber =
-        ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)(Unsafe.unsafe)
+        ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)
 
       val startLeftFiber  = leftFiber.startSuspended()
       val startRightFiber = rightFiber.startSuspended()

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -68,7 +68,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             val cb = (exit: Exit[_, _]) => k(Exit.Success(exit.asInstanceOf[Exit[E, A]]))
             tell(FiberMessage.Stateful { (fiber, _) =>
               if (fiber._exitValue ne null) cb(fiber._exitValue)
-              else fiber.addObserver(cb)
+              else fiber.addObserver(cb)(Unsafe.unsafe)
             })
             Left(ZIO.succeed(tell(FiberMessage.Stateful { (fiber, _) =>
               fiber.removeObserver(cb)
@@ -176,7 +176,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private[zio] def addObserver(observer: Exit[E, A] => Unit): Unit =
+  private[zio] def addObserver(observer: Exit[E, A] => Unit)(implicit unsafe: Unsafe): Unit =
     if (_exitValue ne null) observer(_exitValue)
     else observers = observer :: observers
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1291,7 +1291,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private[zio] def startConcurrently(effect: ZIO[_, E, A]): Unit =
     tell(FiberMessage.Resume(effect))
 
-  private[zio] def startSuspended(): ZIO[_, E, A] => Any = {
+  private[zio] def startSuspended()(implicit unsafe: Unsafe): ZIO[_, E, A] => Any = {
     val alreadyCalled = new AtomicBoolean(false)
     val callback = (effect: ZIO[_, E, A]) => {
       if (alreadyCalled.compareAndSet(false, true)) {


### PR DESCRIPTION
Currently, the `zio/interop-cats` library is not binary compatible with `2.1-RC1` because of 2 methods due to the removal of the `Unsafe` implicit param.

1. `FiberRuntime#addObserver`
2. `FiberRuntime#startSuspended`

With these changes we can have more people trialling the 2.1 RC versions as the ecosystem will have less binary incompatible changes and reduces the overhead of having to migrate other zio libraries to make the compatible with 2.1.x