### PR TITLE
Maintain binary compatibility of Duration#asScala

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import Dependencies._
 import MimaSettings.mimaSettings
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import sbt.Keys
-import com.typesafe.tools.mima.core._
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
@@ -215,11 +214,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(scalacOptions += "-Wconf:msg=[zio.stacktracer.TracingImplicits.disableAutoTrace]:silent")
   .jvmSettings(
     replSettings,
-    mimaSettings(failOnProblem = true),
-    mimaBinaryIssueFilters ++= Seq(
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala")
-    )
+    mimaSettings(failOnProblem = true)
   )
   .jsSettings(
     jsSettings,

--- a/core/shared/src/main/scala/zio/Duration.scala
+++ b/core/shared/src/main/scala/zio/Duration.scala
@@ -173,7 +173,9 @@ final class DurationOps(private val duration: Duration) extends AnyVal {
     }
   }
 
-  def asScala: ScalaFiniteDuration = duration match {
+  def asScala: ScalaDuration = asFiniteDuration
+
+  def asFiniteDuration: ScalaFiniteDuration = duration match {
     case Duration.Zero => ScalaDuration.Zero
     case _             => ScalaFiniteDuration(duration.toNanos, TimeUnit.NANOSECONDS)
   }


### PR DESCRIPTION
Those changes are not binary compatible (as Mima says) and will trigger runtime errors if a library is using it.
Did the test and got:
```
Exception in thread "main" java.lang.NoSuchMethodError: 'scala.concurrent.duration.Duration zio.DurationOps$.asScala$extension(java.time.Duration)'
```