### PR TITLE
Remove outdated comparison with Future from the tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ZIO is a zero-dependency Scala library for asynchronous and concurrent programmi
 
 Powered by highly-scalable, non-blocking fibers that never waste or leak resources, ZIO lets you build scalable, resilient, and reactive applications that meet the needs of your business.
 
- - **High-performance**. Build scalable applications with 100x the performance of Scala's `Future`.
+ - **High-performance**. Build scalable applications with minimal runtime overhead.
  - **Type-safe**. Use the full power of the Scala compiler to catch bugs at compile time.
  - **Concurrent**. Easily build concurrent apps without deadlocks, race conditions, or complexity.
  - **Asynchronous**. Write sequential code that looks the same whether it's asynchronous or synchronous.

--- a/website/src/pages/en/index.js.org
+++ b/website/src/pages/en/index.js.org
@@ -15,7 +15,7 @@ const GridBlock = CompLibrary.GridBlock;
 
 const features = [{
         name: 'High-Performance',
-        description: 'Build scalable applications with 100x the performance of Scala’s Future'
+        description: 'Build scalable applications with minimal runtime overhead'
     },
     {
         name: '',
@@ -138,7 +138,7 @@ class Index extends React.Component {
       <Block layout="fourColumn">
         {[
           {
-            content: 'Build scalable applications with 100x the performance of Scala’s Future',
+            content: 'Build scalable applications with minimal runtime overhead',
             title: 'High-performance',
           },
           {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -12,7 +12,7 @@ const baseUrl = '/';
 const features = [
   {
     title: 'High-performance',
-    content: 'Build scalable applications with 100x the performance of Scala’s Future',
+    content: 'Build scalable applications with minimal runtime overhead',
   },
   {
     title: 'Type-safe',

--- a/website/src/pages/version2-only-index.js.txt
+++ b/website/src/pages/version2-only-index.js.txt
@@ -12,7 +12,7 @@ const baseUrl = '/';
 const features = [
   {
     title: 'High-performance',
-    content: 'Build scalable applications with 100x the performance of Scala’s Future',
+    content: 'Build scalable applications with minimal runtime overhead',
   },
   {
     title: 'Type-safe',


### PR DESCRIPTION
I think that comparison might have been true at the time it was written before Scala 2.13 was released, but is not true anymore. If anyone has a better suggestion for the wording, let me know.