### PR TITLE
Add support for comparing related types in assertTrue in Scala 2

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -226,7 +226,7 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         result <- resultZIO
       } yield assertTrue(result.is(_.left).contains("type mismatch"))
     } @@ scala2Only,
-    test("comparison compiles when comparing different types") {
+    test("comparison compiles when comparing different primitive types") {
       val a  = 1
       val b  = 2
       val aL = 1L

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -216,9 +216,11 @@ object SmartAssertionSpec extends ZIOBaseSpec {
     },
     test("equalTo does not compile when comparing unrelated types in Scala 2") {
       val resultZIO = typeCheck("""
-      val a = Vector(1, 2)
-      val l = List(1, 2)
-      assertTrue(a == l) && assertTrue(l == a)
+      class A
+      class B
+      val a = new A()
+      val b = new B()
+      assertTrue(a == b) && assertTrue(b == a)
       """)
       for {
         result <- resultZIO

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -327,13 +327,14 @@ $TestResult($ast.withCode($codeString).meta(location = $location))
     // `true` for conversion from `lhs` to `rhs`.
     def implicitConversionDirection(lhs: Type, rhs: Type): Option[Boolean] =
       if (tpesPriority(lhs) == -1 || tpesPriority(rhs) == -1) {
-        scala.util.Try(c.inferImplicitValue((tq"$lhs => $rhs").tpe)).getOrElse(EmptyTree) match {
-          case EmptyTree => {
-            scala.util.Try(c.inferImplicitValue((tq"$rhs => $lhs").tpe)).getOrElse(EmptyTree) match {
+        // tq"lhs => rhs" does not work. It seems to generate untyped tree that cannot be typechecked
+        val function1 = weakTypeOf[_ => _]
+        c.inferImplicitValue(appliedType(function1, lhs, rhs)) match {
+          case EmptyTree =>
+            c.inferImplicitValue(appliedType(function1, rhs, lhs)) match {
               case EmptyTree => None
               case _         => Some(false)
             }
-          }
           case _ => Some(true)
         }
       } else if (tpesPriority(rhs) - tpesPriority(lhs) > 0) Some(true)


### PR DESCRIPTION
Fixes #8874 