### PR TITLE
Improve GHA execution time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,9 +109,6 @@ jobs:
     steps:
       - name: Checkout Current Branch
         uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: '0'
-          
       - name: Setup Scala and Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -284,8 +281,6 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -309,9 +304,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.1
-        with:
-          fetch-depth: 0
-
       - uses: actions/download-artifact@v3
         with:
           name: website-artifact
@@ -331,7 +323,6 @@ jobs:
         uses: actions/checkout@v4.1.1
         with:
           ref: ${{ github.head_ref }}
-          fetch-depth: '0'
       - name: Commit Changes
         run: |
           cd website


### PR DESCRIPTION
`fetch-depth: 0` causes the entire history to be fetched, which is taking 1 min+ in some cases: https://github.com/zio/zio/actions/runs/8910178849/job/24486926464.

By default, the `checkout` GHA uses `fetch-depth: 1` which only fetches the tip of the git history