### PR TITLE
Change ZTestLogger.default layer return type to Unit

### DIFF
--- a/test/shared/src/main/scala/zio/test/ZTestLogger.scala
+++ b/test/shared/src/main/scala/zio/test/ZTestLogger.scala
@@ -35,7 +35,7 @@ object ZTestLogger {
    * A layer which constructs a new `ZTestLogger` and runs the effect it is
    * provided to with the `Runtime` updated to add the `ZTestLogger`.
    */
-  val default: ZLayer[Any, Nothing, Any] =
+  val default: ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped {
       for {
         testLogger <- ZTestLogger.make


### PR DESCRIPTION
When this layer is used it's showing "unused" warning on `provide` method (because indeed, `Any` created by this layer is not used). Any other side effect layer returns Unit (like `removeDefaultLoggers`).

Of course it's binary and source incompatible change, but this is test only library, so it should be fine.