### PR TITLE
avoid allocating Fiber.Status to process FiberMessage.Stateful

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -136,7 +136,7 @@ trait Runtime[+R] { self =>
           import internal.{FiberMessage, OneShot}
           val result = OneShot.make[Exit[E, A]]
           fiber.tell(
-            FiberMessage.Stateful((fiber, _) => fiber.addObserver(exit => result.set(exit.asInstanceOf[Exit[E, A]])))
+            FiberMessage.Stateful(fiber => fiber.addObserver(exit => result.set(exit.asInstanceOf[Exit[E, A]])))
           )
           result.get()
         case Right(exit) => exit

--- a/core/shared/src/main/scala/zio/internal/FiberMessage.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMessage.scala
@@ -26,10 +26,10 @@ import zio._
  */
 private[zio] sealed trait FiberMessage
 private[zio] object FiberMessage {
-  final case class InterruptSignal(cause: Cause[Nothing])                        extends FiberMessage
-  final case class Stateful(onFiber: (FiberRuntime[_, _], Fiber.Status) => Unit) extends FiberMessage
-  final case class Resume(effect: ZIO[_, _, _])                                  extends FiberMessage
-  case object YieldNow                                                           extends FiberMessage
+  final case class InterruptSignal(cause: Cause[Nothing])        extends FiberMessage
+  final case class Stateful(onFiber: FiberRuntime[_, _] => Unit) extends FiberMessage
+  final case class Resume(effect: ZIO[_, _, _])                  extends FiberMessage
+  case object YieldNow                                           extends FiberMessage
 
   val resumeUnit: FiberMessage = Resume(ZIO.unit)
 }


### PR DESCRIPTION
I'm working on integrating Kyo's adaptive scheduler as pluggable alternative to `ZScheduler` in systems using ZIO. I'm not sure why yet I see more overhead to process fiber messages but something I noticed in the profiling session is that every message requires a `Fiber.Status` allocation during processing. It seems the status is actually unused.