### PR TITLE
Revert binary incompatible change on `MutableConcurrentQueue`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/MutableConcurrentQueueSpec.scala
@@ -53,15 +53,6 @@ object MutableConcurrentQueueSpec extends ZIOBaseSpec {
         && assert(q.poll(-1))(equalTo(-1))
         && assert(q.isEmpty())(isTrue))
       }
-    ),
-    suite("Partitioned queues")(
-      test("partitioned queues have n * 4 rounded to the next power of 2 capacity") {
-        val q1       = MutableConcurrentQueue.unboundedPartitioned().nPartitions()
-        val q2       = MutableConcurrentQueue.boundedPartitioned(100).nPartitions()
-        val expected = RingBuffer.nextPow2(java.lang.Runtime.getRuntime.availableProcessors() * 4)
-
-        assertTrue(q1 == expected, q2 == expected)
-      }
     )
   )
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1381,16 +1381,16 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 }
 
 object FiberRuntime {
-  private[zio] final val MaxForksBeforeYield      = 128
-  private[zio] final val MaxOperationsBeforeYield = 1024 * 10
-  private[zio] final val MaxDepthBeforeTrampoline = 300
-  private[zio] final val MaxWorkStealingDepth     = 150
-  private[zio] final val WorkStealingSafetyMargin = 50
+  private final val MaxForksBeforeYield      = 128
+  private final val MaxOperationsBeforeYield = 1024 * 10
+  private final val MaxDepthBeforeTrampoline = 300
+  private final val MaxWorkStealingDepth     = 150
+  private final val WorkStealingSafetyMargin = 50
 
-  private[zio] final val IgnoreContinuation: Any => Unit = _ => ()
+  private final val IgnoreContinuation: Any => Unit = _ => ()
 
-  private[zio] type EvaluationSignal = Int
-  private[zio] object EvaluationSignal {
+  private type EvaluationSignal = Int
+  private object EvaluationSignal {
     final val Continue = 1
     final val YieldNow = 2
     final val Done     = 3

--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -31,29 +31,8 @@ private[zio] object MutableConcurrentQueue {
     if (capacity == 1) new OneElementConcurrentQueue()
     else RingBuffer[A](capacity)
 
-  /**
-   * @param preferredCapacity
-   *   The preferred total capacity of the queue. The actual capacity of each
-   *   partition will vary depending on the number of partition and whether
-   *   `roundToPow2` is set to true.
-   * @param roundToPow2
-   *   whether to round the capacity of each partition to the nearest power of
-   *   2.
-   */
-  def boundedPartitioned[A <: AnyRef](preferredCapacity: Int, roundToPow2: Boolean = true): PartitionedRingBuffer[A] =
-    new PartitionedRingBuffer[A](defaultPartitions, preferredCapacity, roundToPow2)
-
-  def unbounded[A]: LinkedQueue[A] =
-    unbounded[A](addMetrics = true)
-
-  def unbounded[A](addMetrics: Boolean = true): LinkedQueue[A] =
-    new LinkedQueue[A](addMetrics)
-
-  def unboundedPartitioned[A <: AnyRef](addMetrics: Boolean = true): PartitionedLinkedQueue[A] =
-    new PartitionedLinkedQueue[A](defaultPartitions, addMetrics)
-
-  private val defaultPartitions =
-    java.lang.Runtime.getRuntime.availableProcessors() << 2
+  def unbounded[A]: MutableConcurrentQueue[A] =
+    new LinkedQueue[A](addMetrics = true)
 
   /**
    * Rounds up to the nearest power of 2 and subtracts 1. e.g.,

--- a/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
+++ b/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
@@ -23,7 +23,8 @@ import scala.annotation.tailrec
  * nursery and occassional garbage collection.
  */
 private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsAlive[A]) { self =>
-  private[this] val nursery           = MutableConcurrentQueue.boundedPartitioned[WeakReference[A]](nurserySize)
+  private[this] def nCpu              = java.lang.Runtime.getRuntime.availableProcessors()
+  private[this] val nursery           = new PartitionedRingBuffer[WeakReference[A]](nCpu * 4, nurserySize, roundToPow2 = true)
   private[this] val nurseryActualSize = nursery.capacity
 
   private[this] val graduates = Platform.newConcurrentSet[WeakReference[A]](nurseryActualSize * 2)(Unsafe.unsafe)


### PR DESCRIPTION
/fixes #8772

Note that I made some of the final vals and `EvaluationSignal` private in `FIberRuntime`. I checked and those are not used anywhere outside of the zio codebase (and shouldn't), so I'm making them private just so we don't have to worry about them in the future