### PR TITLE
Micro-optimize `ZIO.environment`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3147,7 +3147,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Accesses the whole environment of the effect.
    */
   def environment[R](implicit trace: Trace): URIO[R, ZEnvironment[R]] =
-    ZIO.suspendSucceed(FiberRef.currentEnvironment.get.asInstanceOf[URIO[R, ZEnvironment[R]]])
+    FiberRef.currentEnvironment.get.asInstanceOf[URIO[R, ZEnvironment[R]]]
 
   /**
    * Accesses the environment of the effect.


### PR DESCRIPTION
Came across this and found it a bit bizarre. AFAICT the wrapping of `FiberRef#get` in `suspendSucceed` is unnecessary since it doesn't capture any side effects