### PR TITLE
Additional tests for queues with bounded parallelism

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueBackPressureBenchmark.scala
@@ -11,9 +11,9 @@ import java.util.concurrent.TimeUnit
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
 @OutputTimeUnit(TimeUnit.SECONDS)
-@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
-@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
-@Fork(3)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(2)
 /**
  * This benchmark offers and takes a number of items in parallel, with a very
  * small queue to enforce back pressure mechanism is used.
@@ -38,11 +38,37 @@ class QueueBackPressureBenchmark {
   }
 
   @Benchmark
-  def zioQueue(): Int = {
+  def zioQueueMPMC(): Int = {
 
     val io = for {
       offers <- ZIO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.offer(0).unit)))
       takes  <- ZIO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.take.unit)))
+      _      <- offers.join
+      _      <- takes.join
+    } yield 0
+
+    unsafeRun(io)
+  }
+
+  @Benchmark
+  def zioQueueSPMC(): Int = {
+
+    val io = for {
+      offers <- zioQ.offer(0).replicateZIO(totalSize).fork
+      takes  <- ZIO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.take.unit)))
+      _      <- offers.join
+      _      <- takes.join
+    } yield 0
+
+    unsafeRun(io)
+  }
+
+  @Benchmark
+  def zioQueueMPSC(): Int = {
+
+    val io = for {
+      offers <- ZIO.forkAll(List.fill(parallelism)(repeat(totalSize / parallelism)(zioQ.offer(0).unit)))
+      takes  <- zioQ.take.replicateZIO(totalSize).fork
       _      <- offers.join
       _      <- takes.join
     } yield 0

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -756,7 +756,7 @@ object QueueSpec extends ZIOBaseSpec {
       } yield assertCompletes
     } @@ jvm(nonFlaky),
     suite("back-pressured bounded queue stress testing") {
-      val genChunk = Gen.chunkOfBounded(1, 200)(smallInt)
+      val genChunk = Gen.chunkOfBounded(20, 100)(smallInt)
       List(
         test("many to many unbounded parallelism") {
           check(smallInt, genChunk) { (n, as) =>
@@ -772,60 +772,75 @@ object QueueSpec extends ZIOBaseSpec {
         test("many to many bounded parallelism") {
           check(smallInt, genChunk) { (n, as) =>
             for {
-              queue    <- Queue.bounded[Int](n)
-              takers   <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
-              offerors <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10).fork
-              _        <- offerors.join
-              taken    <- takers.join
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
+              _      <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10)
+              taken  <- takers.join
             } yield assertTrue(as.sorted == taken.sorted)
           }
         },
         test("single to many") {
           check(smallInt, genChunk) { (n, as) =>
             for {
-              queue    <- Queue.bounded[Int](n)
-              takers   <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
-              offerors <- ZIO.foreach(as)(a => queue.offer(a)).fork
-              _        <- offerors.join
-              taken    <- takers.join
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
+              _      <- ZIO.foreach(as)(a => queue.offer(a))
+              taken  <- takers.join
             } yield assertTrue(as.sorted == taken.sorted)
           }
         },
         test("many to single") {
           check(smallInt, genChunk) { (n, as) =>
             for {
-              queue    <- Queue.bounded[Int](n)
-              taker    <- ZIO.foreach(as)(_ => queue.take).fork
-              offerors <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10).fork
-              _        <- offerors.join
-              taken    <- taker.join
+              queue <- Queue.bounded[Int](n)
+              taker <- ZIO.foreach(as)(_ => queue.take).fork
+              _     <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10)
+              taken <- taker.join
             } yield assertTrue(as.sorted == taken.sorted)
           }
         },
         test("fewer to more") {
           check(smallInt, genChunk) { (n, as) =>
             for {
-              queue    <- Queue.bounded[Int](n)
-              takers   <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
-              offerors <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(3).fork
-              _        <- offerors.join
-              taken    <- takers.join
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
+              _      <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(3)
+              taken  <- takers.join
             } yield assertTrue(as.sorted == taken.sorted)
           }
         },
         test("more to fewer") {
           check(smallInt, genChunk) { (n, as) =>
             for {
-              queue    <- Queue.bounded[Int](n)
-              takers   <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(3).fork
-              offerers <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10).fork
-              _        <- offerers.join
-              taken    <- takers.join
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(3).fork
+              _      <- ZIO.foreachPar(as)(a => queue.offer(a)).withParallelism(10)
+              taken  <- takers.join
+            } yield assertTrue(as.sorted == taken.sorted)
+          }
+        },
+        test("offer all to many consumers") {
+          check(smallInt, genChunk) { (n, as) =>
+            for {
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreachPar(as)(_ => queue.take).withParallelism(10).fork
+              _      <- queue.offerAll(as)
+              taken  <- takers.join
+            } yield assertTrue(as.sorted == taken.sorted)
+          }
+        },
+        test("offer all to one consumers") {
+          check(smallInt, genChunk) { (n, as) =>
+            for {
+              queue  <- Queue.bounded[Int](n)
+              takers <- ZIO.foreach(as)(_ => queue.take).fork
+              _      <- queue.offerAll(as)
+              taken  <- takers.join
             } yield assertTrue(as.sorted == taken.sorted)
           }
         }
       )
-    } @@ jvm(samples(1000) @@ sequential),
+    } @@ jvm(samples(500) @@ sequential),
     test("isEmpty") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -414,7 +414,7 @@ object Queue extends QueuePlatformSpecific {
 
           // We need to check in case someone added a putter or pulled from the queue since our last check
           // while we were still holding the lock
-          if (!queue.isFull() && !putters0.isEmpty) unsafeOnQueueEmptySpace(queue, takers)
+          if (!queue.isFull()) unsafeOnQueueEmptySpace(queue, takers)
         }
       }
 


### PR DESCRIPTION
Adding more tests to increase confidence that #9044 didn't introduce any regressions