### PR TITLE
fix: untie streams-test from core-test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -362,7 +362,6 @@ lazy val streams = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 lazy val streamsTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("streams-tests"))
   .dependsOn(streams)
-  .dependsOn(coreTests % "test->test;compile->compile")
   .dependsOn(concurrent)
   .settings(stdSettings("streams-tests"))
   .settings(crossProjectSettings)
@@ -373,7 +372,6 @@ lazy val streamsTests = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     Compile / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.AllLibraryJars
   )
   .enablePlugins(BuildInfoPlugin)
-  .jvmConfigure(_.dependsOn(coreTests.jvm % "test->compile"))
   .jsSettings(
     jsSettings,
     scalacOptions ++= {

--- a/streams-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/ZIOBaseSpec.scala
@@ -1,0 +1,48 @@
+package zio
+
+import zio.test._
+
+import scala.annotation.tailrec
+
+trait ZIOBaseSpec extends ZIOSpecDefault {
+  override def aspects: Chunk[TestAspectPoly] =
+    if (TestPlatform.isJVM) Chunk(TestAspect.timeout(120.seconds), TestAspect.timed)
+    else
+      Chunk(TestAspect.timeout(120.seconds), TestAspect.sequential, TestAspect.timed, TestAspect.size(10))
+
+  sealed trait ZIOTag {
+    val value: String
+    val subTags: List[ZIOTag] = Nil
+  }
+  object ZIOTag {
+    case object errors extends ZIOTag { override val value = "errors" }
+    case object future extends ZIOTag { override val value = "future" }
+    case object interop extends ZIOTag {
+      override val value                 = "interop"
+      override val subTags: List[ZIOTag] = List(future)
+    }
+    case object interruption extends ZIOTag { override val value = "interruption" }
+    case object regression   extends ZIOTag { override val value = "regression"   }
+    case object supervision  extends ZIOTag { override val value = "supervision"  }
+  }
+
+  def zioTag(zioTag: ZIOTag, zioTags: ZIOTag*): TestAspectPoly = {
+    val tags = zioTags.map(_.value) ++ getSubTags(zioTag) ++ zioTags.flatMap(getSubTags)
+    TestAspect.tag(zioTag.value, tags.distinct: _*)
+  }
+
+  private def getSubTags(zioTag: ZIOTag): List[String] = {
+    @tailrec
+    def loop(currentZioTag: ZIOTag, remainingZioTags: List[ZIOTag], result: List[String]): List[String] =
+      (currentZioTag.subTags, remainingZioTags) match {
+        case (Nil, Nil)      => currentZioTag.value :: result
+        case (Nil, t :: ts)  => loop(t, ts, currentZioTag.value :: result)
+        case (st :: sts, ts) => loop(st, sts ++ ts, currentZioTag.value :: result)
+      }
+    zioTag.subTags match {
+      case t :: ts => loop(t, ts, Nil)
+      case Nil     => Nil
+    }
+  }
+
+}


### PR DESCRIPTION
Removing the dependency of streams-test on core-test turns out to save quite a lot of compilation time 💸 💸 💸 

The only thing streams-test needs is the `ZIOBaseSpec`, which I just duplicated.