### PR TITLE
Don't use Java reflection for ScalaJS / Native

### DIFF
--- a/test/js/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
+++ b/test/js/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+trait FieldExtractorPlatformSpecific {
+  def productFields(obj: Product): Iterator[String] = Iterator.fill(obj.productArity)("")
+}

--- a/test/jvm/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
+++ b/test/jvm/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+trait FieldExtractorPlatformSpecific {
+  def productFields(obj: Product): Iterator[String] = obj.getClass.getDeclaredFields.iterator.map(_.getName)
+}

--- a/test/native/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
+++ b/test/native/src/main/scala-2.12/zio/test/FieldExtractorPlatformSpecific.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+trait FieldExtractorPlatformSpecific {
+  def productFields(obj: Product): Iterator[String] = Iterator.fill(obj.productArity)("")
+}

--- a/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
@@ -20,7 +20,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.Assertion.Arguments.valueArgument
 import zio.test.{ErrorMessage => M}
 
-trait AssertionVariants {
+trait AssertionVariants extends FieldExtractorPlatformSpecific {
   private def diffProduct[T](
     obj1: T,
     obj2: T,
@@ -53,7 +53,7 @@ trait AssertionVariants {
       case (obj1: Product, obj2: Product) if obj1.productArity == obj2.productArity =>
         obj1.productIterator
           .zip(obj2.productIterator)
-          .zip(obj1.getClass.getDeclaredFields.iterator.map(_.getName))
+          .zip(productFields(obj1))
           .flatMap { case ((subObj1, subObj2), paramName) =>
             val newParamName = if (paramName.nonEmpty) s".$paramName" else ""
             if (subObj1 != subObj2 && !subObj1.isInstanceOf[Product])


### PR DESCRIPTION
A previous PR (#8614) broke `zio-test_2.12` for ScalaJS & Native due to usage of Java reflection.

This PR implements a platform-specific `productFields` method, where in ScalaJS and Scala Native it returns an iterator of empty strings.

This is OK because the next line in the code handles empty strings explicitely: https://github.com/zio/zio/blob/730070564731507396f90e7f4612fad5a144c5e4/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala#L58

See Discord chat for more info: https://discord.com/channels/629491597070827530/629491597070827534/1238126111490048094