### PR TITLE
Ensure bounded queue items are correctly ordered

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -19,7 +19,8 @@ import java.util.concurrent.TimeUnit
  * small queue to enforce back pressure mechanism is used.
  */
 class QueueBackPressureBenchmark {
-  val queueSize   = 2
+  @Param(Array("2", "8", "32"))
+  var queueSize   = 2
   val totalSize   = 1000
   val parallelism = 5
 

--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit
  * small queue to enforce back pressure mechanism is used.
  */
 class QueueBackPressureBenchmark {
-  @Param(Array("2", "8", "32"))
+  @Param(Array("2", "8", "16"))
   var queueSize   = 2
   val totalSize   = 1000
   val parallelism = 5

--- a/core/js-native/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/js-native/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,5 +1,6 @@
 package zio
 
 private[zio] trait QueuePlatformSpecific {
+  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS or Scala Native, so we use an ArrayDeque instead
   type ConcurrentDeque[A] = java.util.ArrayDeque[A]
 }

--- a/core/js-native/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/js-native/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,0 +1,5 @@
+package zio
+
+private[zio] trait QueuePlatformSpecific {
+  type ConcurrentDeque[A] = java.util.ArrayDeque[A]
+}

--- a/core/jvm/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,0 +1,5 @@
+package zio
+
+private[zio] trait QueuePlatformSpecific {
+  type ConcurrentDeque[A] = java.util.concurrent.ConcurrentLinkedDeque[A]
+}

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -173,14 +173,14 @@ object Queue {
               }
             } else false
 
-          if (noRemaining) ZIO.succeed(true)
+          if (noRemaining) Exit.`true`
           else {
             // not enough takers, offer to the queue
             val succeeded = queue.offer(a)
 
             if (succeeded) {
               strategy.unsafeCompleteTakers(queue, takers)
-              ZIO.succeed(true)
+              Exit.`true`
             } else
               strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
           }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -30,9 +30,11 @@ object MimaSettings {
         exclude[IncompatibleResultTypeProblem]("zio.stream.ZChannel#MergeState#BothRunning.*"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel#MergeState#BothRunning.copy"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel#MergeState#BothRunning.*"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala"),
-        ProblemFilters.exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension")
+        exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
+        exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala"),
+        exclude[IncompatibleResultTypeProblem]("zio.DurationOps.asScala$extension"),
+        exclude[IncompatibleMethTypeProblem]("zio.Queue#Strategy*"),
+        exclude[ReversedMissingMethodProblem]("zio.Queue#Strategy*")
       ),
       mimaFailOnProblem := failOnProblem
     )

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -600,7 +600,15 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          } @@ jvm(nonFlaky)
+          } @@ jvm(nonFlaky),
+          test("preservers order of elements") {
+            val expected = Chunk.fromIterable(0 until 100)
+            ZStream
+              .fromChunk(expected)
+              .buffer(16)
+              .runCollect
+              .map(v => assertTrue(v == expected))
+          } @@ jvm(nonFlaky(1000))
         ),
         suite("bufferChunksDropping")(
           test("buffer the Stream with Error") {


### PR DESCRIPTION
/fixes #8699
/claim #8699

When we add messages to a full queue, they are added to a secondary queue along with a promise used to notify the thread that added the item to the queue that the item has been added. The current implementation allows for multiple threads to be polling from this secondary queue, which causes a race condition on which thread will complete the promise first.

In order to ensure ordering of the items in the bounded queue, we need to ensure that only a single thread is polling the secondary queue. This PR achieves this through the usage of 2 `AtomicBoolean`s, which are used to "lock" the notification system that the queue has available capacity / available messages.

Since the CAS of the `AtomicBoolean`s incurs a small performance overhead, I also did a minor rewrite the code in order to avoid entering the `unsafeCompleteTakers` and `unsafeOnQueueEmptySpace` methods when we can either defer it or when not necessary (i.e., takers or putters are empty).

Since the new approach results in much less contention of the secondary queues, it ends up performing roughly the same when the bounded queue is often full when adding a new message (size = 2 below) and much better when its more likely to have spare capacity (sizes 8 and 16)

series/2.x:
```
[info] Benchmark                            (queueSize)   Mode  Cnt     Score     Error  Units
[info] QueueBackPressureBenchmark.zioQueue            2  thrpt   10  2223.742 ±  19.110  ops/s
[info] QueueBackPressureBenchmark.zioQueue            8  thrpt   10  3742.335 ±  71.540  ops/s
[info] QueueBackPressureBenchmark.zioQueue           16  thrpt   10  3847.973 ± 343.916  ops/s
```

PR:
```
[info] Benchmark                            (queueSize)   Mode  Cnt     Score     Error  Units
[info] QueueBackPressureBenchmark.zioQueue            2  thrpt   10  2251.100 ±  12.681  ops/s
[info] QueueBackPressureBenchmark.zioQueue            8  thrpt   10  4230.365 ± 112.985  ops/s
[info] QueueBackPressureBenchmark.zioQueue           16  thrpt   10  4361.052 ± 279.429  ops/s
```

Note regarding binary compatibility:
The changes in this PR are not binary compatible according to MiMa, because in Java there are no `sealed` classes. Therefore, it thinks it's possible for `Strategy` to be extended. However, this is definitely not possible in Scala code, and I find it very difficult to believe anyone is extending this class via Java code, so I think it's safe to exclude these mima warnings.