### PR TITLE
Optimize foreachPar when using bounded parallelism

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6010,7 +6010,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         for {
           queue <- Queue.bounded[A](size)
           _     <- queue.offerAll(as)
-          _     <- ZIO.collectAllParUnboundedDiscard(ZIO.replicate(n)(worker(queue)))
+          _     <- ZIO.collectAllParUnboundedDiscard(ZIO.replicate(n.min(size))(worker(queue)))
         } yield ()
       }
     }


### PR DESCRIPTION
When using `foreachPar` with bounded parallelism, when the `size` of the collection is lower than the parallelism setting `n`, we are still creating `n` fibers to process a queue of `size` elements. For example with `withParallelism(16)`, we are going to create 16 fibers to process a queue of 2 elements. This is unnecessary and we can simply take the minimum between `size` and `n`.