### PR TITLE
avoid extra function allocations in ZIO.succeed (scala 3)

### DIFF
--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -173,7 +173,9 @@ trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: => A)(implicit trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => a)
+    new ZIO.Sync[A](trace) {
+      def eval() = a
+    }
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -178,7 +178,9 @@ trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: Unsafe ?=> A)(implicit trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => Unsafe.unsafe(a))
+    new ZIO.Sync[A](trace) {
+      def eval() = Unsafe.unsafe(a)
+    }
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5827,7 +5827,16 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     failureK: Cause[E1] => ZIO[R, E2, A2]
   ) extends Continuation
       with ZIO[R, E2, A2]
-  private[zio] final case class Sync[A](trace: Trace, eval: () => A) extends ZIO[Any, Nothing, A]
+  private[zio] abstract class Sync[A](val trace: Trace) extends ZIO[Any, Nothing, A] {
+    def eval(): A
+    def canEqual(that: Any) = that.isInstanceOf[Sync[_]]
+    def productArity        = 2
+    def productElement(n: Int) =
+      n match {
+        case 0 => trace
+        case 1 => () => eval()
+      }
+  }
   private[zio] final case class Async[R, E, A](
     trace: Trace,
     registerCallback: (ZIO[R, E, A] => Unit) => ZIO[R, E, A],


### PR DESCRIPTION
The `Unsafe` encoding in Scala 3 produces extra function allocations to adapt the function taking `Unsafe` to `Function0` in `ZIO.Sync`. This PR changes `ZIO.Sync` to be an `abstract class` and provide the thunk as an overriden method. With this approach, only the `Sync` object is allocated in `ZIO.succeed`.

This isn't an issue in Scala 2 because the function is a by-name parameter, which Scala already encodes as `Function0` in the bytecode and doesn't require a new allocation.