### PR TITLE
Introduce memory leak tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -693,14 +693,17 @@ lazy val benchmarks = project.module
 
 lazy val memoryLeakTests = project.module
   .in(file("memory-leak-tests"))
-  .dependsOn(core.jvm, streams.jvm, coreTests.jvm % "test->test;compile->compile")
-  .dependsOn(testRunner.jvm)
+  .dependsOn(core.jvm, streams.jvm)
   .settings(
     crossScalaVersions --= List(Scala212, Scala3),
     publish / skip           := true,
     Test / parallelExecution := false,
     Test / fork              := true,
-    Test / javacOptions      := List("-XX:+ExitOnOutOfMemoryError", "-Xmx500M", "-Xms500M"),
+    Test / javaOptions       := List("-XX:+ExitOnOutOfMemoryError", "-Xmx1G", "-Xms200M"),
+    libraryDependencies ++= Seq(
+      "org.scalameta" %% "munit" % "1.0.0" % Test
+    ),
+    testFrameworks := Seq(TestFramework("munit.Framework")),
     Compile / console / scalacOptions := Seq(
       "-language:higherKinds",
       "-language:existentials",

--- a/build.sbt
+++ b/build.sbt
@@ -691,21 +691,20 @@ lazy val benchmarks = project.module
     assembly / mainClass     := Some("org.openjdk.jmh.Main")
   )
 
-
 lazy val memoryLeakTests = project.module
   .in(file("memory-leak-tests"))
   .dependsOn(core.jvm, streams.jvm, coreTests.jvm % "test->test;compile->compile")
   .dependsOn(testRunner.jvm)
   .settings(
     crossScalaVersions --= List(Scala212, Scala3),
-    publish / skip := true,
+    publish / skip           := true,
     Test / parallelExecution := false,
-    Test / fork    := true,
-    Test / javacOptions := List("-XX:+ExitOnOutOfMemoryError", "-Xmx500M", "-Xms500M"),
+    Test / fork              := true,
+    Test / javacOptions      := List("-XX:+ExitOnOutOfMemoryError", "-Xmx500M", "-Xms500M"),
     Compile / console / scalacOptions := Seq(
       "-language:higherKinds",
       "-language:existentials",
-      "-Xsource:2.13",
+      "-Xsource:2.13"
     )
   )
   .settings(scalacOptions += "-Wconf:msg=[@nowarn annotation does not suppress any warnings]:silent")

--- a/build.sbt
+++ b/build.sbt
@@ -691,6 +691,25 @@ lazy val benchmarks = project.module
     assembly / mainClass     := Some("org.openjdk.jmh.Main")
   )
 
+
+lazy val memoryLeakTests = project.module
+  .in(file("memory-leak-tests"))
+  .dependsOn(core.jvm, streams.jvm, coreTests.jvm % "test->test;compile->compile")
+  .dependsOn(testRunner.jvm)
+  .settings(
+    crossScalaVersions --= List(Scala212, Scala3),
+    publish / skip := true,
+    Test / parallelExecution := false,
+    Test / fork    := true,
+    Test / javacOptions := List("-XX:+ExitOnOutOfMemoryError", "-Xmx500M", "-Xms500M"),
+    Compile / console / scalacOptions := Seq(
+      "-language:higherKinds",
+      "-language:existentials",
+      "-Xsource:2.13",
+    )
+  )
+  .settings(scalacOptions += "-Wconf:msg=[@nowarn annotation does not suppress any warnings]:silent")
+
 lazy val jsdocs = project
   .settings(libraryDependencies += ("org.scala-js" %%% "scalajs-dom" % "2.8.0").cross(CrossVersion.for3Use2_13))
   .enablePlugins(ScalaJSPlugin)

--- a/memory-leak-tests/src/test/scala/zio/BytesFormatter.scala
+++ b/memory-leak-tests/src/test/scala/zio/BytesFormatter.scala
@@ -1,0 +1,18 @@
+package zio
+
+import java.text.{DecimalFormat, NumberFormat}
+import java.util.Locale
+
+object BytesFormatter {
+  private val formatter = NumberFormat.getInstance(Locale.US).asInstanceOf[DecimalFormat]
+  private val symbols   = formatter.getDecimalFormatSymbols
+
+  symbols.setGroupingSeparator('_')
+  formatter.setDecimalFormatSymbols(symbols)
+
+  implicit class BytesFmt(private val x: Long) extends AnyVal {
+    def fmtBytes: String = formatter.format(x)
+    def fmtDelta: String =
+      if (x > 0) s"+${x.fmtBytes}" else x.fmtBytes
+  }
+}

