### PR TITLE
Improve performance of `foreachPar` et.al.

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -624,6 +624,16 @@ object Fiber extends FiberPlatformSpecific {
      * Adds a message to interrupt this fiber.
      */
     private[zio] def tellInterrupt(cause: Cause[Nothing]): Unit
+
+    /**
+     * Transfers all children of this fiber that are currently running to the
+     * specified fiber scope
+     *
+     * '''NOTE''': This method must be invoked by the fiber itself after it has
+     * evaluated the effects but prior to exiting
+     */
+    private[zio] def transferChildren(scope: FiberScope): Unit
+
   }
 
   private[zio] object Runtime {

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -546,8 +546,12 @@ object FiberRef {
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
     FiberRef.unsafe.make(Runtime.defaultReportFatal)(Unsafe.unsafe)
 
-  private[zio] val currentRuntimeFlags: FiberRef.WithPatch[RuntimeFlags, RuntimeFlags.Patch] =
+  private[zio] val currentInheritableRuntimeFlags: FiberRef.WithPatch[RuntimeFlags, RuntimeFlags.Patch] =
     FiberRef.unsafe.makeRuntimeFlags(RuntimeFlags.none)(Unsafe.unsafe)
+
+  @deprecated("Kept for binary compatibility purposes, use currentInheritableRuntimeFlags instead", "2.1.0")
+  private[zio] val currentRuntimeFlags: FiberRef.WithPatch[RuntimeFlags, RuntimeFlags.Patch] =
+    currentInheritableRuntimeFlags
 
   private[zio] val currentSupervisor: FiberRef.WithPatch[Supervisor[Any], Supervisor.Patch] =
     FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor)(Unsafe.unsafe)

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -552,12 +552,8 @@ object FiberRef {
   private[zio] val currentReportFatal: FiberRef[Throwable => Nothing] =
     FiberRef.unsafe.make(Runtime.defaultReportFatal)(Unsafe.unsafe)
 
-  private[zio] val currentInheritableRuntimeFlags: FiberRef.WithPatch[RuntimeFlags, RuntimeFlags.Patch] =
-    FiberRef.unsafe.makeRuntimeFlags(RuntimeFlags.none)(Unsafe.unsafe)
-
-  @deprecated("Kept for binary compatibility purposes, use currentInheritableRuntimeFlags instead", "2.1.0")
   private[zio] val currentRuntimeFlags: FiberRef.WithPatch[RuntimeFlags, RuntimeFlags.Patch] =
-    currentInheritableRuntimeFlags
+    FiberRef.unsafe.makeRuntimeFlags(RuntimeFlags.none)(Unsafe.unsafe)
 
   private[zio] val currentSupervisor: FiberRef.WithPatch[Supervisor[Any], Supervisor.Patch] =
     FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor)(Unsafe.unsafe)

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -19,8 +19,6 @@ package zio
 import zio.internal.{FiberScope, IsFatal}
 import zio.metrics.MetricLabel
 
-import scala.util.hashing.MurmurHash3
-
 /**
  * A `FiberRef` is ZIO's equivalent of Java's `ThreadLocal`. The value of a
  * `FiberRef` is automatically propagated to child fibers when they are forked

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -19,6 +19,8 @@ package zio
 import zio.internal.{FiberScope, IsFatal}
 import zio.metrics.MetricLabel
 
+import scala.util.hashing.MurmurHash3
+
 /**
  * A `FiberRef` is ZIO's equivalent of Java's `ThreadLocal`. The value of a
  * `FiberRef` is automatically propagated to child fibers when they are forked
@@ -489,6 +491,10 @@ object FiberRef {
 
             ZIO.unit
           }
+
+        // Store the hash code in a val to avoid recomputing it on every access of the FiberRefs map
+        // Ideally we'd do that in `FiberRef` itself, but that's not binary compatible
+        final override val hashCode: Int = super.hashCode()
       }
 
     def makeRuntimeFlags(

--- a/core/shared/src/main/scala/zio/FiberRefs.scala
+++ b/core/shared/src/main/scala/zio/FiberRefs.scala
@@ -92,11 +92,11 @@ final class FiberRefs private (
    * Gets the value of the specified `FiberRef` in this collection of `FiberRef`
    * values if it exists or the `initial` value of the `FiberRef` otherwise.
    */
-  def getOrDefault[A](fiberRef: FiberRef[A]): A =
-    getOrNull(fiberRef) match {
-      case null => fiberRef.initial
-      case v    => v
-    }
+  def getOrDefault[@specialized(SpecializeInt) A](fiberRef: FiberRef[A]): A = {
+    val out = fiberRefLocals.getOrElse(fiberRef, null)
+    if (out eq null) fiberRef.initial
+    else out.stack.head.asInstanceOf[StackEntry[A]].value // asInstanceOf needed to avoid boxing
+  }
 
   private[zio] def getOrNull[A](fiberRef: FiberRef[A]): A = {
     val out = fiberRefLocals.getOrElse(fiberRef, null)
@@ -114,16 +114,15 @@ final class FiberRefs private (
 
     val fiberRefLocals0 = childFiberRefs.foldLeft(parentFiberRefs) {
       case (parentFiberRefs, (fiberRef, Value(childStack, childDepth))) =>
-        val ref        = fiberRef.asInstanceOf[FiberRef[Any]]
-        val childValue = childStack.head.value
-
-        if (childStack.head.id == fiberId) {
+        val ref       = fiberRef.asInstanceOf[FiberRef[Any]]
+        val childHead = childStack.head
+        if (childHead.id eq fiberId) {
           parentFiberRefs
         } else {
-
           parentFiberRefs
             .get(ref)
             .fold {
+              val childValue = childHead.value
               if (childValue == ref.initial) parentFiberRefs
               else
                 parentFiberRefs.updated(
@@ -155,23 +154,29 @@ final class FiberRefs private (
                     (ref.initial)
                 }
 
-              val ancestor = findAncestor(parentStack, parentDepth, childStack, childDepth)
+              if (parentStack.head eq childHead) {
+                parentFiberRefs
+              } else {
+                val childValue = childHead.value
 
-              val patch = ref.diff(ancestor, childValue)
+                val ancestor = findAncestor(parentStack, parentDepth, childStack, childDepth)
 
-              val oldValue = parentStack.head.value
-              val newValue = ref.join(oldValue, ref.patch(patch)(oldValue))
+                val patch = ref.diff(ancestor, childValue)
 
-              if (oldValue == newValue) parentFiberRefs
-              else {
-                val newEntry = parentStack match {
-                  case StackEntry(parentFiberId, _, parentVersion) :: tail =>
-                    if (parentFiberId == fiberId)
-                      Value(::(StackEntry(parentFiberId, newValue, parentVersion + 1), tail), parentDepth)
-                    else
-                      Value(::(StackEntry(fiberId, newValue, 0), parentStack), parentDepth + 1)
+                val oldValue = parentStack.head.value
+                val newValue = ref.join(oldValue, ref.patch(patch)(oldValue))
+
+                if (oldValue == newValue) parentFiberRefs
+                else {
+                  val newEntry = parentStack match {
+                    case StackEntry(parentFiberId, _, parentVersion) :: tail =>
+                      if (parentFiberId == fiberId)
+                        Value(::(StackEntry(parentFiberId, newValue, parentVersion + 1), tail), parentDepth)
+                      else
+                        Value(::(StackEntry(fiberId, newValue, 0), parentStack), parentDepth + 1)
+                  }
+                  parentFiberRefs.updated(ref, newEntry)
                 }
-                parentFiberRefs.updated(ref, newEntry)
               }
             }
         }
@@ -198,17 +203,14 @@ final class FiberRefs private (
       else {
         val oldStack = oldEntry.stack.asInstanceOf[::[StackEntry[A]]]
         val oldDepth = oldEntry.depth
-        if (oldStack.head.id == fiberId) {
-          val oldValue = oldStack.head.value
-          if (oldValue == value) oldEntry
-          else
-            Value(
-              ::(StackEntry(fiberId, value, oldStack.head.version + 1), oldStack.tail),
-              oldEntry.depth
-            )
-        } else if (oldStack.head.value == value)
+        if (oldStack.head.value == value)
           oldEntry
-        else
+        else if (oldStack.head.id == fiberId) {
+          Value(
+            ::(StackEntry(fiberId, value, oldStack.head.version + 1), oldStack.tail),
+            oldEntry.depth
+          )
+        } else
           Value(::(StackEntry(fiberId, value, 0), oldStack), oldDepth + 1)
       }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2523,20 +2523,24 @@ sealed trait ZIO[-R, +E, +A]
     that: => ZIO[R1, E1, B]
   )(f: (A, B) => C)(implicit trace: Trace): ZIO[R1, E1, C] =
     ZIO.uninterruptibleMask { restore =>
-      ZIO.transplant { graft =>
-        val promise = Promise.unsafe.make[Unit, Boolean](FiberId.None)(Unsafe.unsafe)
-        val ref     = new java.util.concurrent.atomic.AtomicBoolean(false)
+      ZIO.withFiberRuntime[R1, E1, C] { (fiber, _) =>
+        val promise     = Promise.unsafe.make[Unit, Boolean](FiberId.None)(Unsafe.unsafe)
+        val ref         = new java.util.concurrent.atomic.AtomicBoolean(false)
+        val parentScope = fiber.scope
 
         def fork[R, E, A](zio: => ZIO[R, E, A], side: Boolean): ZIO[R, Nothing, Fiber[E, A]] =
-          graft(restore(zio))
+          restore(zio)
             .foldCauseZIO(
               cause => promise.fail(()) *> ZIO.refailCause(cause),
               a =>
-                if (ref.getAndSet(true)) {
-                  promise.unsafe.done(ZIO.succeedNow(side))(Unsafe.unsafe)
-                  ZIO.succeed(a)
-                } else {
-                  ZIO.succeed(a)
+                ZIO.withFiberRuntime[Any, Nothing, A] { (childFiber, _) =>
+                  childFiber.transferChildren(parentScope)
+                  if (ref.getAndSet(true)) {
+                    promise.unsafe.done(ZIO.succeedNow(side))(Unsafe.unsafe)
+                    ZIO.succeed(a)
+                  } else {
+                    ZIO.succeed(a)
+                  }
                 }
             )
             .forkDaemon
@@ -2584,7 +2588,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       parentRuntimeFlags: RuntimeFlags,
       overrideScope: FiberScope = null
     )(implicit unsafe: Unsafe): internal.FiberRuntime[E1, A] = {
-      val childFiber = ZIO.unsafe.makeChildFiber(trace, effect, parentFiber, parentRuntimeFlags, overrideScope)
+      val childFiber = makeChildFiber(trace, effect, parentFiber, parentRuntimeFlags, overrideScope)(unsafe)
 
       childFiber.startConcurrently(effect)
 
@@ -2605,11 +2609,10 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       val childFiber = internal.FiberRuntime[E1, A](childId, childFiberRefs, parentRuntimeFlags)
 
       // Call the supervisor who can observe the fork of the child fiber
-      val childEnvironment = childFiberRefs.getOrDefault(FiberRef.currentEnvironment)
-
       val supervisor = childFiber.getSupervisor()
 
       if (supervisor ne Supervisor.none) {
+        val childEnvironment = childFiberRefs.getOrDefault(FiberRef.currentEnvironment)
         supervisor.onStart(
           childEnvironment,
           effect.asInstanceOf[ZIO[Any, Any, Any]],
@@ -2628,6 +2631,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
       childFiber
     }
+
   }
 
   /**
@@ -6031,33 +6035,38 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         ZIO.uninterruptibleMask { restore =>
           val promise = Promise.unsafe.make[Unit, Unit](FiberId.None)(Unsafe.unsafe)
           val ref     = new java.util.concurrent.atomic.AtomicInteger(0)
-          ZIO.transplant { graft =>
-            ZIO.foreach(as) { a =>
-              graft {
-                restore(ZIO.suspendSucceed(f(a))).foldCauseZIO(
-                  cause => promise.fail(()) *> ZIO.refailCause(cause),
-                  _ =>
-                    if (ref.incrementAndGet == size) {
-                      promise.unsafe.done(ZIO.unit)(Unsafe.unsafe)
-                      ZIO.unit
-                    } else {
-                      ZIO.unit
+          ZIO
+            .withFiberRuntime[R, Nothing, Iterable[Fiber.Runtime[E, Unit]]] { (fiber, _) =>
+              ZIO.foreach(as) { a =>
+                restore(f(a))
+                  .foldCauseZIO(
+                    cause => promise.fail(()) *> ZIO.refailCause(cause),
+                    _ => {
+                      ZIO.withFiberRuntime[Any, Nothing, Unit] { (childFiber, _) =>
+                        ZIO.succeed {
+                          childFiber.transferChildren(fiber.scope)
+                          if (ref.incrementAndGet == size) {
+                            promise.unsafe.done(ZIO.unit)(Unsafe.unsafe)
+                          }
+                        }
+                      }
                     }
-                )
-              }.forkDaemon
+                  )
+                  .forkDaemon
+              }
             }
-          }.flatMap { fibers =>
-            restore(promise.await).foldCauseZIO(
-              cause =>
-                ZIO
-                  .foreachParUnbounded(fibers)(_.interrupt)
-                  .flatMap(Exit.collectAllPar(_) match {
-                    case Some(Exit.Failure(causes)) => ZIO.refailCause(cause.stripFailures && causes)
-                    case _                          => ZIO.refailCause(cause.stripFailures)
-                  }),
-              _ => ZIO.foreachDiscard(fibers)(_.inheritAll)
-            )
-          }
+            .flatMap { fibers =>
+              restore(promise.await).foldCauseZIO(
+                cause =>
+                  ZIO
+                    .foreachParUnbounded(fibers)(_.interrupt)
+                    .flatMap(Exit.collectAllPar(_) match {
+                      case Some(Exit.Failure(causes)) => ZIO.refailCause(cause.stripFailures && causes)
+                      case _                          => ZIO.refailCause(cause.stripFailures)
+                    }),
+                _ => ZIO.foreachDiscard(fibers)(_.inheritAll)
+              )
+            }
         }
       }
     }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2594,7 +2594,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       parentRuntimeFlags: RuntimeFlags,
       overrideScope: FiberScope = null
     )(implicit unsafe: Unsafe): internal.FiberRuntime[E1, A] = {
-      val childFiber = makeChildFiber(trace, effect, parentFiber, parentRuntimeFlags, overrideScope)(unsafe)
+      val childFiber = ZIO.unsafe.makeChildFiber(trace, effect, parentFiber, parentRuntimeFlags, overrideScope)
 
       childFiber.startConcurrently(effect)
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -519,9 +519,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     _fiberRefs.get(fiberRef)
 
   private[zio] def getFiberRefs(): FiberRefs = {
-    // We only include flags that can be inherited by the parent fiber
+    // NOTE: Only include flags that can be inherited by the parent fiber in the FiberRefs
+    // Including them won't cause a bug, but it degrades performance as
+    // it makes the joining of the FiberRefs more complex in `inheritAll`
     val flags0 = FiberRuntime.excludeNonInheritable(_runtimeFlags)
     setFiberRef(FiberRef.currentRuntimeFlags, flags0)
+
     _fiberRefs
   }
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1377,6 +1377,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private[zio] def tellInterrupt(cause: Cause[Nothing]): Unit =
     tell(FiberMessage.InterruptSignal(cause))
 
+  /**
+   * Transfers all children of this fiber that are currently running to the
+   * specified fiber scope
+   *
+   * '''NOTE''': This method must be invoked by the fiber itself after it has
+   * evaluated the effects but prior to exiting
+   */
   private[zio] def transferChildren(scope: FiberScope): Unit = {
     val children = _children
     if ((children ne null) && !children.isEmpty) {


### PR DESCRIPTION
/fixes #8813 (or at least, they're now equally performant)

### Issue No.1: Setting / unsetting of `FiberRef.forkScopeOverride` on each forked effect:

The main issue with the performance of `foreachPar` (and other variants) was that `ZIO.transplant` works by updating `FiberRef.forkScopeOverride` in each forked effect. This causes the `FiberRefs` map to be updated twice: Once when the fiber is created, and another on join. This adds a significant overhead since updating values in immutable Maps is fairly expensive.

What `ZIO.transplant` was trying to achieve, is to accommodate for cases this happens:

```scala
ZIO.foreachPar(1 to 100)(i => ZIO.succeed(doSomething(i)).fork)
```

In this case, the _parent_ fiber will create 100 _child_ fibers, and each one will create a _grandchild_ fiber. When the _child_ fiber forks the _grandchild_, it'll have no more effects to evaluate and exit, interrupting the _grandchild_ that is still alive. In case the grandchild is uninterruptible, then it'll wait for it, but if it's interruptible then it'll kill it. Thus, `ZIO.transplant` was used so that if any children created any grandchildren, they would be added to the parent's scope instead of the child's scope, and therefore they wouldn't be interrupted.

This PR changes the way the grandchildren are transplanted into the parent's scope. Instead of modifying `FiberRef.forkScopeOverride`, we add a "finalizer" to the forked effect that transfers all the grandchildren that are still alive to the parent's scope when the child exits. While this might seem like adding overhead, the only case where children might still be alive is only when we're forking in the local scope and we're not awaiting on their completion which is a very rare usage pattern - and arguably wrong since `forkDaemon` should be used in this case. So in most - if not all - cases, there wouldn't be any _alive_ children to transfer.

### Issue No.2: Unnecessary update of `FiberRef.currentRuntimeFlags`:

In the meanwhile, there was another issue affecting performance that went unnoticed in previous optimization rounds (the `ForkJoinBenchmark` used `.await` instead of `.join` so I didn't notice this earlier). The main difference between the 2 is that `.join` inherits all the `FiberRefs` the child fibers. When a fiber finishes evaluation, it enables the `WindDown` flag, which then caused the call to `getFiberRefs` in `inheritAll` to create a new `FiberRefs` map. However, it seems that was unnecessary, because we're not inheriting `Interruption` or `WindDown` from child fibers. Therefore I changed the logic that updates the `currentRuntimeFlags` FiberRef (which is only read in `inheritAll`, to exclude `Interruption` and `WindDown`.
