### PR TITLE
Avoid unnecessary `flatMap`s in different ZIO methods

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -50,7 +50,7 @@ object SerializableSpec extends ZIOBaseSpec {
         v2                      <- returnQueue.take
       } yield assert(v1)(equalTo(10)) &&
         assert(v2)(equalTo(20))
-    } @@ exceptScala3,
+    },
     test("Ref is serializable") {
       val current = "This is some value"
       for {
@@ -68,12 +68,19 @@ object SerializableSpec extends ZIOBaseSpec {
       } yield assert(result)(equalTo(list))
     },
     test("ZIO is serializable") {
-      val v = ZIO.service[Int].map(_ + 1)
+      val v = ZIO.service[Int].map(_ + 1).provideEnvironment(ZEnvironment(9))
       for {
         returnZIO <- serializeAndBack(v)
-        computeV  <- returnZIO.provideEnvironment(ZEnvironment(9))
+        computeV  <- returnZIO
       } yield assert(computeV)(equalTo(10))
     } @@ exceptScala212,
+    test("ZEnvironment is serializable") {
+      val env = ZEnvironment(10)
+      for {
+        returnedEnv <- serializeAndBack(env)
+        computeV     = returnedEnv.get[Int]
+      } yield assert(computeV)(equalTo(10))
+    },
     test("FiberStatus is serializable") {
       val list = List("1", "2", "3")
       val io   = ZIO.succeed(list)
@@ -94,19 +101,19 @@ object SerializableSpec extends ZIOBaseSpec {
     testSync("Cause.die is serializable") {
       val cause = Cause.die(TestException("test"))
       assert(serializeAndDeserialize(cause))(equalTo(cause))
-    } @@ exceptScala3,
+    },
     testSync("Cause.fail is serializable") {
       val cause = Cause.fail("test")
       assert(serializeAndDeserialize(cause))(equalTo(cause))
-    } @@ exceptScala3,
+    },
     testSync("Cause.&& is serializable") {
       val cause = Cause.fail("test") && Cause.fail("Another test")
       assert(serializeAndDeserialize(cause))(equalTo(cause))
-    } @@ exceptScala3,
+    },
     testSync("Cause.++ is serializable") {
       val cause = Cause.fail("test") ++ Cause.fail("Another test")
       assert(serializeAndDeserialize(cause))(equalTo(cause))
-    } @@ exceptScala3,
+    },
     testSync("Exit.succeed is serializable") {
       val exit = Exit.succeed("test")
       assert(serializeAndDeserialize(exit))(equalTo(exit))
@@ -114,15 +121,15 @@ object SerializableSpec extends ZIOBaseSpec {
     testSync("Exit.fail is serializable") {
       val exit = Exit.fail("test")
       assert(serializeAndDeserialize(exit))(equalTo(exit))
-    } @@ exceptScala3,
+    },
     testSync("Exit.die is serializable") {
       val exit = Exit.die(TestException("test"))
       assert(serializeAndDeserialize(exit))(equalTo(exit))
-    } @@ exceptScala3,
+    },
     testSync("FiberFailure is serializable") {
       val failure = FiberFailure(Cause.fail("Uh oh"))
       assert(serializeAndDeserialize(failure))(equalTo(failure))
-    } @@ exceptScala3,
+    },
     testSync("InterruptStatus.interruptible is serializable") {
       val interruptStatus = InterruptStatus.interruptible
       assert(serializeAndDeserialize(interruptStatus))(equalTo(interruptStatus))
@@ -146,7 +153,7 @@ object SerializableSpec extends ZIOBaseSpec {
         out1 <- ZIO.unit.repeat(schedule)
         out2 <- ZIO.unit.repeat(serializeAndDeserialize(schedule))
       } yield assert(out2)(equalTo(out1))
-    } @@ scala2Only,
+    },
     test("Chunk.single is serializable") {
       val chunk = Chunk.single(1)
       for {
@@ -176,7 +183,7 @@ object SerializableSpec extends ZIOBaseSpec {
       for {
         deserialized <- serializeAndBack(chunk)
       } yield assert(deserialized)(equalTo(chunk))
-    } @@ scala2Only,
+    },
     test("Chunk.fromIterable is serializable") {
       val chunk = Chunk.fromIterable(Vector(1, 2, 3))
       for {

--- a/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/SerializableSpec.scala
@@ -80,7 +80,7 @@ object SerializableSpec extends ZIOBaseSpec {
         returnedEnv <- serializeAndBack(env)
         computeV     = returnedEnv.get[Int]
       } yield assert(computeV)(equalTo(10))
-    },
+    } @@ exceptScala212,
     test("FiberStatus is serializable") {
       val list = List("1", "2", "3")
       val io   = ZIO.succeed(list)

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -218,7 +218,7 @@ final class ZEnvironment[+R] private (
     taggedIsSubtype(tag, ScopeTag)
 
   val unsafe: UnsafeAPI with UnsafeAPI2 with UnsafeAPI3 =
-    new UnsafeAPI with UnsafeAPI2 with UnsafeAPI3 {
+    new UnsafeAPI with UnsafeAPI2 with UnsafeAPI3 with Serializable {
       private[ZEnvironment] def add[A](tag: LightTypeTag, a: A)(implicit unsafe: Unsafe): ZEnvironment[R with A] =
         if (a.isInstanceOf[Scope] && isScopeTag(tag))
           addScope(a.asInstanceOf[Scope]).asInstanceOf[ZEnvironment[R with A]]

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -24,7 +24,7 @@ import scala.util.hashing.MurmurHash3
 private[zio] final class UpdateOrderLinkedMap[K, +V](
   fields: Vector[Any],
   underlying: HashMap[K, (Int, V)]
-) { self =>
+) extends Serializable { self =>
   import UpdateOrderLinkedMap._
 
   def size: Int = underlying.size
@@ -89,6 +89,7 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
 
   def iterator: Iterator[(K, V)] = iteratorLz.iterator
 
+  @transient
   private[this] lazy val iteratorLz: LzList[(K, V)] = {
     val it = iterator0
     def loop(): LzList[(K, V)] =
@@ -121,6 +122,7 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
 
   def reverseIterator: Iterator[(K, V)] = reverseIteratorLz.iterator
 
+  @transient
   private[this] lazy val reverseIteratorLz: LzList[(K, V)] = {
     val it = reverseIterator0
     def loop(): LzList[(K, V)] =


### PR DESCRIPTION
There are a few ZIO methods where we can reduce the number of flatMap's required by making use of the `getWith` method of `FiberRef`s