### PR TITLE
Add a TestAspect to run tests in the blocking threadpool

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -268,8 +268,8 @@ object TestAspect extends TimeoutVariants {
     aroundAll(effect, ZIO.unit)
 
   /**
-   * An aspect that runs each test on the blocking threadpool.
-   * Useful for tests that contain blocking code
+   * An aspect that runs each test on the blocking threadpool. Useful for tests
+   * that contain blocking code
    */
   val blocking: TestAspectPoly =
     new PerTest.Poly {

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -268,6 +268,18 @@ object TestAspect extends TimeoutVariants {
     aroundAll(effect, ZIO.unit)
 
   /**
+   * An aspect that runs each test on the blocking threadpool.
+   * Useful for tests that contain blocking code
+   */
+  val blocking: TestAspectPoly =
+    new PerTest.Poly {
+      def perTest[R, E](test: ZIO[R, TestFailure[E], TestSuccess])(implicit
+        trace: Trace
+      ): ZIO[R, TestFailure[E], TestSuccess] =
+        ZIO.blocking(test)
+    }
+
+  /**
    * An aspect that runs each test on a separate fiber and prints a fiber dump
    * if the test fails or has not terminated within the specified duration.
    */


### PR DESCRIPTION
While it's bad practise to have thread-blocking code even in test suites, in some cases it might make things simpler (e.g., using `Thread.sleep` or synchronously running non-ZIO effects).

I think it makes sense to have a TestAspect that can be used to annotate the test/suite to execute tests in the blocking threadpool