### PR TITLE
Zio 8958

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -29,7 +29,10 @@ object MimaSettings {
         exclude[ReversedMissingMethodProblem]("zio.Fiber#Runtime#UnsafeAPI.poll"),
         exclude[IncompatibleResultTypeProblem]("zio.stream.ZChannel#MergeState#BothRunning.*"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel#MergeState#BothRunning.copy"),
-        exclude[DirectMissingMethodProblem]("zio.stream.ZChannel#MergeState#BothRunning.*")
+        exclude[DirectMissingMethodProblem]("zio.stream.ZChannel#MergeState#BothRunning.*"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala"),
+        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension")
       ),
       mimaFailOnProblem := failOnProblem
     )

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4416,7 +4416,81 @@ object ZStreamSpec extends ZIOBaseSpec {
               }
             }
             assertZIO(stream.via(pipeline).runCollect.exit)(fails(hasMessage(containsString("fail"))))
-          } @@ TestAspect.jvmOnly
+          } @@ TestAspect.jvmOnly,
+          test("respects env") {
+            val src: ZStream[Resource, Nothing, (Int, Resource)] = ZStream
+              .range(0, 100, 10)
+              .mapZIO{a =>
+                ZIO.serviceWith[Resource]{resource =>
+                  (a, resource)
+                }
+              }
+
+            val pl0: ZPipeline[Any, Nothing, (Int, Resource), (Int, Resource, Scope)] = ZPipeline.fromFunction { strm: ZStream[Any, Nothing, (Int, Resource)] =>
+              ZStream
+                .unwrapScoped[Any] {
+                  ZIO.scopeWith { scope =>
+                    ZIO.succeed {
+                      ZStream
+                        .serviceWithStream[Scope] { scope2 =>
+                          strm.map{
+                            case (i, res) =>
+                              (i, res, scope2)
+                          }
+                        }
+                        .provideEnvironment(ZEnvironment(scope))
+                    }
+                  }
+                }
+            }
+
+            val strm: ZStream[Resource, Nothing, (Int, Resource, Scope)] = src >>> pl0
+            val z00: ZIO[Any, Nothing, Chunk[(Int, Resource, Scope)]] = strm.runCollect.provideLayer(ZLayer.succeed(Resource(12)))
+            z00.map{ chunk =>
+              zio.test.assertTrue{
+                chunk.map(_._3).toSet.size == 1
+              } &&
+              zio.test.assertTrue{
+                chunk
+                  .map{
+                    case (i, res, _) =>
+                      (i, res)
+                  } ==
+                  Chunk.tabulate(100)((_, Resource(12)))
+              }
+            }
+          },
+          test("respects env multiple levels") {
+            val src = ZStream.range(0, 100, 10)
+
+            val pl1: ZPipeline[Any, Nothing, Int, (Int, Resource)] = ZPipeline.fromFunction{ strm : ZStream[Any, Nothing, Int] =>
+              strm
+                .mapZIO{i =>
+                  ZIO.serviceWith[Resource]{r =>
+                    (i, r)
+                  }
+                }
+                .provideEnvironment(ZEnvironment(Resource(11)))
+            }
+
+            val pl2: ZPipeline[Any, Nothing, (Int, Resource), (Int, Resource, Resource)] = ZPipeline.fromFunction{ strm : ZStream[Any, Nothing, (Int, Resource)] =>
+              strm
+                .mapZIO{
+                  case (i, r0) =>
+                    ZIO.serviceWith[Resource]{r1 =>
+                      (i, r0, r1)
+                    }
+                }
+                .provideEnvironment(ZEnvironment(Resource(12)))
+            }
+
+            val strm: ZStream[Any, Nothing, (Int, Resource, Resource)] = src >>> pl1 >>> pl2
+            val z: ZIO[Any, Nothing, Chunk[(Int, Resource, Resource)]] = strm.runCollect
+
+            assertZIO(z){
+              zio.test.Assertion.equalTo(zio.Chunk.tabulate(100)((_, Resource(11), Resource(12))))
+            }
+          }
         ),
         test("toIterator") {
           ZIO.scoped {
@@ -5638,4 +5712,6 @@ object ZStreamSpec extends ZIOBaseSpec {
   val dog: Animal = Dog("dog1")
   val cat1: Cat   = Cat("cat1")
   val cat2: Cat   = Cat("cat2")
+
+  case class Resource(idx : Int)
 }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4427,7 +4427,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               }
 
             val pl0: ZPipeline[Any, Nothing, (Int, Resource), (Int, Resource, Scope)] =
-              ZPipeline.fromFunction { strm: ZStream[Any, Nothing, (Int, Resource)] =>
+              ZPipeline.fromFunction { (strm: ZStream[Any, Nothing, (Int, Resource)]) =>
                 ZStream
                   .unwrapScoped[Any] {
                     ZIO.scopeWith { scope =>
@@ -4463,7 +4463,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             val src = ZStream.range(0, 100, 10)
 
             val pl1: ZPipeline[Any, Nothing, Int, (Int, Resource)] =
-              ZPipeline.fromFunction { strm: ZStream[Any, Nothing, Int] =>
+              ZPipeline.fromFunction { (strm: ZStream[Any, Nothing, Int]) =>
                 strm.mapZIO { i =>
                   ZIO.serviceWith[Resource] { r =>
                     (i, r)
@@ -4473,7 +4473,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               }
 
             val pl2: ZPipeline[Any, Nothing, (Int, Resource), (Int, Resource, Resource)] =
-              ZPipeline.fromFunction { strm: ZStream[Any, Nothing, (Int, Resource)] =>
+              ZPipeline.fromFunction { (strm: ZStream[Any, Nothing, (Int, Resource)]) =>
                 strm.mapZIO { case (i, r0) =>
                   ZIO.serviceWith[Resource] { r1 =>
                     (i, r0, r1)

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -250,12 +250,12 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
               //when input's provided env is null, we have to explicitly provide it with the 'outer' env
               //otherwise any env provided by downstream will override the 'correct' env when the input channel executes effects.
               val nextChannel = {
-                if(null != input.providedEnv)
+                if (null != input.providedEnv)
                   mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
                 else
                   ZChannel
                     .environment[Env]
-                    .flatMap{env =>
+                    .flatMap { env =>
                       mkChannel(inpAsChannel.provideEnvironment(env))
                     }
               }

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -246,7 +246,19 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
 
             case ZChannel.DeferedUpstream(mkChannel) =>
               val inpAsChannel: ZChannel[Env, Any, Any, Any, Any, Any, Any] = execToPullingChannel(input)
-              val nextChannel                                               = mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
+
+              //when input's provided env is null, we have to explicitly provide it with the 'outer' env
+              //otherwise any env provided by downstream will override the 'correct' env when the input channel executes effects.
+              val nextChannel = {
+                if(null != input.providedEnv)
+                  mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
+                else
+                  ZChannel
+                    .environment[Env]
+                    .flatMap{env =>
+                      mkChannel(inpAsChannel.provideEnvironment(env))
+                    }
+              }
 
               val previousInput = input
               input = null

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -249,13 +249,12 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
 
               //when input's provided env is null, we have to explicitly provide it with the 'outer' env
               //otherwise any env provided by downstream will override the 'correct' env when the input channel executes effects.
-              val nextChannel = {
+              val nextChannel: Channel[Env] = {
                 if (null != input.providedEnv)
                   mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
                 else
-                  ZChannel
-                    .environment[Env]
-                    .flatMap { env =>
+                  ZChannel //todo: can we eliminate the effect evaluation here? i.e. by usingFiber.currentFiber()
+                    .environmentWithChannel[Env] { env =>
                       mkChannel(inpAsChannel.provideEnvironment(env))
                     }
               }


### PR DESCRIPTION
/claim #8958
addresses #8958 
there's a corner case when using `ZPipeline.fromFunctionwhere downstream's environment can hide the correct environment, this pr attempts to fix this by forcing the correct environment on the composed upstream.