### PR TITLE
Add `ChunkBuilder#isEmpty` method

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
@@ -28,7 +28,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.boolean)) { as =>
           val builder = new ChunkBuilder.Boolean
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -54,7 +54,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.byte)) { as =>
           val builder = new ChunkBuilder.Byte
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -80,7 +80,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.char)) { as =>
           val builder = new ChunkBuilder.Char
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -106,7 +106,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.double)) { as =>
           val builder = new ChunkBuilder.Double
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -132,7 +132,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.float)) { as =>
           val builder = new ChunkBuilder.Float
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -158,7 +158,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.int)) { as =>
           val builder = new ChunkBuilder.Int
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -184,7 +184,7 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.long)) { as =>
           val builder = new ChunkBuilder.Long
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
@@ -210,11 +210,11 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.short)) { as =>
           val builder = new ChunkBuilder.Short
-          testIsEmpty(builder, as)
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     ),
-    suite("AnyRef")(
+    suite("Obj")(
       test("addOne")(
         check(Gen.chunkOf(Gen.string)) { as =>
           val builder = ChunkBuilder.make[String]()
@@ -231,23 +231,23 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       },
       test("isEmpty") {
         check(Gen.chunkOf1(Gen.string)) { as =>
-          val builder = ChunkBuilder.make[String]()
-          testIsEmpty(builder, as)
+          val builder = new ChunkBuilder.Obj[String]
+          testIsEmpty(builder, builder.isEmpty, as)
         }
       }
     )
   )
 
-  private def testIsEmpty[A](builder: ChunkBuilder[A], as: NonEmptyChunk[A]): TestResult = {
-    val a0 = builder.isEmpty
+  private def testIsEmpty[A](builder: ChunkBuilder[A], check: => Boolean, as: NonEmptyChunk[A]): TestResult = {
+    val a0 = check
     builder.sizeHint(16)
-    val a1 = builder.isEmpty
+    val a1 = check
     builder += as(0)
-    val a2 = builder.isEmpty
+    val a2 = check
     builder ++= as
-    val a3 = builder.isEmpty
+    val a3 = check
     builder.clear()
-    val a4 = builder.isEmpty
+    val a4 = check
     assertTrue(a0, a1, !a2, !a3, a4)
   }
 }

--- a/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
@@ -24,6 +24,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Boolean
         assert(builder.toString)(equalTo("ChunkBuilder.Boolean"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.boolean)) { as =>
+          val builder = new ChunkBuilder.Boolean
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Byte")(
@@ -44,6 +50,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Byte
         assert(builder.toString)(equalTo("ChunkBuilder.Byte"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.byte)) { as =>
+          val builder = new ChunkBuilder.Byte
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Char")(
@@ -64,6 +76,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Char
         assert(builder.toString)(equalTo("ChunkBuilder.Char"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.char)) { as =>
+          val builder = new ChunkBuilder.Char
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Double")(
@@ -84,6 +102,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Double
         assert(builder.toString)(equalTo("ChunkBuilder.Double"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.double)) { as =>
+          val builder = new ChunkBuilder.Double
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Float")(
@@ -104,6 +128,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Float
         assert(builder.toString)(equalTo("ChunkBuilder.Float"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.float)) { as =>
+          val builder = new ChunkBuilder.Float
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Int")(
@@ -124,6 +154,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Int
         assert(builder.toString)(equalTo("ChunkBuilder.Int"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.int)) { as =>
+          val builder = new ChunkBuilder.Int
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Long")(
@@ -144,6 +180,12 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Long
         assert(builder.toString)(equalTo("ChunkBuilder.Long"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.long)) { as =>
+          val builder = new ChunkBuilder.Long
+          testIsEmpty(builder, as)
+        }
       }
     ),
     suite("Short")(
@@ -164,7 +206,48 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
       test("toString") {
         val builder = new ChunkBuilder.Short
         assert(builder.toString)(equalTo("ChunkBuilder.Short"))
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.short)) { as =>
+          val builder = new ChunkBuilder.Short
+          testIsEmpty(builder, as)
+        }
+      }
+    ),
+    suite("AnyRef")(
+      test("addOne")(
+        check(Gen.chunkOf(Gen.string)) { as =>
+          val builder = ChunkBuilder.make[String]()
+          as.foreach(builder += _)
+          assert(builder.result())(equalTo(as))
+        }
+      ),
+      test("addAll") {
+        check(Gen.chunkOf(Gen.string)) { as =>
+          val builder = ChunkBuilder.make[String]()
+          builder ++= as
+          assert(builder.result())(equalTo(as))
+        }
+      },
+      test("isEmpty") {
+        check(Gen.chunkOf1(Gen.string)) { as =>
+          val builder = ChunkBuilder.make[String]()
+          testIsEmpty(builder, as)
+        }
       }
     )
   )
+
+  private def testIsEmpty[A](builder: ChunkBuilder[A], as: NonEmptyChunk[A]): TestResult = {
+    val a0 = builder.isEmpty
+    builder.sizeHint(16)
+    val a1 = builder.isEmpty
+    builder += as(0)
+    val a2 = builder.isEmpty
+    builder ++= as
+    val a3 = builder.isEmpty
+    builder.clear()
+    val a4 = builder.isEmpty
+    assertTrue(a0, a1, !a2, !a3, a4)
+  }
 }

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -37,7 +37,13 @@ import scala.{
  * build chunks of unboxed primitives and for compatibility with the Scala
  * collection library.
  */
-sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]]
+sealed abstract class ChunkBuilder[A] extends Builder[A, Chunk[A]] {
+
+  /**
+   * Determines if the builder is empty.
+   */
+  def isEmpty: Boolean
+}
 
 object ChunkBuilder {
 
@@ -74,6 +80,8 @@ object ChunkBuilder {
         if (arrayBuilder ne null) {
           arrayBuilder.clear()
         }
+      def isEmpty: SBoolean =
+        (arrayBuilder eq null) || arrayBuilder.length == 0
       def result(): Chunk[A] =
         if (arrayBuilder eq null) {
           Chunk.empty
@@ -148,6 +156,8 @@ object ChunkBuilder {
             self.lastByte == that.lastByte
         case _ => false
       }
+    def isEmpty: SBoolean =
+      maxBitIndex == 0
     def result(): Chunk[SBoolean] = {
       val bytes: Chunk[SByte] = Chunk.fromArray(arrayBuilder.result() :+ lastByte)
       BitChunkByte(bytes, 0, 8 * (bytes.length - 1) + maxBitIndex)
@@ -182,6 +192,8 @@ object ChunkBuilder {
         case that: Byte => self.arrayBuilder == that.arrayBuilder
         case _          => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SByte] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -212,6 +224,8 @@ object ChunkBuilder {
         case that: Char => self.arrayBuilder == that.arrayBuilder
         case _          => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SChar] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -243,6 +257,8 @@ object ChunkBuilder {
         case that: Double => self.arrayBuilder == that.arrayBuilder
         case _            => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SDouble] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -273,6 +289,8 @@ object ChunkBuilder {
         case that: Float => self.arrayBuilder == that.arrayBuilder
         case _           => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SFloat] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -303,6 +321,8 @@ object ChunkBuilder {
         case that: Int => self.arrayBuilder == that.arrayBuilder
         case _         => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SInt] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -333,6 +353,8 @@ object ChunkBuilder {
         case that: Long => self.arrayBuilder == that.arrayBuilder
         case _          => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SLong] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =
@@ -363,6 +385,8 @@ object ChunkBuilder {
         case that: Short => self.arrayBuilder == that.arrayBuilder
         case _           => false
       }
+    def isEmpty: SBoolean =
+      arrayBuilder.length == 0
     def result(): Chunk[SShort] =
       Chunk.fromArray(arrayBuilder.result())
     override def sizeHint(n: SInt): Unit =

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -15,6 +15,7 @@ object MimaSettings {
         exclude[Problem]("zio.internal.*"),
         exclude[FinalMethodProblem]("zio.ZIO#EvaluationStep#*"),
         exclude[IncompatibleResultTypeProblem]("zio.Chunk.iterate"),
+        exclude[ReversedMissingMethodProblem]("zio.ChunkBuilder.isEmpty"),
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -15,7 +15,6 @@ object MimaSettings {
         exclude[Problem]("zio.internal.*"),
         exclude[FinalMethodProblem]("zio.ZIO#EvaluationStep#*"),
         exclude[IncompatibleResultTypeProblem]("zio.Chunk.iterate"),
-        exclude[ReversedMissingMethodProblem]("zio.ChunkBuilder.isEmpty"),
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),


### PR DESCRIPTION
Being able to know whether the `ChunkBuilder` currently contains any elements can be quite useful in some cases, e.g.,

```scala
def collectFooAndBar(): ChunkBuilder[String] = {
  val builder1 = new ChunkBuilder.Obj[String]
  val builder2 = new ChunkBuilder.Obj[String]

  foo(builder1)
  bar(builder2)
  
  if (builder1.isEmpty) builder2
  else if (builder2.isEmpty) builder1
  else builder1 ++= builder2.result() 
}
```

Note that MiMa didn't like me adding an abstract method on `ChunkBuilder` (even though it's a `sealed abstract class`, and just to play it safe I added another final class extension to ChunkBuilder, and only the final classes have the `isEmpty` method. Let me know if you think it's okay to add the abstract method and I'll do that