### PR TITLE
Fix pruning on union types when a service implements multiple services

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -47,6 +47,16 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
         f6 eq foo1,
         f7 eq foo2
       )
+    },
+    test("pruning a union on a subtype that implements multiple services") {
+      trait Foo
+      trait Bar
+      final class FooBar extends Foo with Bar
+
+      val env = ZEnvironment(new FooBar)
+      val pruned = env.prune[Foo & Bar]
+
+      assertTrue(env == pruned)
     }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -53,7 +53,7 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
       trait Bar
       final class FooBar extends Foo with Bar
 
-      val env = ZEnvironment(new FooBar)
+      val env    = ZEnvironment(new FooBar)
       val pruned = env.prune[Foo & Bar]
 
       assertTrue(env == pruned)

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -124,7 +124,9 @@ final class ZEnvironment[+R] private (
 
         // We need to check whether one of the services we added is a subtype of the missing service
         val newTags = newMap.keySet
-        missing.filterInPlace(tag => !newTags.exists(taggedIsSubtype(_, tag)))
+        missing.foreach { tag =>
+          if (newTags.exists(taggedIsSubtype(_, tag))) missing.remove(tag)
+        }
 
         if (missing.nonEmpty)
           throw new Error(

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -31,6 +31,8 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
 
   def isEmpty: Boolean = size == 0
 
+  def keySet: Set[K] = underlying.keySet
+
   def updated[V1 >: V](key: K, value: V1): UpdateOrderLinkedMap[K, V1] = {
     val existing = underlying.getOrElse(key, null)
     if (existing eq null) {


### PR DESCRIPTION
It seems that #8846 accidentally introduced a bug where pruning on a union type containing services that are implemented by the same service throws an error.

Previously, the following code:

```scala
trait Foo
trait Bar
final class FooBar extends Foo, Bar

@main def broken =
  ZEnvironment(new FooBar).prune[Foo & Bar]
```
throws this error:
```
java.lang.Error: Defect in zio.ZEnvironment: HashSet(Bar) statically known to be contained within the environment are missing
```