### PR TITLE
Publish with Java 11 rather than 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
@@ -290,7 +290,7 @@ jobs:
         uses: actions/setup-java@v4.2.1
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 11
           check-latest: true
       - name: Install libuv
         run: sudo apt-get update && sudo apt-get install -y libuv1-dev


### PR DESCRIPTION
See this comment: https://github.com/zio/zio/pull/8760#discussion_r1574508729

Publishing with Java 17 triggers a runtime error when using ZIO with Java 11:
> [error] Uncaught exception when running tests: java.lang.UnsupportedClassVersionError: zio/internal/MutableQueueFieldsPadding has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0

I think we have to publish with the lowest version we support.