### PR TITLE
Add Conversion to FiniteDuration to zio.duration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import Dependencies._
 import MimaSettings.mimaSettings
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import sbt.Keys
+import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -214,7 +215,10 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(scalacOptions += "-Wconf:msg=[zio.stacktracer.TracingImplicits.disableAutoTrace]:silent")
   .jvmSettings(
     replSettings,
-    mimaSettings(failOnProblem = true)
+    mimaSettings(failOnProblem = true),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala")
   )
   .jsSettings(
     jsSettings,

--- a/build.sbt
+++ b/build.sbt
@@ -219,6 +219,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     mimaBinaryIssueFilters ++= Seq(
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala")
+    )
   )
   .jsSettings(
     jsSettings,

--- a/core-tests/shared/src/test/scala/zio/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/DurationSpec.scala
@@ -5,7 +5,7 @@ import zio.test.assert
 import java.time.temporal.ChronoUnit
 import java.time.{Duration => JavaDuration}
 import java.util.concurrent.TimeUnit
-import scala.concurrent.duration.{Duration => ScalaDuration}
+import scala.concurrent.duration.{Duration => ScalaDuration, FiniteDuration => ScalaFiniteDuration}
 
 object DurationSpec extends ZIOBaseSpec {
 
@@ -154,7 +154,7 @@ object DurationSpec extends ZIOBaseSpec {
         assert(Duration.Infinity.isZero)(equalTo(false))
       },
       test("It converts into the infinite s.c.d.Duration") {
-        assert(Duration.Infinity.asScala)(equalTo(ScalaDuration.Inf: ScalaDuration))
+        assert(Duration.Infinity.asScala)(equalTo(ScalaFiniteDuration(Long.MaxValue, TimeUnit.NANOSECONDS)))
       },
       test("It converts into a Long.MaxValue second-long JDK Duration") {
         assert(Duration.Infinity)(equalTo(JavaDuration.ofNanos(Long.MaxValue)))

--- a/core-tests/shared/src/test/scala/zio/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/DurationSpec.scala
@@ -1,3 +1,4 @@
+
 package zio
 
 import zio.test.Assertion.{equalTo, not}
@@ -152,6 +153,9 @@ object DurationSpec extends ZIOBaseSpec {
       },
       test("Infinity is not zero") {
         assert(Duration.Infinity.isZero)(equalTo(false))
+      },
+      test("It converts into the infinite s.c.d.Duration") {
+        assert(Duration.Infinity.asScala)(equalTo(ScalaFiniteDuration(Long.MaxValue, TimeUnit.NANOSECONDS)))
       },
       test("It converts into a Long.MaxValue second-long JDK Duration") {
         assert(Duration.Infinity)(equalTo(JavaDuration.ofNanos(Long.MaxValue)))

--- a/core-tests/shared/src/test/scala/zio/DurationSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/DurationSpec.scala
@@ -1,4 +1,3 @@
-
 package zio
 
 import zio.test.Assertion.{equalTo, not}

--- a/core/shared/src/main/scala/zio/Duration.scala
+++ b/core/shared/src/main/scala/zio/Duration.scala
@@ -173,10 +173,9 @@ final class DurationOps(private val duration: Duration) extends AnyVal {
     }
   }
 
-  def asScala: ScalaDuration = duration match {
-    case Duration.Infinity => ScalaDuration.Inf
-    case Duration.Zero     => ScalaDuration.Zero
-    case _                 => ScalaFiniteDuration(duration.toNanos, TimeUnit.NANOSECONDS)
+  def asScala: ScalaFiniteDuration = duration match {
+    case Duration.Zero => ScalaDuration.Zero
+    case _             => ScalaFiniteDuration(duration.toNanos, TimeUnit.NANOSECONDS)
   }
 
   def asJava: JavaDuration = duration


### PR DESCRIPTION
fixes #8797 
/claim #8797

Hi ZIO Team,

I have added specific exclusions to the MiMa settings in our build.sbt to address the binary compatibility issues reported for the `zio.DurationOps.asScala$extension` and `zio.DurationOps.asScala` methods.

Exclusions Added:
```
ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala")
```
The rationale to add this issues to exclude in mima checks is that they are unlikely to impact us because the change would only affect us if someone created a subtype of the extension methods class, which is highly improbable