### PR TITLE
Reduce generated code size for ZLayer.make

### DIFF
--- a/core-tests/shared/src/test/scala/zio/autowire/LargeAutoWireSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/autowire/LargeAutoWireSpec.scala
@@ -1,0 +1,319 @@
+package zio.autowire
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+
+object LargeAutoWireSpec extends ZIOBaseSpec {
+  case class V0(
+    v13: V13,
+    v14: V14,
+    v10: V10,
+    v7: V7,
+    v23: V23,
+    v27: V27
+  )
+  object V0 {
+    val layer = ZLayer.derive[V0]
+  }
+  case class V1(
+    v3: V3,
+    v9: V9
+  )
+  object V1 {
+    val layer = ZLayer.derive[V1]
+  }
+  case class V2(
+    v1: V1,
+    v29: V29,
+    v11: V11,
+    v22: V22
+  )
+  object V2 {
+    val layer = ZLayer.derive[V2]
+  }
+  case class V3(
+    v21: V21,
+    v20: V20,
+    v27: V27,
+    v19: V19
+  )
+  object V3 {
+    val layer = ZLayer.derive[V3]
+  }
+  case class V4(
+    v25: V25,
+    v22: V22
+  )
+  object V4 {
+    val layer = ZLayer.derive[V4]
+  }
+  case class V5(
+    v6: V6,
+    v19: V19,
+    v3: V3,
+    v14: V14,
+    v17: V17
+  )
+  object V5 {
+    val layer = ZLayer.derive[V5]
+  }
+  case class V6(
+    v3: V3,
+    v23: V23
+  )
+  object V6 {
+    val layer = ZLayer.derive[V6]
+  }
+  case class V7(
+    v13: V13,
+    v25: V25
+  )
+  object V7 {
+    val layer = ZLayer.derive[V7]
+  }
+  case class V8(
+    v6: V6,
+    v7: V7,
+    v5: V5
+  )
+  object V8 {
+    val layer = ZLayer.derive[V8]
+  }
+  case class V9(
+    v15: V15,
+    v22: V22,
+    v11: V11,
+    v21: V21
+  )
+  object V9 {
+    val layer = ZLayer.derive[V9]
+  }
+  case class V10(
+    v2: V2,
+    v17: V17,
+    v1: V1,
+    v21: V21,
+    v12: V12,
+    v29: V29
+  )
+  object V10 {
+    val layer = ZLayer.derive[V10]
+  }
+  case class V11(
+    v15: V15,
+    v13: V13
+  )
+  object V11 {
+    val layer = ZLayer.derive[V11]
+  }
+  case class V12(
+    v23: V23,
+    v1: V1
+  )
+  object V12 {
+    val layer = ZLayer.derive[V12]
+  }
+  case class V13(
+    v15: V15,
+    v4: V4,
+    v27: V27
+  )
+  object V13 {
+    val layer = ZLayer.derive[V13]
+  }
+  case class V14(
+    v9: V9,
+    v7: V7,
+    v17: V17,
+    v29: V29,
+    v27: V27,
+    v4: V4,
+    v11: V11
+  )
+  object V14 {
+    val layer = ZLayer.derive[V14]
+  }
+  case class V15(
+    v22: V22,
+    v19: V19
+  )
+  object V15 {
+    val layer = ZLayer.derive[V15]
+  }
+  case class V16(
+    v20: V20,
+    v10: V10,
+    v24: V24
+  )
+  object V16 {
+    val layer = ZLayer.derive[V16]
+  }
+  case class V17(
+    v23: V23,
+    v24: V24,
+    v12: V12,
+    v15: V15,
+    v20: V20,
+    v11: V11,
+    v22: V22
+  )
+  object V17 {
+    val layer = ZLayer.derive[V17]
+  }
+  case class V18(
+    v0: V0,
+    v10: V10,
+    v7: V7
+  )
+  object V18 {
+    val layer = ZLayer.derive[V18]
+  }
+  case class V19(
+  )
+  object V19 {
+    val layer = ZLayer.derive[V19]
+  }
+  case class V20(
+    v4: V4,
+    v25: V25,
+    v22: V22
+  )
+  object V20 {
+    val layer = ZLayer.derive[V20]
+  }
+  case class V21(
+    v4: V4,
+    v11: V11
+  )
+  object V21 {
+    val layer = ZLayer.derive[V21]
+  }
+  case class V22(
+    v19: V19
+  )
+  object V22 {
+    val layer = ZLayer.derive[V22]
+  }
+  case class V23(
+    v13: V13,
+    v11: V11,
+    v27: V27
+  )
+  object V23 {
+    val layer = ZLayer.derive[V23]
+  }
+  case class V24(
+    v2: V2,
+    v15: V15,
+    v23: V23
+  )
+  object V24 {
+    val layer = ZLayer.derive[V24]
+  }
+  case class V25(
+    v27: V27
+  )
+  object V25 {
+    val layer = ZLayer.derive[V25]
+  }
+  case class V26(
+    v21: V21,
+    v23: V23
+  )
+  object V26 {
+    val layer = ZLayer.derive[V26]
+  }
+  case class V27(
+  )
+  object V27 {
+    val layer = ZLayer.derive[V27]
+  }
+  case class V28(
+    v16: V16,
+    v5: V5
+  )
+  object V28 {
+    val layer = ZLayer.derive[V28]
+  }
+  case class V29(
+    v21: V21,
+    v7: V7,
+    v26: V26,
+    v27: V27
+  )
+  object V29 {
+    val layer = ZLayer.derive[V29]
+  }
+
+  val t = ZLayer.make[
+    V0 &
+      V1 &
+      V2 &
+      V3 &
+      V4 &
+      V5 &
+      V6 &
+      V7 &
+      V8 &
+      V9 &
+      V10 &
+      V11 &
+      V12 &
+      V13 &
+      V14 &
+      V15 &
+      V16 &
+      V17 &
+      V18 &
+      V19 &
+      V20 &
+      V21 &
+      V22 &
+      V23 &
+      V24 &
+      V25 &
+      V26 &
+      V27 &
+      V28 &
+      V29 &
+      Any
+  ](
+    V0.layer,
+    V1.layer,
+    V2.layer,
+    V3.layer,
+    V4.layer,
+    V5.layer,
+    V6.layer,
+    V7.layer,
+    V8.layer,
+    V9.layer,
+    V10.layer,
+    V11.layer,
+    V12.layer,
+    V13.layer,
+    V14.layer,
+    V15.layer,
+    V16.layer,
+    V17.layer,
+    V18.layer,
+    V19.layer,
+    V20.layer,
+    V21.layer,
+    V22.layer,
+    V23.layer,
+    V24.layer,
+    V25.layer,
+    V26.layer,
+    V27.layer,
+    V28.layer,
+    V29.layer
+  )
+
+  def spec = suite("LargeAutoWireSpec")(
+    test("ZLayer.make") {
+      assertZIO(ZIO.unit.provideLayer(t).exit)(succeeds(anything))
+    }
+  )
+}

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -4,14 +4,15 @@ import zio._
 import zio.internal.TerminalRendering
 
 import scala.reflect.macros.blackbox
