### PR TITLE
Improve `ZLayer.derive` and allow Tags to be derived via `derives` keyword for Scala 3

### DIFF
--- a/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ServiceTagVersionSpecific.scala
@@ -3,6 +3,9 @@ package zio
 import scala.quoted.*
 
 trait TagVersionSpecific {
+  transparent inline def derived[A]: Tag[A] =
+    ${ TagMacros.materialize[A] }
+
   implicit transparent inline def materialize[A]: Tag[A] =
     ${ TagMacros.materialize[A] }
 }

--- a/core/shared/src/main/scala-3/zio/internal/macros/ZLayerDerivationMacros.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/ZLayerDerivationMacros.scala
@@ -57,7 +57,7 @@ object ZLayerDerivationMacros {
       unroll(ctorType)
     }
 
-    val trace = '{ summon[Trace] }.asTerm
+    val trace = '{ Trace.empty }.asTerm
 
     val (fromServices, fromDefaults) =
       params.zip(paramTypes).partitionMap { case (pTerm, pType) =>
@@ -101,14 +101,14 @@ object ZLayerDerivationMacros {
 
           hookRETypes match {
             case None =>
-              '{ ZIO.succeed[A](${ newInstance }) }.asTerm
+              '{ Exit.succeed[A](${ newInstance }) }.asTerm
 
             case Some((rType, eType)) =>
               (rType.asType, eType.asType) match {
                 case ('[r], '[e]) =>
                   '{
                     val instance = ${ newInstance }
-                    instance.asInstanceOf[ZLayer.Derive.Scoped[r, e]].scoped.as(instance)
+                    instance.asInstanceOf[ZLayer.Derive.Scoped[r, e]].scoped(using Trace.empty).as(instance)(using Trace.empty)
                   }.asTerm
               }
           }
@@ -116,7 +116,8 @@ object ZLayerDerivationMacros {
         case ((pName, pType), rType) :: ps =>
           (rType.asType, eInit.asType, pType.asType) match {
             case ('[r], '[e], '[a]) =>
-              val nextEffect = '{ ZIO.service[a] }
+              val tag        = summonTag[a]
+              val nextEffect = '{ ZIO.service[a](using $tag, Trace.empty) }
 
               val lambda = Lambda(
                 Symbol.spliceOwner,
@@ -188,7 +189,8 @@ object ZLayerDerivationMacros {
                 runNoDefault(fromServices.zip(serviceTypes), args)
                   .asExprOf[ZIO[r with Scope, e, A]]
 
-              '{ ZLayer.scoped($make) }.asTerm
+              val tag = summonTag[A]
+              '{ ZLayer.scoped($make)(using $tag, summon[Trace]) }.asTerm
           }
 
         case ((pName, pType, d), (rType, eType)) :: ps =>
@@ -236,5 +238,10 @@ object ZLayerDerivationMacros {
         runDefault(fromDefaults.zip(reTypes), Map.empty)
           .asExprOf[ZLayer[r, e, A]]
     }
+  }
+
+  private def summonTag[A: Type](using Quotes): Expr[Tag[A]] = {
+    import quotes.reflect._
+    Expr.summon[Tag[A]].getOrElse(report.errorAndAbort(s"Cannot find Tag[${TypeRepr.of[A].show}] in implicit scope"))
   }
 }


### PR DESCRIPTION
There are 2 changes in this PR:
1. We add the `derived` method in the companion object of `Tag`. This allows a Tag to be created in the companion object of a service via the `derives` keyword, e.g., `final class Foo() derives Tag`. The reasoning behind this change is that it allows advanced users to avoid allocations of `Tag` on the call-site of methods requiring an implicit Tag (e.g., `ZIO.environment*` / `ZIO.service*) 
2. Reduces the code generated by the `ZLayer.derive` macro by using `Trace.empty` _except_ in the top-level `ZLayer.scoped`. This way the traces still capture the callsite of the ZLayer creation in case of an error, but without generating a new Trace for each new service that is created

I've tested these changes on a large Scala 3 codebase at $WORK which makes heavy use of the `ZLayer.derive` method and noticed no regressions and a small reduction in generated artifact size.

@ghostdogpr I know macros isn't your domain but I'm not sure who else to request a review from 🥲