### PR TITLE
Extend ControlThrowable on control flow exceptions

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -19,16 +19,16 @@ package zio.internal
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.tailrec
+import scala.util.control.ControlThrowable
 import java.util.{Set => JavaSet}
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
+
 import zio._
 import zio.metrics.{Metric, MetricLabel}
 import zio.Exit.Failure
 import zio.Exit.Success
 import zio.internal.SpecializationHelpers.SpecializeInt
-
-import scala.util.control.ControlThrowable
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
     extends Fiber.Runtime.Internal[E, A]

--- a/core/shared/src/main/scala/zio/internal/ReifyStack.scala
+++ b/core/shared/src/main/scala/zio/internal/ReifyStack.scala
@@ -1,7 +1,5 @@
 package zio.internal
 
-import zio._
+import scala.util.control.ControlThrowable
 
-import scala.util.control.NoStackTrace
-
-private[zio] object AsyncJump extends Exception with NoStackTrace
+private[zio] object AsyncJump extends ControlThrowable

--- a/core/shared/src/main/scala/zio/internal/ReifyStack.scala
+++ b/core/shared/src/main/scala/zio/internal/ReifyStack.scala
@@ -1,5 +1,0 @@
-package zio.internal
-
-import scala.util.control.ControlThrowable
-
-private[zio] object AsyncJump extends ControlThrowable


### PR DESCRIPTION
`ControlThrowable` is a special class intended to mark exceptions that are used for control flow. Tools like Datadog avoid instrumenting this kind of classes which prevents overwhelming exception profiling (source: https://github.com/DataDog/dd-trace-java/issues/5825#issuecomment-1790349773)