### PR TITLE
Fix slow slink guarantees

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -857,7 +857,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           }
 
         ZChannel
-          .fromZIO(pullL.forkIn(scope).zipWith(pullR.forkIn(scope))(BothRunning(_, _): MergeState))
+          .fromZIO(pullL.forkDaemon.zipWith(pullR.forkDaemon)(BothRunning(_, _): MergeState))
           .flatMap(go)
           .embedInput(input)
       }


### PR DESCRIPTION
/claim #8792

`tapSink` usage `merge` with a `HaltStrategy.Both`, that should guarantee execution of both sides (left and right) to the completion.

This was the regression introduced in this PR: https://github.com/zio/zio/pull/8311