### PR TITLE
Attempt to fix ZLayer#mapZIO flaky compilation

### DIFF
--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -649,9 +649,14 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
          */
         def mapZIO[R1 <: R, E1 >: E, B: Tag](
           k: A => ZIO[R1, E1, B]
-        )(implicit tag: Tag[A], trace: Trace): Default.WithContext[R1, E1, B] =
+        )(implicit tag: Tag[A], trace: Trace): Default.WithContext[R1, E1, B] = {
           // used explicit type parameters to prevent a random compile error
-          fromLayer[R1, E1, B](self.layer.flatMap[R1, E1, B](a => ZLayer[R1, E1, B](k(a.get[A])))) //
+          val newLayer: ZLayer[R1, E1, B] = self.layer.flatMap[R1, E1, B] { a =>
+            val f = k(a.get[A])
+            ZLayer[R1, E1, B](f)
+          }
+          fromLayer[R1, E1, B](newLayer)
+        }
       }
 
       implicit def deriveDefaultConfig[A: Tag](implicit


### PR DESCRIPTION
This method has been spuriously failing to compile for no good reason whatsoever. I believe it might be related to how it `ZLayer.fromZIO` takes a by-name parameter which might be causing some issues with some macro. Hopefully this resolves it as it's a fairly when it happens