### PR TITLE
fix ZStream#mapZIOParUnordered memory leak

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1970,18 +1970,6 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       .concatMap(ZChannel.writeChunk(_))
       .mapOutZIOParUnordered[R1, E1, Chunk[A2]](n, bufferSize)(a => f(a).map(Chunk.single(_)))
       .toStream
-  /*val channels: ZChannel[R, Any, Any, Any, E, ZChannel[R1, Any, Any, Any, E1, Chunk[A2], Unit], Any] = self
-      .toChannel
-      .concatMap { chunk =>
-        ZChannel.writeChunk{
-          chunk
-            .map { a =>
-              ZChannel.fromZIO(f(a)).flatMap(a2 => ZChannel.write(Chunk.single(a2)))
-            }
-        }
-      }
-    val resChannel: ZChannel[R1, Any, Any, Any, E1, Chunk[A2], Any] = ZChannel.mergeAll(channels, n, bufferSize, ZChannel.MergeStrategy.BackPressure)
-    resChannel.toStream*/
 
   /**
    * Merges this stream and the specified stream together.


### PR DESCRIPTION
Fixes #8996 
All tests pass (at least locally, lol). There should be no performance regression. In fact, I get almost 50% improvement locally
```
// before
[info] Benchmark                              (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt  Score   Error  Units
[info] StreamParBenchmark.zioMapParUnordered         10000         5000              50  thrpt   15  1.915 ± 0.042  ops/s

// after
[info] Benchmark                              (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt  Score   Error  Units
[info] StreamParBenchmark.zioMapParUnordered         10000         5000              50  thrpt   15  2.739 ± 0.018  ops/s
```
I used
```
@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 2)
@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 2)
```
 instead of current
```
@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 1)
```
For better accuracy