### PR TITLE
Add TestAspect.withLiveClock to the docs

### DIFF
--- a/docs/reference/test/aspects/index.md
+++ b/docs/reference/test/aspects/index.md
@@ -163,6 +163,11 @@ object MySpec extends ZIOSpecDefault {
     test("A ignored test") {
       assertTrue(false)
     } @@ ignore, //@@ ignore marks test as ignored
+    test("A test using a live service instead of the test service") {
+      for {
+        _ <- TestClock.timeZone
+      } yield assertCompletes
+    } @@ withLiveClock, //@@ withLiveClock uses the live Clock service from the ZIO runtime in the test
     test("A flaky test that only works on the JVM and sometimes fails; let's compose some aspects!") {
       assertTrue(false)
     } @@ jvmOnly           // only run on the JVM

--- a/docs/reference/test/installation.md
+++ b/docs/reference/test/installation.md
@@ -6,7 +6,7 @@ sidebar_label: "Installation"
 
 In order to use ZIO Test, we need to add the required configuration in our SBT settings:
 
-```scala mdoc:passthrough
+````scala mdoc:passthrough
 
 println("""```scala""")
 println(s"""libraryDependencies ++= Seq(
@@ -15,12 +15,14 @@ println(s"""libraryDependencies ++= Seq(
   "dev.zio" %% "zio-test-magnolia" % "${zio.BuildInfo.version.split('+').head}" % Test
 )""")
 println("""```""")
-```
-
+````
 
 If our SBT version is older than 1.8.0, we also need to add the test framework manually:
-```scala mdoc:passthrough
+
+````scala mdoc:passthrough
 println("""```scala""")
 println("""testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")""")
 println("""```""")
-```
+````
+
+**NOTE**: In order to use the live version of a service in our tests, we can use some new helpful test aspects e.g `withLiveClock`, `withLiveConsole`, `withLiveRandom`, `withLiveSystem`, etc.

--- a/docs/reference/test/services/clock.md
+++ b/docs/reference/test/services/clock.md
@@ -3,7 +3,7 @@ id: clock
 title: "TestClock"
 ---
 
-In most cases we want unit tests to be as fast as possible. Waiting for real time to pass by is a real killer for this. 
+In most cases we want unit tests to be as fast as possible. Waiting for real time to pass by is a real killer for this.
 
 ZIO exposes a `TestClock` that can control the time. We can deterministically and efficiently **test effects involving the passage of time** without actually having to wait for the full amount of time to pass.
 
@@ -24,7 +24,7 @@ for {
 } yield assertTrue(result.isEmpty)
 ```
 
-Note how we forked the fiber that `sleep` was invoked on. Calls to `sleep` and methods derived from it will semantically block until the time is set to on or after the time they are scheduled to run. 
+Note how we forked the fiber that `sleep` was invoked on. Calls to `sleep` and methods derived from it will semantically block until the time is set to on or after the time they are scheduled to run.
 
 If we didn't fork the fiber on which we called sleep we would never get to set the time on the line below. Thus, a useful pattern when using `TestClock` is to fork the effect being tested, then adjust the clock time, and finally verify that the expected effects have been performed.
 
@@ -50,9 +50,9 @@ for {
   d <- q.take.as(true)
   e <- q.poll.map(_.isEmpty)
 } yield assertTrue(a && b && c && d && e)
-``` 
+```
 
-Here we verify that no effect is performed before the recurrence period, that an effect is performed after the recurrence period, and that the effect is performed exactly once. 
+Here we verify that no effect is performed before the recurrence period, that an effect is performed after the recurrence period, and that the effect is performed exactly once.
 
 The key thing to note here is that after each recurrence the next recurrence is scheduled to occur at the appropriate time in the future, so when we adjust the clock by 60 minutes exactly one value is placed in the queue, and when we adjust the clock by another 60 minutes exactly one more value is placed in the queue.
 
@@ -176,3 +176,56 @@ test("zipLatest") {
   } yield assertTrue(result == List(0 -> 0, 0 -> 1, 1 -> 1, 1 -> 2))
 }
 ```
+
+### Example 5
+
+`TestClock` is used to speed up the tests by simulating the passage of time. This is useful for triggering scheduled effects, which is useful for testing time-dependent code. `TestClock` does nothing to advance events on its own and is initialized to 00:00 1/1/70.
+
+However, we can use a live clock to simulate events, enabling a fixed ratio of 'real' to 'test' time. `TestClock.adjust()` can be used to advance time, but a real clock may be required to space out the advancements properly.
+
+The test below creates a stream of 30 elements that are spaced 1 second apart. The test advances the clock by 1 second 30 times, allowing the stream to generate all 30 elements.
+
+```scala mdoc:compile-only
+import zio._
+import zio.stream._
+import zio.test.{test, _}
+import zio.test.Assertion._
+
+
+test("test clock") {
+  val stream = ZStream.iterate(0)(_ + 1).schedule(Schedule.spaced(1.second))
+  val s1 = stream.take(30)
+  val sink = ZSink.collectAll[Int]
+  for {
+    _ <- TestClock.adjust(1.second)
+    .repeat(Schedule.recurs(30)).fork
+    runner <- s1.run(sink)
+  } yield assert(runner.size)(equalTo(30))
+}
+```
+
+The test doesn't work because the fast forward is too fast and by the time the stream generator takes the first element, it has moved all the way to the end of the 30 seconds. We need to slow down the rate at which the test clock advances.
+
+The problem is that the `Schedule` needs a clock to do the spacing. We can't use the test clock since this is what we need to change. We opt to use the live clock instead with the `@@ withLiveClock` test aspect. We also use `Schedule.spaced` to dictate the spacing of the events in real time.
+
+```scala mdoc:compile-only
+import zio._
+import zio.stream._
+import zio.test.{test, _}
+import zio.test.Assertion._
+import zio.test.TestAspect._
+
+
+test("live clock") {
+  val stream = ZStream.iterate(0)(_ + 1).schedule(Schedule.spaced(1.second))
+  val s1 = stream.take(30)
+  val sink = ZSink.collectAll[Int]
+  for {
+    _ <- TestClock.adjust(1.second)
+    .repeat(Schedule.spaced(10.milliseconds)).fork
+    runner <- s1.run(sink)
+  } yield assert(runner.size)(equalTo(30))
+} @@ withLiveClock
+```
+
+Using this technique, we can simulate the advancement of 1 second in the test clock for every 10 milliseconds in real time using the live clock.

--- a/docs/reference/test/services/clock.md
+++ b/docs/reference/test/services/clock.md
@@ -197,9 +197,9 @@ test("test clock") {
   val s1 = stream.take(30)
   val sink = ZSink.collectAll[Int]
   for {
-    _ <- TestClock.adjust(1.second)
-    .repeat(Schedule.recurs(30)).fork
-    runner <- s1.run(sink)
+    fiber <- s1.run(sink).fork
+    _ <- TestClock.adjust(1.second).repeat(Schedule.recurs(30))
+    runner <- fiber.join
   } yield assert(runner.size)(equalTo(30))
 }
 ```
@@ -221,11 +221,11 @@ test("live clock") {
   val s1 = stream.take(30)
   val sink = ZSink.collectAll[Int]
   for {
-    _ <- TestClock.adjust(1.second)
-    .repeat(Schedule.spaced(10.milliseconds)).fork
+    fiber <- TestClock.adjust(1.second).repeat(Schedule.spaced(10.milliseconds)).fork
+    _ <- fiber.join
     runner <- s1.run(sink)
   } yield assert(runner.size)(equalTo(30))
-} @@ withLiveClock
+} @@ TestAspect.withLiveClock
 ```
 
 Using this technique, we can simulate the advancement of 1 second in the test clock for every 10 milliseconds in real time using the live clock.


### PR DESCRIPTION
fixes #8735 
/claim https://github.com/zio/zio/issues/8735
/split @mobley-trent
@mobley-trent I have added this PR with minor tweaks(as per review comments)  in adjusting testclock after the fork to work it as expected 