### PR TITLE
Typo in stream reference

### DIFF
--- a/docs/reference/stream/zstream/operations.md
+++ b/docs/reference/stream/zstream/operations.md
@@ -363,7 +363,7 @@ val indexedStream: ZStream[Any, Nothing, (String, Long)] =
 
 ## Cross Product
 
-ZIO stream has `ZStram#cross` and its variants to compute _Cartesian Product_ of two streams:
+ZIO stream has `ZStream#cross` and its variants to compute _Cartesian Product_ of two streams:
 
 ```scala mdoc:silent:nest
 val first = ZStream(1, 2, 3)

--- a/website/versioned_docs/version-1.0.18/reference/stream/zstream.md
+++ b/website/versioned_docs/version-1.0.18/reference/stream/zstream.md
@@ -1030,7 +1030,7 @@ val indexedStream: ZStream[Any, Nothing, (String, Long)] =
 
 ### Cross Product
 
-ZIO stream has `ZStram#cross` and its variants to compute _Cartesian Product_ of two streams:
+ZIO stream has `ZStream#cross` and its variants to compute _Cartesian Product_ of two streams:
 
 ```scala
 val first = ZStream(1, 2, 3)


### PR DESCRIPTION
Typo fix for `ZStream` reference.