### PR TITLE
Optimizations of future interop methods

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -906,7 +906,8 @@ object Fiber extends FiberPlatformSpecific {
     new Fiber.Synthetic[Throwable, A] {
       lazy val ftr: Future[A] = thunk
 
-      final def await(implicit trace: Trace): UIO[Exit[Throwable, A]] = ZIO.fromFuture(ftr).exit
+      final def await(implicit trace: Trace): UIO[Exit[Throwable, A]] =
+        ZIO.suspend(ZIO.fromFutureNow(ftr)(trace, Unsafe.unsafe)).exit
 
       final def children(implicit trace: Trace): UIO[Chunk[Fiber.Runtime[_, _]]] = ZIO.succeed(Chunk.empty)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3708,26 +3708,66 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    */
   def fromFuture[A](make: ExecutionContext => scala.concurrent.Future[A])(implicit trace: Trace): Task[A] =
     ZIO.executorWith { executor =>
-      import scala.util.{Failure, Success}
-      val ec = executor.asExecutionContext
-      ZIO.attempt(make(ec)).flatMap { f =>
-        val canceler: UIO[Unit] = f match {
-          case cancelable: CancelableFuture[A] =>
-            ZIO.suspendSucceed(if (f.isCompleted) ZIO.unit else ZIO.fromFuture(_ => cancelable.cancel()).ignore)
-          case _ => ZIO.unit
-        }
+      ZIO.suspend {
+        import scala.util.{Success, Failure}
 
-        f.value
-          .fold(
+        val ec = executor.asExecutionContext
+        val f  = make(ec)
+        f.value match {
+          case None =>
             ZIO.asyncInterrupt { (k: Task[A] => Unit) =>
               f.onComplete {
                 case Success(a) => k(Exit.succeed(a))
                 case Failure(t) => k(ZIO.fail(t))
               }(ec)
 
-              Left(canceler)
+              Left {
+                f match {
+                  case cf: CancelableFuture[A] =>
+                    ZIO.suspendSucceed(if (cf.isCompleted) Exit.unit else ZIO.fromFuture(cf.cancel()).ignore)
+                  case _ =>
+                    Exit.unit
+                }
+              }
             }
-          )(ZIO.fromTry(_))
+          case Some(Success(value)) => Exit.succeed(value)
+          case Some(Failure(t))     => ZIO.fail(t)
+        }
+      }
+    }
+
+  /**
+   * Returns an effect that, when executed, will both create and launch a
+   * [[scala.concurrent.Future]] and run it on ZIO's own executor.
+   *
+   * @see
+   *   Overloaded method that allows using the ZIO executor-backed execution
+   *   context
+   */
+  def fromFuture[A](future: => scala.concurrent.Future[A])(implicit trace: Trace): Task[A] =
+    ZIO.suspend {
+      import scala.util.{Success, Failure}
+      val f = future
+      f.value match {
+        case None =>
+          ZIO.executorWith { executor =>
+            val ec = executor.asExecutionContext
+            ZIO.asyncInterrupt { (k: Task[A] => Unit) =>
+              f.onComplete {
+                case Success(a) => k(Exit.succeed(a))
+                case Failure(t) => k(ZIO.fail(t))
+              }(ec)
+              Left {
+                f match {
+                  case cf: CancelableFuture[A] =>
+                    ZIO.suspendSucceed(if (cf.isCompleted) Exit.unit else ZIO.fromFuture(cf.cancel()).ignore)
+                  case _ => Exit.unit
+                }
+              }
+            }
+          }
+        case Some(Success(value)) => Exit.succeed(value)
+        case Some(Failure(t))     => ZIO.fail(t)
       }
     }
 
@@ -3736,7 +3776,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * and we pass to [fromFuture] to transform into Task[A]
    */
   def fromPromiseScala[A](promise: => scala.concurrent.Promise[A])(implicit trace: Trace): Task[A] =
-    ZIO.fromFuture(_ => promise.future)
+    ZIO.fromFuture(promise.future)
 
   /**
    * Imports a function that creates a [[scala.concurrent.Future]] from an
@@ -3752,30 +3792,31 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   )(implicit trace: Trace): Task[A] =
     ZIO.executorWith { executor =>
       import scala.util.{Failure, Success}
-      val ec          = executor.asExecutionContext
       val interrupted = new java.util.concurrent.atomic.AtomicBoolean(false)
       val latch       = scala.concurrent.Promise[Unit]()
-      val interruptibleEC = new scala.concurrent.ExecutionContext {
-        def execute(runnable: Runnable): Unit =
-          if (!interrupted.get) ec.execute(runnable)
-          else {
-            val _ = latch.success(())
-          }
-        def reportFailure(cause: Throwable): Unit =
-          ec.reportFailure(cause)
-      }
-      attempt(make(interruptibleEC)).flatMap { f =>
-        f.value
-          .fold(
+      ZIO.suspend {
+        val ec = executor.asExecutionContext
+        val interruptibleEC = new scala.concurrent.ExecutionContext {
+          def execute(runnable: Runnable): Unit =
+            if (!interrupted.get) ec.execute(runnable)
+            else latch.success(())
+          def reportFailure(cause: Throwable): Unit =
+            ec.reportFailure(cause)
+        }
+        val f = make(interruptibleEC)
+        f.value match {
+          case None =>
             ZIO.async { (cb: Task[A] => Any) =>
               f.onComplete {
                 case Success(a) => latch.success(()); cb(Exit.succeed(a))
                 case Failure(t) => latch.success(()); cb(ZIO.fail(t))
               }(interruptibleEC)
             }
-          )(ZIO.fromTry(_))
+          case Some(Success(value)) => Exit.succeed(value)
+          case Some(Failure(t))     => ZIO.fail(t)
+        }
       }.onInterrupt(
-        ZIO.succeed(interrupted.set(true)) *> ZIO.fromFuture(_ => latch.future).orDie
+        ZIO.succeed(interrupted.set(true)) *> ZIO.fromFuture(latch.future).orDie
       )
     }
 
@@ -5759,7 +5800,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         type OutError       = Throwable
         type OutSuccess     = A
         def make(input: => FutureLike[A])(implicit trace: Trace): ZIO[Any, Throwable, A] =
-          ZIO.fromFuture(_ => input)
+          ZIO.fromFuture(input)
       }
 
     /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3730,8 +3730,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                 }
               }
             }
-          case Some(Success(value)) => Exit.succeed(value)
-          case Some(Failure(t))     => ZIO.fail(t)
+          case Some(outcome) => outcome.fold(ZIO.fail(_), ZIO.successFn)
         }
       }
     }
@@ -3766,8 +3765,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
               }
             }
           }
-        case Some(Success(value)) => Exit.succeed(value)
-        case Some(Failure(t))     => ZIO.fail(t)
+        case Some(outcome) => outcome.fold(ZIO.fail(_), ZIO.successFn)
       }
     }
 
@@ -3812,8 +3810,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                 case Failure(t) => latch.success(()); cb(ZIO.fail(t))
               }(interruptibleEC)
             }
-          case Some(Success(value)) => Exit.succeed(value)
-          case Some(Failure(t))     => ZIO.fail(t)
+          case Some(outcome) => outcome.fold(ZIO.fail(_), ZIO.successFn)
         }
       }.onInterrupt(
         ZIO.succeed(interrupted.set(true)) *> ZIO.fromFuture(latch.future).orDie


### PR DESCRIPTION
While working on https://github.com/zio/interop-cats/issues/695 I noticed that some of the future interop methods could be slightly optimized to avoid a couple of flatmaps and allocations.

~~There is also a user-facing improvement in this PR, which is the addition of the `ZIO.fromFuture` method that takes a `=> A` instead of `ExecutionContext => A`. This should improve UX (and performance for cases that the future is already completed) when the user doesn't need to use the `ExecutionContext`~~

EDIT: Seems that this UX improvement might end up being a footgun for users, so I've reverted this change for now