### PR TITLE
ZPipeline.fromFunction benchmark and optimization

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -240,21 +240,23 @@ class StreamBenchmarks {
     unsafeRun(result)
   }
 
-  val chunkToConst : Chunk[Int] => Int = _ => 1
-  val strmChunkToStrmConsts : ZStream[Any, Nothing, Chunk[Int]] => ZStream[Any, Nothing, Int] = _.map(chunkToConst)
+  val chunkToConst: Chunk[Int] => Int                                                        = _ => 1
+  val strmChunkToStrmConsts: ZStream[Any, Nothing, Chunk[Int]] => ZStream[Any, Nothing, Int] = _.map(chunkToConst)
 
   @Benchmark
-  def zioChunkToConstDirect : Long = {
+  def zioChunkToConstDirect: Long = {
     val result =
-      strmChunkToStrmConsts(ZStream
-        .fromChunks(zioChunks: _*).chunks
+      strmChunkToStrmConsts(
+        ZStream
+          .fromChunks(zioChunks: _*)
+          .chunks
       ).runCount
 
     unsafeRun(result)
   }
 
   @Benchmark
-  def zioChunkToConstBaseline : Long = {
+  def zioChunkToConstBaseline: Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
@@ -265,8 +267,8 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def zioChunkToConstFromFunction : Long = {
-    val result =ZStream
+  def zioChunkToConstFromFunction: Long = {
+    val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
       .via(ZPipeline.fromFunction(strmChunkToStrmConsts))
@@ -276,8 +278,8 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def zioChunkToConstFromFunction2 : Long = {
-    val result =ZStream
+  def zioChunkToConstFromFunction2: Long = {
+    val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
       .via(ZPipeline.fromFunction2(strmChunkToStrmConsts))

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -240,6 +240,106 @@ class StreamBenchmarks {
     unsafeRun(result)
   }
 
+  val strmIdFunc : ZStream[Any, Nothing, Int] => ZStream[Any, Nothing, Int] = identity
+
+  @Benchmark
+  def zioIdentityDirect : Long = {
+    val result = strmIdFunc(ZStream
+        .fromChunks(zioChunks: _*)
+      )
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIdentityVia : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via(ZPipeline.map(identity[Int]))
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIdentityFromFunction : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via{
+        ZPipeline.fromFunction(strmIdFunc)
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIdentityMap : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .map(identity)
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIdentityMapChunks : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .chunks
+      .map(identity)
+      .flattenChunks
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  val incIntFunc : Int => Int = _ + 1
+  val strmIncFunc : ZStream[Any, Nothing, Int] => ZStream[Any, Nothing, Int] = _.map(incIntFunc)
+
+  @Benchmark
+  def zioIncDirect : Long = {
+    val result = strmIncFunc(ZStream
+      .fromChunks(zioChunks: _*)
+    )
+    .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIncVia : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via(ZPipeline.map(incIntFunc))
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIncFromFunction : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via{
+        ZPipeline.fromFunction(strmIncFunc)
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIncMap : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .map(incIntFunc)
+      .runCount
+
+    unsafeRun(result)
+  }
 }
 
 @State(JScope.Thread)

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -267,22 +267,22 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def zioChunkToConstFromFunction: Long = {
+  def zioChunkToConstFromFunctionOrig: Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
-      .via(ZPipeline.fromFunction(strmChunkToStrmConsts))
+      .via(ZPipeline.fromFunctionOrig(strmChunkToStrmConsts))
       .runCount
 
     unsafeRun(result)
   }
 
   @Benchmark
-  def zioChunkToConstFromFunction2: Long = {
+  def zioChunkToConstFromFunction: Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
-      .via(ZPipeline.fromFunction2(strmChunkToStrmConsts))
+      .via(ZPipeline.fromFunction(strmChunkToStrmConsts))
       .runCount
 
     unsafeRun(result)

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -267,17 +267,6 @@ class StreamBenchmarks {
   }
 
   @Benchmark
-  def zioChunkToConstFromFunctionOrig: Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .chunks
-      .via(ZPipeline.fromFunctionOrig(strmChunkToStrmConsts))
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
   def zioChunkToConstFromFunction: Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -240,130 +240,52 @@ class StreamBenchmarks {
     unsafeRun(result)
   }
 
-  val strmIdFunc : ZStream[Any, Nothing, Int] => ZStream[Any, Nothing, Int] = identity
+  val chunkToConst : Chunk[Int] => Int = _ => 1
+  val strmChunkToStrmConsts : ZStream[Any, Nothing, Chunk[Int]] => ZStream[Any, Nothing, Int] = _.map(chunkToConst)
 
   @Benchmark
-  def zioIdentityDirect : Long = {
-    val result = strmIdFunc(ZStream
-        .fromChunks(zioChunks: _*)
-      )
-      .runCount
+  def zioChunkToConstDirect : Long = {
+    val result =
+      strmChunkToStrmConsts(ZStream
+        .fromChunks(zioChunks: _*).chunks
+      ).runCount
 
     unsafeRun(result)
   }
 
   @Benchmark
-  def zioIdentityVia : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .via(ZPipeline.map(identity[Int]))
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def zioIdentityFromFunction : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .via{
-        ZPipeline.fromFunction(strmIdFunc)
-      }
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def zioIdentityFromFunction2 : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .via{
-        ZPipeline.fromFunction2(strmIdFunc)
-      }
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def zioIdentityMap : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .map(identity)
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def zioIdentityMapChunks : Long = {
+  def zioChunkToConstBaseline : Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
       .chunks
-      .map(identity)
-      .flattenChunks
-      .runCount
-
-    unsafeRun(result)
-  }
-
-  val incIntFunc : Int => Int = _ + 1
-  val strmIncFunc : ZStream[Any, Nothing, Int] => ZStream[Any, Nothing, Int] = _.map(incIntFunc)
-
-  @Benchmark
-  def zioIncDirect : Long = {
-    val result = strmIncFunc(ZStream
-      .fromChunks(zioChunks: _*)
-    )
-    .runCount
-
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def zioIncVia : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .via(ZPipeline.map(incIntFunc))
+      .via(ZPipeline.map(chunkToConst))
       .runCount
 
     unsafeRun(result)
   }
 
   @Benchmark
-  def zioIncFromFunction : Long = {
-    val result = ZStream
+  def zioChunkToConstFromFunction : Long = {
+    val result =ZStream
       .fromChunks(zioChunks: _*)
-      .via{
-        ZPipeline.fromFunction(strmIncFunc)
-      }
+      .chunks
+      .via(ZPipeline.fromFunction(strmChunkToStrmConsts))
       .runCount
 
     unsafeRun(result)
   }
 
   @Benchmark
-  def zioIncFromFunction2 : Long = {
-    val result = ZStream
+  def zioChunkToConstFromFunction2 : Long = {
+    val result =ZStream
       .fromChunks(zioChunks: _*)
-      .via{
-        ZPipeline.fromFunction2(strmIncFunc)
-      }
+      .chunks
+      .via(ZPipeline.fromFunction2(strmChunkToStrmConsts))
       .runCount
 
     unsafeRun(result)
   }
 
-  @Benchmark
-  def zioIncMap : Long = {
-    val result = ZStream
-      .fromChunks(zioChunks: _*)
-      .map(incIntFunc)
-      .runCount
-
-    unsafeRun(result)
-  }
 }
 
 @State(JScope.Thread)

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -275,6 +275,18 @@ class StreamBenchmarks {
   }
 
   @Benchmark
+  def zioIdentityFromFunction2 : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via{
+        ZPipeline.fromFunction2(strmIdFunc)
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
   def zioIdentityMap : Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
@@ -325,6 +337,18 @@ class StreamBenchmarks {
       .fromChunks(zioChunks: _*)
       .via{
         ZPipeline.fromFunction(strmIncFunc)
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioIncFromFunction2 : Long = {
+    val result = ZStream
+      .fromChunks(zioChunks: _*)
+      .via{
+        ZPipeline.fromFunction2(strmIncFunc)
       }
       .runCount
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -276,7 +276,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
         ZStream
           .range(0, 20, 5)
           .via {
-            ZPipeline.fromFunction2 { strm: ZStream[Any, Any, Int] =>
+            ZPipeline.fromFunction { strm: ZStream[Any, Any, Int] =>
               strm.map(_ + 1)
             }
           }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -272,7 +272,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
           } yield assert(result)(fails(equalTo(EncodingException("Not a valid hex digit: 'g'"))))
         }
       ),
-      test("fromFunction2") {
+      test("fromFunction") {
         ZStream
           .range(0, 20, 5)
           .via {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -275,7 +275,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
       test("fromFunction2") {
         ZStream
           .range(0, 20, 5)
-          .via{
+          .via {
             ZPipeline.fromFunction2 { strm: ZStream[Any, Any, Int] =>
               strm.map(_ + 1)
             }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -276,7 +276,7 @@ object ZPipelineSpec extends ZIOBaseSpec {
         ZStream
           .range(0, 20, 5)
           .via {
-            ZPipeline.fromFunction { strm: ZStream[Any, Any, Int] =>
+            ZPipeline.fromFunction { (strm: ZStream[Any, Any, Int]) =>
               strm.map(_ + 1)
             }
           }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -271,7 +271,18 @@ object ZPipelineSpec extends ZIOBaseSpec {
                 .exit
           } yield assert(result)(fails(equalTo(EncodingException("Not a valid hex digit: 'g'"))))
         }
-      )
+      ),
+      test("fromFunction2") {
+        ZStream
+          .range(0, 20, 5)
+          .via{
+            ZPipeline.fromFunction2 { strm: ZStream[Any, Any, Int] =>
+              strm.map(_ + 1)
+            }
+          }
+          .runCollect
+          .map(assert(_)(equalTo(Chunk.range(1, 21))))
+      }
     )
 
   val weirdStringGenForSplitLines: Gen[Any, Chunk[String]] = Gen

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1420,6 +1420,10 @@ object ZChannel {
     channel: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone]
   ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
 
+  private[zio] final case class DeferedUpstream[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone](
+    mkChannel : ZChannel[Any, Any, Any, Any, InErr, InElem, InDone] => ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone]
+  ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
+
   private[zio] final case class BracketOut[R, E, Z](
     acquire: () => ZIO[R, E, Z],
     finalizer: (Z, Exit[Any, Any]) => URIO[R, Any]

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1421,7 +1421,15 @@ object ZChannel {
   ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
 
   private[zio] final case class DeferedUpstream[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone](
-    mkChannel : ZChannel[Any, Any, Any, Any, InErr, InElem, InDone] => ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone]
+    mkChannel: ZChannel[Any, Any, Any, Any, InErr, InElem, InDone] => ZChannel[
+      Env,
+      Any,
+      Any,
+      Any,
+      OutErr,
+      OutElem,
+      OutDone
+    ]
   ) extends ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
 
   private[zio] final case class BracketOut[R, E, Z](

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1440,7 +1440,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * Constructs a pipeline from a stream transformation function.
    */
-  def fromFunction[Env, Err, In, Out](
+  def fromFunctionOrig[Env, Err, In, Out](
     f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
 
@@ -1455,7 +1455,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     new ZPipeline(channel)
   }
 
-  def fromFunction2[Env, Err, In, Out](
+  def fromFunction[Env, Err, In, Out](
     f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
     def fc(

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1455,6 +1455,17 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     new ZPipeline(channel)
   }
 
+  def fromFunction2[Env, Err, In, Out](
+   f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
+  )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
+    def fc(upstream : ZChannel[Any, Any, Any, Any, ZNothing, Chunk[In], Any]): ZChannel[Env, Any, Any, Any, Err, Chunk[Out], Any] =
+      f(upstream.toStream).toChannel
+
+    val resCh: ZChannel.DeferedUpstream[Env, ZNothing, Chunk[In], Any, Err, Chunk[Out], Any] = ZChannel.DeferedUpstream(fc)
+    val resPl: ZPipeline[Env, Err, In, Out] = resCh.toPipeline
+    resPl
+  }
+
   /**
    * Creates a pipeline from a chunk processing function.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1440,21 +1440,6 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * Constructs a pipeline from a stream transformation function.
    */
-  def fromFunctionOrig[Env, Err, In, Out](
-    f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
-  )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
-
-    val channel: ZChannel[Env, ZNothing, Chunk[In], Any, Err, Chunk[Out], Any] =
-      ZChannel.unwrap {
-        for {
-          input <- SingleProducerAsyncInput.make[ZNothing, Chunk[In], Any]
-          stream = ZStream.fromChannel(ZChannel.fromInput(input))
-        } yield f(stream).channel.embedInput(input)
-      }
-
-    new ZPipeline(channel)
-  }
-
   def fromFunction[Env, Err, In, Out](
     f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1456,12 +1456,15 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   }
 
   def fromFunction2[Env, Err, In, Out](
-   f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
+    f: ZStream[Any, Nothing, In] => ZStream[Env, Err, Out]
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
-    def fc(upstream : ZChannel[Any, Any, Any, Any, ZNothing, Chunk[In], Any]): ZChannel[Env, Any, Any, Any, Err, Chunk[Out], Any] =
+    def fc(
+      upstream: ZChannel[Any, Any, Any, Any, ZNothing, Chunk[In], Any]
+    ): ZChannel[Env, Any, Any, Any, Err, Chunk[Out], Any] =
       f(upstream.toStream).toChannel
 
-    val resCh: ZChannel.DeferedUpstream[Env, ZNothing, Chunk[In], Any, Err, Chunk[Out], Any] = ZChannel.DeferedUpstream(fc)
+    val resCh: ZChannel.DeferedUpstream[Env, ZNothing, Chunk[In], Any, Err, Chunk[Out], Any] =
+      ZChannel.DeferedUpstream(fc)
     val resPl: ZPipeline[Env, Err, In, Out] = resCh.toPipeline
     resPl
   }

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -185,7 +185,7 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
 
             case ZChannel.DeferedUpstream(mkChannel) =>
               val inpAsChannel: ZChannel[Env, Any, Any, Any, Any, Any, Any] = execToPullingChannel(input)
-              val nextChannel = mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
+              val nextChannel                                               = mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
 
               val previousInput = input
               input = null
@@ -758,8 +758,10 @@ private[zio] object ChannelExecutor {
     read()
   }
 
-  private[zio] def execToPullingChannel[Env](exec : ErasedExecutor[Env])(implicit trace: Trace) : ZChannel[Env, Any, Any, Any, Any, Any, Any] = {
-    def ch2(st : ChannelState[Env, Any]) : ZChannel[Env, Any, Any, Any, Any, Any, Any] = {
+  private[zio] def execToPullingChannel[Env](
+    exec: ErasedExecutor[Env]
+  )(implicit trace: Trace): ZChannel[Env, Any, Any, Any, Any, Any, Any] = {
+    def ch2(st: ChannelState[Env, Any]): ZChannel[Env, Any, Any, Any, Any, Any, Any] =
       st match {
         case ChannelState.Done =>
           exec.getDone match {
@@ -769,8 +771,8 @@ private[zio] object ChannelExecutor {
               ZChannel.refailCause(c)
           }
         case ChannelState.Emit =>
-              ZChannel.write(exec.getEmit)  *>
-              ch2(exec.run())
+          ZChannel.write(exec.getEmit) *>
+            ch2(exec.run())
         case ChannelState.Effect(zio) =>
           ZChannel.fromZIO(zio) *> ch2(exec.run())
         case r @ ChannelState.Read(upstream, onEffect, onEmit, onDone) =>
@@ -782,10 +784,8 @@ private[zio] object ChannelExecutor {
             )
           } *> ch2(exec.run())
       }
-    }
     ZChannel.suspend(ch2(exec.run()))
   }
-
 
 }
 


### PR DESCRIPTION
this addresses the performance issue described in #8758

as seen in the benchmark:
```
Benchmark                                      (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
StreamBenchmarks.zioChunkToConstBaseline              10000         5000  thrpt   15  150.019 ± 8.568  ops/s
StreamBenchmarks.zioChunkToConstDirect                10000         5000  thrpt   15  242.002 ± 3.854  ops/s
StreamBenchmarks.zioChunkToConstFromFunction          10000         5000  thrpt   15   12.341 ± 0.068  ops/s
StreamBenchmarks.zioChunkToConstFromFunction2         10000         5000  thrpt   15  139.780 ± 1.310  ops/s
```

`ZPipeline.fromFunction` has a major overhead, this PR introduces an alternative encoding and interpretation for `ZPipeline.fromFunction` notes as `zioChunkToConstFromFunction2` in the benchmark above.