### PR TITLE
Make layer's generated code deterministic

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -84,17 +84,19 @@ private[zio] trait LayerMacroUtils {
   }
 
   private def buildFinalTree(tree: LayerTree[LayerExpr]): LayerExpr = {
-    val memoMap: Map[LayerExpr, LayerExpr] =
+    val memoList: List[(LayerExpr, LayerExpr)] =
       tree.toList.map { node =>
         val freshName = c.freshName("layer")
         val termName  = TermName(freshName)
         node -> c.Expr(q"$termName")
-      }.toMap
+      }
 
     val definitions =
-      memoMap.map { case (expr, memoizedNode) =>
+      memoList.map { case (expr, memoizedNode) =>
         q"val ${TermName(memoizedNode.tree.toString())} = $expr"
       }
+
+    val memoMap: Map[LayerExpr, LayerExpr] = memoList.toMap
 
     val layerExpr = tree.fold[LayerExpr](
       z = reify(ZLayer.succeed(())),

--- a/core/shared/src/main/scala/zio/internal/macros/LayerTree.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerTree.scala
@@ -1,6 +1,7 @@
 package zio.internal.macros
 
 import zio.internal.macros.LayerTree.{ComposeH, ComposeV, Empty, Value}
+import scala.collection.mutable
 
 sealed abstract class LayerTree[+A] extends Product with Serializable { self =>
 
@@ -24,7 +25,8 @@ sealed abstract class LayerTree[+A] extends Product with Serializable { self =>
 
   def toSet[A1 >: A]: Set[A1] = fold[Set[A1]](Set.empty[A1], Set(_), _ ++ _, _ ++ _)
 
-  def toList: List[A] = toSet.toList
+  def toList: List[A] =
+    fold[mutable.LinkedHashSet[A]](mutable.LinkedHashSet.empty[A], mutable.LinkedHashSet(_), _ ++ _, _ ++ _).toList
 }
 
 object LayerTree {


### PR DESCRIPTION
Code generated by ZLayer's macros' is slightly different between compilations, the order of definitions and layer variable's names keep changing.
We're using bazel as a build tool and it's important for build to produce an exact same file for the same input, otherwise it's dependent targets are re-evaluated.