### PR TITLE
Optimize `ZIO#absolve`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -161,7 +161,10 @@ sealed trait ZIO[-R, +E, +A]
    * `ZIO`. The inverse operation of `ZIO.either`.
    */
   final def absolve[E1 >: E, B](implicit ev: A IsSubtypeOfOutput Either[E1, B], trace: Trace): ZIO[R, E1, B] =
-    self.flatMap(ev(_).fold(ZIO.fail(_), ZIO.succeed(_)))
+    self.flatMap(ev(_) match {
+      case Right(v) => ZIO.succeed(v)
+      case Left(e)  => ZIO.fail(e)
+    })
 
   /**
    * Attempts to convert defects into a failure, throwing away all information

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -161,7 +161,7 @@ sealed trait ZIO[-R, +E, +A]
    * `ZIO`. The inverse operation of `ZIO.either`.
    */
   final def absolve[E1 >: E, B](implicit ev: A IsSubtypeOfOutput Either[E1, B], trace: Trace): ZIO[R, E1, B] =
-    ZIO.absolve(self.map(ev))
+    self.flatMap(ev(_).fold(ZIO.fail(_), ZIO.succeed(_)))
 
   /**
    * Attempts to convert defects into a failure, throwing away all information


### PR DESCRIPTION
Currently a single call to `absolve` requires 3 flatMaps (1 for `map`, 1 for `ZIO.suspendSucceed` and 1 for `ZIO.fromEither`. We can reduce this down to a single flatMap to avoid the added overhead