### PR TITLE
Improve rechunk performance

### DIFF
--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -1,0 +1,82 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio.stream.{ZPipeline, ZStream}
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(value = 1)
+class RechunkBenchmark {
+
+  @Param(Array("10000"))
+  var chunkCount: Int = _
+
+  @Param(Array("10"))
+  var smallChunkSize: Int = _
+
+  @Param(Array("10000"))
+  var largeChunkSize: Int = _
+
+  var smallChunks: IndexedSeq[Chunk[Int]] = _
+  var largeChunks: IndexedSeq[Chunk[Int]] = _
+
+  @Setup
+  def setup(): Unit = {
+    smallChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(smallChunkSize)(i)))
+    largeChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(largeChunkSize)(i)))
+  }
+
+  @Benchmark
+  def rechunkSmallToLarge: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToSmall: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallToSmall: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunk2SmallToLarge: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunk2LargeToSmall: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk2(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunk2SmallToSmall: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallTo1: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk(1)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunk2SmallTo1: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(1)).runCount
+    unsafeRun(result)
+  }
+}

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -51,32 +51,8 @@ class RechunkBenchmark {
   }
 
   @Benchmark
-  def rechunk2SmallToLarge: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(largeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunk2LargeToSmall: Long = {
-    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk2(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunk2SmallToSmall: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
   def rechunkSmallTo1: Long = {
     val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk(1)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunk2SmallTo1: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk2(1)).runCount
     unsafeRun(result)
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1889,6 +1889,22 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     new ZPipeline(ZChannel.suspend(process(new ZStream.Rechunker(target), target)))
   }
 
+  def rechunk2[In](n: => Int)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline(ZChannel.succeed(new ZStream.Rechunker2[In](scala.math.max(n, 1))).flatMap { rechunker =>
+      lazy val loop: ZChannel[Any, ZNothing, Chunk[In], Any, ZNothing, Chunk[In], Any] =
+        ZChannel.readWithCause(
+          (in: Chunk[In]) => {
+            val out = rechunker.rechunk(in)
+            if (out ne null) out *> loop
+            else loop
+          },
+          (cause: Cause[ZNothing]) => rechunker.done() *> ZChannel.refailCause(cause),
+          (_: Any) => rechunker.done()
+        )
+
+      loop
+    })
+
   /**
    * Creates a pipeline that randomly samples elements according to the
    * specified percentage.

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1852,45 +1852,8 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * A pipeline that rechunks the stream into chunks of the specified size.
    */
-  def rechunk[In](n: => Int)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] = {
-
-    def process(
-      rechunker: ZStream.Rechunker[In],
-      target: Int
-    ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[In], Any] =
-      ZChannel.readWithCause(
-        (chunk: Chunk[In]) =>
-          if (chunk.size == target && rechunker.isEmpty) {
-            ZChannel.write(chunk) *> process(rechunker, target)
-          } else if (chunk.size > 0) {
-            var chunks: List[Chunk[In]] = Nil
-            var result: Chunk[In]       = null
-            var i                       = 0
-
-            while (i < chunk.size) {
-              while (i < chunk.size && (result eq null)) {
-                result = rechunker.write(chunk(i))
-                i += 1
-              }
-
-              if (result ne null) {
-                chunks = result :: chunks
-                result = null
-              }
-            }
-
-            ZChannel.writeAll(chunks.reverse: _*) *> process(rechunker, target)
-          } else process(rechunker, target),
-        (cause: Cause[ZNothing]) => rechunker.emitIfNotEmpty() *> ZChannel.refailCause(cause),
-        (_: Any) => rechunker.emitIfNotEmpty()
-      )
-
-    val target = scala.math.max(n, 1)
-    new ZPipeline(ZChannel.suspend(process(new ZStream.Rechunker(target), target)))
-  }
-
-  def rechunk2[In](n: => Int)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    new ZPipeline(ZChannel.succeed(new ZStream.Rechunker2[In](scala.math.max(n, 1))).flatMap { rechunker =>
+  def rechunk[In](n: => Int)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    new ZPipeline(ZChannel.succeed(new ZStream.Rechunker[In](scala.math.max(n, 1))).flatMap { rechunker =>
       lazy val loop: ZChannel[Any, ZNothing, Chunk[In], Any, ZNothing, Chunk[In], Any] =
         ZChannel.readWithCause(
           (in: Chunk[In]) => {


### PR DESCRIPTION
Closes #8894 

Benchmarks run on a Mac M1 Pro 16GB:

`rechunk` => Previous implementation
`rechunk2` => Updated implementation

```
[info] Benchmark                              (chunkCount)  (largeChunkSize)  (smallChunkSize)   Mode  Cnt    Score   Error  Units
[info] RechunkBenchmark.rechunk2LargeToSmall         10000             10000                10  thrpt   15    0.502 ± 0.004  ops/s
[info] RechunkBenchmark.rechunk2SmallTo1             10000             10000                10  thrpt   15   65.180 ± 0.238  ops/s
[info] RechunkBenchmark.rechunk2SmallToLarge         10000             10000                10  thrpt   15  528.593 ± 3.568  ops/s
[info] RechunkBenchmark.rechunk2SmallToSmall         10000             10000                10  thrpt   15  377.880 ± 1.653  ops/s
[info] RechunkBenchmark.rechunkLargeToSmall          10000             10000                10  thrpt   15    0.466 ± 0.005  ops/s
[info] RechunkBenchmark.rechunkSmallTo1              10000             10000                10  thrpt   15   52.800 ± 0.368  ops/s
[info] RechunkBenchmark.rechunkSmallToLarge          10000             10000                10  thrpt   15  455.335 ± 2.171  ops/s
[info] RechunkBenchmark.rechunkSmallToSmall          10000             10000                10  thrpt   15  371.793 ± 1.503  ops/s
```

Largest improvement was in going from small to large chunks (~15%) and special case of rechunking to 1 (~20%), about a 5-8% consistent improvement for rechunking to smaller chunks and marginal gains on "no change" chunks (~3%)

/claim #8894 