### PR TITLE
fix: implementation leak in pipeToOrFail

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -517,6 +517,16 @@ object ZChannelSpec extends ZIOBaseSpec {
               assertZIO(sums.get)(equalTo(Chunk(3, 7)))
           }
         },
+        test("pipeline with failure") {
+          val sut = ZChannel.fail("Boom") pipeToOrFail ZChannel
+            .readWithCause[Any, Nothing, Any, Any, String, Nothing, Unit](
+              _ => ZChannel.unit,
+              cause => ZChannel.refailCause(Cause.fail("kaboom") && cause),
+              _ => ZChannel.unit
+            )
+
+          assertZIO(sut.run.exit)(failsCause(containsCause(Cause.fail("Boom"))))
+        },
         test("resources") {
           Ref.make(Chunk[String]()).flatMap { events =>
             val left = ZChannel

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -951,17 +951,17 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               if (channelFailure eq null)
                 cause
               else
-              cause.fold[Cause[OutErr1]](
-                Cause.empty,
-                (e, st) => Cause.fail(e, st),
-                (t, st) =>
-                  t match {
-                    case t: ChannelFailure if t == channelFailure =>
-                      t.err
-                    case t => Cause.die(t, st)
-                  },
-                (fid, st) => Cause.interrupt(fid, st)
-              )(_ ++ _, _ && _, (cause, _) => cause)
+                cause.fold[Cause[OutErr1]](
+                  Cause.empty,
+                  (e, st) => Cause.fail(e, st),
+                  (t, st) =>
+                    t match {
+                      case t: ChannelFailure if t == channelFailure =>
+                        t.err
+                      case t => Cause.die(t, st)
+                    },
+                  (fid, st) => Cause.interrupt(fid, st)
+                )(_ ++ _, _ && _, (cause, _) => cause)
             ),
           done => ZChannel.succeedNow(done)
         )

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -948,6 +948,9 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           elem => ZChannel.write(elem) *> writer,
           cause =>
             ZChannel.refailCause(
+              if (channelFailure eq null)
+                cause
+              else
               cause.fold[Cause[OutErr1]](
                 Cause.empty,
                 (e, st) => Cause.fail(e, st),

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -946,12 +946,20 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
       lazy val writer: ZChannel[Env1, OutErr1, OutElem2, OutDone2, OutErr1, OutElem2, OutDone2] =
         ZChannel.readWithCause(
           elem => ZChannel.write(elem) *> writer,
-          {
-            case Cause.Die(value: ChannelFailure, _) if value == channelFailure => {
-              ZChannel.refailCause(channelFailure.err)
-            }
-            case cause => ZChannel.refailCause(cause)
-          },
+          cause =>
+            ZChannel.refailCause(
+              cause.fold[Cause[OutErr1]](
+                Cause.empty,
+                (e, st) => Cause.fail(e, st),
+                (t, st) =>
+                  t match {
+                    case t: ChannelFailure if t == channelFailure =>
+                      t.err
+                    case t => Cause.die(t, st)
+                  },
+                (fid, st) => Cause.interrupt(fid, st)
+              )(_ ++ _, _ && _, (cause, _) => cause)
+            ),
           done => ZChannel.succeedNow(done)
         )
 


### PR DESCRIPTION
While looking at error accumulation in streams, I discovered that `pipeToOrFail` leaks its internal implementation when the downstream channel does anything but pass the error:
```
          val sut = ZChannel.fail("Boom") pipeToOrFail ZChannel
            .readWithCause[Any, Nothing, Any, Any, String, Nothing, Unit](
              _ => ZChannel.unit,
              cause => ZChannel.refailCause(Cause.fail("kaboom") && cause),
              _ => ZChannel.unit
            )

          assertZIO(sut.run.exit)(failsCause(containsCause(Cause.fail("Boom"))))
```
yields
```
        ✗ Both(
            left = Fail(
              value = "kaboom",
              trace = StackTrace(
                fiberId = None(),
                stackTrace = Chunk()
              )
            ),
            right = Die(
              value = Exception in thread "zio-fiber-" java.lang.String: Boom,
              trace = StackTrace(
                fiberId = None(),
                stackTrace = Chunk()
              )
            )
          ) did not contain Fail(
            value = "Boom",
            trace = StackTrace(
              fiberId = None(),
              stackTrace = Chunk()
            )
          )
```

The `right` should be a `Fail` there.