### PR TITLE
Resolve #8696

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -885,7 +885,7 @@ object ZSTMSpec extends ZIOBaseSpec {
                    case 0 => STM.retry
                    case n => STM.succeed(n)
                  }
-          txn2 = ref1.set(1)
+          txn2    = ref1.set(1)
           fib    <- txn1.commit.forkDaemon
           _      <- liveClockSleep(1.second)
           _      <- txn2.commit

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -885,7 +885,7 @@ object ZSTMSpec extends ZIOBaseSpec {
                    case 0 => STM.retry
                    case n => STM.succeed(n)
                  }
-          txn2 = ref1.set(1) // if this is `ref2.set(1)`, it doesn't hang
+          txn2 = ref1.set(1)
           fib    <- txn1.commit.forkDaemon
           _      <- liveClockSleep(1.second)
           _      <- txn2.commit

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1620,18 +1620,16 @@ object ZSTM {
     /**
      * Creates a function that can reset the journal.
      */
-    def prepareResetJournal(journal: Journal): () => Any = {
-      () => {
-        val saved = new MutableMap[TRef[_], Entry](journal.size)
-        val it = journal.entrySet.iterator
-        while (it.hasNext) {
-          val entry = it.next
-          saved.put(entry.getKey, entry.getValue.copy())
-        }
-        journal.clear()
-        journal.putAll(saved)
-        ()
+    def prepareResetJournal(journal: Journal): () => Any = () => {
+      val saved = new MutableMap[TRef[_], Entry](journal.size)
+      val it = journal.entrySet.iterator
+      while (it.hasNext) {
+        val entry = it.next
+        saved.put(entry.getKey, entry.getValue.copy())
       }
+      journal.clear()
+      journal.putAll(saved)
+      ()
     }
 
     /**

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -2069,7 +2069,7 @@ object ZSTM {
       /**
        * Resets the Entry with a given value.
        */
-      def reset(resetValue: Any): Entry = new Entry {
+      private[stm] def reset(resetValue: Any): Entry = new Entry {
         type S = self.S
         val tref     = self.tref
         val expected = self.expected

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1621,15 +1621,17 @@ object ZSTM {
      * Creates a function that can reset the journal.
      */
     def prepareResetJournal(journal: Journal): () => Any = {
-      val saved = new MutableMap[TRef[_], Entry](journal.size)
-
-      val it = journal.entrySet.iterator
-      while (it.hasNext) {
-        val entry = it.next
-        saved.put(entry.getKey, entry.getValue.copy())
+      () => {
+        val saved = new MutableMap[TRef[_], Entry](journal.size)
+        val it = journal.entrySet.iterator
+        while (it.hasNext) {
+          val entry = it.next
+          saved.put(entry.getKey, entry.getValue.copy())
+        }
+        journal.clear()
+        journal.putAll(saved)
+        ()
       }
-
-      () => { journal.clear(); journal.putAll(saved); () }
     }
 
     /**


### PR DESCRIPTION
This PR resolves #8696, which happens as the journal reset does not happen accurately, and instead empties the journal. I resolved this issue with the `prepareJournalReset` function.

I tested using the same code provided in the issue #8696, and it no longer hangs.
Thanks!

/claim #8696