### PR TITLE
add: missing `TestLens#cause`

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -446,6 +446,10 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         test("success") {
           val exit: Exit[Int, String] = Exit.succeed("Yes")
           assertTrue(exit.is(_.success) == "No")
+        },
+        test("cause") {
+          val exit: Exit[String, String] = Exit.succeed("Success!")
+          assertTrue(exit.is(_.cause) == Cause.fail("Fail!"))
         }
       ),
       suite("subtype")(

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -103,6 +103,9 @@ class SmartAssertMacros(val c: blackbox.Context) {
       case AST.Method(lhs, lhsTpe, _, "interrupted", _, _, span) if lhsTpe <:< weakTypeOf[TestLens[Cause[_]]] =>
         q"${parseAsAssertion(lhs)(start)} >>> $SA.asCauseInterrupted.span($span)"
 
+      case AST.Method(lhs, lhsTpe, _, "cause", _, _, span) if lhsTpe <:< weakTypeOf[TestLens[Exit[_, _]]] =>
+        q"${parseAsAssertion(lhs)(start)} >>> $SA.asExitCause.span($span)"
+
       case _ =>
         start
     }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -119,6 +119,10 @@ object SmartAssertMacros {
        val arrow = transformAs[Start, Exit[e, a]](lhs.asInstanceOf[Expr[TestLens[Exit[e, a]]]])(start)
        '{ $arrow >>> SmartAssertions.asExitInterrupted }
 
+      case '{ type e; type a; TestLensExitOps($lhs: TestLens[Exit[`e`, `a`]]).cause } =>
+       val arrow = transformAs[Start, Exit[e, a]](lhs.asInstanceOf[Expr[TestLens[Exit[e, a]]]])(start)
+       '{ $arrow >>> SmartAssertions.asExitCause }
+
      case other =>
        start
     }


### PR DESCRIPTION
Resolves #8872 

The entire suite of tests is configured with `TestAspects.failing` - I think we should have 'positive' cases as well...