### PR TITLE
Optimize `FiberRef#locally`

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -560,6 +560,15 @@ object Fiber extends FiberPlatformSpecific {
     private[zio] def getFiberRef[A](fiberRef: FiberRef[A]): A
 
     /**
+     * Retrieves the state of the fiber ref, or `null` if it hasn't been modified.
+     *
+     * '''NOTE''': This method is safe to invoke on any fiber, but if not
+     * invoked on this fiber, then values derived from the fiber's state
+     * (including the log annotations and log level) may not be up-to-date.
+     */
+    private[zio] def getFiberRefOrNull[A](fiberRef: FiberRef[A]): A
+
+    /**
      * Retrieves all fiber refs of the fiber.
      *
      * '''NOTE''': This method is safe to invoke on any fiber, but if not
@@ -610,6 +619,13 @@ object Fiber extends FiberPlatformSpecific {
      * '''NOTE''': This method must be invoked by the fiber itself.
      */
     private[zio] def setFiberRef[A](fiberRef: FiberRef[A], value: A): Unit
+
+    /**
+     * Resets the fiber ref to its initial value.
+     *
+     * '''NOTE''': This method must be invoked by the fiber itself.
+     */
+    private[zio] def resetFiberRef(fiberRef: FiberRef[?]): Unit
 
     /**
      * Wholesale replaces all fiber refs of this fiber.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -560,7 +560,8 @@ object Fiber extends FiberPlatformSpecific {
     private[zio] def getFiberRef[A](fiberRef: FiberRef[A]): A
 
     /**
-     * Retrieves the state of the fiber ref, or `null` if it hasn't been modified.
+     * Retrieves the state of the fiber ref, or `null` if it hasn't been
+     * modified.
      *
      * '''NOTE''': This method is safe to invoke on any fiber, but if not
      * invoked on this fiber, then values derived from the fiber's state

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -541,6 +541,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private[zio] def getFiberRef[A](fiberRef: FiberRef[A]): A =
     _fiberRefs.getOrDefault(fiberRef)
 
+  private[zio] def getFiberRefOrNull[A](fiberRef: FiberRef[A]): A =
+    _fiberRefs.getOrNull(fiberRef)
+
   /**
    * Retrieves the state of the fiber ref, or else the specified value.
    */
@@ -1313,6 +1316,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
   private[zio] def setFiberRef[@specialized(SpecializeInt) A](fiberRef: FiberRef[A], value: A): Unit =
     _fiberRefs = _fiberRefs.updatedAs(fiberId)(fiberRef, value)
+
+  private[zio] def resetFiberRef(fiberRef: FiberRef[?]): Unit =
+    _fiberRefs = _fiberRefs.delete(fiberRef)
 
   private[zio] def setFiberRefs(fiberRefs0: FiberRefs): Unit =
     this._fiberRefs = fiberRefs0


### PR DESCRIPTION
The way that `FiberRefs` work is that they start as an empty Map, and any `FiberRef` that has been modified is added to the `FiberRefs` map. i.e., until a modification to a `FiberRef` is made, we don't store their initial values.

This holds true except the case where we use `locally`. In this case, when we "revert" the modification to the `FiberRef`, we store the value in the `FiberRefs` map even in cases where the value is the initial one. Since the underlying Map that `FiberRefs` uses is immutable, it is better to keep it as lean as possible.

In this PR, we change the logic in `FiberRef#locally` so that it checks if the old value was the initial one or not via `getFiberRefOrNull`. If the old value was the initial one (i.e., we got `null`), instead of storing the old value, we just remove the entry from the `FiberRefs` when we revert the change