### PR TITLE
Allow providing alternative implementations for generating `FiberId`s

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -16,8 +16,8 @@ object FiberRefsSpec extends ZIOBaseSpec {
       } yield assertTrue(value)
     } +
       test("interruptedCause") {
-        val parent = Unsafe.unsafe(implicit unsafe => FiberId.make(Trace.empty))
-        val child  = Unsafe.unsafe(implicit unsafe => FiberId.make(Trace.empty))
+        val parent = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Random.make(Trace.empty))
+        val child  = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Random.make(Trace.empty))
 
         val parentFiberRefs = FiberRefs.empty
         val childFiberRefs  = parentFiberRefs.updatedAs(child)(FiberRef.interruptedCause, Cause.interrupt(parent))
@@ -33,7 +33,7 @@ object FiberRefsSpec extends ZIOBaseSpec {
        */
       suite("optimizations") {
         implicit val unsafe: Unsafe = Unsafe.unsafe
-        val fiberId                 = FiberId.make(implicitly)
+        val fiberId                 = FiberId.Gen.Random.make(implicitly)
 
         val fiberRefs = List(
           FiberRef.unsafe.make[Int](0, join = (a, b) => a + b),
@@ -53,24 +53,24 @@ object FiberRefsSpec extends ZIOBaseSpec {
         } +
           test("forkAs returns the same map if no fibers are modified during fork") {
             val fr   = makeFiberRefs(fiberRefs.take(4))
-            val isEq = fr.forkAs(FiberId.make(implicitly)) eq fr
+            val isEq = fr.forkAs(FiberId.Gen.Random.make(implicitly)) eq fr
             assertTrue(isEq)
           } +
           test("joinAs returns the same map when fiber refs are unchanged after joining") {
             val fr1  = makeFiberRefs(fiberRefs.drop(1))
             val fr2  = makeFiberRefs(fiberRefs.drop(2))
-            val isEq = fr1.joinAs(FiberId.make(implicitly))(fr2) eq fr1
+            val isEq = fr1.joinAs(FiberId.Gen.Random.make(implicitly))(fr2) eq fr1
             assertTrue(isEq)
           } +
           // Sanity checks
           test("forkAs returns a different map if forked fibers are modified") {
             val fr   = makeFiberRefs(fiberRefs)
-            val isEq = fr.forkAs(FiberId.make(implicitly)) ne fr
+            val isEq = fr.forkAs(FiberId.Gen.Random.make(implicitly)) ne fr
             assertTrue(isEq)
           } +
           test("joinAs returns a different map when fiber refs are changed after joining") {
             val fr1, fr2 = makeFiberRefs(fiberRefs)
-            val isEq     = fr1.joinAs(FiberId.make(implicitly))(fr2) ne fr1
+            val isEq     = fr1.joinAs(FiberId.Gen.Random.make(implicitly))(fr2) ne fr1
             assertTrue(isEq)
           }
       }

--- a/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefsSpec.scala
@@ -16,8 +16,8 @@ object FiberRefsSpec extends ZIOBaseSpec {
       } yield assertTrue(value)
     } +
       test("interruptedCause") {
-        val parent = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Random.make(Trace.empty))
-        val child  = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Random.make(Trace.empty))
+        val parent = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Live.make(Trace.empty))
+        val child  = Unsafe.unsafe(implicit unsafe => FiberId.Gen.Live.make(Trace.empty))
 
         val parentFiberRefs = FiberRefs.empty
         val childFiberRefs  = parentFiberRefs.updatedAs(child)(FiberRef.interruptedCause, Cause.interrupt(parent))
