### PR TITLE
Revert changes in #8660

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2580,7 +2580,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def fork[R, E1, E2, A, B](
       trace: Trace,
       effect: ZIO[R, E1, A],
-      parentFiber: Fiber.Runtime.Internal[E2, B],
+      parentFiber: Fiber.Runtime[E2, B],
       parentRuntimeFlags: RuntimeFlags,
       overrideScope: FiberScope = null
     )(implicit unsafe: Unsafe): internal.FiberRuntime[E1, A] = {
@@ -2594,7 +2594,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def makeChildFiber[R, E1, E2, A, B](
       trace: Trace,
       effect: ZIO[R, E1, A],
-      parentFiber: Fiber.Runtime.Internal[E2, B],
+      parentFiber: Fiber.Runtime[E2, B],
       parentRuntimeFlags: RuntimeFlags,
       overrideScope: FiberScope
     )(implicit unsafe: Unsafe): internal.FiberRuntime[E1, A] = {
@@ -5135,7 +5135,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def yieldNow(implicit trace: Trace): UIO[Unit] = ZIO.YieldNow(trace, false)
 
   private[zio] def withFiberRuntime[R, E, A](
-    onState: (Fiber.Runtime.Internal[E, A], Fiber.Status.Running) => ZIO[R, E, A]
+    onState: (Fiber.Runtime[E, A], Fiber.Status.Running) => ZIO[R, E, A]
   )(implicit trace: Trace): ZIO[R, E, A] =
     Stateful(trace, onState)
 
@@ -5850,7 +5850,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   private[zio] final case class GenerateStackTrace(trace: Trace) extends ZIO[Any, Nothing, StackTrace]
   private[zio] final case class Stateful[R, E, A](
     trace: Trace,
-    onState: (Fiber.Runtime.Internal[E, A], Fiber.Status.Running) => ZIO[R, E, A]
+    onState: (Fiber.Runtime[E, A], Fiber.Status.Running) => ZIO[R, E, A]
   ) extends ZIO[R, E, A]
   private[zio] final case class WhileLoop[R, E, A](
     trace: Trace,


### PR DESCRIPTION
The changes done in #8660 did not seem to be needed afterall (see linked issue), and they're causing binary incompatibility issues with zio/cats-interop