### PR TITLE
Avoid unnecessary parking/unparking of threads when yielding

### DIFF
--- a/benchmarks/src/main/scala/zio/AsyncResumptionBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/AsyncResumptionBenchmark.scala
@@ -42,11 +42,3 @@ class AsyncResumptionBenchmark {
   }
 
 }
-
-object AsyncResumptionBenchmark {
-  def main(args: Array[String]): Unit = {
-    val that = new AsyncResumptionBenchmark
-    while (true)
-      that.zioAsyncResumptionBenchmark
-  }
-}

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -438,7 +438,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
 }
 
 private object ZScheduler {
-  private val poolSize   = java.lang.Runtime.getRuntime.availableProcessors
+  private val poolSize = java.lang.Runtime.getRuntime.availableProcessors
 
   def markCurrentWorkerAsBlocking(): Unit = {
     val worker = workerOrNull()

--- a/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/ZScheduler.scala
@@ -30,16 +30,16 @@ import scala.collection.mutable
  * Lerche. [[https://tokio.rs/blog/2019-10-scheduler]]
  */
 private final class ZScheduler(autoBlocking: Boolean) extends Executor {
-  import ZScheduler.workerOrNull
 
-  private[this] val poolSize        = java.lang.Runtime.getRuntime.availableProcessors
+  import Trace.{empty => emptyTrace}
+  import ZScheduler.{poolSize, workerOrNull}
+
   private[this] val globalQueue     = new PartitionedLinkedQueue[Runnable](poolSize * 4)
   private[this] val cache           = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
   private[this] val state           = new AtomicInteger(poolSize << 16)
   private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
-  private[this] val emptyTrace      = Trace.empty
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
 
@@ -276,31 +276,21 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
         var searching       = false
         while (!isInterrupted) {
           currentBlocking = blocking
-          if (currentBlocking) {
-            if (nextRunnable ne null) {
-              runnable = nextRunnable
-              nextRunnable = null
-            }
+          val currentNextRunnable = nextRunnable
+          if (currentBlocking) ()
+          else if (currentNextRunnable ne null) {
+            runnable = currentNextRunnable
+            nextRunnable = null
           } else {
             if ((currentOpCount & 63) == 0) {
               runnable = globalQueue.poll(random)
               if (runnable eq null) {
-                if (nextRunnable ne null) {
-                  runnable = nextRunnable
-                  nextRunnable = null
-                } else {
-                  runnable = localQueue.poll(null)
-                }
+                runnable = localQueue.poll(null)
               }
             } else {
-              if (nextRunnable ne null) {
-                runnable = nextRunnable
-                nextRunnable = null
-              } else {
-                runnable = localQueue.poll(null)
-                if (runnable eq null) {
-                  runnable = globalQueue.poll(random)
-                }
+              runnable = localQueue.poll(null)
+              if (runnable eq null) {
+                runnable = globalQueue.poll(random)
               }
             }
             if (runnable eq null) {
@@ -405,6 +395,10 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
           val idx = workers.indexOf(self)
           if (idx >= 0) {
             val runnables = self.localQueue.pollUpTo(256)
+            if (nextRunnable ne null) {
+              globalQueue.offer(nextRunnable)
+              nextRunnable = null
+            }
             globalQueue.offerAll(runnables)
             val worker = cache.poll()
             if (worker eq null) {
@@ -444,6 +438,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
 }
 
 private object ZScheduler {
+  private val poolSize   = java.lang.Runtime.getRuntime.availableProcessors
 
   def markCurrentWorkerAsBlocking(): Unit = {
     val worker = workerOrNull()

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -61,6 +61,11 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   /**
    * Submits an effect for execution and signals that the current fiber is ready
    * to yield.
+   *
+   * '''NOTE''': The implementation of this method in the ZScheduler will
+   * attempt to run the runnable on the current thread if the current worker's
+   * queues are empty. This leads to improved performance as we avoid
+   * unnecessary parking/un-parking of threads.
    */
   def submitAndYield(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =
     submit(runnable)
@@ -68,6 +73,10 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
   /**
    * Submits an effect for execution and signals that the current fiber is ready
    * to yield or throws.
+   *
+   * @see
+   *   [[submitAndYield]] for an explanation of the implementation in
+   *   ZScheduler.
    */
   final def submitAndYieldOrThrow(runnable: Runnable)(implicit unsafe: Unsafe): Unit =
     if (!submitAndYield(runnable)) throw new RejectedExecutionException(s"Unable to run ${runnable.toString()}")

--- a/core/shared/src/main/scala/zio/internal/FiberMessage.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMessage.scala
@@ -29,7 +29,9 @@ private[zio] object FiberMessage {
   final case class InterruptSignal(cause: Cause[Nothing])        extends FiberMessage
   final case class Stateful(onFiber: FiberRuntime[_, _] => Unit) extends FiberMessage
   final case class Resume(effect: ZIO[_, _, _])                  extends FiberMessage
-  case object YieldNow                                           extends FiberMessage
+
+  @deprecated("We no longer use a message to propagate yielding", "2.1.7")
+  case object YieldNow extends FiberMessage
 
   val resumeUnit: FiberMessage = Resume(ZIO.unit)
 }


### PR DESCRIPTION
Followup of #9016

/closes #9012
/cc @eyalfa

When we yield, we attempt resumption on the same thread without unparking another thread if:
1. the current thread is a `ZScheduler#Worker`
2. the worker's local queue is empty

This way we don't need to unpark another worker when the current worker is capable of continuing evaluation of the effect.
With these changes & the ones in #9016, ZIO's yielding is now faster than CE, and almost 1 order of magnitude faster than v2.1.6 🚀.

Baseline (v2.1.6):
```
[info] Benchmark                                              Mode  Cnt    Score    Error  Units
[info] AsyncResumptionBenchmark.catsAsyncResumptionBenchmark  avgt    5  168.198 ±  0.886  ns/op
[info] AsyncResumptionBenchmark.zioAsyncResumptionBenchmark   avgt    5  963.987 ± 52.768  ns/op
```

series/2.x:
```
[info] Benchmark                                              Mode  Cnt    Score   Error  Units
[info] AsyncResumptionBenchmark.zioAsyncResumptionBenchmark   avgt    5  223.190 ± 5.169  ns/op
```
PR:
```
[info] Benchmark                                              Mode  Cnt    Score   Error  Units
[info] AsyncResumptionBenchmark.zioAsyncResumptionBenchmark   avgt    5  104.383 ± 0.872  ns/op
``` 