### PR TITLE
Optimize failures, retries and stack trace generation

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -169,8 +169,8 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
           case Then(left, right)   => loop(left, right :: stack)
           case Both(left, right)   => loop(left, right :: stack)
           case Stackless(cause, _) => loop(cause, stack)
-          case _ if stack.isEmpty  => None
-          case _                   => loop(stack.head, stack.tail)
+          case _ if stack.nonEmpty => loop(stack.head, stack.tail)
+          case _                   => None
         }
       }
     }
@@ -274,11 +274,8 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
         case Then(left, right)   => loop(z, left, right :: stack)
         case Both(left, right)   => loop(z, left, right :: stack)
         case Stackless(cause, _) => loop(z, cause, stack)
-        case _ =>
-          stack match {
-            case hd :: tl => loop(z, hd, tl)
-            case _        => z
-          }
+        case _ if stack.nonEmpty => loop(z, stack.head, stack.tail)
+        case _                   => z
       }
     }
 

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -487,7 +487,7 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
           now   <- Clock.currentDateTime
           dec   <- self.step(now, in, state)
           v <- dec match {
-                 case (state, out, Done) => ref.set((Some(out), state)) *> ZIO.fail(None)
+                 case (state, out, Done) => ref.set((Some(out), state)) *> Exit.failNone
                  case (state, out, Continue(interval)) =>
                    ref.set((Some(out), state)) *> ZIO.sleep(Duration.fromInterval(now, interval.start)) as out
                }
@@ -495,7 +495,7 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
 
       val last = ref.get.flatMap {
         case (None, _)    => ZIO.fail(new NoSuchElementException("There is no value left"))
-        case (Some(b), _) => ZIO.succeed(b)
+        case (Some(b), _) => Exit.succeed(b)
       }
 
       val reset = ref.set((None, self.initial))

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -487,7 +487,7 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
           now   <- Clock.currentDateTime
           dec   <- self.step(now, in, state)
           v <- dec match {
-                 case (state, out, Done) => ref.set((Some(out), state)) *> Exit.failNone
+                 case (state, out, Done) => ref.set((Some(out), state)) *> Exit.fail(None)
                  case (state, out, Continue(interval)) =>
                    ref.set((Some(out), state)) *> ZIO.sleep(Duration.fromInterval(now, interval.start)) as out
                }

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -487,7 +487,8 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
           now   <- Clock.currentDateTime
           dec   <- self.step(now, in, state)
           v <- dec match {
-                 case (state, out, Done) => ref.set((Some(out), state)) *> Exit.fail(None)
+                 case (state, out, Done) =>
+                   ref.set((Some(out), state)) *> Exit.failNone.asInstanceOf[Exit[None.type, Out]]
                  case (state, out, Continue(interval)) =>
                    ref.set((Some(out), state)) *> ZIO.sleep(Duration.fromInterval(now, interval.start)) as out
                }

