### PR TITLE
Fix Versioning On Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
     steps:
       - name: Checkout Current Branch
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: '0'
       - name: Setup Scala and Java
         uses: actions/setup-java@v4.2.1
         with:


### PR DESCRIPTION
To have proper versioning we need to get the entire git history. fixes #8822 

cc @ghostdogpr 