### PR TITLE
Add `xDiscard` variant of `ZIO.when` and `ZIO.unless`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2241,10 +2241,18 @@ sealed trait ZIO[-R, +E, +A]
 
   /**
    * The moral equivalent of `if (!p) exp`
+   *
+   * @see
+   *   [[unless0]] for a variant that discards the result of the computation
    */
   final def unless(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.unless(p)(self)
 
+  /**
+   * Variant of [[unless]] that discards the result of the computation. Useful
+   * for cases where we only care about the side-effects, e.g., logging or
+   * raising errors
+   */
   final def unless0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
     ZIO.unless(p)(self)
 
@@ -2372,7 +2380,7 @@ sealed trait ZIO[-R, +E, +A]
 
   /**
    * Variant of [[when]] that discards the result. Useful for running effects
-   * where we only care about the side-effects, e.g., logging
+   * where we only care about the side-effects, e.g., logging or raising errors
    */
   final def when0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
     ZIO.when0(p)(self)
@@ -4816,7 +4824,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   /**
    * Variant of [[unless]] that discards the result of the computation. Useful
-   * for cases where we only care about the side-effects, e.g., logging
+   * for cases where we only care about the side-effects, e.g., logging or
+   * raising errors
    */
   def unless0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
     suspendSucceed(if (p) unit else zio.unit)
@@ -5010,7 +5019,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   /**
    * Variant of [[when]] that discards the result. Useful for running effects
-   * where we only care about the side-effects, e.g., logging
+   * where we only care about the side-effects, e.g., logging or raising errors
    */
   def when0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
     suspendSucceed(if (p) zio.unit else unit)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2240,7 +2240,7 @@ sealed trait ZIO[-R, +E, +A]
     )
 
   /**
-   * The moral equivalent of `if (!p) exp`
+   * The moral equivalent of `if (!p) Some(exp) else None`
    */
   final def unless(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.unless(p)(self)
@@ -2252,7 +2252,7 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.unlessDiscard(p)(self)
 
   /**
-   * The moral equivalent of `if (!p) exp` when `p` has side-effects
+   * The moral equivalent of `if (!p) Some(exp) else None` when `p` has side-effects
    */
   final def unlessZIO[R1 <: R, E1 >: E](p: => ZIO[R1, E1, Boolean])(implicit
     trace: Trace
@@ -2260,7 +2260,7 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.unlessZIO(p)(self)
 
   /**
-   * The moral equivalent of `if (!p) exp: Unit` when `p` has side-effects
+   * The moral equivalent of `if (!p) { expr; () }` when `p` has side-effects
    */
   final def unlessZIODiscard[R1 <: R, E1 >: E](p: => ZIO[R1, E1, Boolean])(implicit
     trace: Trace
@@ -2404,7 +2404,7 @@ sealed trait ZIO[-R, +E, +A]
     }
 
   /**
-   * The moral equivalent of `if (p) exp` when `p` has side-effects
+   * The moral equivalent of `if (p) Some(exp) else None` when `p` has side-effects
    */
   final def whenZIO[R1 <: R, E1 >: E](
     p: => ZIO[R1, E1, Boolean]
@@ -2412,7 +2412,7 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.whenZIO(p)(self)
 
   /**
-   * The moral equivalent of `if (p) exp: Unit` when `p` has side-effects
+   * The moral equivalent of `if (p) { expr; () }` when `p` has side-effects
    */
   final def whenZIODiscard[R1 <: R, E1 >: E](
     p: => ZIO[R1, E1, Boolean]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2252,7 +2252,8 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.unlessDiscard(p)(self)
 
   /**
-   * The moral equivalent of `if (!p) Some(exp) else None` when `p` has side-effects
+   * The moral equivalent of `if (!p) Some(exp) else None` when `p` has
+   * side-effects
    */
   final def unlessZIO[R1 <: R, E1 >: E](p: => ZIO[R1, E1, Boolean])(implicit
     trace: Trace
@@ -2404,7 +2405,8 @@ sealed trait ZIO[-R, +E, +A]
     }
 
   /**
-   * The moral equivalent of `if (p) Some(exp) else None` when `p` has side-effects
+   * The moral equivalent of `if (p) Some(exp) else None` when `p` has
+   * side-effects
    */
   final def whenZIO[R1 <: R, E1 >: E](
     p: => ZIO[R1, E1, Boolean]
@@ -4833,7 +4835,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     suspendSucceed(if (p) unit else zio.unit)
 
   /**
-   * The moral equivalent of `if (!p) Some(expr) else None` when `p` has side-effects
+   * The moral equivalent of `if (!p) Some(expr) else None` when `p` has
+   * side-effects
    */
   def unlessZIO[R, E](p: => ZIO[R, E, Boolean]): ZIO.UnlessZIO[R, E] =
     new ZIO.UnlessZIO(() => p)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2245,6 +2245,9 @@ sealed trait ZIO[-R, +E, +A]
   final def unless(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.unless(p)(self)
 
+  final def unless0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
+    ZIO.unless(p)(self)
+
   /**
    * The moral equivalent of `if (!p) exp` when `p` has side-effects
    */
@@ -2360,9 +2363,19 @@ sealed trait ZIO[-R, +E, +A]
 
   /**
    * The moral equivalent of `if (p) exp`
+   *
+   * @see
+   *   [[when]] for a variant that discards the result of the computation
    */
   final def when(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.when(p)(self)
+
+  /**
+   * Variant of [[when]] that discards the result. Useful for running effects
+   * where we only care about the side-effects, e.g., logging
+   */
+  final def when0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
+    ZIO.when0(p)(self)
 
   /**
    * Executes this workflow when value of the specified `FiberRef` satisfies the
@@ -4794,9 +4807,19 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   /**
    * The moral equivalent of `if (!p) exp`
+   *
+   * @see
+   *   [[unless0]] for a variant that discards the result of the computation
    */
   def unless[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
     suspendSucceed(if (p) none else zio.asSome)
+
+  /**
+   * Variant of [[unless]] that discards the result of the computation. Useful
+   * for cases where we only care about the side-effects, e.g., logging
+   */
+  def unless0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
+    suspendSucceed(if (p) unit else zio.unit)
 
   /**
    * The moral equivalent of `if (!p) exp` when `p` has side-effects
@@ -4978,9 +5001,19 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   /**
    * The moral equivalent of `if (p) exp`
+   *
+   * @see
+   *   [[when0]] for a variant that discards the result of the computation
    */
   def when[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
     suspendSucceed(if (p) zio.asSome else none)
+
+  /**
+   * Variant of [[when]] that discards the result. Useful for running effects
+   * where we only care about the side-effects, e.g., logging
+   */
+  def when0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
+    suspendSucceed(if (p) zio.unit else unit)
 
   /**
    * Runs an effect when the supplied `PartialFunction` matches for the given

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2241,20 +2241,15 @@ sealed trait ZIO[-R, +E, +A]
 
   /**
    * The moral equivalent of `if (!p) exp`
-   *
-   * @see
-   *   [[unless0]] for a variant that discards the result of the computation
    */
   final def unless(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.unless(p)(self)
 
   /**
-   * Variant of [[unless]] that discards the result of the computation. Useful
-   * for cases where we only care about the side-effects, e.g., logging or
-   * raising errors
+   * The moral equivalent of `if (!p) { expr; () }`
    */
-  final def unless0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
-    ZIO.unless(p)(self)
+  final def unlessDiscard(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
+    ZIO.unlessDiscard(p)(self)
 
   /**
    * The moral equivalent of `if (!p) exp` when `p` has side-effects
@@ -2263,6 +2258,14 @@ sealed trait ZIO[-R, +E, +A]
     trace: Trace
   ): ZIO[R1, E1, Option[A]] =
     ZIO.unlessZIO(p)(self)
+
+  /**
+   * The moral equivalent of `if (!p) exp: Unit` when `p` has side-effects
+   */
+  final def unlessZIODiscard[R1 <: R, E1 >: E](p: => ZIO[R1, E1, Boolean])(implicit
+    trace: Trace
+  ): ZIO[R1, E1, Unit] =
+    ZIO.unlessZIODiscard(p)(self)
 
   /**
    * Takes some fiber failures and converts them into errors.
@@ -2370,20 +2373,16 @@ sealed trait ZIO[-R, +E, +A]
     self.exit.zipWithPar(that.exit)(_.zipWith(_)(f, _ && _)).flatMap(ZIO.done(_))
 
   /**
-   * The moral equivalent of `if (p) exp`
-   *
-   * @see
-   *   [[when]] for a variant that discards the result of the computation
+   * The moral equivalent of `if (p) Some(exp) else None`
    */
   final def when(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Option[A]] =
     ZIO.when(p)(self)
 
   /**
-   * Variant of [[when]] that discards the result. Useful for running effects
-   * where we only care about the side-effects, e.g., logging or raising errors
+   * The moral equivalent of `if (p) { expr; () }`
    */
-  final def when0(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
-    ZIO.when0(p)(self)
+  final def whenDiscard(p: => Boolean)(implicit trace: Trace): ZIO[R, E, Unit] =
+    ZIO.whenDiscard(p)(self)
 
   /**
    * Executes this workflow when value of the specified `FiberRef` satisfies the
@@ -2411,6 +2410,14 @@ sealed trait ZIO[-R, +E, +A]
     p: => ZIO[R1, E1, Boolean]
   )(implicit trace: Trace): ZIO[R1, E1, Option[A]] =
     ZIO.whenZIO(p)(self)
+
+  /**
+   * The moral equivalent of `if (p) exp: Unit` when `p` has side-effects
+   */
+  final def whenZIODiscard[R1 <: R, E1 >: E](
+    p: => ZIO[R1, E1, Boolean]
+  )(implicit trace: Trace): ZIO[R1, E1, Unit] =
+    ZIO.whenZIODiscard(p)(self)
 
   /**
    * Executes this workflow with the specified implementation of the clock
@@ -4814,27 +4821,28 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     )
 
   /**
-   * The moral equivalent of `if (!p) exp`
-   *
-   * @see
-   *   [[unless0]] for a variant that discards the result of the computation
+   * The moral equivalent of `if (!p) Some(exp) else None`
    */
   def unless[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
     suspendSucceed(if (p) none else zio.asSome)
 
   /**
-   * Variant of [[unless]] that discards the result of the computation. Useful
-   * for cases where we only care about the side-effects, e.g., logging or
-   * raising errors
+   * The moral equivalent of `if (!p) { expr; () }`
    */
-  def unless0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
+  def unlessDiscard[R, E](p: => Boolean)(zio: => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
     suspendSucceed(if (p) unit else zio.unit)
 
   /**
-   * The moral equivalent of `if (!p) exp` when `p` has side-effects
+   * The moral equivalent of `if (!p) Some(expr) else None` when `p` has side-effects
    */
   def unlessZIO[R, E](p: => ZIO[R, E, Boolean]): ZIO.UnlessZIO[R, E] =
     new ZIO.UnlessZIO(() => p)
+
+  /**
+   * The moral equivalent of `if (!p) { expr; () }` when `p` has side-effects
+   */
+  def unlessZIODiscard[R, E](p: => ZIO[R, E, Boolean]): ZIO.UnlessZIODiscard[R, E] =
+    new ZIO.UnlessZIODiscard(() => p)
 
   /**
    * The inverse operation `IO.sandboxed`
@@ -5009,19 +5017,15 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.foreachPar(in)(f(_).flip).flip
 
   /**
-   * The moral equivalent of `if (p) exp`
-   *
-   * @see
-   *   [[when0]] for a variant that discards the result of the computation
+   * The moral equivalent of `if (p) Some(exp) else None`
    */
   def when[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
     suspendSucceed(if (p) zio.asSome else none)
 
   /**
-   * Variant of [[when]] that discards the result. Useful for running effects
-   * where we only care about the side-effects, e.g., logging or raising errors
+   * The moral equivalent of `if (p) { expr; () }`
    */
-  def when0[R, E, A](p: => Boolean)(zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Unit] =
+  def whenDiscard[R, E](p: => Boolean)(zio: => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
     suspendSucceed(if (p) zio.unit else unit)
 
   /**
@@ -5047,6 +5051,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    */
   def whenZIO[R, E](p: => ZIO[R, E, Boolean]): ZIO.WhenZIO[R, E] =
     new ZIO.WhenZIO(() => p)
+
+  /**
+   * The moral equivalent of `if (p) exp: Unit` when `p` has side-effects
+   */
+  def whenZIODiscard[R, E](p: => ZIO[R, E, Boolean]): ZIO.WhenZIODiscard[R, E] =
+    new ZIO.WhenZIODiscard(() => p)
 
   /**
    * Locally installs a supervisor and an effect that succeeds with all the
@@ -5357,12 +5367,22 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   final class UnlessZIO[R, E](private val b: () => ZIO[R, E, Boolean]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, A](zio: => ZIO[R1, E1, A])(implicit trace: Trace): ZIO[R1, E1, Option[A]] =
-      ZIO.suspendSucceed(b().flatMap(b => if (b) none else zio.asSome))
+      ZIO.suspendSucceed(b()).flatMap(b => if (b) none else zio.asSome)
+  }
+
+  final class UnlessZIODiscard[R, E](private val b: () => ZIO[R, E, Boolean]) extends AnyVal {
+    def apply[R1 <: R, E1 >: E](zio: => ZIO[R1, E1, Any])(implicit trace: Trace): ZIO[R1, E1, Unit] =
+      ZIO.suspendSucceed(b()).flatMap(b => if (b) unit else zio.unit)
   }
 
   final class WhenZIO[R, E](private val b: () => ZIO[R, E, Boolean]) extends AnyVal {
     def apply[R1 <: R, E1 >: E, A](zio: => ZIO[R1, E1, A])(implicit trace: Trace): ZIO[R1, E1, Option[A]] =
       ZIO.suspendSucceed(b()).flatMap(b => if (b) zio.asSome else none)
+  }
+
+  final class WhenZIODiscard[R, E](private val b: () => ZIO[R, E, Boolean]) extends AnyVal {
+    def apply[R1 <: R, E1 >: E](zio: => ZIO[R1, E1, Any])(implicit trace: Trace): ZIO[R1, E1, Unit] =
+      ZIO.suspendSucceed(b()).flatMap(b => if (b) zio.unit else unit)
   }
 
   final class TimeoutTo[-R, +E, +A, +B](self: ZIO[R, E, A], b: () => B) {


### PR DESCRIPTION
In many cases, we only care about the effect we provide to `ZIO.when` / `ZIO.unless` for its side-effects (e.g., logging, raising errors). Besides a minor performance penalty due to the allocation of `Some` when the condition matches, users are often forced to use `.unit` on the resulting effect to satisfy discarded value linters or help with type inference.

This PR adds `xDiscard` variants to these methods where the result type is `Unit` as a UX improvement to this problem.

Note on the naming (/cc @jdegoes)

I used the `Discard` suffix for consistency with `foreachPar` et.al, although I'm not too happy with it - I don't think `whenDiscard` reads well. To me, it reads as if "when the condition matches, discard the computation".

Alternative names that could be used (open to more ideas):
- `when0` (my favourite but doesn't read well with `whenZIO0`
- `when_` (similar to cats, but I don't really it fits ZIO)
- `whenRun`
- `whenUnit`