--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -18,8 +18,6 @@ package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.annotation.tailrec
-
 final case class StackTrace(
   fiberId: FiberId,
   stackTrace: Chunk[Trace]
@@ -30,7 +28,7 @@ final case class StackTrace(
     else if (that.isEmpty) self
     else StackTrace(self.fiberId combine that.fiberId, self.stackTrace ++ that.stackTrace)
 
-  def isEmpty: Boolean = self == StackTrace.none
+  def isEmpty: Boolean = (fiberId eq FiberId.None) && stackTrace.isEmpty
 
   def size: Int = stackTrace.length
 

--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -26,7 +26,11 @@ final case class StackTrace(
 ) { self =>
 
   def ++(that: StackTrace): StackTrace =
-    StackTrace(self.fiberId combine that.fiberId, self.stackTrace ++ that.stackTrace)
+    if ((self eq that) || self.isEmpty) that
+    else if (that.isEmpty) self
+    else StackTrace(self.fiberId combine that.fiberId, self.stackTrace ++ that.stackTrace)
+
+  def isEmpty: Boolean = self == StackTrace.none
 
   def size: Int = stackTrace.length
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -843,8 +843,8 @@ sealed trait ZIO[-R, +E, +A]
    * non-empty or fails with the error `None` if the list is empty.
    */
   final def head[B](implicit ev: A IsSubtypeOfOutput List[B], trace: Trace): ZIO[R, Option[E], B] =
-    self.foldCauseZIO(
-      e => ZIO.refailCause(e.map(Option(_))),
+    self.foldZIO(
+      e => Exit.fail(Some(e)),
       a => ev(a).headOption.fold[ZIO[R, Option[E], B]](Exit.failNone)(ZIO.successFn)
     )
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -411,7 +411,7 @@ sealed trait ZIO[-R, +E, +A]
   final def catchSomeDefect[R1 <: R, E1 >: E, A1 >: A](
     pf: PartialFunction[Throwable, ZIO[R1, E1, A1]]
   )(implicit trace: Trace): ZIO[R1, E1, A1] =
-    unrefineWith(pf)(ZIO.fail(_)).catchAll(identity)
+    unrefineWith(pf)(ZIO.failFn).catchAll(identity)
 
   /**
    * Returns an effect that succeeds with the cause of failure of this effect,
@@ -670,7 +670,7 @@ sealed trait ZIO[-R, +E, +A]
    * use all methods on the error channel, possibly before flipping back.
    */
   final def flip(implicit trace: Trace): ZIO[R, A, E] =
-    self.foldZIO(ZIO.successFn, ZIO.fail(_))
+    self.foldZIO(ZIO.successFn, ZIO.failFn)
 
   /**
    * Swaps the error/value parameters, applies the function `f` and flips the
@@ -843,9 +843,9 @@ sealed trait ZIO[-R, +E, +A]
    * non-empty or fails with the error `None` if the list is empty.
    */
   final def head[B](implicit ev: A IsSubtypeOfOutput List[B], trace: Trace): ZIO[R, Option[E], B] =
-    self.foldZIO(
-      e => ZIO.fail(Some(e)),
-      a => ev(a).headOption.fold[ZIO[R, Option[E], B]](ZIO.fail(None))(ZIO.successFn)
+    self.foldCauseZIO(
+      e => ZIO.refailCause(e.map(Option(_))),
+      a => ev(a).headOption.fold[ZIO[R, Option[E], B]](Exit.failNone)(ZIO.successFn)
     )
 
   /**
@@ -928,7 +928,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def left[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C], trace: Trace): ZIO[R, Either[E, C], B] =
     self.foldZIO(
-      e => ZIO.fail(Left(e)),
+      e => Exit.fail(Left(e)),
       a => ev(a).fold(ZIO.successFn, c => ZIO.fail(Right(c)))
     )
 
@@ -977,14 +977,14 @@ sealed trait ZIO[-R, +E, +A]
    * `f` function, translating any thrown exceptions into typed failed effects.
    */
   final def mapAttempt[B](f: A => B)(implicit ev: E IsSubtypeOfError Throwable, trace: Trace): RIO[R, B] =
-    foldZIO(e => ZIO.fail(ev(e)), a => ZIO.attempt(f(a)))
+    foldZIO(e => Exit.fail(ev(e)), a => ZIO.attempt(f(a)))
 
   /**
    * Returns an effect whose failure and success channels have been mapped by
    * the specified pair of functions, `f` and `g`.
    */
   def mapBoth[E2, B](f: E => E2, g: A => B)(implicit ev: CanFail[E], trace: Trace): ZIO[R, E2, B] =
-    foldZIO(e => ZIO.fail(f(e)), a => ZIO.succeed(g(a)))
+    foldZIO(e => Exit.fail(f(e)), a => ZIO.succeed(g(a)))
 
   /**
    * Returns an effect with its error channel mapped using the specified
@@ -1033,8 +1033,8 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def none[B](implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, Option[E], Unit] =
     self.foldZIO(
-      e => ZIO.fail(Some(e)),
-      a => ev(a).fold[ZIO[R, Option[E], Unit]](Exit.unit)(_ => ZIO.fail(None))
+      e => Exit.fail(Some(e)),
+      a => ev(a).fold[ZIO[R, Option[E], Unit]](Exit.unit)(_ => Exit.failNone)
     )
 
   /**
@@ -1215,7 +1215,7 @@ sealed trait ZIO[-R, +E, +A]
   final def orElseOptional[R1 <: R, E1, A1 >: A](
     that: => ZIO[R1, Option[E1], A1]
   )(implicit ev: E IsSubtypeOfError Option[E1], trace: Trace): ZIO[R1, Option[E1], A1] =
-    catchAll(ev(_).fold(that)(e => ZIO.fail(Some(e))))
+    catchAll(ev(_).fold(that)(e => Exit.fail(Some(e))))
 
   /**
    * Executes this effect and returns its value, if it succeeds, but otherwise
@@ -1432,9 +1432,8 @@ sealed trait ZIO[-R, +E, +A]
 
       val raceIndicator = new AtomicBoolean(true)
 
-      val leftFiber = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)
-      val rightFiber =
-        ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)
+      val leftFiber  = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)
+      val rightFiber = ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)
 
       val startLeftFiber  = leftFiber.startSuspended()
       val startRightFiber = rightFiber.startSuspended()
@@ -1530,7 +1529,7 @@ sealed trait ZIO[-R, +E, +A]
   final def repeat[R1 <: R, B](schedule: => Schedule[R1, A, B])(implicit
     trace: Trace
   ): ZIO[R1, E, B] =
-    repeatOrElse[R1, E, B](schedule, (e, _) => ZIO.fail(e))
+    repeatOrElse[R1, E, B](schedule, (e, _) => Exit.fail(e))
 
   /**
    * Returns a new effect that repeats this effect the specified number of times
@@ -1756,7 +1755,7 @@ sealed trait ZIO[-R, +E, +A]
   final def retryUntilZIO[R1 <: R](
     f: E => URIO[R1, Boolean]
   )(implicit ev: CanFail[E], trace: Trace): ZIO[R1, E, A] =
-    self.catchAll(e => f(e).flatMap(b => if (b) ZIO.fail(e) else ZIO.yieldNow *> retryUntilZIO(f)))
+    self.catchAll(e => f(e).flatMap(b => if (b) Exit.fail(e) else ZIO.yieldNow *> retryUntilZIO(f)))
 
   /**
    * Retries this effect while its error satisfies the specified predicate.
@@ -1786,7 +1785,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def right[B, C](implicit ev: A IsSubtypeOfOutput Either[B, C], trace: Trace): ZIO[R, Either[B, E], C] =
     self.foldZIO(
-      e => ZIO.fail(Right(e)),
+      e => Exit.fail(Right(e)),
       a => ev(a).fold(b => ZIO.fail(Left(b)), ZIO.successFn)
     )
 
@@ -1878,7 +1877,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def some[B](implicit ev: A IsSubtypeOfOutput Option[B], trace: Trace): ZIO[R, Option[E], B] =
     self.foldZIO(
-      e => ZIO.fail(Some(e)),
+      e => Exit.fail(Some(e)),
       a => ev(a).fold[ZIO[R, Option[E], B]](ZIO.fail(Option.empty[E]))(ZIO.successFn)
     )
 
@@ -1953,8 +1952,8 @@ sealed trait ZIO[-R, +E, +A]
     ev2: NoSuchElementException <:< E1,
     trace: Trace
   ): ZIO[R, E1, B] =
-    self.foldZIO(
-      e => ZIO.fail(e),
+    self.foldCauseZIO(
+      e => ZIO.refailCause(e),
       ev(_) match {
         case Some(value) => Exit.succeed(value)
         case None        => ZIO.fail(ev2(new NoSuchElementException("None.get")))
@@ -2299,7 +2298,7 @@ sealed trait ZIO[-R, +E, +A]
     catchAllCause { cause =>
       cause.find {
         case Cause.Die(t, _) if pf.isDefinedAt(t) => pf(t)
-      }.fold(ZIO.refailCause(cause.map(f)))(ZIO.fail(_))
+      }.fold(ZIO.refailCause(cause.map(f)))(ZIO.failFn)
     }
 
   /**
@@ -2311,7 +2310,7 @@ sealed trait ZIO[-R, +E, +A]
     trace: Trace
   ): ZIO[R, E1, Either[B, A]] =
     self.foldZIO(
-      e => ev(e).fold(b => Exit.succeed(Left(b)), e1 => ZIO.fail(e1)),
+      e => ev(e).fold(b => Exit.succeed(Left(b)), e1 => Exit.fail(e1)),
       a => Exit.succeed(Right(a))
     )
 
@@ -2320,7 +2319,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def unsome[E1](implicit ev: E IsSubtypeOfError Option[E1], trace: Trace): ZIO[R, E1, Option[A]] =
     self.foldZIO(
-      e => ev(e).fold[ZIO[R, E1, Option[A]]](Exit.none)(ZIO.fail(_)),
+      e => ev(e).fold[ZIO[R, E1, Option[A]]](Exit.none)(ZIO.failFn),
       a => Exit.succeed(Some(a))
     )
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -127,7 +127,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
   def interruptAsFork(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
-      val cause = Cause.interrupt(fiberId).traced(StackTrace(self.fiberId, Chunk.single(trace)))
+      val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
 
       tell(FiberMessage.InterruptSignal(cause))
     }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -16,19 +16,17 @@
 
 package zio.internal
 
+import zio.Exit.{Failure, Success}
+import zio._
+import zio.internal.SpecializationHelpers.SpecializeInt
+import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.annotation.tailrec
-import scala.util.control.ControlThrowable
-import java.util.{Set => JavaSet}
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-
-import zio._
-import zio.metrics.{Metric, MetricLabel}
-import zio.Exit.Failure
-import zio.Exit.Success
-import zio.internal.SpecializationHelpers.SpecializeInt
+import java.util.{Set => JavaSet}
+import scala.annotation.tailrec
+import scala.util.control.ControlThrowable
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
     extends Fiber.Runtime.Internal[E, A]
@@ -36,8 +34,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   self =>
   type Erased = ZIO.Erased
 
+  import FiberRuntime.{AsyncJump, DisableAssertions, EvaluationSignal, stackTraceBuilderPool}
   import ZIO._
-  import FiberRuntime.{AsyncJump, EvaluationSignal, DisableAssertions}
 
   private var _lastTrace      = fiberId.location
   private var _fiberRefs      = fiberRefs0
@@ -498,25 +496,30 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
   private def generateStackTrace(): StackTrace = {
-    val builder = StackTraceBuilder.make()(Unsafe.unsafe)
+    val builder = stackTraceBuilderPool.get()
 
     val stack = _stack
     val size  = _stackSize // racy
 
-    if (stack ne null) {
-      var i = (if (stack.length < size) stack.length else size) - 1
-      while (i >= 0) {
-        val k = stack(i)
-        if (k ne null) { // racy
-          builder += k.trace
-          i -= 1
+    try {
+      if (stack ne null) {
+        var i = (if (stack.length < size) stack.length else size) - 1
+
+        while (i >= 0) {
+          val k = stack(i)
+          if (k ne null) { // racy
+            builder += k.trace
+            i -= 1
+          }
         }
       }
+
+      builder += id.location // TODO: Allow parent traces?
+
+      StackTrace(self.fiberId, builder.result())
+    } finally {
+      builder.clear()
     }
-
-    builder += id.location // TODO: Allow parent traces?
-
-    StackTrace(self.fiberId, builder.result())
   }
 
   /**
@@ -800,7 +803,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     cause: Cause[E],
     continueEffect: ZIO[R, E, A]
   ): ZIO[R, E, A] = {
-    import RuntimeFlags.Patch.{isEnabled, isDisabled}
+    import RuntimeFlags.Patch.{isDisabled, isEnabled}
 
     val oldFlags = _runtimeFlags
     val newFlags = RuntimeFlags.patch(patch)(oldFlags)
@@ -1544,4 +1547,14 @@ object FiberRuntime {
 
   private val notBlockingOn: () => FiberId = () => FiberId.None
 
+  /**
+   * ThreadLocal-based pool of StackTraceBuilders to avoid creating a new one
+   * whenever we call ZIO.fail.
+   *
+   * '''NOTE''': Ensure that the `clear()` method on the builder is called after
+   * use.
+   */
+  private val stackTraceBuilderPool: ThreadLocal[StackTraceBuilder] = new ThreadLocal[StackTraceBuilder] {
+    override def initialValue(): StackTraceBuilder = StackTraceBuilder.make()(Unsafe.unsafe)
+  }
 }

--- a/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
@@ -18,18 +18,27 @@ package zio.internal
 
 import zio._
 
+import scala.collection.mutable.ArrayBuilder
+
 private[zio] class StackTraceBuilder private () { self =>
-  private var last: Trace                  = null.asInstanceOf[Trace]
-  private val builder: ChunkBuilder[Trace] = ChunkBuilder.make()
+  private var last: Trace                        = null.asInstanceOf[Trace]
+  private val builder: ArrayBuilder.ofRef[Trace] = new ArrayBuilder.ofRef
 
   def +=(trace: Trace): Unit =
-    if ((trace ne last) && (trace ne null) && (trace ne Trace.empty)) {
+    if ((trace ne null) && (trace ne Trace.empty) && (trace ne last)) {
       builder += trace
       last = trace
     }
 
-  def result(): Chunk[Trace] = builder.result()
+  def clear(): Unit = {
+    builder.clear()
+    last = null.asInstanceOf[Trace]
+  }
+
+  def result(): Chunk[Trace] =
+    Chunk.fromArray(builder.result())
 }
+
 private[zio] object StackTraceBuilder {
   def make()(unsafe: Unsafe): StackTraceBuilder = new StackTraceBuilder()
 }

--- a/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/StackTraceBuilder.scala
@@ -19,10 +19,11 @@ package zio.internal
 import zio._
 
 import scala.collection.mutable.ArrayBuilder
+import scala.reflect.ClassTag
 
 private[zio] class StackTraceBuilder private () { self =>
-  private var last: Trace                        = null.asInstanceOf[Trace]
-  private val builder: ArrayBuilder.ofRef[Trace] = new ArrayBuilder.ofRef
+  private var last: Trace = null.asInstanceOf[Trace]
+  private val builder     = new ArrayBuilder.ofRef()(ClassTag.AnyRef.asInstanceOf[ClassTag[Trace]])
 
   def +=(trace: Trace): Unit =
     if ((trace ne null) && (trace ne Trace.empty) && (trace ne last)) {

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -148,5 +148,5 @@ object Take {
    * End-of-stream marker
    */
   val end: Take[Nothing, Nothing] =
-    Take(Exit.fail(None))
+    Take(Exit.failNone)
 }

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -2030,7 +2030,7 @@ object ZChannel {
           _ <- pull
                  .foldCauseZIO(
                    cause =>
-                     queue.offer(ZIO.failCause(cause)) *>
+                     queue.offer(ZIO.refailCause(cause)) *>
                        ZIO.succeed(false),
                    {
                      case Left(outDone) =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5873,7 +5873,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
      * Terminates with an end of stream signal.
      */
     def end(implicit trace: Trace): B =
-      apply(Exit.fail(None))
+      apply(Exit.failNone)
 
     /**
      * Terminates with the specified error.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -906,7 +906,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
         ZChannel.readWithCause[R1, Err, Elem, Any, Nothing, Nothing, Any](
           value => ZChannel.fromZIO(handoff.offer(Exit.succeed(value))) *> producer(handoff, latch),
           cause => ZChannel.fromZIO(handoff.offer(Exit.failCause(cause.map(Some(_))))),
-          _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None))) *> producer(handoff, latch)
+          _ => ZChannel.fromZIO(handoff.offer(Exit.failNone)) *> producer(handoff, latch)
         )
 
     new ZStream(
@@ -1129,7 +1129,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                  .runForeachScoped(offer)
                  .foldCauseZIO(
                    cause => finalize(Exit.failCause(cause.map(Some(_)))),
-                   _ => finalize(Exit.fail(None))
+                   _ => finalize(Exit.failNone)
                  )
                  .forkScoped
         } yield queuesLock.withPermit(newQueue.get.flatten)
@@ -2647,7 +2647,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             driver
               .next(e)
               .foldZIO(
-                _ => ZIO.fail(e),
+                _ => ZIO.refailCause(Cause.fail(e)),
                 _ => ZIO.succeed(loop.tap(_ => driver.reset))
               )
           )
@@ -4941,8 +4941,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   )(implicit trace: Trace): ZStream[R, E, A] =
     unfoldChunkZIO(fa)(fa =>
       fa.map(chunk => Some((chunk, fa))).catchAll {
-        case None    => ZIO.none
-        case Some(e) => ZIO.fail(e)
+        case None    => Exit.none
+        case Some(e) => Exit.fail(e)
       }
     )
 
@@ -4951,7 +4951,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * with None.
    */
   def repeatZIOOption[R, E, A](fa: => ZIO[R, Option[E], A])(implicit trace: Trace): ZStream[R, E, A] =
-    repeatZIOChunkOption(fa.map(Chunk.single(_)))
+    repeatZIOChunkOption(fa.map(Chunk.single))
 
   /**
    * Creates a stream from an effect producing a value of type `A`, which is
@@ -5568,7 +5568,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def failCause[E](c: Cause[E])(implicit trace: Trace): IO[Option[E], Nothing] =
       ZIO.refailCause(c).mapError(Some(_))
     def empty[A](implicit trace: Trace): IO[Nothing, Chunk[A]]   = ZIO.succeed(Chunk.empty)
-    def end(implicit trace: Trace): IO[Option[Nothing], Nothing] = ZIO.fail(None)
+    def end(implicit trace: Trace): IO[Option[Nothing], Nothing] = Exit.failNone
   }
 
   private[zio] case class BufferedPull[R, E, A](
@@ -5873,7 +5873,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
      * Terminates with an end of stream signal.
      */
     def end(implicit trace: Trace): B =
-      apply(ZIO.fail(None))
+      apply(Exit.fail(None))
 
     /**
      * Terminates with the specified error.


### PR DESCRIPTION
Calls to `ZIO.fail` and `ZIO.failCause` generate stack traces from all the effects that are in the `FiberRuntime` stack. This can end up adding a significant CPU overhead especially in cases where `retry` is used without a sensible Schedule.

@ghostdogpr already encountered an issue in prod related to this. While the origins of that issue are still unknown, I think it's better to try and optimize `ZIO.fail` as much as possible, and avoid is wherever we don't need to generate new stack traces.

Imho the biggest optimization in this PR is the usage of a ThreadLocal to reuse the StackTracesBuilder, so that we don't end up allocating new arrays/builders on every new call to `ZIO.fail`.