### PR TITLE
Repurpose `CooperativeYielding` flag to determine `FiberRuntime`  should auto-yield

### DIFF
--- a/core/shared/src/main/scala/zio/RuntimeFlag.scala
+++ b/core/shared/src/main/scala/zio/RuntimeFlag.scala
@@ -127,7 +127,11 @@ object RuntimeFlag {
 
   /**
    * The cooperative yielding flag determines whether the ZIO runtime will yield
-   * to another fiber.
+   * to another fiber while executing long-running effects or continuously
+   * forking fibers.
+   *
+   * Disabling this flag is highly discouraged but it is necessary for cases where
+   * fine-grained control over fiber scheduling is required.
    */
   case object CooperativeYielding extends RuntimeFlag {
     final val index   = 7

--- a/core/shared/src/main/scala/zio/RuntimeFlag.scala
+++ b/core/shared/src/main/scala/zio/RuntimeFlag.scala
@@ -130,8 +130,8 @@ object RuntimeFlag {
    * to another fiber while executing long-running effects or continuously
    * forking fibers.
    *
-   * Disabling this flag is highly discouraged but it is necessary for cases where
-   * fine-grained control over fiber scheduling is required.
+   * Disabling this flag is highly discouraged but it is necessary for cases
+   * where fine-grained control over fiber scheduling is required.
    */
   case object CooperativeYielding extends RuntimeFlag {
     final val index   = 7


### PR DESCRIPTION
In ZIO 2.1.x we added a "preemption" mechanism for the `FiberRuntime` to automatically yield every on every 128 successive forks. This mechanism improved fork-join performance significantly when using the ZIO-provided executors, but in the case that a custom executor is used, it might be desirable for this behaviour to be controlled at the scheduler level (see discord thread for more info: https://discord.com/channels/629491597070827530/629491597070827534/1242148853327597589)

With this PR, I repurposed the `CooperativeYielding` (which is no longer used for anything else since v2.1.0) to determine whether the fiber should automatically yield every:
- 128 forks
- 10280 operations at the same depth

@jdegoes @ghostdogpr what do you think about repurposing the existing flag for this? Or do you prefer if we deprecated `CooperativeYielding` and added a new flag? Downside of adding a new flag enabled by default is that custom runtimes will not include this new flag