### PR TITLE
Allow "unsafe" creation of a `Queue`

### DIFF
--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -112,7 +112,7 @@ object Queue {
   def unbounded[A](implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.unbounded(_)(Unsafe.unsafe))
 
-  private[zio] object unsafe {
+  object unsafe {
 
     def bounded[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[A] =
       createQueue(MutableConcurrentQueue.bounded[A](requestedCapacity), Strategy.BackPressure(), fiberId)


### PR DESCRIPTION
In `zio-http`, there are a few places where we need to create a queue "unsafely". Currently, this is done but unsafely running the effect, but this is both inefficient and also dangerous as we might end up blocking in cases that the effect might also perform some asynchronous tasks.

With this PR, we expose an option (~~currently available only to the `zio` namespace~~) to create a queue without running an effect

EDIT: Decided to make the object public. I really don't see a reason why we don't want to give users the option to do this