### PR TITLE
Use correct types for definition of `ZLayer.derive` (#8889)

### DIFF
--- a/core/shared/src/main/scala-2/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZLayerCompanionVersionSpecific.scala
@@ -53,7 +53,7 @@ private[zio] trait ZLayerCompanionVersionSpecific {
    * val carLayer: URLayer[Wheels & Engine, Car] = ZLayer.derive[Car]
    * }}}
    */
-  def derive[A]: ZLayer[Nothing, Any, A] = macro zio.internal.macros.ZLayerDerivationMacros.deriveImpl[A]
+  def derive[A]: ZLayer[Any, Nothing, A] = macro zio.internal.macros.ZLayerDerivationMacros.deriveImpl[A]
 }
 
 final class MakePartiallyApplied[R](val dummy: Boolean = true) extends AnyVal {

--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -41,13 +41,13 @@ trait ZLayerCompanionVersionSpecific {
 
   /**
    * Automatically derives a simple layer for the provided type.
-   * 
+   *
    * {{{
    * class Car(wheels: Wheels, engine: Engine) { /* ... */ }
-   * 
+   *
    * val carLayer: URLayer[Wheels & Engine, Car] = ZLayer.derive[Car]
    * }}}
    */
-  transparent inline def derive[A]: ZLayer[Nothing, Any, A] =
+  transparent inline def derive[A]: ZLayer[Any, Nothing, A] =
     ZLayerDerivationMacros.deriveLayer[A]
 }

--- a/core/shared/src/main/scala-3/zio/internal/macros/ZLayerDerivationMacros.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/ZLayerDerivationMacros.scala
@@ -7,7 +7,7 @@ import zio.internal.ansi.AnsiStringOps
 
 object ZLayerDerivationMacros {
 
-  transparent inline def deriveLayer[A]: ZLayer[Nothing, Any, A] = ${ deriveLayerImpl[A] }
+  transparent inline def deriveLayer[A]: ZLayer[Any, Nothing, A] = ${ deriveLayerImpl[A] }
 
   def deriveLayerImpl[A: Type](using Quotes) = {
     import quotes.reflect._
@@ -159,9 +159,9 @@ object ZLayerDerivationMacros {
                 |The type information `R`, `E` in `ZLayer.Derive.Default[A]` for the parameter
                 |`${pName}` is missing. The resolved default instance is:
                 |
-                |  ${d.show}: ${d.asTerm.tpe.widen.show} 
+                |  ${d.show}: ${d.asTerm.tpe.widen.show}
                 |
-                |A frequent reason for this issue is using an incomplete type annotation like 
+                |A frequent reason for this issue is using an incomplete type annotation like
                 |`given ZLayer.Derive.Default[A] = ???`. This can lead to the loss of specific
                 |type details.
                 |


### PR DESCRIPTION
fixes #8889
/claim #8889