### PR TITLE
Improve throughput of `ZIO#fork` by 300%

### DIFF
--- a/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ForkJoinBenchmark.scala
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Warmup(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 4, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
 @Threads(16)
 @Fork(1)
 class ForkJoinBenchmark {

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1191,7 +1191,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       while (iterator.hasNext) {
         val next = iterator.next()
 
-        if (next ne null) {
+        if ((next ne null) && next.isAlive()) {
           next.tellInterrupt(cause)
 
           told = true
@@ -1402,6 +1402,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       def removeObserver(observer: Exit[E, A] => Unit)(implicit unsafe: Unsafe): Unit =
         self.removeObserver(observer)
     }
+
+  override def hashCode(): Int = fiberId.hashCode()
 }
 
 object FiberRuntime {


### PR DESCRIPTION
Seems that the previous `fork` optimizations focused mostly on `forkDaemon` and `fork` was not given too much attention. These 2 tiny changes have a massive impact on the performance of fibers forked via `ZIO#fork`, which is now faster than `forkDaemon` when `FiberRoots` is enabled, and just slightly slower with them disabled.

The first change is to check whether a fiber is still alive prior to interrupting it. This saves us a lot of time of enqueuing interrupt signals into fibers that have already ended execution.

The second change is to make the hashCode of `Fiber.Runtime` be that of its fiber ID, to help speed up insertion of instances of `Fiber.Runtime` into hashsets. The reason why this works is because we expect the ID to be unique for each `Fiber.Runtime`

Before:
```
[info] Benchmark                        (n)   Mode  Cnt     Score     Error  Units
[info] ForkJoinBenchmark.zioForkJoin  10000  thrpt    4  1041.352 ± 304.742  ops/s
```

After:
```
[info] Benchmark                        (n)   Mode  Cnt     Score     Error  Units
[info] ForkJoinBenchmark.zioForkJoin  10000  thrpt    4  3186.028 ± 323.563  ops/s
```