### PR TITLE
Improved rechunker for large chunks

### DIFF
--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -18,18 +18,26 @@ class RechunkBenchmark {
   var chunkCount: Int = _
 
   @Param(Array("10"))
+  var hugeChunkCount: Int = _
+
+  @Param(Array("10"))
   var smallChunkSize: Int = _
 
   @Param(Array("10000"))
   var largeChunkSize: Int = _
 
+  @Param(Array("10000000"))
+  var hugeChunkSize: Int = _
+
   var smallChunks: IndexedSeq[Chunk[Int]] = _
   var largeChunks: IndexedSeq[Chunk[Int]] = _
+  var hugeChunks: IndexedSeq[Chunk[Int]] = _
 
   @Setup
   def setup(): Unit = {
     smallChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(smallChunkSize)(i)))
     largeChunks = (1 to chunkCount).map(i => Chunk.fromArray(Array.fill(largeChunkSize)(i)))
+    hugeChunks = (1 to hugeChunkCount).map(i => Chunk.fromArray(Array.fill(hugeChunkSize)(i)))
   }
 
   @Benchmark
@@ -53,6 +61,57 @@ class RechunkBenchmark {
   @Benchmark
   def rechunkSmallTo1: Long = {
     val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunk(1)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkHugeToLarge: Long = {
+    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunk(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToHuge: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+
+  // ******************************
+
+  @Benchmark
+  def rechunkSmallToLargeOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToSmallOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallToSmallOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallTo1Old: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(1)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkHugeToLargeOld: Long = {
+    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToHugeOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(hugeChunkSize)).runCount
     unsafeRun(result)
   }
 }

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -31,7 +31,7 @@ class RechunkBenchmark {
 
   var smallChunks: IndexedSeq[Chunk[Int]] = _
   var largeChunks: IndexedSeq[Chunk[Int]] = _
-  var hugeChunks: IndexedSeq[Chunk[Int]]  = _
+  var hugeChunks: IndexedSeq[Chunk[Int]] = _
 
   @Setup
   def setup(): Unit = {
@@ -73,6 +73,45 @@ class RechunkBenchmark {
   @Benchmark
   def rechunkLargeToHuge: Long = {
     val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+
+  // ******************************
+
+  @Benchmark
+  def rechunkSmallToLargeOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToSmallOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallToSmallOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallTo1Old: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(1)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkHugeToLargeOld: Long = {
+    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToHugeOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(hugeChunkSize)).runCount
     unsafeRun(result)
   }
 }

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -31,7 +31,7 @@ class RechunkBenchmark {
 
   var smallChunks: IndexedSeq[Chunk[Int]] = _
   var largeChunks: IndexedSeq[Chunk[Int]] = _
-  var hugeChunks: IndexedSeq[Chunk[Int]] = _
+  var hugeChunks: IndexedSeq[Chunk[Int]]  = _
 
   @Setup
   def setup(): Unit = {
@@ -73,45 +73,6 @@ class RechunkBenchmark {
   @Benchmark
   def rechunkLargeToHuge: Long = {
     val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-
-  // ******************************
-
-  @Benchmark
-  def rechunkSmallToLargeOld: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkLargeToSmallOld: Long = {
-    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkSmallToSmallOld: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkSmallTo1Old: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(1)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkHugeToLargeOld: Long = {
-    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkLargeToHugeOld: Long = {
-    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(hugeChunkSize)).runCount
     unsafeRun(result)
   }
 }

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -31,7 +31,7 @@ class RechunkBenchmark {
 
   var smallChunks: IndexedSeq[Chunk[Int]] = _
   var largeChunks: IndexedSeq[Chunk[Int]] = _
-  var hugeChunks: IndexedSeq[Chunk[Int]] = _
+  var hugeChunks: IndexedSeq[Chunk[Int]]  = _
 
   @Setup
   def setup(): Unit = {
@@ -75,7 +75,6 @@ class RechunkBenchmark {
     val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
     unsafeRun(result)
   }
-
 
   // ******************************
 

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -75,4 +75,42 @@ class RechunkBenchmark {
     val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
     unsafeRun(result)
   }
+
+  // ******************************
+
+  @Benchmark
+  def rechunkSmallToLargeOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToSmallOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallToSmallOld: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkSmallTo1Old: Long = {
+    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(1)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkHugeToLargeOld: Long = {
+    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def rechunkLargeToHugeOld: Long = {
+    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(hugeChunkSize)).runCount
+    unsafeRun(result)
+  }
 }

--- a/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RechunkBenchmark.scala
@@ -75,42 +75,4 @@ class RechunkBenchmark {
     val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunk(hugeChunkSize)).runCount
     unsafeRun(result)
   }
-
-  // ******************************
-
-  @Benchmark
-  def rechunkSmallToLargeOld: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkLargeToSmallOld: Long = {
-    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkSmallToSmallOld: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(smallChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkSmallTo1Old: Long = {
-    val result = ZStream.fromChunks(smallChunks: _*).via(ZPipeline.rechunkOld(1)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkHugeToLargeOld: Long = {
-    val result = ZStream.fromChunks(hugeChunks: _*).via(ZPipeline.rechunkOld(largeChunkSize)).runCount
-    unsafeRun(result)
-  }
-
-  @Benchmark
-  def rechunkLargeToHugeOld: Long = {
-    val result = ZStream.fromChunks(largeChunks: _*).via(ZPipeline.rechunkOld(hugeChunkSize)).runCount
-    unsafeRun(result)
-  }
 }

--- a/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkBuilder.scala
@@ -86,7 +86,12 @@ object ChunkBuilder {
         } else {
           arrayBuilder.sizeHint(n)
         }
-      override def knownSize: SInt = arrayBuilder.knownSize
+      override def knownSize: SInt =
+        if (arrayBuilder eq null) {
+          -1
+        } else {
+          arrayBuilder.knownSize
+        }
     }
 
   /**

--- a/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
@@ -1,10 +1,9 @@
 package zio.stream
 
 import zio._
+import zio.stream.ZStream.fromChunk
 import zio.test.Assertion._
 import zio.test._
-
-import scala.collection.immutable.ArraySeq.unsafeWrapArray
 
 object RechunkSpec extends ZIOBaseSpec {
   override def spec =
@@ -20,19 +19,20 @@ object RechunkSpec extends ZIOBaseSpec {
         )
       ),
       test("rechunk large") {
-        val array = (1 to 51).toArray
+        val elems = (1 to 51).toList
         for {
-          result <- ZStream(unsafeWrapArray(array): _*).rechunk(2).chunks.runCollect
+          result <- ZStream.from(elems).rechunk(2).chunks.runCollect
         } yield {
           assertTrue(result.size == 26) &&
           assertTrue(result.dropRight(1).forall(_.size == 2)) &&
-          assertTrue(result.flatten sameElements array)
+          assertTrue(result.flatten.toList == elems)
         }
       },
       test("rechunk mixed large/small sizes")(
         check(Gen.chunkOfN(10)(Gen.chunkOfBounded(0, 50)(Gen.int(1, 100))), Gen.int(10, 60)) { (c, n) =>
+          val in = ZStream.fromChunk(c).flatMap(fromChunk(_))
           for {
-            result  <- ZStream.fromChunks(unsafeWrapArray(c.toArray): _*).rechunk(n).chunks.runCollect
+            result  <- in.rechunk(n).chunks.runCollect
             expected = c.flatten.grouped(n).toList
           } yield assertTrue(result.toList == expected)
         }

--- a/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
@@ -25,14 +25,14 @@ object RechunkSpec extends ZIOBaseSpec {
           result <- ZStream(unsafeWrapArray(array): _*).rechunk(2).chunks.runCollect
         } yield {
           assertTrue(result.size == 26) &&
-            assertTrue(result.dropRight(1).forall(_.size == 2)) &&
-            assertTrue(result.flatten sameElements array)
+          assertTrue(result.dropRight(1).forall(_.size == 2)) &&
+          assertTrue(result.flatten sameElements array)
         }
       },
       test("rechunk mixed large/small sizes")(
         check(Gen.chunkOfN(10)(Gen.chunkOfBounded(0, 50)(Gen.int(1, 100))), Gen.int(10, 60)) { (c, n) =>
           for {
-            result <- ZStream.fromChunks(unsafeWrapArray(c.toArray): _*).rechunk(n).chunks.runCollect
+            result  <- ZStream.fromChunks(unsafeWrapArray(c.toArray): _*).rechunk(n).chunks.runCollect
             expected = c.flatten.grouped(n).toList
           } yield assertTrue(result.toList == expected)
         }

--- a/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
+++ b/streams-tests/jvm/src/test/scala/zio/stream/RechunkSpec.scala
@@ -1,0 +1,41 @@
+package zio.stream
+
+import zio._
+import zio.test.Assertion._
+import zio.test._
+
+import scala.collection.immutable.ArraySeq.unsafeWrapArray
+
+object RechunkSpec extends ZIOBaseSpec {
+  override def spec =
+    suite("RechunkSpec")(
+      test("rechunk small with rest")(
+        assertZIO(ZStream(1, 2, 3, 4, 5).rechunk(2).chunks.runCollect)(
+          equalTo(Chunk(Chunk(1, 2), Chunk(3, 4), Chunk(5)))
+        )
+      ),
+      test("rechunk small with no rest")(
+        assertZIO(ZStream(1, 2, 3, 4).rechunk(2).chunks.runCollect)(
+          equalTo(Chunk(Chunk(1, 2), Chunk(3, 4)))
+        )
+      ),
+      test("rechunk large") {
+        val array = (1 to 51).toArray
+        for {
+          result <- ZStream(unsafeWrapArray(array): _*).rechunk(2).chunks.runCollect
+        } yield {
+          assertTrue(result.size == 26) &&
+            assertTrue(result.dropRight(1).forall(_.size == 2)) &&
+            assertTrue(result.flatten sameElements array)
+        }
+      },
+      test("rechunk mixed large/small sizes")(
+        check(Gen.chunkOfN(10)(Gen.chunkOfBounded(0, 50)(Gen.int(1, 100))), Gen.int(10, 60)) { (c, n) =>
+          for {
+            result <- ZStream.fromChunks(unsafeWrapArray(c.toArray): _*).rechunk(n).chunks.runCollect
+            expected = c.flatten.grouped(n).toList
+          } yield assertTrue(result.toList == expected)
+        }
+      )
+    )
+}

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1869,25 +1869,6 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     })
 
   /**
-   * A pipeline that rechunks the stream into chunks of the specified size.
-   */
-  def rechunkOld[In](n: => Int)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    new ZPipeline(ZChannel.succeed(new ZStream.RechunkerOld[In](scala.math.max(n, 1))).flatMap { rechunker =>
-      lazy val loop: ZChannel[Any, ZNothing, Chunk[In], Any, ZNothing, Chunk[In], Any] =
-        ZChannel.readWithCause(
-          (in: Chunk[In]) => {
-            val out = rechunker.rechunk(in)
-            if (out ne null) out *> loop
-            else loop
-          },
-          (cause: Cause[ZNothing]) => rechunker.done() *> ZChannel.refailCause(cause),
-          (_: Any) => rechunker.done()
-        )
-
-      loop
-    })
-
-  /**
    * Creates a pipeline that randomly samples elements according to the
    * specified percentage.
    */

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5716,9 +5716,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   }
 
   private[zio] class Rechunker[A](n: Int) {
-    private var buffer: Chunk[A] = if (n > 1) Chunk.empty[A] else null
+    private var buffer: Chunk[A]              = if (n > 1) Chunk.empty[A] else null
     private var chunkBuilder: ChunkBuilder[A] = null
-    private var pos: Int                = 0
+    private var pos: Int                      = 0
 
     def isEmpty: Boolean = pos == 0
 
@@ -5760,7 +5760,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       } else {
         // Optimized for large chunks
         var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = null
-        var chunkOffset = 0
+        var chunkOffset                                                         = 0
 
         if (chunkBuilder != null) {
           // Last chunk was small and written to chunkBuilder => add to buffer before continuing with large chunk
@@ -5769,9 +5769,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         }
 
         while (chunkOffset < chunkSize) {
-          val needed = n - pos
+          val needed    = n - pos
           val available = chunkSize - chunkOffset
-          val size = math.min(needed, available)
+          val size      = math.min(needed, available)
           buffer ++= chunk.slice(chunkOffset, chunkOffset + size)
           pos += size
           chunkOffset += size

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5715,66 +5715,6 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       self.collect { case o if tag.runtimeClass.isInstance(o) => o.asInstanceOf[O1] }
   }
 
-  private[zio] class RechunkerOld[A](n: Int) {
-    private val buffer: ChunkBuilder[A] = if (n > 1) ChunkBuilder.make(n) else null
-    private var pos: Int                = 0
-
-    def isEmpty: Boolean = pos == 0
-
-    final def rechunk(
-      chunk: Chunk[A]
-    )(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      val len = chunk.size
-      if (len == 0) {
-        null
-      } else if (isEmpty && len == n) {
-        ZChannel.write(chunk)
-      } else if (n == 1) {
-        rechunk1(chunk, len)
-      } else {
-        var i = 0
-
-        var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = null
-
-        while (i < len) {
-          buffer.addOne(chunk(i))
-          i += 1
-          pos += 1
-          if (pos == n) {
-            val bufferResult = ZChannel.write(buffer.result())
-            channel =
-              if (channel eq null) bufferResult
-              else channel *> bufferResult
-            pos = 0
-            buffer.clear()
-          }
-        }
-
-        channel
-      }
-    }
-
-    private def rechunk1(chunk: Chunk[A], len: Int)(implicit
-      trace: Trace
-    ): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = ZChannel.write(Chunk.single(chunk.head))
-
-      var i = 1
-      while (i < len) {
-        val c = Chunk.single(chunk(i))
-        channel = channel *> ZChannel.write(c)
-        i += 1
-      }
-
-      channel
-    }
-
-    def done()(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] =
-      if (isEmpty) ZChannel.unit
-      else ZChannel.write(buffer.result())
-
-  }
-
   private[zio] class Rechunker[A](n: Int) {
     private var buffer: Chunk[A]              = Chunk.empty[A]
     private val chunkBuilder: ChunkBuilder[A] = ChunkBuilder.make(n)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5715,66 +5715,6 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       self.collect { case o if tag.runtimeClass.isInstance(o) => o.asInstanceOf[O1] }
   }
 
-  private[zio] class RechunkerOld[A](n: Int) {
-    private val buffer: ChunkBuilder[A] = if (n > 1) ChunkBuilder.make(n) else null
-    private var pos: Int                = 0
-
-    def isEmpty: Boolean = pos == 0
-
-    final def rechunk(
-      chunk: Chunk[A]
-    )(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      val len = chunk.size
-      if (len == 0) {
-        null
-      } else if (isEmpty && len == n) {
-        ZChannel.write(chunk)
-      } else if (n == 1) {
-        rechunk1(chunk, len)
-      } else {
-        var i = 0
-
-        var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = null
-
-        while (i < len) {
-          buffer.addOne(chunk(i))
-          i += 1
-          pos += 1
-          if (pos == n) {
-            val bufferResult = ZChannel.write(buffer.result())
-            channel =
-              if (channel eq null) bufferResult
-              else channel *> bufferResult
-            pos = 0
-            buffer.clear()
-          }
-        }
-
-        channel
-      }
-    }
-
-    private def rechunk1(chunk: Chunk[A], len: Int)(implicit
-      trace: Trace
-    ): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = ZChannel.write(Chunk.single(chunk.head))
-
-      var i = 1
-      while (i < len) {
-        val c = Chunk.single(chunk(i))
-        channel = channel *> ZChannel.write(c)
-        i += 1
-      }
-
-      channel
-    }
-
-    def done()(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] =
-      if (isEmpty) ZChannel.unit
-      else ZChannel.write(buffer.result())
-
-  }
-
   private[zio] class Rechunker[A](n: Int) {
     private var buffer: Chunk[A]              = Chunk.empty[A]
     private var chunkBuilder: ChunkBuilder[A] = null

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5715,6 +5715,66 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       self.collect { case o if tag.runtimeClass.isInstance(o) => o.asInstanceOf[O1] }
   }
 
+  private[zio] class RechunkerOld[A](n: Int) {
+    private var buffer: ChunkBuilder[A] = if (n > 1) ChunkBuilder.make(n) else null
+    private var pos: Int                = 0
+
+    def isEmpty: Boolean = pos == 0
+
+    final def rechunk(
+      chunk: Chunk[A]
+    )(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
+      val len = chunk.size
+      if (len == 0) {
+        null
+      } else if (isEmpty && len == n) {
+        ZChannel.write(chunk)
+      } else if (n == 1) {
+        rechunk1(chunk, len)
+      } else {
+        var i = 0
+
+        var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = null
+
+        while (i < len) {
+          buffer += chunk(i)
+          i += 1
+          pos += 1
+          if (pos == n) {
+            val bufferResult = ZChannel.write(buffer.result())
+            channel =
+              if (channel eq null) bufferResult
+              else channel *> bufferResult
+            pos = 0
+            buffer = ChunkBuilder.make(n)
+          }
+        }
+
+        channel
+      }
+    }
+
+    private def rechunk1(chunk: Chunk[A], len: Int)(implicit
+      trace: Trace
+    ): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
+      var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = ZChannel.write(Chunk.single(chunk.head))
+
+      var i = 1
+      while (i < len) {
+        val c = Chunk.single(chunk(i))
+        channel = channel *> ZChannel.write(c)
+        i += 1
+      }
+
+      channel
+    }
+
+    def done()(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] =
+      if (isEmpty) ZChannel.unit
+      else ZChannel.write(buffer.result())
+
+  }
+
   private[zio] class Rechunker[A](n: Int) {
     private var buffer: Chunk[A]              = if (n > 1) Chunk.empty[A] else null
     private var chunkBuilder: ChunkBuilder[A] = null

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5715,66 +5715,6 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       self.collect { case o if tag.runtimeClass.isInstance(o) => o.asInstanceOf[O1] }
   }
 
-  private[zio] class RechunkerOld[A](n: Int) {
-    private var buffer: ChunkBuilder[A] = if (n > 1) ChunkBuilder.make(n) else null
-    private var pos: Int                = 0
-
-    def isEmpty: Boolean = pos == 0
-
-    final def rechunk(
-      chunk: Chunk[A]
-    )(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      val len = chunk.size
-      if (len == 0) {
-        null
-      } else if (isEmpty && len == n) {
-        ZChannel.write(chunk)
-      } else if (n == 1) {
-        rechunk1(chunk, len)
-      } else {
-        var i = 0
-
-        var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = null
-
-        while (i < len) {
-          buffer += chunk(i)
-          i += 1
-          pos += 1
-          if (pos == n) {
-            val bufferResult = ZChannel.write(buffer.result())
-            channel =
-              if (channel eq null) bufferResult
-              else channel *> bufferResult
-            pos = 0
-            buffer = ChunkBuilder.make(n)
-          }
-        }
-
-        channel
-      }
-    }
-
-    private def rechunk1(chunk: Chunk[A], len: Int)(implicit
-      trace: Trace
-    ): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = {
-      var channel: ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] = ZChannel.write(Chunk.single(chunk.head))
-
-      var i = 1
-      while (i < len) {
-        val c = Chunk.single(chunk(i))
-        channel = channel *> ZChannel.write(c)
-        i += 1
-      }
-
-      channel
-    }
-
-    def done()(implicit trace: Trace): ZChannel[Any, ZNothing, Any, Any, ZNothing, Chunk[A], Any] =
-      if (isEmpty) ZChannel.unit
-      else ZChannel.write(buffer.result())
-
-  }
-
   private[zio] class Rechunker[A](n: Int) {
     private var buffer: Chunk[A] = if (n > 1) Chunk.empty[A] else null
     private var chunkBuilder: ChunkBuilder[A] = null


### PR DESCRIPTION
Another improvement for https://github.com/zio/zio/issues/8894. 
This PR improves rechunking of large chunks with a factor ~100 on my laptop.
In order to keep good performance for small chunks it still keeps the current implementation for chunks with sizes less than 22. That number comes from running benchmarks to check when the new implementation becomes faster than the current... 


 ```[info] Benchmark                                (chunkCount)  (hugeChunkCount)  (hugeChunkSize)  (largeChunkSize)  (smallChunkSize)   Mode  Cnt    Score     Error  Units
[info] RechunkBenchmark.rechunkHugeToLarge             10000                10         10000000             10000                10  thrpt   15  348.844 ± 114.362  ops/s
[info] RechunkBenchmark.rechunkHugeToLargeOld          10000                10         10000000             10000                10  thrpt   15    3.017 ±   0.093  ops/s
[info] RechunkBenchmark.rechunkLargeToHuge             10000                10         10000000             10000                10  thrpt   15  145.574 ±  26.776  ops/s
[info] RechunkBenchmark.rechunkLargeToHugeOld          10000                10         10000000             10000                10  thrpt   15    1.413 ±   0.042  ops/s
[info] RechunkBenchmark.rechunkLargeToSmall            10000                10         10000000             10000                10  thrpt   15    0.467 ±   0.009  ops/s
[info] RechunkBenchmark.rechunkLargeToSmallOld         10000                10         10000000             10000                10  thrpt   15    0.330 ±   0.011  ops/s
[info] RechunkBenchmark.rechunkSmallTo1                10000                10         10000000             10000                10  thrpt   15   33.108 ±   7.354  ops/s
[info] RechunkBenchmark.rechunkSmallTo1Old             10000                10         10000000             10000                10  thrpt   15   33.058 ±   6.834  ops/s
[info] RechunkBenchmark.rechunkSmallToLarge            10000                10         10000000             10000                10  thrpt   15  206.091 ±  55.451  ops/s
[info] RechunkBenchmark.rechunkSmallToLargeOld         10000                10         10000000             10000                10  thrpt   15  178.054 ±  16.808  ops/s
[info] RechunkBenchmark.rechunkSmallToSmall            10000                10         10000000             10000                10  thrpt   15  141.338 ±  28.417  ops/s
[info] RechunkBenchmark.rechunkSmallToSmallOld         10000                10         10000000             10000                10  thrpt   15  139.137 ±  35.000  ops/s
```

I kept both implementations in the first commit, if someone want's to compare themselves...

Regards David