### PR TITLE
Fix dependency in the build a restful webservice tutorial

### DIFF
--- a/docs/guides/tutorials/build-a-restful-webservice.md
+++ b/docs/guides/tutorials/build-a-restful-webservice.md
@@ -14,7 +14,7 @@ We need to add the following dependencies to our project:
 
 ```scala
 libraryDependencies ++= Seq(
-  "zio.dev"  %% "zio-http" % "3.0.0-RC6"
+  "dev.zio"  %% "zio-http" % "3.0.0-RC6"
 )
 ```
 


### PR DESCRIPTION
The dependency is located under `dev.zio` instead of `zio.dev`. 