### PR TITLE
feat: accumulate errors in ZChannel.mapOutZIOPar

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -753,6 +753,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
 }
 
 object Cause extends Serializable {
+  val unit: Cause[Unit] = fail(())
   val empty: Cause[Nothing]                                                            = Empty
   def die(defect: Throwable, trace: StackTrace = StackTrace.none): Cause[Nothing]      = Die(defect, trace)
   def fail[E](error: E, trace: StackTrace = StackTrace.none): Cause[E]                 = Fail(error, trace)

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -753,7 +753,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
 }
 
 object Cause extends Serializable {
-  val unit: Cause[Unit] = fail(())
+  val unit: Cause[Unit]                                                                = fail(())
   val empty: Cause[Nothing]                                                            = Empty
   def die(defect: Throwable, trace: StackTrace = StackTrace.none): Cause[Nothing]      = Die(defect, trace)
   def fail[E](error: E, trace: StackTrace = StackTrace.none): Cause[E]                 = Fail(error, trace)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2691,10 +2691,9 @@ object ZStreamSpec extends ZIOBaseSpec {
             sealed abstract class DbError extends Product with Serializable
             case object Missing           extends DbError
             case object QtyTooLarge       extends DbError
-            case object NameTooLong       extends DbError
 
             for {
-              exit <- (ZStream(1 to 2: _*) ++ ZStream.fail[DbError](NameTooLong))
+              exit <- ZStream(1 to 2: _*)
                         .mapZIOPar(3) {
                           case 1 => ZIO.fail(Missing)
                           case 2 => ZIO.fail(QtyTooLarge)
@@ -2705,8 +2704,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(exit)(
               failsCause(
                 containsCause[DbError](Cause.fail(Missing)) &&
-                  containsCause[DbError](Cause.fail(QtyTooLarge)) &&
-                  containsCause[DbError](Cause.fail(NameTooLong))
+                  containsCause[DbError](Cause.fail(QtyTooLarge))
               )
             )
           } @@ flaky

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -648,29 +648,31 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
       for {
         input       <- SingleProducerAsyncInput.make[InErr, InElem, InDone]
         queueReader  = ZChannel.fromInput(input)
-        queue       <- Queue.bounded[ZIO[Env1, OutErr1, Either[OutDone, OutElem2]]](bufferSize)
-        _           <- scope.addFinalizer(queue.shutdown)
-        errorSignal <- Promise.make[OutErr1, Nothing]
+        outgoing       <- Queue.bounded[ZIO[Env1, Unit, Either[OutDone, OutElem2]]](bufferSize)
+        _           <- scope.addFinalizer(outgoing.shutdown)
+        errorSignal <- Promise.make[Unit, Nothing]
         permits     <- Semaphore.make(n.toLong)
+        failure     <- Ref.make[Cause[OutErr1]](Cause.empty)
         pull        <- (queueReader >>> self).toPullIn(scope)
         _ <- pull
                .foldCauseZIO(
-                 cause => queue.offer(ZIO.refailCause(cause)),
+                 cause => failure.update(_ && cause) *> outgoing.offer(Exit.failCause(Cause.unit)) *> Exit.failCause(Cause.unit),
                  {
                    case Left(outDone) =>
-                     permits.withPermits(n.toLong)(ZIO.unit).interruptible *> queue.offer(ZIO.succeed(Left(outDone)))
+                     permits.withPermits(n.toLong)(ZIO.unit).interruptible *> outgoing.offer(ZIO.succeed(Left(outDone)))
                    case Right(outElem) =>
                      for {
-                       p     <- Promise.make[OutErr1, OutElem2]
+                       p     <- Promise.make[Unit, OutElem2]
                        latch <- Promise.make[Nothing, Unit]
-                       _     <- queue.offer(p.await.map(Right(_)))
+                       _     <- outgoing.offer(p.await.map(Right(_)))
                        _ <- permits.withPermit {
                               latch.succeed(()) *>
                                 ZIO.uninterruptibleMask { restore =>
-                                  restore(errorSignal.await) raceFirstAwait restore(f(outElem))
-                                }
-                                  .tapErrorCause(errorSignal.failCause)
-                                  .intoPromise(p)
+                                  restore(errorSignal.await).raceFirstAwait( restore(f(outElem))
+                                    .catchAllCause(cause => failure.update(_ && cause) *> Exit.failCause(Cause.unit)))
+                                }.foldCauseZIO(
+                                  _ => p.refailCause(Cause.unit) *> errorSignal.refailCause(Cause.unit),
+                                  p.succeed)
                             }.forkIn(scope)
                        _ <- latch.await
                      } yield ()
@@ -680,18 +682,18 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                .interruptible
                .forkIn(scope)
       } yield {
-        lazy val consumer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
+        lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
           ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
-            queue.take.flatten.foldCause(
-              ZChannel.refailCause,
+            outgoing.take.flatten.foldCause(
+              _ => ZChannel.unwrap(failure.get.map(ZChannel.refailCause(_))),
               {
                 case Left(outDone)  => ZChannel.succeedNow(outDone)
-                case Right(outElem) => ZChannel.write(outElem) *> consumer
+                case Right(outElem) => ZChannel.write(outElem) *> writer
               }
             )
           }
 
-        consumer.embedInput(input)
+        writer.embedInput(input)
       }
     }
 


### PR DESCRIPTION
This change makes it so that if multiple workers fail, we give the chance to accumulate all the errors in a single cause.

I also fixed a bug in the logic where the error, whether it happened upstream or inside a worker, was not propagated to the whole `pull` workflow and it would end up pulling more elements from upstream due to the `forever` operator.