### PR TITLE
Improve performance of `Chunk#map`

### DIFF
--- a/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/chunks/ChunkMapBenchmarks.scala
@@ -8,35 +8,61 @@ import java.util.concurrent.TimeUnit
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Warmup(iterations = 10, time = 10)
-@Measurement(iterations = 10, time = 10)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
+@Fork(1)
 class ChunkMapBenchmarks {
   @Param(Array("1000"))
   var size: Int = _
 
-  var chunk: Chunk[Int]   = _
-  var vector: Vector[Int] = _
-  var list: List[Int]     = _
+  var intArray: Array[Int]   = _
+  var intChunk: Chunk[Int]   = _
+  var intVector: Vector[Int] = _
+  var intList: List[Int]     = _
+
+  var stringArray: Array[String]   = _
+  var stringChunk: Chunk[String]   = _
+  var stringVector: Vector[String] = _
+  var stringList: List[String]     = _
 
   @Setup(Level.Trial)
   def setup(): Unit = {
-    val array = (1 to size).toArray
-    chunk = Chunk.fromArray(array)
-    vector = array.toVector
-    list = array.toList
+    intArray = (1 to size).toArray
+    stringArray = intArray.map(_.toString)
+    intChunk = Chunk.fromArray(intArray)
+    stringChunk = intChunk.map(_.toString)
+    intVector = intArray.toVector
+    stringVector = intVector.map(_.toString)
+    intList = intArray.toList
+    stringList = intList.map(_.toString)
   }
 
   @Benchmark
-  def mapChunk(): Chunk[Int] = chunk.map(_ * 2)
+  def mapIntArray(): Array[Int] = intArray.map(_ * 2)
 
   @Benchmark
-  def mapVector(): Vector[Int] = vector.map(_ * 2)
+  def mapStringArray(): Array[String] = stringArray.map(_ + "123")
 
   @Benchmark
-  def mapList(): List[Int] = list.map(_ * 2)
+  def mapIntChunk(): Chunk[Int] = intChunk.map(_ * 2)
+
+  @Benchmark
+  def mapStringChunk(): Chunk[String] = stringChunk.map(_ + "123")
+
+  @Benchmark
+  def mapIntVector(): Vector[Int] = intVector.map(_ * 2)
+
+  @Benchmark
+  def mapStringVector(): Vector[String] = stringVector.map(_ + "123")
+
+  @Benchmark
+  def mapIntList(): List[Int] = intList.map(_ * 2)
+
+  @Benchmark
+  def mapStringList(): List[String] = stringList.map(_ + "123")
 
   @Benchmark
   def mapZIO(): Unit =
-    BenchmarkUtil.unsafeRun(chunk.mapZIODiscard(_ => ZIO.unit))
+    BenchmarkUtil.unsafeRun(stringChunk.mapZIODiscard(_ => ZIO.unit))
 
 }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1756,8 +1756,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       builder.result()
     }
 
