### PR TITLE
Fix behaviour of `ZEnvironment.empty.get[Any]` 

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -57,6 +57,10 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
       val pruned = env.prune[Foo & Bar]
 
       assertTrue(env == pruned)
+    },
+    test("get[Any] on an empty ZEnvironment returns Unit") {
+      val value = ZEnvironment.empty.get[Any]
+      assertTrue(value.isInstanceOf[Unit])
     }
   )
 }

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -270,12 +270,10 @@ final class ZEnvironment[+R] private (
               service = entry.asInstanceOf[A]
             }
           }
-          if (service == null) {
-            null.asInstanceOf[A]
-          } else {
+          if (service != null) {
             self.cache.put(tag, service)
-            service
           }
+          service
         }
       }
 

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -263,7 +263,7 @@ final class ZEnvironment[+R] private (
         else if ((scope ne null) && isScopeTag(tag))
           scope.asInstanceOf[A]
         else if (self.isEmpty && tag == TaggedAny)
-          null.asInstanceOf[A]
+          ().asInstanceOf[A]
         else {
           val it      = self.map.reverseIterator
           var service = null.asInstanceOf[A]

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -21,6 +21,7 @@ import zio.internal.UpdateOrderLinkedMap
 import java.util.concurrent.ConcurrentHashMap
 import scala.annotation.tailrec
 import scala.collection.{immutable, mutable}
+import scala.util.control.ControlThrowable
 import scala.util.hashing.MurmurHash3
 
 final class ZEnvironment[+R] private (
@@ -352,6 +353,9 @@ object ZEnvironment {
       cache = new ConcurrentHashMap[LightTypeTag, Any],
       scope = null
     )
+
+  @deprecated("kept for bin-compat only")
+  private case object MissingService extends ControlThrowable
 
   // Can't use scala -> java collection conversions because they don't cross compile to Scala 2.12.
   @deprecated("Marked as deprecated to avoid usage in non-deprecated methods", "2.1.16")


### PR DESCRIPTION
Prior to v2.1.2, `ZEnvironment.empty.get[Any]` used to return a boxed Unit. However, after the optimizations to `ZEnvironment` in v2.1.2 we were getting a very unexplained SIGFAULT error related to this when we were running the Scala Native tests. At the time, changing the value to return `null` instead fixed this issue and all the tests were passing.

However, after trying to update the ZIO version in interop-cats (see https://github.com/zio/interop-cats/pull/698), it seems that one of the methods used in the test suite really didn't like this change. The most bizarre thing is that the test suite of interop-cats works fine for Scala 3 but not for Scala 2.12/2.13 😕

In any way, I figured out a way to revert the behaviour of `ZEnvironment.empty.get[Any]` to the pre-v2.1.2 and making Scala Native happy by storing the Unit in a val with type `Any`. This forces the Unit to be boxed, which no longer triggers the SIGFAULT issue in Scala Native