### PR TITLE
optimize Stream flatMapPar 

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -122,6 +122,19 @@ class StreamParBenchmark {
   }
 
   @Benchmark
+  def zioFlatMapParChunks: Long = {
+    val result = ZStream
+      .fromIterable(zioChunks)
+      .flatMapPar(4){ c =>
+        val cc = c.flatMap(i => Chunk(i, i + 1))
+        ZStream.fromChunk(cc)
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
   def akkaFlatMapPar: Long = {
     val program = AkkaSource
       .fromIterator(() => akkaChunks.iterator.flatten)

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -111,7 +111,7 @@ class StreamParBenchmark {
   }
 
   @Benchmark
-  def zioFlatMapPar : Long = {
+  def zioFlatMapPar: Long = {
     val result = ZStream
       .fromChunks(zioChunks: _*)
       .flatMapPar(4)(i => ZStream(i, i + 1))
@@ -131,10 +131,10 @@ class StreamParBenchmark {
   }
 
   @Benchmark
-  def fs2FlatMapPar: Long = {
+  def fs2FlatMapPar: Long =
     FS2Stream(fs2Chunks: _*)
       .flatMap(FS2Stream.chunk(_))
-      .map{i =>
+      .map { i =>
         FS2Stream(i, i + 1)
       }
       .covary[CatsIO]
@@ -142,6 +142,5 @@ class StreamParBenchmark {
       .compile
       .fold(0L)((c, _) => c + 1L)
       .unsafeRunSync()
-  }
 
 }

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -125,7 +125,7 @@ class StreamParBenchmark {
   def zioFlatMapParChunks: Long = {
     val result = ZStream
       .fromIterable(zioChunks)
-      .flatMapPar(4){ c =>
+      .flatMapPar(4) { c =>
         val cc = c.flatMap(i => Chunk(i, i + 1))
         ZStream.fromChunk(cc)
       }
@@ -138,7 +138,7 @@ class StreamParBenchmark {
   def zioFlatMapParChunksFair: Long = {
     val result = ZStream
       .fromIterable(zioChunks)
-      .flatMapPar(4){ c =>
+      .flatMapPar(4) { c =>
         ZStream
           .fromChunk(c)
           .flatMap(i => ZStream(i, i + 1))

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -141,7 +141,7 @@ class StreamParBenchmark {
       .flatMapPar(4){ c =>
         ZStream
           .fromChunk(c)
-          .flatMap(i => ZStream(i, i + 1))  
+          .flatMap(i => ZStream(i, i + 1))
       }
       .runCount
 

--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -135,6 +135,20 @@ class StreamParBenchmark {
   }
 
   @Benchmark
+  def zioFlatMapParChunksFair: Long = {
+    val result = ZStream
+      .fromIterable(zioChunks)
+      .flatMapPar(4){ c =>
+        ZStream
+          .fromChunk(c)
+          .flatMap(i => ZStream(i, i + 1))  
+      }
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
   def akkaFlatMapPar: Long = {
     val program = AkkaSource
       .fromIterator(() => akkaChunks.iterator.flatten)

--- a/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
@@ -50,6 +50,17 @@ object UpdateOrderLinkedMapSpec extends ZIOBaseSpec {
         .reverseIterator
         .foreach(_ => ())
       assertCompletes
+    },
+    test("a,b,c,b") {
+      val m0 = UpdateOrderLinkedMap.empty[String, String]
+      val m1 = m0.updated("a", "a1")
+      val m2 = m1.updated("b", "b1")
+      val m3 = m2.updated("c", "c1")
+      val m4 = m3.updated("b", "b2")
+
+      val asSeq = m4.iterator.toSeq
+
+      zio.test.assert(asSeq)(Assertion.equalTo(Seq("a" -> "a1", "c" -> "c1", "b" -> "b2")))
     }
   )
 }


### PR DESCRIPTION
I've introduced a benchmark for `flatMapPar`, initial results:
```
Benchmark                          (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt  Score   Error  Units
StreamParBenchmark.akkaFlatMapPar         10000         5000              50  thrpt   15  1.208 ± 0.011  ops/s
StreamParBenchmark.fs2FlatMapPar          10000         5000              50  thrpt   15  0.124 ± 0.009  ops/s
StreamParBenchmark.zioFlatMapPar          10000         5000              50  thrpt   15  0.201 ± 0.002  ops/s
```

This pr introduces two alternate implementations to `ZChannel.mergeAllWith`, one of them is roughly 50% faster than the original:

```
Benchmark                          (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt  Score   Error  Units
StreamParBenchmark.zioFlatMapPar         10000         5000              50  thrpt   15  0.303 ± 0.002  ops/s
```

the other is over 4 times faster:

```
Benchmark                                   (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt   Score   Error  Units
StreamParBenchmark.zioFlatMapPar                   10000         5000              50  thrpt   15   0.866 ± 0.013  ops/s
```

* the slower implementation is required in order to support `MergeStrategy.BufferSliding`, hence it could not be discarded.

The first implementation basically reuses the same techniques used in #8819, it also uses multiple `Ref`s to reduce contention when updating the `OutDone` value.

The faster implementation takes a different approach, instead of spawning a fiber per nested stream it spawns `n` worker fibers. 
the workers compete over upstream elements using a queue and write the nested streams elements and completions to a second queue. 
Upstream completion places a special message in the second queue, consisting of upstream's completion value and the number of nested streams. The channel draining the second queue keeps track of the number of completions and the special upstream completion message in order to aggregate the final `OutDone` value and detect streams completion.

This pr also add couple of benchmarks showing the effect of chunking on the `flatMapPar` operator, first one is a bit unfair as it replaces some of the stream operations with `Chunk`'s equivalent ones, while second one is closer to `flatMapPar`. Both techniques can only live in user code as they may cause indefinite blocking in case of effectfull streams.

the complete benchmarks results:

```
Benchmark                                   (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt   Score   Error  Units
StreamParBenchmark.zioFlatMapPar                   10000         5000              50  thrpt   15   0.866 ± 0.013  ops/s
StreamParBenchmark.zioFlatMapParChunks             10000         5000              50  thrpt   15  29.721 ± 0.266  ops/s
StreamParBenchmark.zioFlatMapParChunksFair         10000         5000              50  thrpt   15   2.529 ± 0.033  ops/s
```