### PR TITLE
Improve compile-time optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,8 @@ jobs:
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          
+          CI_RELEASE_MODE: 1 # Needed to enable optimizers
+
   publish-website:
     needs: [ci]
     if: github.event_name != 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,8 @@ jobs:
       uses: coursier/cache-action@v6
     - name: Mima Checks
       if: ${{ !startsWith(matrix.scala, '3.') }}
-      run: sbt -v ++${{ matrix.scala }} mimaChecks
+      # Enable optimizers as inlining might affect binary compatibility in rare cases
+      run: CI_RELEASE_MODE=1 sbt -v ++${{ matrix.scala }} mimaChecks
     - name: Test 2.12
       if: ${{ startsWith(matrix.scala, '2.12.') }}
       run: sbt -v ++${{ matrix.scala }} test${{ matrix.platform }}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1497,7 +1497,7 @@ object FiberRuntime {
    * For Scala 3, `-X-elide-below` is ignored, and therefore we need to use an
    * '''inlinable''' build-time constant to disable assertions
    */
-  private final val DisableAssertions = !BuildInfo.isSnapshot
+  private final val DisableAssertions = BuildInfo.optimizationsEnabled
 
   private type EvaluationSignal = Int
   private object EvaluationSignal {

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -11,6 +11,12 @@ object BuildHelper {
   val Scala213: String = "2.13.13"
   val Scala3: String   = "3.3.3"
 
+  lazy val isRelease = {
+    val value = sys.env.get("CI_RELEASE_MODE").isDefined
+    if (value) println("Detected CI_RELEASE_MODE envvar, enabling optimizations")
+    value
+  }
+
   private val stdOptions = Seq(
     "-deprecation",
     "-encoding",
@@ -40,7 +46,8 @@ object BuildHelper {
       Seq(
         "-opt:l:method",
         "-opt:l:inline",
-        "-opt-inline-from:zio.internal.**",
+        "-opt-inline-from:zio.**",
+        "-opt-inline-from:scala.**",
         // To remove calls to `assert` in releases. Assertions are level 2000
         "-Xelide-below",
         "2001"
@@ -51,7 +58,16 @@ object BuildHelper {
     Seq(
       // BuildInfoOption.ConstantValue required to disable assertions in FiberRuntime!
       buildInfoOptions += BuildInfoOption.ConstantValue,
-      buildInfoKeys    := Seq[BuildInfoKey](organization, moduleName, name, version, scalaVersion, sbtVersion, isSnapshot),
+      buildInfoKeys := Seq[BuildInfoKey](
+        organization,
+        moduleName,
+        name,
+        version,
+        scalaVersion,
+        sbtVersion,
+        isSnapshot,
+        BuildInfoKey("optimizationsEnabled" -> isRelease)
+      ),
       buildInfoPackage := packageName
     )
 
@@ -106,7 +122,8 @@ object BuildHelper {
         )
       case Some((2, 13)) =>
         Seq(
-          "-Ywarn-unused:params,-implicits"
+          "-Ywarn-unused:params,-implicits",
+          "-Ybackend-parallelism:4"
         ) ++ std2xOptions ++ optimizerOptions(optimize)
       case Some((2, 12)) =>
         Seq(
@@ -172,7 +189,7 @@ object BuildHelper {
     name                     := s"$prjName",
     crossScalaVersions       := Seq(Scala212, Scala213, Scala3),
     ThisBuild / scalaVersion := Scala213,
-    scalacOptions ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
+    scalacOptions ++= stdOptions ++ extraOptions(scalaVersion.value, optimize = isRelease || !isSnapshot.value),
     scalacOptions --= {
       if (scalaVersion.value == Scala3)
         List("-Xfatal-warnings")


### PR DESCRIPTION
Main changes (mostly for Scala 2.x):

1. Enable inlining from the whole `zio` namespace. Currently, we have a few `@inline` annotations in the objects that are under `zio` instead of `zio.internal` (e.g., in the `ZIO` companion object). These were previously not inlined
2. Enable inlining from `scala.**`. The Scala std library contains a lot of `@inline` annotations which we're currently not utilizing
3. Enable optimizations for snapshot releases as well. This way snapshot artifacts are better aligned with the final released artifacts.