### PR TITLE
Throw compiler error instead of runtime error when failing to cast assertion

### DIFF
--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -243,7 +243,7 @@ object SmartAssertMacros {
           case '[l] =>
             Expr.summon[OptionalImplicit[Diff[l]]] match {
               case Some(optDiff) =>
-                '{${transform(lhs.asExpr)} >>> SmartAssertions.equalTo(${rhs.asExpr})($optDiff.asInstanceOf[OptionalImplicit[Diff[Any]]]).span($span)}.asExprOf[TestArrow[Any, A]]
+                '{${transform(lhs.asExprOf[l])} >>> SmartAssertions.equalTo(${rhs.asExprOf[l]})($optDiff).span($span)}.asExprOf[TestArrow[Any, A]]
               case _ => throw new Error("OptionalImplicit should be always available")
             }
         }


### PR DESCRIPTION
/fixes #8754
/claim #8754

This way we get a compiler error when we can't cast the RHS type to the LHS type