--- a/memory-leak-tests/src/test/scala/zio/MemoryLeakSpec.scala
+++ b/memory-leak-tests/src/test/scala/zio/MemoryLeakSpec.scala
@@ -1,0 +1,112 @@
+package zio
+
+import zio.test.{TestAspect, TestAspectPoly, assertTrue}
+
+import java.lang.management.ManagementFactory
+import BytesFormatter.BytesFmt
+
+trait MemoryLeakSpec extends ZIOBaseSpec {
+
+  case class MemoryHolder(ar: Array[Byte])
+  object MemoryHolder {
+    def apply(bytes: Int = 1024): MemoryHolder = MemoryHolder(Array.ofDim[Byte](bytes))
+  }
+
+  override def aspects: Chunk[TestAspectPoly] =
+    Chunk(TestAspect.timeout(15.seconds), TestAspect.timed, TestAspect.sequential, TestAspect.withLiveClock)
+
+  private def heapUsed: UIO[Long] =
+    ZIO.succeed {
+      val runtime = java.lang.Runtime.getRuntime
+      runtime.gc()
+      java.lang.System.gc()
+      runtime.totalMemory() - runtime.freeMemory()
+    }
+
+  private def currentGC: Chunk[String] = {
+    val gcMxBeans = Chunk.fromJavaIterable(ManagementFactory.getGarbageCollectorMXBeans)
+    gcMxBeans.map(_.getName)
+  }
+
+  case class LeakDetected(heapUsed: Long, zScore: Double)
+
+  private def mean(xs: Chunk[Long]): Double = xs.sum / xs.size.toDouble
+
+  private def variance(xs: Chunk[Long]): Double = {
+    val avg = mean(xs)
+    xs.map(x => math.pow(x - avg, 2)).sum / xs.size
+  }
+
+  private def standardDeviation(xs: Chunk[Long]): Double = math.sqrt(variance(xs))
+
+  private def zScore(xs: Chunk[Long]): Double = {
+    val avg    = mean(xs)
+    val stdDev = standardDeviation(xs)
+    val x      = xs.last
+    (x - avg) / stdDev
+  }
+
+  private def percDiff(a: Long, b: Long): Double =
+    100 * math.abs(a - b) / ((a + b) / 2)
+
+  private def monitorHeap(
+    samplePeriod: Duration,
+    warmupIterations: Int,
+    heapUsedInitial: Long,
+    zScoreThreshold: Double
+  ): Task[LeakDetected] = {
+    println(s"heapUsedInitial = ${heapUsedInitial.fmtBytes}")
+    def go(initialBytes: Long, usedHistory: Chunk[Long] = Chunk.empty): Task[LeakDetected] =
+      ZIO.sleep(samplePeriod) *> heapUsed.flatMap { bytesUsed =>
+        val currentDiff = bytesUsed - initialBytes
+
+        val updated = usedHistory :+ bytesUsed
+
+        val zs = zScore(updated)
+        println(
+          f"Heap: ${bytesUsed.fmtBytes}%12.12s total, ${currentDiff.fmtDelta}%12.12s since start, zScore=${zs}"
+        )
+
+        if (zs > zScoreThreshold) {
+          println(s"LEAK: zscore=${zs} hist=${updated.map(_.fmtBytes)}")
+          Exit.succeed(LeakDetected(bytesUsed, zs))
+        } else go(initialBytes, updated)
+
+      }
+
+    heapUsed.flatMap { usedBytes =>
+      ZIO.logDebug(s"usedBytes per warmup = ${usedBytes.fmtBytes}") *> ZIO.sleep(samplePeriod)
+    }.repeatN(warmupIterations) *> heapUsed.flatMap { initialBytes =>
+      println(s"heap used after warmup = ${initialBytes.fmtBytes}")
+      if (percDiff(heapUsedInitial, initialBytes) > 100.0) {
+        // heap increased twice after warmup, definitely leak
+        Exit.Success(LeakDetected(initialBytes, 2.0))
+      } else go(initialBytes)
+    }
+  }
+
+  private lazy val gc = currentGC
+
+  protected def leakTest(
+    name: String,
+    zScoreThreshold: Double = 2
+  )(effect: => Task[Unit]) =
+    test(name) {
+      println(s"start test $name, using GC = $gc")
+      heapUsed.flatMap { initialBytes =>
+        effect.disconnect
+          .timeout(10.seconds)
+          .raceEither(
+            monitorHeap(
+              samplePeriod = 1.seconds,
+              warmupIterations = 3,
+              heapUsedInitial = initialBytes,
+              zScoreThreshold = zScoreThreshold
+            )
+          )
+          .map { result =>
+            assertTrue(result.isLeft)
+          }
+      }
+    }
+}

