### PR TITLE
Allow application to exit on normal completion

### DIFF
--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -47,6 +47,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
                       "Resources may be leaked. " +
                       "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
                   )
+                  p.unsafe.done(Exit.succeed(Set(fiberId)))
                 } else {
                   try {
                     val completePromise = ZIO.fiberIdWith(fid2 => p.succeed(Set(fiberId, fid2)))

--- a/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -47,7 +47,6 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
                       "Resources may be leaked. " +
                       "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
                   )
-                  p.unsafe.done(Exit.succeed(Set(fiberId)))
                 } else {
                   try {
                     val completePromise = ZIO.fiberIdWith(fid2 => p.succeed(Set(fiberId, fid2)))


### PR DESCRIPTION
The fix in #8796 introduced a bug where the application will only exit when interrupted. e.g., the program below will finish execution but won't exit until it's interrupted externally:

```scala
object Foo extends ZIOAppDefault {
  def run = ZIO.unit
}
```