### PR TITLE
fix: avoid unbounded buffer in mapOutZIOPar

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2677,7 +2677,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 latch <- CountdownLatch.make(parallelism + 1)
                 f <- ZStream
                        .range(0, iterations)
-                       .mapZIOPar(parallelism)(_ => latch.countDown *> latch.await)
+                       .mapZIOPar(parallelism, parallelism)(_ => latch.countDown *> latch.await)
                        .runDrain
                        .fork
                 _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)
@@ -2762,7 +2762,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 latch <- CountdownLatch.make(parallelism + 1)
                 f <- ZStream
                        .range(0, iterations)
-                       .mapZIOParUnordered(parallelism)(_ => latch.countDown *> latch.await)
+                       .mapZIOParUnordered(parallelism, parallelism)(_ => latch.countDown *> latch.await)
                        .runDrain
                        .fork
                 _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2762,7 +2762,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 latch <- CountdownLatch.make(parallelism + 1)
                 f <- ZStream
                        .range(0, iterations)
-                       .mapZIOParUnordered(parallelism, parallelism)(_ => latch.countDown *> latch.await)
+                       .mapZIOParUnordered(parallelism)(_ => latch.countDown *> latch.await)
                        .runDrain
                        .fork
                 _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1929,13 +1929,21 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def mapZIOPar[R1 <: R, E1 >: E, A2](n: => Int)(f: A => ZIO[R1, E1, A2])(implicit
     trace: Trace
   ): ZStream[R1, E1, A2] =
-    self >>> ZPipeline.mapZIOPar(n)(f)
+    mapZIOPar[R1, E1, A2](n, 16)(f)
 
-  @deprecated("use stream.mapZIOPar(n)(f).buffer(bufferSize)", "2.1.7")
-  def mapZIOPar[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: Int)(f: A => ZIO[R1, E1, A2])(implicit
+  /**
+   * Maps over elements of the stream with the specified effectful function,
+   * executing up to `n` invocations of `f` concurrently. Transformed elements
+   * will be emitted in the original order.
+   *
+   * @note
+   *   This combinator destroys the chunking structure. It's recommended to use
+   *   rechunk afterwards.
+   */
+  def mapZIOPar[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: => Int = 16)(f: A => ZIO[R1, E1, A2])(implicit
     trace: Trace
   ): ZStream[R1, E1, A2] =
-    mapZIOPar[R1, E1, A2](n)(f).buffer(bufferSize)
+    self >>> ZPipeline.mapZIOPar(n, bufferSize)(f)
 
   /**
    * Maps over elements of the stream with the specified effectful function,
@@ -1959,13 +1967,17 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def mapZIOParUnordered[R1 <: R, E1 >: E, A2](n: => Int)(f: A => ZIO[R1, E1, A2])(implicit
     trace: Trace
   ): ZStream[R1, E1, A2] =
-    self >>> ZPipeline.mapZIOParUnordered(n)(f)
+    mapZIOParUnordered[R1, E1, A2](n, 16)(f)
 
-  @deprecated("use stream.mapZIOParUnordered(n)(f).buffer(bufferSize)", "2.1.7")
-  def mapZIOParUnordered[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: => Int)(f: A => ZIO[R1, E1, A2])(implicit
+  /**
+   * Maps over elements of the stream with the specified effectful function,
+   * executing up to `n` invocations of `f` concurrently. The element order is
+   * not enforced by this combinator, and elements may be reordered.
+   */
+  def mapZIOParUnordered[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: => Int = 16)(f: A => ZIO[R1, E1, A2])(implicit
     trace: Trace
   ): ZStream[R1, E1, A2] =
-    mapZIOParUnordered[R1, E1, A2](n)(f).buffer(bufferSize)
+    self >>> ZPipeline.mapZIOParUnordered(n, bufferSize)(f)
 
   /**
    * Merges this stream and the specified stream together.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1940,7 +1940,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   This combinator destroys the chunking structure. It's recommended to use
    *   rechunk afterwards.
    */
-  def mapZIOPar[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: => Int = 16)(f: A => ZIO[R1, E1, A2])(implicit
+  def mapZIOPar[R1 <: R, E1 >: E, A2](n: => Int, bufferSize: Int = 16)(f: A => ZIO[R1, E1, A2])(implicit
     trace: Trace
   ): ZStream[R1, E1, A2] =
     self >>> ZPipeline.mapZIOPar(n, bufferSize)(f)


### PR DESCRIPTION
The current version of `ZChannel.mapOutZIOPar` will yield an OOM most certainly if people use it with unbounded parallelism:
```
Queue.bounded(n)
```
All other methods with parallelism accept a buffer size to control the outgoing queue size, so it needs to be added to `mapOutZIOPar` too (which is used by `ZStream.mapZIOPar`).

As a result I had to remove the deprecation notices, I hope in the future we can find a way out of it though.

I am tempted to mark the operators with just the `n` parameter as deprecated, since I made sure all the ones with `bufferSize` had a default value. Thoughts?