### PR TITLE
Optimize `ZIO.foreach` methods

### DIFF
--- a/core/shared/src/main/scala/zio/RuntimeFlags.scala
+++ b/core/shared/src/main/scala/zio/RuntimeFlags.scala
@@ -211,6 +211,9 @@ object RuntimeFlags {
   def enable(flag: RuntimeFlag): RuntimeFlags.Patch =
     RuntimeFlags.Patch(flag.mask, flag.mask)
 
+  private[zio] val disableInterruption: RuntimeFlags.Patch = disable(RuntimeFlag.Interruption)
+  private[zio] val enableInterruption: RuntimeFlags.Patch  = enable(RuntimeFlag.Interruption)
+
   /**
    * No runtime flags.
    */


### PR DESCRIPTION
- Add short-circuit for `ZIO.foreach*` methods when the input collection is empty
- Implement foreach methods specialized inputs (e.g., Set, Map) separately to avoid conversions between an Iterable and the specialized output type