### PR TITLE
Update v2 version on website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -181,7 +181,7 @@ const config = {
           lastVersion: 'current',
           versions: {
             'current': {
-              label: '2.0.x'
+              label: '2.x'
             },
             '1.0.18': {
               label: '1.0.18',


### PR DESCRIPTION
Currently the website shows version `2.0.x`, which is not correct. This PR updates it to 2.x instead.

PS: Should we perhaps change the labels to `v2` and `v1` instead? 🤔 