### PR TITLE
Fix metrics causing the application to hang on termination

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/MetricsSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/MetricsSpec.scala
@@ -1,0 +1,22 @@
+package zio
+
+import zio.metrics.jvm.DefaultJvmMetrics
+import zio.test._
+
+object MetricsSpec extends ZIOBaseSpec {
+
+  def spec: Spec[Any, Any] = suite("MetricsSpec")(
+    suite("Attach default JVM metrics to a layer and check that")(
+      test("The layer can be interrupted") {
+        val run =
+          for {
+            latch <- Promise.make[Nothing, Unit]
+            frk    = (latch.succeed(()) *> ZIO.never).provideLayer(DefaultJvmMetrics.live.unit)
+            _     <- frk.forkDaemon.flatMap(f => latch.await *> f.interrupt *> f.await)
+          } yield ()
+
+        run *> assertCompletes
+      }
+    )
+  )
+}


### PR DESCRIPTION
Because of https://github.com/zio/zio/pull/8638, a layer wrapped in `Reloadable` is now running in an uninterruptible region. When forking fibers in that context, you now have to make them `interruptible` explicitly if needed. That wasn't the case in `BufferPools` and that caused any application using zio metrics to hang on termination because those fibers couldn't be interrupted.