@@ -33,7 +33,7 @@ object FiberRefsSpec extends ZIOBaseSpec {
        */
       suite("optimizations") {
         implicit val unsafe: Unsafe = Unsafe.unsafe
-        val fiberId                 = FiberId.Gen.Random.make(implicitly)
+        val fiberId                 = FiberId.Gen.Live.make(implicitly)
 
         val fiberRefs = List(
           FiberRef.unsafe.make[Int](0, join = (a, b) => a + b),
@@ -53,24 +53,24 @@ object FiberRefsSpec extends ZIOBaseSpec {
         } +
           test("forkAs returns the same map if no fibers are modified during fork") {
             val fr   = makeFiberRefs(fiberRefs.take(4))
-            val isEq = fr.forkAs(FiberId.Gen.Random.make(implicitly)) eq fr
+            val isEq = fr.forkAs(FiberId.Gen.Live.make(implicitly)) eq fr
             assertTrue(isEq)
           } +
           test("joinAs returns the same map when fiber refs are unchanged after joining") {
             val fr1  = makeFiberRefs(fiberRefs.drop(1))
             val fr2  = makeFiberRefs(fiberRefs.drop(2))
-            val isEq = fr1.joinAs(FiberId.Gen.Random.make(implicitly))(fr2) eq fr1
+            val isEq = fr1.joinAs(FiberId.Gen.Live.make(implicitly))(fr2) eq fr1
             assertTrue(isEq)
           } +
           // Sanity checks
           test("forkAs returns a different map if forked fibers are modified") {
             val fr   = makeFiberRefs(fiberRefs)
-            val isEq = fr.forkAs(FiberId.Gen.Random.make(implicitly)) ne fr
+            val isEq = fr.forkAs(FiberId.Gen.Live.make(implicitly)) ne fr
             assertTrue(isEq)
           } +
           test("joinAs returns a different map when fiber refs are changed after joining") {
             val fr1, fr2 = makeFiberRefs(fiberRefs)
-            val isEq     = fr1.joinAs(FiberId.Gen.Random.make(implicitly))(fr2) ne fr1
+            val isEq     = fr1.joinAs(FiberId.Gen.Live.make(implicitly))(fr2) ne fr1
             assertTrue(isEq)
           }
       }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -628,8 +628,11 @@ object Fiber extends FiberPlatformSpecific {
 
   private[zio] object Runtime {
 
-    implicit val fiberOrdering: Ordering[Fiber.Runtime[?, ?]] =
-      Ordering.by[Fiber.Runtime[?, ?], Long](_.id.startTimeMillis)
+    implicit val fiberOrdering: Ordering[Fiber.Runtime[?, ?]] = { (x, y) =>
+      val byTime = x.id.startTimeMillis.compare(y.id.startTimeMillis)
+      if (byTime == 0) x.id.id.compare(y.id.id)
+      else byTime
+    }
 
     abstract class Internal[+E, +A] extends Runtime[E, A]
   }

--- a/core/shared/src/main/scala/zio/FiberId.scala
+++ b/core/shared/src/main/scala/zio/FiberId.scala
@@ -87,7 +87,7 @@ object FiberId {
 
   @deprecated("use `generate` instead", "1.0.0")
   private[zio] def make(location: Trace)(implicit unsafe: Unsafe): FiberId.Runtime =
-    Gen.Random.make(location)
+    Gen.Live.make(location)
 
   private[zio] def generate(fiberRefs: FiberRefs)(location: Trace)(implicit unsafe: Unsafe): FiberId.Runtime =
     fiberRefs.getOrDefault(FiberRef.currentFiberIdGenerator).make(location)
@@ -108,7 +108,7 @@ object FiberId {
      * This is more performant than using `FiberId.Gen.Ordered`, but cannot be
      * used in cases that rely on strict ordering of fibers (e.g., in zio-test)
      */
-    object Random extends Gen {
+    object Live extends Gen {
       def make(location: Trace)(implicit unsafe: Unsafe): FiberId.Runtime = {
         val id = ThreadLocalRandom.current().nextInt(Int.MaxValue)
         FiberId.Runtime(id, java.lang.System.currentTimeMillis(), location)

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -537,6 +537,9 @@ object FiberRef {
   private[zio] val currentFatal: FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
     FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal)(Unsafe.unsafe)
 
+  private[zio] val currentFiberIdGenerator: FiberRef[FiberId.Gen] =
+    FiberRef.unsafe.make[FiberId.Gen](FiberId.Gen.Random)(Unsafe.unsafe)
+
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
     FiberRef.unsafe.makeSet(Runtime.defaultLoggers)(Unsafe.unsafe)
 

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -538,7 +538,7 @@ object FiberRef {
     FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal)(Unsafe.unsafe)
 
   private[zio] val currentFiberIdGenerator: FiberRef[FiberId.Gen] =
-    FiberRef.unsafe.make[FiberId.Gen](FiberId.Gen.Random)(Unsafe.unsafe)
+    FiberRef.unsafe.make[FiberId.Gen](FiberId.Gen.Live)(Unsafe.unsafe)
 
   private[zio] val currentLoggers: FiberRef.WithPatch[Set[ZLogger[String, Any]], SetPatch[ZLogger[String, Any]]] =
     FiberRef.unsafe.makeSet(Runtime.defaultLoggers)(Unsafe.unsafe)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2598,8 +2598,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       parentRuntimeFlags: RuntimeFlags,
       overrideScope: FiberScope
     )(implicit unsafe: Unsafe): internal.FiberRuntime[E1, A] = {
-      val childId         = FiberId.make(trace)
       val parentFiberRefs = parentFiber.getFiberRefs()
+      val childId         = FiberId.generate(parentFiberRefs)(trace)
       val childFiberRefs  = parentFiberRefs.forkAs(childId) // TODO: Optimize
 
       val childFiber = internal.FiberRuntime[E1, A](childId, childFiberRefs, parentRuntimeFlags)

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -8,7 +8,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
 
   override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
-    ZLayer.make[TestEnvironment](testEnvironment, FiberId.Gen.set(FiberId.Gen.Monotonic))
+    testEnvironment
 
   def spec: Spec[TestEnvironment with Scope, Any]
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecDefault.scala
@@ -8,7 +8,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 abstract class ZIOSpecDefault extends ZIOSpec[TestEnvironment] {
 
   override val bootstrap: ZLayer[Any, Any, TestEnvironment] =
-    testEnvironment
+    ZLayer.make[TestEnvironment](testEnvironment, FiberId.Gen.set(FiberId.Gen.Monotonic))
 
   def spec: Spec[TestEnvironment with Scope, Any]
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -80,9 +80,12 @@ package object test extends CompileVariants {
     )
   }
 
+  private def testFiberRefGen(implicit trace: Trace): ULayer[Unit] =
+    ZLayer.scoped(FiberRef.currentFiberIdGenerator.locallyScoped(FiberId.Gen.Monotonic))
+
   val testEnvironment: ZLayer[Any, Nothing, TestEnvironment] = {
     implicit val trace = Tracer.newTrace
-    liveEnvironment >>> TestEnvironment.live
+    liveEnvironment >>> (TestEnvironment.live ++ testFiberRefGen)
   }
 
   /**


### PR DESCRIPTION
Since #8745 got merged in, the TestClock tests have become flaky. It's a bit unclear what the exact reason is, but my current assumption is that it's due to fiber ordering (since TestClock relies on the ordering of fibers).

~~Leaving this as draft for the moment to run CI a few times to see if this resolves it~~