### PR TITLE
custom executor benchmark

### DIFF
--- a/benchmarks/src/main/scala/zio/CustomExecutorBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/CustomExecutorBenchmark.scala
@@ -1,0 +1,60 @@
+package zio
+
+import cats.effect.unsafe.implicits.global
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Await
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Threads(16)
+@Fork(1)
+class CustomExecutorBenchmark {
+  @Param(Array("20"))
+  var depth: Int = _
+
+  lazy val defaultRuntime: Runtime[Any] =
+    Runtime.default
+
+  lazy val customRuntime = {
+    implicit val unsafe: Unsafe = Unsafe.unsafe(identity)
+    val kExecutorLayer =
+      Runtime.setExecutor(Runtime.defaultExecutor) ++
+        Runtime.setBlockingExecutor(Runtime.defaultBlockingExecutor)
+    Runtime.unsafe.fromLayer(kExecutorLayer)
+  }
+
+  @Benchmark
+  def defaultExecutor(): BigInt = zioFib(defaultRuntime)
+
+  @Benchmark
+  def customExecutor(): BigInt = zioFib(customRuntime)
+
+  @Benchmark
+  def defaultExecutorInitBoth(): BigInt = {
+    customRuntime
+    zioFib(defaultRuntime)
+  }
+
+  @Benchmark
+  def customExecutorInitBoth(): BigInt = {
+    defaultRuntime
+    zioFib(customRuntime)
+  }
+
+  private[this] def zioFib(runtime: Runtime[Any]): BigInt = {
+    def fib(n: Int): UIO[BigInt] =
+      if (n <= 1) ZIO.succeed[BigInt](n)
+      else
+        fib(n - 1).flatMap(a => fib(n - 2).flatMap(b => ZIO.succeed(a + b)))
+
+    Unsafe.unsafe { implicit unsafe =>
+      runtime.unsafe.run(ZIO.yieldNow.flatMap(_ => fib(depth))).getOrThrowFiberFailure()
+    }
+  }
+}


### PR DESCRIPTION
I've been working on integrating Kyo's [scheduler](https://github.com/getkyo/kyo/tree/main/kyo-scheduler) as an alternative for `ZExecutor`. There's an odd performance regression that this benchmark reproduces. If a `Runtime` is initialized with custom executors, there's a regression even if only the default runtime is used:

```
[info] Benchmark                                        (depth)   Mode  Cnt     Score    Error  Units
[info] CustomExecutorBenchmark.customExecutor                20  thrpt    5  1730.610 ± 29.088  ops/s
[info] CustomExecutorBenchmark.customExecutorInitBoth        20  thrpt    5  1729.821 ± 55.669  ops/s
[info] CustomExecutorBenchmark.defaultExecutor               20  thrpt    5  2279.128 ± 73.153  ops/s
[info] CustomExecutorBenchmark.defaultExecutorInitBoth       20  thrpt    5  1718.819 ± 63.818  ops/s
```