### PR TITLE
Skip compilation of `scalafix` modules via IntelliJ

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
-import BuildHelper._
-import Dependencies._
+import BuildHelper.*
+import Dependencies.*
 import MimaSettings.mimaSettings
 import explicitdeps.ExplicitDepsPlugin.autoImport.moduleFilterRemoveValue
 import sbt.Keys
@@ -701,7 +701,8 @@ val catsEffectV = "3.5.4"
 val zioActorsV  = "0.1.0"
 
 lazy val scalafixSettings = List(
-  scalaVersion := Scala213,
+  scalaVersion   := Scala213,
+  ideSkipProject := true,
   addCompilerPlugin(scalafixSemanticdb),
   crossScalaVersions --= List(Scala212, Scala3),
   scalacOptions ++= List(
@@ -896,3 +897,5 @@ lazy val docs = project.module
   )
   .enablePlugins(MdocPlugin, DocusaurusPlugin, ScalaUnidocPlugin)
   .aggregate(docs_make_zio_app_configurable)
+
+Global / excludeLintKeys += ideSkipProject

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,4 +17,6 @@ addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"               
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.7")
 
+addSbtPlugin("org.jetbrains.scala" % "sbt-ide-settings" % "1.1.2")
+
 libraryDependencies += "org.snakeyaml" % "snakeyaml-engine" % "2.7"


### PR DESCRIPTION
Currently, it's not possible to compile the full project via intelliJ because it also tries to compile the `scalafix/*` modules. Plus, IntelliJ indexes them, which makes searching for classes quite annoying as lots of them exist in the scalafix modules as well as the "production" modules.

This PR improves DX for people using IntelliJ by ignoring the scalafix modules, so that the project can be fully compiled via IntelliJ. Note that this should have no effect when using the sbt shell or during CI, so it's perfectly safe to use