### PR TITLE
Overload `getFiberRefs` with parameter to optionally sync `RuntimeFlags`

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -569,6 +569,22 @@ object Fiber extends FiberPlatformSpecific {
     private[zio] def getFiberRefs(): FiberRefs
 
     /**
+     * Retrieves all fiber refs of the fiber. The flag is used to determine
+     * whether the FiberRefs should be updated to ensure that the RuntimeFlags
+     * within them are synchronized with the Fiber's state
+     *
+     * Use this method only if you are not interested in the runtime flags and
+     * want to maximize performance
+     *
+     * @param syncRuntimeFlags
+     *   whether the runtime flags contained within the FiberRefs will be
+     *   updated to the current value in the fiber's state
+     * @see
+     *   overloaded method for more info
+     */
+    private[zio] def getFiberRefs(syncRuntimeFlags: Boolean): FiberRefs
+
+    /**
      * Retrieves the executor that this effect is currently executing on.
      *
      * '''NOTE''': This method must be invoked by the fiber itself.

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -571,6 +571,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     _fiberRefs
   }
 
+  private[zio] def getFiberRefs(syncRuntimeFlags: Boolean): FiberRefs =
+    if (syncRuntimeFlags) getFiberRefs() else _fiberRefs
+
   /**
    * Retrieves the interrupted cause of the fiber, which will be `Cause.empty`
    * if the fiber has not been interrupted.


### PR DESCRIPTION
Some context: In `zio-query`, we extract multiple `FiberRef`s in the hotpath when deduplicating requests. For performance reasons, we want to get the `FiberRefs` from the fiber itself by doing something like:

```scala
ZIO.withFiberRuntime[Any, Nothing, Result[R, E, B]] { (fiberState, _) =>
  val rfs        = fiberState.getFiberRefs()
  val isEnabled  = rfs.getOrDefault(ZQuery.cachingEnabled)
  val cache      = rfs.getOrDefault(ZQuery.currentCache)
  // other
}
```

The issue here however is that `fiberState.getFiberRefs()` also updates the runtime flags within the FiberRefs, whereas in this case we don't care about them.

With this PR we add an overload to the `getFiberRefs` where the user can specify that they do not care whether the state of the RuntimeFlags within the `FiberRefs` is synchronized