### PR TITLE
Disable `FiberRuntime` assertions for release versions

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1488,8 +1488,8 @@ object FiberRuntime {
   private final val IgnoreContinuation: Any => Unit = _ => ()
 
   /**
-   * For Scala 3, `-X-elide-below` is ignored, and therefore we need to use an '''inlinable'''
-   * build-time constant to disable assertions
+   * For Scala 3, `-X-elide-below` is ignored, and therefore we need to use an
+   * '''inlinable''' build-time constant to disable assertions
    */
   private final val DisableAssertions = !BuildInfo.isSnapshot
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -37,7 +37,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   type Erased = ZIO.Erased
 
   import ZIO._
-  import FiberRuntime.{AsyncJump, EvaluationSignal}
+  import FiberRuntime.{AsyncJump, EvaluationSignal, DisableAssertions}
 
   private var _lastTrace      = fiberId.location
   private var _fiberRefs      = fiberRefs0
@@ -234,7 +234,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    */
   @tailrec
   private def drainQueueOnCurrentThread(depth: Int): Unit = {
-    assert(running.get)
+    assert(DisableAssertions || running.get)
 
     var evaluationSignal: EvaluationSignal = EvaluationSignal.Continue
     try {
@@ -271,7 +271,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
   private def drainQueueLaterOnExecutor(): Unit = {
-    assert(running.get)
+    assert(DisableAssertions || running.get)
 
     runningExecutor = self.getCurrentExecutor()
     runningExecutor.submitOrThrow(self)(Unsafe.unsafe)
@@ -336,7 +336,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
           processStatefulMessage(onFiber)
 
         case FiberMessage.Resume(nextEffect0) =>
-          assert(resumption eq null)
+          assert(DisableAssertions || (resumption eq null))
 
           resumption = nextEffect0.asInstanceOf[ZIO.Erased]
 
@@ -375,7 +375,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     initialDepth: Int,
     effect0: ZIO.Erased
   ): Exit[E, A] = {
-    assert(running.get)
+    assert(DisableAssertions || running.get)
 
     self._asyncContWith = null
     self._blockingOn = FiberRuntime.notBlockingOn
@@ -458,7 +458,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
   private def evaluateMessageWhileSuspended(depth: Int, fiberMessage: FiberMessage): EvaluationSignal = {
-    assert(running.get)
+    assert(DisableAssertions || running.get)
 
     fiberMessage match {
       case FiberMessage.InterruptSignal(cause) =>
@@ -923,7 +923,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     startStackIndex: Int,
     currentDepth: Int
   ): Exit[Any, Any] = {
-    assert(running.get)
+    assert(DisableAssertions || running.get)
 
     // Note that assigning `cur` as the result of `try` or `if` can cause Scalac to box local variables.
     var cur        = effect
@@ -1486,6 +1486,12 @@ object FiberRuntime {
   private final val StackIdxGcThreshold = 128
 
   private final val IgnoreContinuation: Any => Unit = _ => ()
+
+  /**
+   * For Scala 3, `-X-elide-below` is ignored, and therefore we need to use an '''inlinable'''
+   * build-time constant to disable assertions
+   */
+  private final val DisableAssertions = !BuildInfo.isSnapshot
 
   private type EvaluationSignal = Int
   private object EvaluationSignal {

--- a/core/shared/src/main/scala/zio/internal/Hub.scala
+++ b/core/shared/src/main/scala/zio/internal/Hub.scala
@@ -76,7 +76,8 @@ private[zio] object Hub {
    * Constructs a new bounded hub with the requested capacity.
    */
   def bounded[A](requestedCapacity: Int): Hub[A] = {
-    assert(requestedCapacity > 0)
+    // NOTE: Do not use `assert` as the compiler removes it in releases
+    require(requestedCapacity > 0)
     if (requestedCapacity == 1) new BoundedHubSingle
     else if (nextPow2(requestedCapacity) == requestedCapacity) new BoundedHubPow2(requestedCapacity)
     else new BoundedHubArb(requestedCapacity)

--- a/core/shared/src/main/scala/zio/internal/RingBufferArb.scala
+++ b/core/shared/src/main/scala/zio/internal/RingBufferArb.scala
@@ -24,7 +24,8 @@ private[zio] final class RingBufferArb[A] private (capacity: Int) extends RingBu
 
 private[zio] object RingBufferArb {
   final def apply[A](capacity: Int): RingBufferArb[A] = {
-    assert(capacity >= 2)
+    // NOTE: Do not use `assert` as the compiler removes it in releases
+    require(capacity >= 2)
 
     new RingBufferArb(capacity)
   }

--- a/core/shared/src/main/scala/zio/internal/RingBufferPow2.scala
+++ b/core/shared/src/main/scala/zio/internal/RingBufferPow2.scala
@@ -26,7 +26,8 @@ private[zio] final class RingBufferPow2[A](val requestedCapacity: Int)
 
 private[zio] object RingBufferPow2 {
   def apply[A](requestedCapacity: Int): RingBufferPow2[A] = {
-    assert(requestedCapacity > 0)
+    // NOTE: Do not use `assert` as the compiler removes it in releases
+    require(requestedCapacity > 0)
 
     new RingBufferPow2(requestedCapacity)
   }

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -38,13 +38,16 @@ object BuildHelper {
   private def optimizerOptions(optimize: Boolean) =
     if (optimize)
       Seq(
+        "-opt:l:method",
         "-opt:l:inline",
-        "-opt-inline-from:zio.internal.**"
+        "-opt-inline-from:zio.internal.**",
+        "-Xelide-below:2001" // To remove calls to `assert` in releases. Assertions are level 2000
       )
     else Nil
 
   def buildInfoSettings(packageName: String) =
     Seq(
+      buildInfoOptions += BuildInfoOption.ConstantValue,
       buildInfoKeys    := Seq[BuildInfoKey](organization, moduleName, name, version, scalaVersion, sbtVersion, isSnapshot),
       buildInfoPackage := packageName
     )

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -47,6 +47,7 @@ object BuildHelper {
 
   def buildInfoSettings(packageName: String) =
     Seq(
+      // BuildInfoOption.ConstantValue required to disable assertions in FiberRuntime!
       buildInfoOptions += BuildInfoOption.ConstantValue,
       buildInfoKeys    := Seq[BuildInfoKey](organization, moduleName, name, version, scalaVersion, sbtVersion, isSnapshot),
       buildInfoPackage := packageName


### PR DESCRIPTION
Currently, the `FiberRuntime` asserts on each iteration of the runloop where the `running` flag is correctly set. This is done to prevent bugs in the `FiberRuntime` state management creeping in during development, which would have catastrophic consequences if they made it through. However, since this is a volatile read, it comes at a measurable performance cost which we would like to avoid in the final release artifacts.

In Scala 2, disabling the assertions is quite simple; we just need to use the `-Xelide-below` compiler flag. However, Scala 3 ignores this option so we need to get creative.

First, we add the `BuildInfoOption.ConstantValue` option to BuildInfo options to make the keys `final` and thus inlinable. Then we use this value in the assert statement to disable assertions. Unlike Scala 2, Scala 3's assert is defined as:

```scala 3
  transparent inline def assert(inline assertion: Boolean): Unit =
    if !assertion then scala.runtime.Scala3RunTime.assertFailed()
```

This means that because we're using inlinable constants, the call to `assert(DisableAssertions || state.get)` fully disappears when `DisableAssertions = true`