### PR TITLE
Fix flaky test in ReentrantLockSpec

### DIFF
--- a/concurrent/shared/src/test/scala/zio/concurrent/ReentrantLockSpec.scala
+++ b/concurrent/shared/src/test/scala/zio/concurrent/ReentrantLockSpec.scala
@@ -59,6 +59,7 @@ object ReentrantLockSpec extends ZIOSpecDefault {
               lock.withLock.flatMap(_ => ref.update(_ + 10) <* wlatch2.succeed(()))
             )).fork
           _        <- latch1.await
+          _        <- Live.live(ZIO.sleep(10.milli))
           waiters1 <- lock.queueLength
           _        <- f1.interrupt
           _        <- wlatch.succeed(()) *> wlatch2.await


### PR DESCRIPTION
This test can be flaky due the "main" fiber reading `lock.queueLength` before the forked fibers have attempted to acquire the lock. Even with the use of latches, there are no guarantees that the forked fibers will manage to reach the `withLock` step before the main fiber reads `lock.queueLength`

With these change we give more than enough time to the forked fibers to reach it. Note that I tested it locally with `nonFlaky(10000)` and the test passed, but I kept the `@@ flaky` aspect _just in case_