### PR TITLE
Reimplement someOrElse with better type inference

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3648,6 +3648,9 @@ object ZIOSpec extends ZIOBaseSpec {
       test("falls back to the default value if None") {
         assertZIO(ZIO.succeed(None).someOrElse(42))(equalTo(42))
       },
+      test("works when the default is an instance of a covariant type constructor applied to Nothing") {
+        assertZIO(ZIO.succeed(Option.empty[List[String]]).someOrElse(List.empty))(equalTo(List.empty))
+      },
       test("does not change failed state") {
         assertZIO(ZIO.fail(ExampleError).someOrElse(42).exit)(fails(equalTo(ExampleError)))
       } @@ zioTag(errors)
@@ -3658,6 +3661,9 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       test("falls back to the default effect if None") {
         assertZIO(ZIO.succeed(None).someOrElseZIO(ZIO.succeed(42)))(equalTo(42))
+      },
+      test("works when the output of the default is an instance of a covariant type constructor applied to Nothing") {
+        assertZIO(ZIO.succeed(Option.empty[List[String]]).someOrElseZIO(ZIO.succeed(List.empty)))(equalTo(List.empty))
       },
       test("does not change failed state") {
         assertZIO(ZIO.fail(ExampleError).someOrElseZIO(ZIO.succeed(42)).exit)(fails(equalTo(ExampleError)))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -450,6 +450,9 @@ object ZSTMSpec extends ZIOBaseSpec {
         test("falls back to the default value if None") {
           assertZIO(STM.succeed(None).someOrElse(42).commit)(equalTo(42))
         },
+        test("works when the default is an instance of a covariant type constructor applied to Nothing") {
+          assertZIO(STM.succeed(Option.empty[List[String]]).someOrElse(List.empty).commit)(equalTo(List.empty))
+        },
         test("does not change failed state") {
           assertZIO(STM.fail(ExampleError).someOrElse(42).commit.exit)(fails(equalTo(ExampleError)))
         } @@ zioTag(errors)
@@ -460,6 +463,9 @@ object ZSTMSpec extends ZIOBaseSpec {
         },
         test("falls back to the default value if None") {
           assertZIO(STM.succeed(None).someOrElseSTM(STM.succeed(42)).commit)(equalTo(42))
+        },
+        test("works when the output of the default is an instance of a covariant type constructor applied to Nothing") {
+          assertZIO(STM.succeed(Option.empty[List[String]]).someOrElseSTM(STM.succeed(List.empty)).commit)(equalTo(List.empty))
         },
         test("does not change failed state") {
           assertZIO(STM.fail(ExampleError).someOrElseSTM(STM.succeed(42)).commit.exit)(fails(equalTo(ExampleError)))

--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -465,7 +465,8 @@ object ZSTMSpec extends ZIOBaseSpec {
           assertZIO(STM.succeed(None).someOrElseSTM(STM.succeed(42)).commit)(equalTo(42))
         },
         test("works when the output of the default is an instance of a covariant type constructor applied to Nothing") {
-          assertZIO(STM.succeed(Option.empty[List[String]]).someOrElseSTM(STM.succeed(List.empty)).commit)(equalTo(List.empty))
+          val stm = STM.succeed(Option.empty[List[String]]).someOrElseSTM(STM.succeed(List.empty))
+          assertZIO(stm.commit)(equalTo(List.empty))
         },
         test("does not change failed state") {
           assertZIO(STM.fail(ExampleError).someOrElseSTM(STM.succeed(42)).commit.exit)(fails(equalTo(ExampleError)))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1883,9 +1883,9 @@ sealed trait ZIO[-R, +E, +A]
     f(self.some).unsome
 
   /**
-   * Extracts the optional value, or returns the given 'default'.
-   * Superseded by `someOrElse` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or returns the given 'default'. Superseded by
+   * `someOrElse` with better type inference. This method was left for binary
+   * compatibility.
    */
   private final def someOrElse[B](
     default: => B
@@ -1896,14 +1896,14 @@ sealed trait ZIO[-R, +E, +A]
    * Extracts the optional value, or returns the given 'default'.
    */
   final def someOrElse[B, C](
-                                   default: => C
-                                 )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R, E, B] =
+    default: => C
+  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R, E, B] =
     map(a => ev0(a).getOrElse(default))
 
   /**
-   * Extracts the optional value, or executes the effect 'default'.
-   * Superseded by someOrElseZIO with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or executes the effect 'default'. Superseded
+   * by someOrElseZIO with better type inference. This method was left for
+   * binary compatibility.
    */
   private final def someOrElseZIO[B, R1 <: R, E1 >: E](
     default: => ZIO[R1, E1, B]
@@ -1917,8 +1917,8 @@ sealed trait ZIO[-R, +E, +A]
    * Extracts the optional value, or executes the effect 'default'.
    */
   final def someOrElseZIO[B, R1 <: R, E1 >: E, C](
-                                                        default: => ZIO[R1, E1, C]
-                                                      )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R1, E1, B] =
+    default: => ZIO[R1, E1, C]
+  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R1, E1, B] =
     self.flatMap(ev0(_) match {
       case Some(value) => ZIO.succeed(value)
       case None        => default.map(ev1)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1884,21 +1884,44 @@ sealed trait ZIO[-R, +E, +A]
 
   /**
    * Extracts the optional value, or returns the given 'default'.
+   * Superseded by `someOrElse` with better type inference.
+   * This method was left for binary compatibility.
    */
-  final def someOrElse[B](
+  private final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, E, B] =
     map(a => ev(a).getOrElse(default))
 
   /**
-   * Extracts the optional value, or executes the effect 'default'.
+   * Extracts the optional value, or returns the given 'default'.
    */
-  final def someOrElseZIO[B, R1 <: R, E1 >: E](
+  final def someOrElse[B, C](
+                                   default: => C
+                                 )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R, E, B] =
+    map(a => ev0(a).getOrElse(default))
+
+  /**
+   * Extracts the optional value, or executes the effect 'default'.
+   * Superseded by someOrElseZIO with better type inference.
+   * This method was left for binary compatibility.
+   */
+  private final def someOrElseZIO[B, R1 <: R, E1 >: E](
     default: => ZIO[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R1, E1, B] =
     self.flatMap(ev(_) match {
       case Some(value) => ZIO.succeed(value)
       case None        => default
+    })
+
+  /**
+   * Extracts the optional value, or executes the effect 'default'.
+   */
+  final def someOrElseZIO[B, R1 <: R, E1 >: E, C](
+                                                        default: => ZIO[R1, E1, C]
+                                                      )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZIO[R1, E1, B] =
+    self.flatMap(ev0(_) match {
+      case Some(value) => ZIO.succeed(value)
+      case None        => default.map(ev1)
     })
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1887,7 +1887,7 @@ sealed trait ZIO[-R, +E, +A]
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private[ZIO] final def someOrElse[B](
+  protected final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, E, B] =
     map(a => ev(a).getOrElse(default))
@@ -1905,7 +1905,7 @@ sealed trait ZIO[-R, +E, +A]
    * by someOrElseZIO with better type inference. This method was left for
    * binary compatibility.
    */
-  private[ZIO] final def someOrElseZIO[B, R1 <: R, E1 >: E](
+  protected final def someOrElseZIO[B, R1 <: R, E1 >: E](
     default: => ZIO[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1887,7 +1887,7 @@ sealed trait ZIO[-R, +E, +A]
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private final def someOrElse[B](
+  private[zio] final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, E, B] =
     map(a => ev(a).getOrElse(default))
@@ -1905,7 +1905,7 @@ sealed trait ZIO[-R, +E, +A]
    * by someOrElseZIO with better type inference. This method was left for
    * binary compatibility.
    */
-  private final def someOrElseZIO[B, R1 <: R, E1 >: E](
+  private[zio] final def someOrElseZIO[B, R1 <: R, E1 >: E](
     default: => ZIO[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1887,7 +1887,7 @@ sealed trait ZIO[-R, +E, +A]
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private[zio] final def someOrElse[B](
+  private[ZIO] final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, E, B] =
     map(a => ev(a).getOrElse(default))
@@ -1905,7 +1905,7 @@ sealed trait ZIO[-R, +E, +A]
    * by someOrElseZIO with better type inference. This method was left for
    * binary compatibility.
    */
-  private[zio] final def someOrElseZIO[B, R1 <: R, E1 >: E](
+  private[ZIO] final def someOrElseZIO[B, R1 <: R, E1 >: E](
     default: => ZIO[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -563,9 +563,9 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     )
 
   /**
-   * Extracts the optional value, or returns the given 'default'.
-   * Superseded by `someOrElse` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or returns the given 'default'. Superseded by
+   * `someOrElse` with better type inference. This method was left for binary
+   * compatibility.
    */
   private def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
     map(_.getOrElse(default))
@@ -577,11 +577,13 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
     map(_.getOrElse(default))
 
   /**
-   * Extracts the optional value, or executes the effect 'default'.
-   * Superseded by `someOrElseSTM` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or executes the effect 'default'. Superseded
+   * by `someOrElseSTM` with better type inference. This method was left for
+   * binary compatibility.
    */
-  private def someOrElseSTM[B, R1 <: R, E1 >: E](default: ZSTM[R1, E1, B])(implicit ev: A <:< Option[B]): ZSTM[R1, E1, B] =
+  private def someOrElseSTM[B, R1 <: R, E1 >: E](
+    default: ZSTM[R1, E1, B]
+  )(implicit ev: A <:< Option[B]): ZSTM[R1, E1, B] =
     self.flatMap(ev(_) match {
       case Some(value) => ZSTM.succeedNow(value)
       case None        => default
@@ -590,7 +592,9 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
   /**
    * Extracts the optional value, or executes the effect 'default'.
    */
-  def someOrElseSTM[B, R1 <: R, E1 >: E, C](default: ZSTM[R1, E1, C])(implicit ev0: A <:< Option[B], ev1: C <:< B): ZSTM[R1, E1, B] =
+  def someOrElseSTM[B, R1 <: R, E1 >: E, C](
+    default: ZSTM[R1, E1, C]
+  )(implicit ev0: A <:< Option[B], ev1: C <:< B): ZSTM[R1, E1, B] =
     self.flatMap(ev0(_) match {
       case Some(value) => ZSTM.succeedNow(value)
       case None        => default.map(ev1)

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -567,7 +567,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private[stm] def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
+  protected def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
     map(_.getOrElse(default))
 
   /**
@@ -581,7 +581,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * by `someOrElseSTM` with better type inference. This method was left for
    * binary compatibility.
    */
-  private[stm] def someOrElseSTM[B, R1 <: R, E1 >: E](
+  protected def someOrElseSTM[B, R1 <: R, E1 >: E](
     default: ZSTM[R1, E1, B]
   )(implicit ev: A <:< Option[B]): ZSTM[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -567,7 +567,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
+  private[stm] def someOrElse[B](default: => B)(implicit ev: A <:< Option[B]): ZSTM[R, E, B] =
     map(_.getOrElse(default))
 
   /**
@@ -581,7 +581,7 @@ sealed trait ZSTM[-R, +E, +A] extends Serializable { self =>
    * by `someOrElseSTM` with better type inference. This method was left for
    * binary compatibility.
    */
-  private def someOrElseSTM[B, R1 <: R, E1 >: E](
+  private[stm] def someOrElseSTM[B, R1 <: R, E1 >: E](
     default: ZSTM[R1, E1, B]
   )(implicit ev: A <:< Option[B]): ZSTM[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -858,6 +858,10 @@ object ZManagedSpec extends ZIOBaseSpec {
         val managed: TaskManaged[Int] = ZManaged.succeed(None).someOrElse(42)
         assertZIO(managed.useNow)(equalTo(42))
       },
+      test("works when the output of the default is an instance of a covariant type constructor applied to Nothing") {
+        val managed: TaskManaged[List[String]] = ZManaged.succeed(Option.empty[List[String]]).someOrElseManaged(ZManaged.succeed(List.empty))
+        assertZIO(managed.useNow)(equalTo(List.empty))
+      },
       test("does not change failed state") {
         val managed: TaskManaged[Int] = ZManaged.fail(ExampleError).someOrElse(42)
         managed.exit.use(res => ZIO.succeed(assert(res)(fails(equalTo(ExampleError)))))
@@ -871,6 +875,10 @@ object ZManagedSpec extends ZIOBaseSpec {
       test("falls back to the default value if None") {
         val managed: TaskManaged[Int] = ZManaged.succeed(None).someOrElseManaged(ZManaged.succeed(42))
         assertZIO(managed.useNow)(equalTo(42))
+      },
+      test("works when the default contains an instance of a covariant type constructor applied to Nothing") {
+        val managed: TaskManaged[List[String]] = ZManaged.succeed(Option.empty[List[String]]).someOrElse(List.empty)
+        assertZIO(managed.useNow)(equalTo(List.empty))
       },
       test("does not change failed state") {
         val managed: TaskManaged[Int] = ZManaged.fail(ExampleError).someOrElseManaged(ZManaged.succeed(42))

--- a/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
+++ b/managed-tests/shared/src/test/scala/zio/managed/ZManagedSpec.scala
@@ -859,7 +859,8 @@ object ZManagedSpec extends ZIOBaseSpec {
         assertZIO(managed.useNow)(equalTo(42))
       },
       test("works when the output of the default is an instance of a covariant type constructor applied to Nothing") {
-        val managed: TaskManaged[List[String]] = ZManaged.succeed(Option.empty[List[String]]).someOrElseManaged(ZManaged.succeed(List.empty))
+        val managed: TaskManaged[List[String]] =
+          ZManaged.succeed(Option.empty[List[String]]).someOrElseManaged(ZManaged.succeed(List.empty))
         assertZIO(managed.useNow)(equalTo(List.empty))
       },
       test("does not change failed state") {

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -836,7 +836,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private[managed] final def someOrElse[B](
+  protected final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R, E, B] =
     map(a => ev(a).getOrElse(default))
@@ -854,7 +854,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * by `someOrElseManaged` with better type inference. This method was left for
    * binary compatibility.
    */
-  private[managed] final def someOrElseManaged[B, R1 <: R, E1 >: E](
+  protected final def someOrElseManaged[B, R1 <: R, E1 >: E](
     default: => ZManaged[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -832,9 +832,9 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
     )
 
   /**
-   * Extracts the optional value, or returns the given 'default'.
-   * Superseded by `someOrElse` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or returns the given 'default'. Superseded by
+   * `someOrElse` with better type inference. This method was left for binary
+   * compatibility.
    */
   private final def someOrElse[B](
     default: => B
@@ -845,14 +845,14 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * Extracts the optional value, or returns the given 'default'.
    */
   final def someOrElse[B, C](
-                           default: => C
-                         )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R, E, B] =
+    default: => C
+  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R, E, B] =
     map(a => ev0(a).getOrElse(default))
 
   /**
-   * Extracts the optional value, or executes the effect 'default'.
-   * Superseded by `someOrElseManaged` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or executes the effect 'default'. Superseded
+   * by `someOrElseManaged` with better type inference. This method was left for
+   * binary compatibility.
    */
   private final def someOrElseManaged[B, R1 <: R, E1 >: E](
     default: => ZManaged[R1, E1, B]
@@ -866,8 +866,8 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * Extracts the optional value, or executes the effect 'default'.
    */
   final def someOrElseManaged[B, R1 <: R, E1 >: E, C](
-                                                    default: => ZManaged[R1, E1, C]
-                                                  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R1, E1, B] =
+    default: => ZManaged[R1, E1, C]
+  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R1, E1, B] =
     self.flatMap(ev0(_) match {
       case Some(value) => ZManaged.succeed(value)
       case None        => default.map(ev1)

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -836,7 +836,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private final def someOrElse[B](
+  private[managed] final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R, E, B] =
     map(a => ev(a).getOrElse(default))
@@ -854,7 +854,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
    * by `someOrElseManaged` with better type inference. This method was left for
    * binary compatibility.
    */
-  private final def someOrElseManaged[B, R1 <: R, E1 >: E](
+  private[managed] final def someOrElseManaged[B, R1 <: R, E1 >: E](
     default: => ZManaged[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R1, E1, B] =
     self.flatMap(ev(_) match {

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -833,21 +833,44 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
 
   /**
    * Extracts the optional value, or returns the given 'default'.
+   * Superseded by `someOrElse` with better type inference.
+   * This method was left for binary compatibility.
    */
-  final def someOrElse[B](
+  private final def someOrElse[B](
     default: => B
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R, E, B] =
     map(a => ev(a).getOrElse(default))
 
   /**
-   * Extracts the optional value, or executes the effect 'default'.
+   * Extracts the optional value, or returns the given 'default'.
    */
-  final def someOrElseManaged[B, R1 <: R, E1 >: E](
+  final def someOrElse[B, C](
+                           default: => C
+                         )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R, E, B] =
+    map(a => ev0(a).getOrElse(default))
+
+  /**
+   * Extracts the optional value, or executes the effect 'default'.
+   * Superseded by `someOrElseManaged` with better type inference.
+   * This method was left for binary compatibility.
+   */
+  private final def someOrElseManaged[B, R1 <: R, E1 >: E](
     default: => ZManaged[R1, E1, B]
   )(implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZManaged[R1, E1, B] =
     self.flatMap(ev(_) match {
       case Some(value) => ZManaged.succeed(value)
       case None        => default
+    })
+
+  /**
+   * Extracts the optional value, or executes the effect 'default'.
+   */
+  final def someOrElseManaged[B, R1 <: R, E1 >: E, C](
+                                                    default: => ZManaged[R1, E1, C]
+                                                  )(implicit ev0: A IsSubtypeOfOutput Option[B], ev1: C <:< B, trace: Trace): ZManaged[R1, E1, B] =
+    self.flatMap(ev0(_) match {
+      case Some(value) => ZManaged.succeed(value)
+      case None        => default.map(ev1)
     })
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3041,9 +3041,9 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     self.mapError(Some(_)).someOrFail(None)
 
   /**
-   * Extracts the optional value, or returns the given 'default'.
-   * Superseded by `someOrElse` with better type inference.
-   * This method was left for binary compatibility.
+   * Extracts the optional value, or returns the given 'default'. Superseded by
+   * `someOrElse` with better type inference. This method was left for binary
+   * compatibility.
    */
   private def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
     map(_.getOrElse(default))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3045,7 +3045,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
+  private[stream] def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
     map(_.getOrElse(default))
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3045,7 +3045,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * `someOrElse` with better type inference. This method was left for binary
    * compatibility.
    */
-  private[stream] def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
+  protected def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
     map(_.getOrElse(default))
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3042,8 +3042,16 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
 
   /**
    * Extracts the optional value, or returns the given 'default'.
+   * Superseded by `someOrElse` with better type inference.
+   * This method was left for binary compatibility.
    */
-  def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
+  private def someOrElse[A2](default: => A2)(implicit ev: A <:< Option[A2], trace: Trace): ZStream[R, E, A2] =
+    map(_.getOrElse(default))
+
+  /**
+   * Extracts the optional value, or returns the given 'default'.
+   */
+  def someOrElse[A2, C](default: => C)(implicit ev0: A <:< Option[A2], ev1: C <:< A2, trace: Trace): ZStream[R, E, A2] =
     map(_.getOrElse(default))
 
   /**


### PR DESCRIPTION
/claim #8890

The suggested trick with `private` did not work, however `protected` did.