### PR TITLE
feat: accumulate errors in parallel stream ops

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -697,12 +697,12 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           queue.take
             .flatMap(_.join)
             // we just need to observe the error and get the full cause from the ref, or just terminate the channel, depending.
-            .foldZIO(
+            .fold(
               {
-                case None       => failure.get.map(ZChannel.failCause(_))
-                case Some(done) => ZIO.succeed(ZChannel.succeedNow(done))
+                case None       => ZChannel.unwrap(failure.get.map(ZChannel.failCause(_)))
+                case Some(done) => ZChannel.succeedNow(done)
               },
-              out2 => ZIO.succeed(ZChannel.write(out2) *> readerCh)
+              out2 => ZChannel.write(out2) *> readerCh
             )
         }
 


### PR DESCRIPTION
fibers running in parallel may fail for various reasons at the same time, and this is valuable information one could use in an investigation.

i replaced the code that carried the error in the fiber error channel with a mutable cell, where fibers failures/defects can accumulate into a single cause. it also seemed unnecessary to use a promise for the termination signal, so i dropped that part. with that change we recover the ability to track parallel errors ✌️ 

one thing i am currently leaving out is the interruption of running fibers, but if desirable this could be tracked just as well:

```scala
leftFib.interrupt 
  *> failure.update(_ && Cause.interrupt(leftFib.id)) 
  *> rightEx
```

does that seem like a valuable addition? if yes, i can look at the other parallel operators.