### PR TITLE
Fix premature interrupt of debounce

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4093,6 +4093,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               _     <- fiber.interrupt
               value <- ref.get
             } yield assert(value)(equalTo(true))
+          },
+          test("should not interrupt children of a pending stream") {
+            val stream1 = (ZStream.succeed(0) ++ ZStream.fromZIO(ZIO.sleep(200.millis)).as(1))
+              .debounce(100.millis)
+
+            val stream2 = ZStream.succeed(42)
+
+            for {
+              fiber  <- (stream1 merge stream2).runCollect.fork
+              _      <- TestClock.adjust(10.millis).repeatN(30)
+              result <- fiber.join
+            } yield assertTrue(result == Chunk(42, 0, 1))
           }
         ) @@ TestAspect.timeout(40.seconds),
         suite("timeout")(


### PR DESCRIPTION
Fixes #8734

Addresses an issue when using debounce in the presence of `merge` (or any operator implemented with a `toPullIn`). When racing the previous and the `handoff.take`, The remaining fiber from a `raceWith` operation is forwarded to the next loop of the channel if it loses to the `fiber.join`. In normal stream operation this doesn't cause a problem because the fiber appears to exists as a single operation. However, when converted to a `pull` based operation, each effect finishes when the channel executor hits a continuation operation like `Emit`, this results in the parent fiber getting interrupted along with any children.

The solution is to scope the `handoff` to the stream so that it can't be prematurely interrupted at the end of a pull cycle.

/claim #8734