### PR TITLE
Improve error from `assertTrue` in `ZIO#flatMap`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TSemaphoreSpec.scala
@@ -125,7 +125,7 @@ object TSemaphoreSpec extends ZIOBaseSpec {
             semaphore <- TSemaphore.make(2L)
             actual    <- semaphore.acquireBetween(3L, 5L)
           } yield actual
-        transaction.commitEither *> assertTrue(false)
+        transaction.commitEither.as(assertTrue(false))
       } @@ timeout(1.second) @@ failing,
       test("acquireUpTo") {
         for {

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -21,6 +21,23 @@ object SmartAssertionSpec extends ZIOBaseSpec {
   private val company: Company = Company("Ziverge", List(User("Bobo", List.tabulate(2)(n => Post(s"Post #$n")))))
 
   def spec = suite("SmartAssertionSpec")(
+    suite("assertTrue: UIO")(
+      test("reports readable error") {
+        for {
+          result <- typeCheck("""ZIO.succeed(42).flatMap(i => assertTrue(i + 1 == 43))""")
+        } yield assertTrue(result.is(_.left).contains("not supported"))
+      },
+      test("reports readable error for multiple assertions") {
+        for {
+          result <- typeCheck("""ZIO.succeed(42).flatMap(i => assertTrue(i + 1 == 43, i + 2 == 44))""")
+        } yield assertTrue(result.is(_.left).contains("not supported"))
+      },
+      test("doesn't break test constructor") {
+        for {
+          result <- typeCheck("""test("")(ZIO.succeed(42).flatMap(i => assertTrue(i + 1 == 43)))""")
+        } yield assertTrue(result.is(_.left).contains("not supported"))
+      }
+    ),
     suite("Array")(
       suite("==")(
         test("success") {

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -36,6 +36,7 @@ trait CompileVariants {
    */
   def assertTrue(expr: Boolean, exprs: Boolean*): TestResult = macro SmartAssertMacros.assert_impl
   def assertTrue(expr: Boolean): TestResult = macro SmartAssertMacros.assertOne_impl
+  def assertTrue(exprs: Any*): UIO[Nothing] = macro SmartAssertMacros.assertFlatMapError_impl
 
   /**
    * Checks the assertion holds for the given value.

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -12,6 +12,9 @@ class SmartAssertMacros(val c: blackbox.Context) {
   private val Arrow      = q"_root_.zio.test.TestArrow"
   private val TestResult = q"_root_.zio.test.TestResult"
 
+  def assertFlatMapError_impl(exprs: Expr[Any]*): c.Tree =
+    c.abort(c.enclosingPosition, ".flatMap(... => assertTrue(...)) not supported.\nUse `.map` instead.")
+
   def assert_impl(expr: c.Expr[Boolean], exprs: c.Expr[Boolean]*): c.Tree =
     exprs.map(assertOne_impl).foldLeft(assertOne_impl(expr)) { (acc, assert) =>
       q"$acc && $assert"

--- a/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
@@ -44,6 +44,9 @@ trait CompileVariants {
   inline def assertTrue(inline exprs: => Boolean*): TestResult =
     ${SmartAssertMacros.smartAssert('exprs)}
 
+  inline def assertTrue(inline expr: Any, inline exprs: => Any*): UIO[Nothing] =
+    scala.compiletime.error(".flatMap(... => assertTrue(...)) not supported.\nUse `.map` instead.")
+
   inline def assert[A](inline value: => A)(inline assertion: Assertion[A])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     ${Macros.assert_impl('value)('assertion, 'trace, 'sourceLocation)}
 


### PR DESCRIPTION
~~This is an experimental fix to resolve #8668. I only implemented the fix for Scala 2 as I am not sure this is binary compatible... Can someone comment?~~

I also can try removing the partial application (after switching to `Any` parameters), but it won't work if we add a signature:
```
def assertTrue(expr: Boolean, exprs: Boolean*): UIO[TestResult] = ???
```

