### PR TITLE
Provide `trace` explicitly in `ZLayer#provide` macros

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -106,7 +106,7 @@ private[zio] trait LayerMacroUtils {
     )
 
     c.Expr(q"""
-    implicit val $trace: ${typeOf[Trace]} = ${reify(Tracer)}.newTrace
+    implicit val $trace: Trace = ${reify(Tracer)}.newTrace
     def $compose[R1, E, O1, O2](lhs: $layerSym[R1, E, O1], rhs: $layerSym[O1, E, O2]) = lhs.to(rhs)
     ..$definitions
     ${layerExpr.tree}

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -102,12 +102,12 @@ private[zio] trait LayerMacroUtils {
       z = reify(ZLayer.unit),
       value = memoMap,
       composeH = (lhs, rhs) => c.Expr(q"$lhs ++ $rhs"),
-      composeV = (lhs, rhs) => c.Expr(q"$compose($lhs, $rhs)")
+      composeV = (lhs, rhs) => c.Expr(q"$compose($lhs, $rhs)($trace)")
     )
 
     c.Expr(q"""
-    implicit val $trace: Trace = ${reify(Tracer)}.newTrace
-    def $compose[R1, E, O1, O2](lhs: $layerSym[R1, E, O1], rhs: $layerSym[O1, E, O2]) = lhs.to(rhs)
+    val $trace: ${typeOf[Trace]} = ${reify(Tracer)}.newTrace
+    def $compose[R1, E, O1, O2](lhs: $layerSym[R1, E, O1], rhs: $layerSym[O1, E, O2])(implicit trace: ${typeOf[Trace]}) = lhs.to(rhs)
     ..$definitions
     ${layerExpr.tree}
     """)


### PR DESCRIPTION
/fix #8936

The issue seems to be that `Trace` is not a concrete type, which the compiler infers to `Object`. Wartremover then assumes that the type was not provided. The solution is to make the trace a value and pass it explicitly to the `compose` method

NOTE for Scala 3:

In a service at $WORK I noticed that after upgrading to ZIO 2.1.3 the artifact size increased from 5.8MB to 6.1MB. After working on this ticket and looking at the generated code, the `compose` function that was being created for each layer was generating a lot of extra bytecode so I made it a method in the object itself. Since the trait is package-private, the method is reachable publicly. I published zio locally and tested it with the service and it worked just fine. Also the artifact size went down to 5.7MB with this change