-    override protected def mapChunk[B](f: A => B): Chunk[B] =
-      Chunk.fromArray(self.array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: A => B): Chunk[B] = {
+      implicit val ct: ClassTag[B] = ClassTag.AnyRef.asInstanceOf[ClassTag[B]]
+      Chunk.fromArray(self.array.map(f))
+    }
   }
 
   private final case class Concat[A](override protected val left: Chunk[A], override protected val right: Chunk[A])

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1048,20 +1048,14 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
    * Returns a chunk with the elements mapped by the specified function.
    */
   protected def mapChunk[B](f: A => B): Chunk[B] = {
-    val len = self.length
-    if (len == 0) Chunk.Empty
-    else {
-      val iter   = self.chunkIterator
-      val head   = f(iter.nextAt(0))
-      val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-      var i      = 1
-      newArr(0) = head
-      while (iter.hasNextAt(i)) {
-        newArr(i) = f(iter.nextAt(i))
-        i += 1
-      }
-      Chunk.fromArray(newArr)
+    val iter   = self.chunkIterator
+    val newArr = Array.ofDim[AnyRef](self.length).asInstanceOf[Array[B]]
+    var i      = 0
+    while (iter.hasNextAt(i)) {
+      newArr(i) = f(iter.nextAt(i))
+      i += 1
     }
+    Chunk.fromArray(newArr)
   }
 
   /**
@@ -1762,22 +1756,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       builder.result()
     }
 
-    override protected def mapChunk[B](f: A => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: A => B): Chunk[B] =
+      Chunk.fromArray(self.array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
   }
 
   private final case class Concat[A](override protected val left: Chunk[A], override protected val right: Chunk[A])
@@ -2517,22 +2497,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Byte => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Byte => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Byte =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Byte] =
@@ -2581,22 +2547,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Char => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Char => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Char =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Char] =
@@ -2645,22 +2597,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       index < length
     override def int(index: Int)(implicit ev: Int <:< Int): Int =
       array(index + offset)
-    override protected def mapChunk[B](f: Int => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Int => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Int =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Int] =
@@ -2709,22 +2647,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       index < length
     override def long(index: Int)(implicit ev: Long <:< Long): Long =
       array(index + offset)
-    override protected def mapChunk[B](f: Long => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Long => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Long =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Long] =
@@ -2773,22 +2697,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Double => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Double => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Double =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Double] =
@@ -2837,22 +2747,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       array(index + offset)
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Float => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Float => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Float =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Float] =
@@ -2899,22 +2795,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Short => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Short => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Short =
       array(index + offset)
     override def short(index: Int)(implicit ev: Short <:< Short): Short =
@@ -2965,22 +2847,8 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Boolean => B): Chunk[B] = {
-      val len = self.length
-      if (len == 0) Empty
-      else {
-        val oldArr = array
-        val head   = f(oldArr(0))
-        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
-        var i      = 1
-        newArr(0) = head
-        while (i < len) {
-          newArr(i) = f(oldArr(i))
-          i += 1
-        }
-        Chunk.fromArray(newArr)
-      }
-    }
+    override protected def mapChunk[B](f: Boolean => B): Chunk[B] =
+      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
     def nextAt(index: Int): Boolean =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Boolean] =

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1048,17 +1048,20 @@ sealed abstract class Chunk[+A] extends ChunkLike[A] with Serializable { self =>
    * Returns a chunk with the elements mapped by the specified function.
    */
   protected def mapChunk[B](f: A => B): Chunk[B] = {
-    val iterator = self.chunkIterator
-    var index    = 0
-    val builder  = ChunkBuilder.make[B]()
-    builder.sizeHint(length)
-    while (iterator.hasNextAt(index)) {
-      val a = iterator.nextAt(index)
-      index += 1
-      val b = f(a)
-      builder += b
+    val len = self.length
+    if (len == 0) Chunk.Empty
+    else {
+      val iter   = self.chunkIterator
+      val head   = f(iter.nextAt(0))
+      val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+      var i      = 1
+      newArr(0) = head
+      while (iter.hasNextAt(i)) {
+        newArr(i) = f(iter.nextAt(i))
+        i += 1
+      }
+      Chunk.fromArray(newArr)
     }
-    builder.result()
   }
 
   /**

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -2497,8 +2497,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Byte => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Byte => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Byte =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Byte] =
@@ -2547,8 +2574,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Char => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Char => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Char =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Char] =
@@ -2597,8 +2651,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       index < length
     override def int(index: Int)(implicit ev: Int <:< Int): Int =
       array(index + offset)
-    override protected def mapChunk[B](f: Int => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Int => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Int =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Int] =
@@ -2647,8 +2728,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       index < length
     override def long(index: Int)(implicit ev: Long <:< Long): Long =
       array(index + offset)
-    override protected def mapChunk[B](f: Long => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Long => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Long =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Long] =
@@ -2697,8 +2805,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Double => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Double => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Double =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Double] =
@@ -2747,8 +2882,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       array(index + offset)
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Float => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Float => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Float =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Float] =
@@ -2795,8 +2957,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Short => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Short => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Short =
       array(index + offset)
     override def short(index: Int)(implicit ev: Short <:< Short): Short =
@@ -2847,8 +3036,35 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
     def hasNextAt(index: Int): Boolean =
       index < length
-    override protected def mapChunk[B](f: Boolean => B): Chunk[B] =
-      Chunk.fromArray(array.map(f)(ClassTag.AnyRef.asInstanceOf[ClassTag[B]]))
+    override protected def mapChunk[B](f: Boolean => B): Chunk[B] = {
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        var newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          val newVal = f(oldArr(i))
+          try {
+            newArr(i) = newVal
+          } catch {
+            case _: ClassCastException =>
+              val newArr2 = Array.ofDim[AnyRef](len)
+              var ii      = 0
+              while (ii < i) {
+                newArr2(ii) = newArr(ii).asInstanceOf[AnyRef]
+                ii += 1
+              }
+              newArr = newArr2.asInstanceOf[Array[B]]
+              newArr(i) = newVal
+          }
+          i += 1
+        }
+        Chunk.fromArray(newArr)
+      }
+    }
     def nextAt(index: Int): Boolean =
       array(index + offset)
     def sliceIterator(offset: Int, length: Int): ChunkIterator[Boolean] =

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1760,17 +1760,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     }
 
     override protected def mapChunk[B](f: A => B): Chunk[B] = {
-      val len     = self.length
-      val builder = ChunkBuilder.make[B]()
-      builder.sizeHint(len)
-
-      var i = 0
-      while (i < len) {
-        builder += f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      builder.result()
     }
   }
 
@@ -2512,16 +2515,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Byte => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Byte =
       array(index + offset)
@@ -2572,16 +2579,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Char => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Char =
       array(index + offset)
@@ -2632,16 +2643,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def int(index: Int)(implicit ev: Int <:< Int): Int =
       array(index + offset)
     override protected def mapChunk[B](f: Int => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Int =
       array(index + offset)
@@ -2692,16 +2707,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override def long(index: Int)(implicit ev: Long <:< Long): Long =
       array(index + offset)
     override protected def mapChunk[B](f: Long => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Long =
       array(index + offset)
@@ -2752,16 +2771,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Double => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Double =
       array(index + offset)
@@ -2812,16 +2835,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Float => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Float =
       array(index + offset)
@@ -2870,16 +2897,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Short => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Short =
       array(index + offset)
@@ -2932,16 +2963,20 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     def hasNextAt(index: Int): Boolean =
       index < length
     override protected def mapChunk[B](f: Boolean => B): Chunk[B] = {
-      val len   = self.length
-      val array = Array.ofDim[AnyRef](len).asInstanceOf[Array[B]]
-
-      var i = 0
-      while (i < len) {
-        array(i) = f(self(i))
-        i += 1
+      val len = self.length
+      if (len == 0) Empty
+      else {
+        val oldArr = array
+        val head   = f(oldArr(0))
+        val newArr = Array.ofDim[B](len)(Chunk.Tags.fromValue(head))
+        var i      = 1
+        newArr(0) = head
+        while (i < len) {
+          newArr(i) = f(oldArr(i))
+          i += 1
+        }
+        Chunk.fromArray(newArr)
       }
-
-      Chunk.fromArray(array)
     }
     def nextAt(index: Int): Boolean =
       array(index + offset)


### PR DESCRIPTION
Currently, the performance of `Chunk#map` on objects is pretty bad (twice as slow as a List):

```
[info] Benchmark                           (size)  Mode  Cnt      Score      Error  Units
[info] ChunkMapBenchmarks.mapIntArray        1000  avgt    3   1101.557 ±  113.502  ns/op
[info] ChunkMapBenchmarks.mapIntChunk        1000  avgt    3   1860.365 ±  125.207  ns/op
[info] ChunkMapBenchmarks.mapIntList         1000  avgt    3   5143.359 ±  182.614  ns/op
[info] ChunkMapBenchmarks.mapIntVector       1000  avgt    3   1824.895 ±   85.139  ns/op
[info] ChunkMapBenchmarks.mapStringArray     1000  avgt    3   6479.824 ±  451.645  ns/op
[info] ChunkMapBenchmarks.mapStringChunk     1000  avgt    3  15152.216 ± 5031.553  ns/op
[info] ChunkMapBenchmarks.mapStringList      1000  avgt    3   8458.140 ±  229.246  ns/op
[info] ChunkMapBenchmarks.mapStringVector    1000  avgt    3   8870.203 ±  555.245  ns/op
[info] ChunkMapBenchmarks.mapZIO             1000  avgt    3   7821.970 ±  941.872  ns/op
```

This PR optimizes it to be only slightly slower than `Array#map`: 

```
[info] Benchmark                          (size)  Mode  Cnt     Score     Error  Units
[info] ChunkMapBenchmarks.mapIntArray       1000  avgt    3  1117.467 ±  83.962  ns/op
[info] ChunkMapBenchmarks.mapIntChunk       1000  avgt    3  1592.925 ± 346.177  ns/op
[info] ChunkMapBenchmarks.mapStringArray    1000  avgt    3  6448.460 ± 213.366  ns/op
[info] ChunkMapBenchmarks.mapStringChunk    1000  avgt    3  6886.193 ± 409.168  ns/op
```