### PR TITLE
fix: restore non-determinism in mapOutZIOParUnordered

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2820,8 +2820,8 @@ object ZStreamSpec extends ZIOBaseSpec {
               val l = data.length
 
               for {
-                f <- s.mapZIOParUnordered(8)({case (x, i) => ZIO.succeed(x).delay((l-i).seconds)}).runCollect.fork
-                _ <- ZIO.iterate(0)(_ <= l)(i => TestClock.adjust(1.second).as(i+1))
+                f   <- s.mapZIOParUnordered(8) { case (x, i) => ZIO.succeed(x).delay((l - i).seconds) }.runCollect.fork
+                _   <- ZIO.iterate(0)(_ <= l)(i => TestClock.adjust(1.second).as(i + 1))
                 res <- f.join
               } yield assert(res)(equalTo(data.reverse))
             }

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -716,7 +716,64 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
   final def mapOutZIOParUnordered[Env1 <: Env, OutErr1 >: OutErr, OutElem2](n: Int, bufferSize: Int = 16)(
     f: OutElem => ZIO[Env1, OutErr1, OutElem2]
   )(implicit trace: Trace): ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem2, OutDone] =
-    mapOutZIOPar[Env1, OutErr1, OutElem2](n, bufferSize)(f)
+    ZChannel.unwrapScopedWith { scope =>
+      for {
+        input       <- SingleProducerAsyncInput.make[InErr, InElem, InDone]
+        queueReader  = ZChannel.fromInput(input)
+        outgoing    <- Queue.bounded[Exit[Either[Unit, OutDone], OutElem2]](bufferSize)
+        _           <- scope.addFinalizer(outgoing.shutdown)
+        errorSignal <- Promise.make[Unit, Nothing]
+        permits     <- Semaphore.make(n.toLong)
+        failure     <- Ref.make[Cause[OutErr1]](Cause.empty)
+        pull        <- (queueReader >>> self).toPullIn(scope)
+        _ <- pull
+               .foldCauseZIO(
+                 cause =>
+                   failure.update(_ && cause) *>
+                     outgoing.offer(Exit.fail(Left(()))) *>
+                     Exit.failCause(Cause.unit),
+                 {
+                   case Left(outDone) =>
+                     permits.withPermits(n.toLong)(ZIO.unit).interruptible *> outgoing.offer(Exit.fail(Right(outDone)))
+                   case Right(outElem) =>
+                     for {
+                       latch <- Promise.make[Nothing, Unit]
+                       _ <- permits.withPermit {
+                              latch.succeed(()) *>
+                                ZIO.uninterruptibleMask { restore =>
+                                  restore(errorSignal.await).raceFirstAwait(
+                                    restore(f(outElem))
+                                      .catchAllCause(cause => failure.update(_ && cause) *> Exit.failCause(Cause.unit))
+                                  )
+                                }.foldCauseZIO(
+                                  _ => outgoing.offer(Exit.fail(Left(()))) *> errorSignal.refailCause(Cause.unit),
+                                  elem => outgoing.offer(Exit.succeed(elem))
+                                )
+                            }.forkIn(scope)
+                       _ <- latch.await
+                     } yield ()
+                 }
+               )
+               .forever
+               .interruptible
+               .forkIn(scope)
+      } yield {
+        lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
+          ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
+            outgoing.take.flatMap {
+              case Exit.Failure(cause) =>
+                cause.failureOrCause match {
+                  case Left(Left(()))       => failure.get.map(ZChannel.refailCause(_))
+                  case Left(Right(outDone)) => Exit.succeed(ZChannel.succeedNow(outDone))
+                  case Right(cause)         => Exit.succeed(ZChannel.refailCause(cause))
+                }
+              case Exit.Success(outElem) => Exit.succeed(ZChannel.write(outElem) *> writer)
+            }
+          }
+
+        writer.embedInput(input)
+      }
+    }
 
   /**
    * Returns a new channel which creates a new channel for each emitted element

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1858,7 +1858,8 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       ZChannel
         .identity[Nothing, Chunk[In], Any]
         .concatMap(ZChannel.writeChunk(_))
-        .mergeMap(n, bufferSize)(in => ZStream.fromZIO(f(in)).channel)
+        .mapOutZIOParUnordered(n, bufferSize)(f)
+        .mapOut(Chunk.single)
     )
 
   /**


### PR DESCRIPTION
When I reverted the optimised implementations of `mapOutZIOPar*`, I noticed the unordered version did not exist before, so I just used the ordered version under the hood. This PR restores the non-determinism:

- `mapOutZIOPar`: order of incoming elements is preserved downstream. This is achieved by injecting a promise in the outgoing queue as soon as an incoming element arrives (although we could just inject the fiber itself) before taking another elements.
- `mapOutZIOParUnordered`: order of incoming elements is _not_ necessarily preserved, depends on how fast `f` runs for each element. This is achieved by injecting the result in the outgoing queue when the workflow of `f(incoming)` has finished.