### PR TITLE
Lower upper bound of zio_fiber_lifetimes buckets

### DIFF
--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -391,7 +391,7 @@ object Metric {
     val fiberSuccesses = Metric.counter("zio_fiber_successes")
     val fiberFailures  = Metric.counter("zio_fiber_failures")
     val fiberLifetimes =
-      Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 100))
+      Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 30)) // ~18 minutes
   }
 
   /**

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -391,7 +391,7 @@ object Metric {
     val fiberSuccesses = Metric.counter("zio_fiber_successes")
     val fiberFailures  = Metric.counter("zio_fiber_failures")
     val fiberLifetimes =
-      Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 30)) // ~18 minutes
+      Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 20)) // ~18 minutes
   }
 
   /**

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -391,7 +391,10 @@ object Metric {
     val fiberSuccesses = Metric.counter("zio_fiber_successes")
     val fiberFailures  = Metric.counter("zio_fiber_failures")
     val fiberLifetimes =
-      Metric.histogram("zio_fiber_lifetimes", MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 20)) // ~18 minutes
+      Metric.histogram(
+        "zio_fiber_lifetimes",
+        MetricKeyType.Histogram.Boundaries.exponential(0.001, 2.0, 20)
+      ) // ~18 minutes
   }
 
   /**


### PR DESCRIPTION
From quadrilions of years (https://www.wolframalpha.com/input?i=0.001+*+2%5E100+seconds) to 18 minutes (https://www.wolframalpha.com/input?i=0.001+*+2%5E20+seconds)