### PR TITLE
Add exclusion for Scala 3

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -39,7 +39,7 @@ object MimaSettings {
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mergeAllWith0$default$4"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mergeAllWith0$default$3"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mergeAllWith0"),
-        exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mapOutZIOParUnordered1$default$2"),
+        exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mapOutZIOParUnordered1$default$2*"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mapOutZIOParUnordered1"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mergeAllWith0"),
         exclude[DirectMissingMethodProblem]("zio.stream.ZChannel.mergeAllWith0$default$3"),


### PR DESCRIPTION
There was a small conflict in PRs that were merged together causing CI to fail due to mima checks for Scala 3