--- a/memory-leak-tests/src/test/scala/zio/TestUtils.scala
+++ b/memory-leak-tests/src/test/scala/zio/TestUtils.scala
@@ -1,0 +1,9 @@
+package zio
+
+object TestUtils {
+
+  def unsafeRunNewRuntime[E, A](zio: ZIO[Any, E, A]): A = {
+    val rt = Runtime(ZEnvironment.empty, FiberRefs.empty, RuntimeFlags.default)
+    Unsafe.unsafe(implicit unsafe => rt.unsafe.run(zio).getOrThrowFiberFailure())
+  }
+}

--- a/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
+++ b/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
@@ -4,16 +4,16 @@ import zio._
 
 object ZStreamMemoryLeakSpec extends MemoryLeakSpec {
   def spec = suite("ZStream Memory Leak spec")(
-    leakTest("mapZIOParUnordered not leak") {
+    leakTest("mapZIOParUnordered(1) doesn't leak") {
       ZStream
         .iterate(1)(_ + 1)
         .mapZIOParUnordered(1)(i => ZIO.when(i % 1000 == 0)(ZIO.logDebug(s"$i")))
         .runDrain
     },
-    leakTest("flatMapPar with Int.MaxValue not leak") {
+    leakTest("flatMapPar(1) doesn't leak") {
       ZStream
         .iterate(MemoryHolder())(_ => MemoryHolder())
-        .flatMapPar(Int.MaxValue) { i =>
+        .flatMapPar(1) { i =>
           ZStream.fromZIO(ZIO.logDebug(s"$i"))
         }
         .runDrain

--- a/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
+++ b/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
@@ -2,21 +2,30 @@ package zio.stream
 
 import zio._
 
-object ZStreamMemoryLeakSpec extends MemoryLeakSpec {
-  def spec = suite("ZStream Memory Leak spec")(
-    leakTest("mapZIOParUnordered(1) doesn't leak") {
-      ZStream
-        .iterate(1)(_ + 1)
-        .mapZIOParUnordered(1)(i => ZIO.when(i % 1000 == 0)(ZIO.logDebug(s"$i")))
-        .runDrain
-    },
-    leakTest("flatMapPar(1) doesn't leak") {
-      ZStream
-        .iterate(MemoryHolder())(_ => MemoryHolder())
-        .flatMapPar(1) { i =>
-          ZStream.fromZIO(ZIO.logDebug(s"$i"))
-        }
-        .runDrain
-    }
-  )
+class ZStreamMemoryLeakSpec extends MemoryLeakSpec {
+
+  leakTest("mapZIOParUnordered(8) doesn't leak") {
+    ZStream
+      .iterate(MemoryHolder())(_ => MemoryHolder())
+      .mapZIOParUnordered(1)(i => ZIO.logDebug(s"$i"))
+      .runDrain
+  }
+
+  leakTest("flatMapPar(1) doesn't leak") {
+    ZStream
+      .iterate(MemoryHolder())(_ => MemoryHolder())
+      .flatMapPar(1) { i =>
+        ZStream.fromZIO(ZIO.logDebug(s"$i").delay(5.millis))
+      }
+      .runDrain
+  }
+
+  leakTest("flatMapPar(Int.MaxValue) doesn't leak") {
+    ZStream
+      .iterate(1)(_ + 1)
+      .flatMapPar(Int.MaxValue) { i =>
+        ZStream.fromZIO(ZIO.logDebug(s"$i").delay(30.millis))
+      }
+      .runDrain
+  }
 }

--- a/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
+++ b/memory-leak-tests/src/test/scala/zio/stream/ZStreamMemoryLeakSpec.scala
@@ -1,0 +1,22 @@
+package zio.stream
+
+import zio._
+
+object ZStreamMemoryLeakSpec extends MemoryLeakSpec {
+  def spec = suite("ZStream Memory Leak spec")(
+    leakTest("mapZIOParUnordered not leak") {
+      ZStream
+        .iterate(1)(_ + 1)
+        .mapZIOParUnordered(1)(i => ZIO.when(i % 1000 == 0)(ZIO.logDebug(s"$i")))
+        .runDrain
+    },
+    leakTest("flatMapPar with Int.MaxValue not leak") {
+      ZStream
+        .iterate(MemoryHolder())(_ => MemoryHolder())
+        .flatMapPar(Int.MaxValue) { i =>
+          ZStream.fromZIO(ZIO.logDebug(s"$i"))
+        }
+        .runDrain
+    }
+  )
+}


### PR DESCRIPTION
I think we need to test against memory leaks before merging big refactoring or optimization PRs (see https://github.com/zio/zio/issues?q=is%3Aissue+memory+leak ).


These tests are long at execution time (10 seconds each), so I've decided to put them into a separate project. 

My suggestion is to run these tests before release or before merge PR manually or via github comment by bot. 
Or we can include these tests in standard CI, but CI time will be increased proportionally to number of tests

It's only start of it, we need to cover more zio and zio stream operators in further