+import zio.internal.stacktracer.Tracer
 
 private[zio] trait LayerMacroUtils {
   val c: blackbox.Context
   import c.universe._
 
-  type LayerExpr = c.Expr[ZLayer[_, _, _]]
+  type LayerExpr = Expr[ZLayer[_, _, _]]
 
-  private def verifyLayers(layers: Seq[c.Expr[ZLayer[_, _, _]]]): Unit =
+  private def verifyLayers(layers: Seq[LayerExpr]): Unit =
     for (layer <- layers) {
       layer.tree match {
         case Apply(tree, _) =>
@@ -34,78 +35,79 @@ private[zio] trait LayerMacroUtils {
       }
     }
 
-  private def isByName(tpe: c.Type): Boolean =
-    tpe.typeSymbol.isClass && tpe.typeSymbol.asClass == c.universe.definitions.ByNameParamClass
+  private def isByName(tpe: Type): Boolean =
+    tpe.typeSymbol.isClass && tpe.typeSymbol.asClass == definitions.ByNameParamClass
 
-  def constructLayer[R0: c.WeakTypeTag, R: c.WeakTypeTag, E](
-    layers: Seq[c.Expr[ZLayer[_, E, _]]],
+  def constructLayer[R0: WeakTypeTag, R: WeakTypeTag, E](
+    layers: Seq[LayerExpr],
     provideMethod: ProvideMethod
-  ): c.Expr[ZLayer[R0, E, R]] = {
-
+  ): Expr[ZLayer[R0, E, R]] = {
     verifyLayers(layers)
     val remainderTypes = getRequirements[R0]
     val targetTypes    = getRequirements[R]
 
-    val debugMap: PartialFunction[LayerExpr, ZLayer.Debug] =
-      scala.Function.unlift((_: LayerExpr).tree match {
-        case q"zio.ZLayer.Debug.tree"    => Some(ZLayer.Debug.Tree)
-        case q"zio.ZLayer.Debug.mermaid" => Some(ZLayer.Debug.Mermaid)
-        case _                           => None
-      })
+    val debugMap: PartialFunction[LayerExpr, ZLayer.Debug] = {
+      case q"zio.ZLayer.Debug.tree"    => ZLayer.Debug.Tree
+      case q"zio.ZLayer.Debug.mermaid" => ZLayer.Debug.Mermaid
+    }
 
-    val builder = LayerBuilder[c.Type, LayerExpr](
+    def typeToNode(tpe: Type): Node[Type, LayerExpr] =
+      Node(Nil, List(tpe), c.Expr[ZLayer[_, E, _]](q"${reify(ZLayer)}.environment[$tpe]"))
+
+    val builder = LayerBuilder[Type, LayerExpr](
       target0 = targetTypes,
       remainder = remainderTypes,
       providedLayers0 = layers.toList,
       layerToDebug = debugMap,
-      sideEffectType = c.weakTypeOf[Unit].dealias,
-      anyType = c.weakTypeOf[Any].dealias,
+      sideEffectType = definitions.UnitTpe,
+      anyType = definitions.AnyTpe,
       typeEquals = _ <:< _,
       foldTree = buildFinalTree,
       method = provideMethod,
       exprToNode = getNode,
-      typeToNode = tpe => Node(Nil, List(tpe), c.Expr[ZLayer[_, E, _]](q"_root_.zio.ZLayer.environment[$tpe]")),
+      typeToNode = typeToNode,
       showExpr = expr => CleanCodePrinter.show(c)(expr.tree),
       showType = _.toString,
       reportWarn = c.warning(c.enclosingPosition, _),
       reportError = c.abort(c.enclosingPosition, _)
     )
 
-    builder.build.asInstanceOf[c.Expr[ZLayer[R0, E, R]]]
+    c.Expr[ZLayer[R0, E, R]](builder.build.tree)
   }
 
-  def provideBaseImpl[F[_, _, _], R0: c.WeakTypeTag, R: c.WeakTypeTag, E, A](
-    layers: Seq[c.Expr[ZLayer[_, E, _]]],
+  def provideBaseImpl[F[_, _, _], R0: WeakTypeTag, R: WeakTypeTag, E, A](
+    layers: Seq[Expr[ZLayer[_, E, _]]],
     method: String,
     provideMethod: ProvideMethod
-  ): c.Expr[F[R0, E, A]] = {
+  ): Expr[F[R0, E, A]] = {
     val expr = constructLayer[R0, R, E](layers, provideMethod)
-    c.Expr[F[R0, E, A]](q"${c.prefix}.${TermName(method)}(${expr.tree})")
+    c.Expr[F[R0, E, A]](q"${c.prefix}.${TermName(method)}($expr)")
   }
 
   private def buildFinalTree(tree: LayerTree[LayerExpr]): LayerExpr = {
-    val memoList: List[(LayerExpr, LayerExpr)] =
-      tree.toList.map { node =>
-        val freshName = c.freshName("layer")
-        val termName  = TermName(freshName)
-        node -> c.Expr(q"$termName")
-      }
+    val memoList: List[(LayerExpr, LayerExpr)] = tree.toList.map { node =>
+      val termName = TermName(c.freshName("layer"))
+      node -> c.Expr(q"$termName")
+    }
 
-    val definitions =
-      memoList.map { case (expr, memoizedNode) =>
-        q"val ${TermName(memoizedNode.tree.toString())} = $expr"
-      }
+    val definitions = memoList.map { case (expr, memoizedNode) =>
+      q"val ${TermName(memoizedNode.tree.toString)} = $expr"
+    }
 
-    val memoMap: Map[LayerExpr, LayerExpr] = memoList.toMap
-
+    val memoMap  = memoList.toMap
+    val trace    = TermName(c.freshName("trace"))
+    val compose  = TermName(c.freshName("compose"))
+    val layerSym = typeOf[ZLayer[_, _, _]].typeSymbol
     val layerExpr = tree.fold[LayerExpr](
-      z = reify(ZLayer.succeed(())),
-      value = memoMap(_),
-      composeH = (lhs, rhs) => c.Expr(q"""$lhs ++ $rhs"""),
-      composeV = (lhs, rhs) => c.Expr(q"""$lhs >>> $rhs""")
+      z = reify(ZLayer.unit),
+      value = memoMap,
+      composeH = (lhs, rhs) => c.Expr(q"$lhs ++ $rhs"),
+      composeV = (lhs, rhs) => c.Expr(q"$compose($lhs, $rhs)")
     )
 
     c.Expr(q"""
+    implicit val $trace: ${typeOf[Trace]} = ${reify(Tracer)}.newTrace
+    def $compose[R1, E, O1, O2](lhs: $layerSym[R1, E, O1], rhs: $layerSym[O1, E, O2]) = lhs.to(rhs)
     ..$definitions
     ${layerExpr.tree}
     """)
@@ -115,7 +117,7 @@ private[zio] trait LayerMacroUtils {
    * Converts a LayerExpr to a Node annotated by the Layer's input and output
    * types.
    */
-  def getNode(layer: LayerExpr): Node[c.Type, LayerExpr] = {
+  def getNode(layer: LayerExpr): Node[Type, LayerExpr] = {
     val typeArgs = layer.actualType.dealias.typeArgs
     // ZIO[in, _, out]
     val in  = typeArgs.head
@@ -123,10 +125,10 @@ private[zio] trait LayerMacroUtils {
     Node(getRequirements(in), getRequirements(out), layer)
   }
 
-  def getRequirements[T: c.WeakTypeTag]: List[c.Type] =
+  def getRequirements[T: WeakTypeTag]: List[Type] =
     getRequirements(weakTypeOf[T])
 
-  def getRequirements(tpe: Type): List[c.Type] = {
+  def getRequirements(tpe: Type): List[Type] = {
     val intersectionTypes = tpe.dealias.map(_.dealias).intersectionTypes
 
     intersectionTypes
@@ -135,7 +137,7 @@ private[zio] trait LayerMacroUtils {
       .distinct
   }
 
-  def assertProperVarArgs(layer: Seq[c.Expr[_]]): Unit = {
+  def assertProperVarArgs(layer: Seq[Expr[_]]): Unit = {
     val _ = layer.map(_.tree) collect { case Typed(_, Ident(typeNames.WILDCARD_STAR)) =>
       c.abort(
         c.enclosingPosition,

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -48,7 +48,6 @@ private [zio] object LayerMacroUtils {
 
     '{
       given trace: Trace = Tracer.newTrace
-      val empty = ZLayer.succeed(())
       val compose = [R1, O1, O2] => (lhs: ZLayer[R1, E, O1], rhs: ZLayer[O1, E, O2]) => lhs.to(rhs)
 
       ${
@@ -75,7 +74,7 @@ private [zio] object LayerMacroUtils {
           val layerExprs = tree.toList
           ValDef.let(Symbol.spliceOwner, layerExprs.map(_.asTerm)) { idents =>
             val exprMap = layerExprs.zip(idents.map(_.asExprOf[ZLayer[_, E, _]])).toMap
-            tree.fold('empty, exprMap, composeH, composeV).asTerm
+            tree.fold('{ZLayer.unit}, exprMap, composeH, composeV).asTerm
           }.asExprOf[ZLayer[_, E, _]]
         }
 

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -3,126 +3,102 @@ package zio.internal.macros
 import zio._
 import scala.quoted._
 import scala.compiletime._
-import zio.internal.macros.StringUtils.StringOps
 import zio.internal.ansi.AnsiStringOps
+import zio.internal.macros.StringUtils.StringOps
+import zio.internal.stacktracer.Tracer
 
 private [zio] object LayerMacroUtils {
-  type LayerExpr[E] = Expr[ZLayer[_,E,_]]
+  type LayerExpr[E] = Expr[ZLayer[_, E, _]]
 
-  def renderExpr[A](expr: Expr[A])(using Quotes): String = {
-    import quotes.reflect._
-    scala.util.Try(expr.asTerm.pos.sourceCode).toOption.flatten.getOrElse(expr.show)
-  }
-
-  def constructLayer[R0: Type, R: Type, E: Type](using ctx: Quotes)(
-    layers: Seq[Expr[ZLayer[_, E, _]]],
+  def constructLayer[R0: Type, R: Type, E: Type](using Quotes)(
+    layers: Seq[LayerExpr[E]],
     provideMethod: ProvideMethod
   ): Expr[ZLayer[R0, E, R]] = {
-    import ctx.reflect._
-
-    val targetTypes    = getRequirements[R]
-    val remainderTypes = getRequirements[R0]
-
-    val layerToDebug: PartialFunction[LayerExpr[E], ZLayer.Debug] =
-      ((_: LayerExpr[E]) match {
-        case '{zio.ZLayer.Debug.tree}    => Some(ZLayer.Debug.Tree)
-        case '{zio.ZLayer.Debug.mermaid} => Some(ZLayer.Debug.Mermaid)
-        case _                           => None
-      }).unlift
-
-    val builder = LayerBuilder[TypeRepr, LayerExpr[E]](
-      target0 = targetTypes,
-      remainder = remainderTypes,
-      providedLayers0 = layers.toList,
-      layerToDebug = layerToDebug,
-      typeEquals = _ <:< _,
-      sideEffectType = TypeRepr.of[Unit],
-      anyType = TypeRepr.of[Any],
-      foldTree = buildFinalTree,
-      method = provideMethod,
-      exprToNode = getNode,
-      typeToNode = tpe => Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ZLayer.environment[t] } }),
-      showExpr = expr => scala.util.Try(expr.asTerm.pos.sourceCode).toOption.flatten.getOrElse(expr.show),
-      showType = _.show,
-      reportWarn = report.warning(_),
-      reportError = report.errorAndAbort(_)
-    )
-
-    builder.build.asInstanceOf[Expr[ZLayer[R0, E, R]]]
-  }
-
-  def buildFinalTree[E: Type](tree: LayerTree[LayerExpr[E]])(using ctx: Quotes): LayerExpr[E] = {
-    import ctx.reflect._
-
-    val empty: LayerExpr[E] = '{ZLayer.succeed(())}
-
-    def composeH(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
-      lhs match {
-        case '{$lhs: ZLayer[i, e, o]} =>
-          rhs match {
-            case '{$rhs: ZLayer[i2, e2, o2]} =>
-              val tag = Expr.summon[EnvironmentTag[o2]]
-                .getOrElse(report.errorAndAbort(s"Cannot find EnvironmentTag[${TypeRepr.of[o2].show}] in implicit scope"))
-              '{$lhs.++($rhs)(using $tag)}
-          }
-      }
-
-    def composeV(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
-      lhs match {
-        case '{$lhs: ZLayer[i, E, o]} =>
-          rhs match {
-            case '{$rhs: ZLayer[`o`, E, o2]} =>
-              '{$lhs to $rhs}
-          }
-      }
-
-    val layerExprs: List[LayerExpr[E]] = tree.toList
-
-    ValDef.let(Symbol.spliceOwner, layerExprs.map(_.asTerm)) { idents =>
-      val exprMap = layerExprs.zip(idents).toMap
-
-      tree.fold[LayerExpr[E]](
-        empty,
-        exprMap(_).asExpr.asInstanceOf[LayerExpr[E]],
-        composeH,
-        composeV
-      ).asTerm
-
-    }.asExpr.asInstanceOf[LayerExpr[E]]
-
-  }
-
-  def getNode[E: Type](layer: LayerExpr[E])(using ctx: Quotes): Node[ctx.reflect.TypeRepr, LayerExpr[E]] = {
     import quotes.reflect._
-    layer match {
+
+    def renderExpr[A](expr: Expr[A]): String =
+      scala.util.Try(expr.asTerm.pos.sourceCode).toOption.flatten.getOrElse(expr.show)
+
+    def getNode(layer: LayerExpr[E]): Node[TypeRepr, LayerExpr[E]] = layer match {
       case '{ $layer: ZLayer[in, e, out] } =>
         val inputs = getRequirements[in]
         val outputs = getRequirements[out]
         Node(inputs, outputs, layer)
     }
-  }
 
-  def getRequirements[T: Type](using ctx: Quotes) : List[ctx.reflect.TypeRepr] = {
-    import ctx.reflect._
+    def getRequirements[T: Type]: List[TypeRepr] = {
+      def loop(tpe: TypeRepr): List[TypeRepr] =
+        tpe.dealias.simplified match {
+          case AndType(lhs, rhs) => loop(lhs) ++ loop(rhs)
+          case AppliedType(_, TypeBounds(_,_) :: _) => Nil
+          case other if other =:= TypeRepr.of[Any] => Nil
+          case other if other.dealias.simplified != other => loop(other)
+          case other => List(other.dealias)
+        }
 
-    def loop(tpe: TypeRepr): List[TypeRepr] =
-      tpe.dealias.simplified match {
-        case AndType(lhs, rhs) =>
-          loop(lhs) ++ loop(rhs)
+      loop(TypeRepr.of[T])
+    }
 
-        case AppliedType(_, TypeBounds(_,_) :: _) =>
-          List.empty
+    val targetTypes = getRequirements[R]
+    val remainderTypes = getRequirements[R0]
+    val layerToDebug: PartialFunction[LayerExpr[E], ZLayer.Debug] = {
+      case '{ZLayer.Debug.tree} => ZLayer.Debug.Tree
+      case '{ZLayer.Debug.mermaid} => ZLayer.Debug.Mermaid
+    }
 
-        case other if other =:= TypeRepr.of[Any] =>
-          List.empty
+    '{
+      given trace: Trace = Tracer.newTrace
+      val empty = ZLayer.succeed(())
+      val compose = [R1, O1, O2] => (lhs: ZLayer[R1, E, O1], rhs: ZLayer[O1, E, O2]) => lhs.to(rhs)
 
-        case other if other.dealias.simplified != other =>
-          loop(other)
+      ${
+        def typeToNode(tpe: TypeRepr): Node[TypeRepr, LayerExpr[E]] =
+          Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ZLayer.environment[t]} })
 
-        case other =>
-          List(other.dealias)
+        def composeH(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
+          lhs match { case '{$lhs: ZLayer[i, E, o]} =>
+            rhs match { case '{$rhs: ZLayer[i2, E, o2]} =>
+              val tag = Expr.summon[EnvironmentTag[o2]]
+                .getOrElse(report.errorAndAbort(s"Cannot find EnvironmentTag[${TypeRepr.of[o2].show}] in implicit scope"))
+              '{$lhs.++($rhs)(using $tag)}
+            }
+          }
+
+        def composeV(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
+          lhs match { case '{$lhs: ZLayer[i, E, o]} =>
+            rhs match { case '{$rhs: ZLayer[`o`, E, o2]} =>
+              '{compose($lhs, $rhs)}
+            }
+          }
+
+        def buildFinalTree(tree: LayerTree[LayerExpr[E]]): LayerExpr[E] = {
+          val layerExprs = tree.toList
+          ValDef.let(Symbol.spliceOwner, layerExprs.map(_.asTerm)) { idents =>
+            val exprMap = layerExprs.zip(idents.map(_.asExprOf[ZLayer[_, E, _]])).toMap
+            tree.fold('empty, exprMap, composeH, composeV).asTerm
+          }.asExprOf[ZLayer[_, E, _]]
+        }
+
+        val builder = LayerBuilder[TypeRepr, LayerExpr[E]](
+          target0 = targetTypes,
+          remainder = remainderTypes,
+          providedLayers0 = layers.toList,
+          layerToDebug = layerToDebug,
+          typeEquals = _ <:< _,
+          sideEffectType = TypeRepr.of[Unit],
+          anyType = TypeRepr.of[Any],
+          foldTree = buildFinalTree,
+          method = provideMethod,
+          exprToNode = getNode,
+          typeToNode = typeToNode,
+          showExpr = renderExpr,
+          showType = _.show,
+          reportWarn = report.warning,
+          reportError = report.errorAndAbort
+        )
+
+        builder.build.asTerm.asExprOf[ZLayer[R0, E, R]]
       }
-
-    loop(TypeRepr.of[T])
+    }
   }
 }

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -493,6 +493,14 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
   ): ZLayer[RIn, E, ROut] =
     ZLayer.fromZIO(zio)
 
+  /**
+   * A layer that succeeds with a unit value.
+   */
+  val unit: ULayer[Unit] = {
+    implicit val trace: Trace = Trace.empty
+    ZLayer.succeed(())
+  }
+
   object Derive {
 
     /**


### PR DESCRIPTION
fixes #8855
/claim #8855

 - generate a single trace at the top of the block
 - cache the empty layer
 - apply vertical composition by value
 - keep horizontal composition as-is to preserve semantics