### PR TITLE
Add working knownSize implementation to ChunkBuilder instances (Scala 2.13+)

### DIFF
--- a/core-tests/shared/src/test/scala-2.13+/ChunkBuilderVersionSpecific.scala
+++ b/core-tests/shared/src/test/scala-2.13+/ChunkBuilderVersionSpecific.scala
@@ -1,6 +1,5 @@
 import zio.ChunkBuilder
 import zio.ZIOBaseSpec
-import zio.test.Assertion._
 import zio.test._
 
 object ChunkBuilderVersionSpecific extends ZIOBaseSpec {
@@ -13,7 +12,7 @@ object ChunkBuilderVersionSpecific extends ZIOBaseSpec {
           as.foreach(builder += _)
           assertTrue(builder.knownSize == as.size)
         }
-      ),
+      )
     ),
     suite("Byte")(
       test("knownSize")(
@@ -22,7 +21,7 @@ object ChunkBuilderVersionSpecific extends ZIOBaseSpec {
           as.foreach(builder += _)
           assertTrue(builder.knownSize == as.size)
         }
-      ),
+      )
     ),
     suite("Char")(
       test("knownSize")(

--- a/core-tests/shared/src/test/scala-2.13+/ChunkBuilderVersionSpecific.scala
+++ b/core-tests/shared/src/test/scala-2.13+/ChunkBuilderVersionSpecific.scala
@@ -1,0 +1,82 @@
+import zio.ChunkBuilder
+import zio.ZIOBaseSpec
+import zio.test.Assertion._
+import zio.test._
+
+object ChunkBuilderVersionSpecific extends ZIOBaseSpec {
+
+  def spec = suite("ChunkBuilderVersionSpecific")(
+    suite("Boolean")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.boolean)) { as =>
+          val builder = new ChunkBuilder.Boolean
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      ),
+    ),
+    suite("Byte")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.byte)) { as =>
+          val builder = new ChunkBuilder.Byte
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      ),
+    ),
+    suite("Char")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.char)) { as =>
+          val builder = new ChunkBuilder.Char
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    ),
+    suite("Double")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.double)) { as =>
+          val builder = new ChunkBuilder.Double
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    ),
+    suite("Float")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.float)) { as =>
+          val builder = new ChunkBuilder.Float
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    ),
+    suite("Int")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.int)) { as =>
+          val builder = new ChunkBuilder.Int
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    ),
+    suite("Long")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.long)) { as =>
+          val builder = new ChunkBuilder.Long
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    ),
+    suite("Short")(
+      test("knownSize")(
+        check(Gen.chunkOf(Gen.short)) { as =>
+          val builder = new ChunkBuilder.Short
+          as.foreach(builder += _)
+          assertTrue(builder.knownSize == as.size)
+        }
+      )
+    )
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
@@ -11,14 +11,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.boolean)) { as =>
           val builder = new ChunkBuilder.Boolean
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.boolean)) { as =>
           val builder = new ChunkBuilder.Boolean
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -31,14 +31,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.byte)) { as =>
           val builder = new ChunkBuilder.Byte
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.byte)) { as =>
           val builder = new ChunkBuilder.Byte
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -51,14 +51,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.char)) { as =>
           val builder = new ChunkBuilder.Char
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.char)) { as =>
           val builder = new ChunkBuilder.Char
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -71,14 +71,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.double)) { as =>
           val builder = new ChunkBuilder.Double
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.double)) { as =>
           val builder = new ChunkBuilder.Double
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -91,14 +91,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.float)) { as =>
           val builder = new ChunkBuilder.Float
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.float)) { as =>
           val builder = new ChunkBuilder.Float
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -111,14 +111,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.int)) { as =>
           val builder = new ChunkBuilder.Int
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.int)) { as =>
           val builder = new ChunkBuilder.Int
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -131,14 +131,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.long)) { as =>
           val builder = new ChunkBuilder.Long
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.long)) { as =>
           val builder = new ChunkBuilder.Long
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {
@@ -151,14 +151,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.short)) { as =>
           val builder = new ChunkBuilder.Short
           as.foreach(builder += _)
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.short)) { as =>
           val builder = new ChunkBuilder.Short
           builder ++= as
-          assertTrue(builder.result() == as, builder.knownSize == as.size)
+          assertTrue(builder.result() == as)
         }
       },
       test("toString") {

--- a/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkBuilderSpec.scala
@@ -11,14 +11,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.boolean)) { as =>
           val builder = new ChunkBuilder.Boolean
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.boolean)) { as =>
           val builder = new ChunkBuilder.Boolean
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -31,14 +31,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.byte)) { as =>
           val builder = new ChunkBuilder.Byte
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.byte)) { as =>
           val builder = new ChunkBuilder.Byte
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -51,14 +51,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.char)) { as =>
           val builder = new ChunkBuilder.Char
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.char)) { as =>
           val builder = new ChunkBuilder.Char
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -71,14 +71,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.double)) { as =>
           val builder = new ChunkBuilder.Double
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.double)) { as =>
           val builder = new ChunkBuilder.Double
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -91,14 +91,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.float)) { as =>
           val builder = new ChunkBuilder.Float
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.float)) { as =>
           val builder = new ChunkBuilder.Float
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -111,14 +111,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.int)) { as =>
           val builder = new ChunkBuilder.Int
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.int)) { as =>
           val builder = new ChunkBuilder.Int
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -131,14 +131,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.long)) { as =>
           val builder = new ChunkBuilder.Long
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.long)) { as =>
           val builder = new ChunkBuilder.Long
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {
@@ -151,14 +151,14 @@ object ChunkBuilderSpec extends ZIOBaseSpec {
         check(Gen.chunkOf(Gen.short)) { as =>
           val builder = new ChunkBuilder.Short
           as.foreach(builder += _)
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       ),
       test("addAll") {
         check(Gen.chunkOf(Gen.short)) { as =>
           val builder = new ChunkBuilder.Short
           builder ++= as
-          assert(builder.result())(equalTo(as))
+          assertTrue(builder.result() == as, builder.knownSize == as.size)
         }
       },
       test("toString") {

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -91,6 +91,7 @@ object ChunkBuilder {
         } else {
           arrayBuilder.sizeHint(n)
         }
+      override def knownSize: SInt = arrayBuilder.knownSize
     }
 
   /**
@@ -167,6 +168,7 @@ object ChunkBuilder {
     }
     override def toString: String =
       "ChunkBuilder.Boolean"
+    override def knownSize: SInt = arrayBuilder.knownSize * 8 + maxBitIndex
   }
 
   /**
@@ -201,6 +203,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Byte"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -235,6 +238,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Char"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -270,6 +274,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Double"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -304,6 +309,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Float"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -338,6 +344,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Int"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -372,6 +379,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Long"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -406,5 +414,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Short"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 }

--- a/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkBuilder.scala
@@ -91,7 +91,6 @@ object ChunkBuilder {
         } else {
           arrayBuilder.sizeHint(n)
         }
-      override def knownSize: SInt = arrayBuilder.knownSize
     }
 
   /**
@@ -168,7 +167,6 @@ object ChunkBuilder {
     }
     override def toString: String =
       "ChunkBuilder.Boolean"
-    override def knownSize: SInt = arrayBuilder.knownSize * 8 + maxBitIndex
   }
 
   /**
@@ -203,7 +201,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Byte"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -238,7 +235,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Char"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -274,7 +270,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Double"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -309,7 +304,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Float"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -344,7 +338,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Int"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -379,7 +372,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Long"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -414,6 +406,5 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Short"
-    override def knownSize: SInt = arrayBuilder.knownSize
   }
 }

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -86,6 +86,7 @@ object ChunkBuilder {
         } else {
           arrayBuilder.sizeHint(n)
         }
+      override def knownSize: SInt = arrayBuilder.knownSize
     }
 
   /**
@@ -158,6 +159,8 @@ object ChunkBuilder {
     }
     override def toString: String =
       "ChunkBuilder.Boolean"
+
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -188,6 +191,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Byte"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -218,6 +222,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Char"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -249,6 +254,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Double"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -279,6 +285,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Float"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -309,6 +316,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Int"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -339,6 +347,7 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Long"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 
   /**
@@ -369,5 +378,6 @@ object ChunkBuilder {
       arrayBuilder.sizeHint(n)
     override def toString: String =
       "ChunkBuilder.Short"
+    override def knownSize: SInt = arrayBuilder.knownSize
   }
 }

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -159,8 +159,7 @@ object ChunkBuilder {
     }
     override def toString: String =
       "ChunkBuilder.Boolean"
-
-    override def knownSize: SInt = arrayBuilder.knownSize
+    override def knownSize: SInt = arrayBuilder.knownSize * 8 + maxBitIndex
   }
 
   /**


### PR DESCRIPTION
While implementing https://github.com/zio/zio-http/pull/2862 we needed to get the size of a `ChunkBuilder.Byte` and saw this was not yet implemented and returned always the default `-1` from the underlying `Growable` trait implementation.

This add the implementation for all current `ChunkBuilders` Scala 2.13+.

Scala 2.12 is not supported because the underlying `scala.collection.mutalbe.ArrayBuilder` does not have a suitable `knownSize` implementation: https://www.scala-lang.org/api/2.12.9/scala/collection/mutable/ArrayBuilder.html