### PR TITLE
Use `add` instead of `union` when extending a Scope

### DIFF
--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -178,7 +178,7 @@ object Scope {
 
   final class ExtendPartiallyApplied[R](private val scope: Scope) extends AnyVal {
     def apply[E, A](zio: => ZIO[Scope with R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-      zio.provideSomeEnvironment[R](_.union[Scope](ZEnvironment(scope)))
+      zio.provideSomeEnvironment[R](_.add(scope))
   }
 
   final class UsePartiallyApplied[R](private val scope: Scope.Closeable) extends AnyVal {

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -178,7 +178,7 @@ object Scope {
 
   final class ExtendPartiallyApplied[R](private val scope: Scope) extends AnyVal {
     def apply[E, A](zio: => ZIO[Scope with R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-      zio.provideSomeEnvironment[R](_.add(scope))
+      zio.provideSomeEnvironment[R](_.add[Scope](scope))
   }
 
   final class UsePartiallyApplied[R](private val scope: Scope.Closeable) extends AnyVal {


### PR DESCRIPTION
Seems like an oversight; with this change we can avoid creation of a new ZEnvironment and the followup union / pruning