### PR TITLE
Fix typo in docs: FiberRef reference page

### DIFF
--- a/docs/reference/state-management/fiberref.md
+++ b/docs/reference/state-management/fiberref.md
@@ -491,7 +491,7 @@ object RefExample extends ZIOAppDefault {
       left = ref.updateAndGet(_ + 1).debug("left1") *>
         ref.updateAndGet(_ + 1).debug("left2")
       right = ref.updateAndGet(_ + 1).debug("right1") *>
-        ref.updateAndGet(_ + 1).debug("right2")
+        ref.updateAndGet(_ + 3).debug("right2")
       _ <- left <&> right
     } yield ()
 }


### PR DESCRIPTION
I noticed what is most likely a typo: the code snippet and the example output below it do not match. Fixed the inconsistency by changing the code to match the example.

The example output in question (below the changed code snippet): 

> One potential result of running this program is as follows:
> 
> ```scala
> left1: 1
> right1: 2
> left2: 3
> right2: 6
> ```

The code snippet in question before I made any changes:

> ```scala mdoc:compile-only
> import zio._
> 
> object RefExample extends ZIOAppDefault {
> 
>   def run =
>     for {
>       ref <- Ref.make(0)
>       left = ref.updateAndGet(_ + 1).debug("left1") *>
>         ref.updateAndGet(_ + 1).debug("left2")
>       right = ref.updateAndGet(_ + 1).debug("right1") *>
>         ref.updateAndGet(_ + 1).debug("right2")
>       _ <- left <&> right
>     } yield ()
> }
> ```

While fixing this inconsistency could also be done by changing the example output instead of the code snippet, the next code example below this one also uses  `ref.updateAndGet(_ + 3).debug("right2")`, implying that incrementing by 3 was the orignal intention of the writer of the example.