### PR TITLE
Add TestAspect.checks to allow running aspects within property-based specs

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -457,7 +457,7 @@ object TestAspectSpec extends ZIOBaseSpec {
   }
 
   val resetCounterServiceAspect = ZIO.serviceWith[CounterService] { cs =>
-    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+    new TestAspect.CheckAspect {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace) =
         zio <* cs.reset
     }

--- a/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestAspectSpec.scala
@@ -383,7 +383,28 @@ object TestAspectSpec extends ZIOBaseSpec {
       for {
         value <- ZIO.config(Config.string("key"))
       } yield assertTrue(value == "value")
-    } @@ withConfigProvider(ConfigProvider.fromMap(Map("key" -> "value")))
+    } @@ withConfigProvider(ConfigProvider.fromMap(Map("key" -> "value"))),
+    suite("checks")(
+      test("runs aspect for every check sample") {
+        check(Gen.int)(_ => assertCompletesZIO) *>
+          checksCounter.get.map(assert(_)(equalTo((3, 3))))
+      } @@ samples(3) @@ checks(checksCounterAspect),
+      test("can interact with services in the environment") {
+        check(Gen.int) { n =>
+          for {
+            service <- ZIO.service[CounterService]
+            _       <- service.increment(n)
+            m       <- service.get
+          } yield assert(m)(equalTo(n))
+        }
+      }
+        .@@(checksZIO(resetCounterServiceAspect))
+        .provide(CounterService.live),
+      test("can combine multiple aspects") {
+        check(Gen.int)(_ => assertCompletesZIO) *>
+          checksCounter.get.map(assert(_)(equalTo((6, 6))))
+      } @@ samples(3) @@ checks(checksCounterAspect) @@ checks(checksCounterAspect)
+    ) @@ sequential @@ after(resetChecksCounter)
   )
 
   def diesWithSubtypeOf[E](implicit ct: ClassTag[E]): TestFailure[E] => Boolean =
@@ -404,4 +425,41 @@ object TestAspectSpec extends ZIOBaseSpec {
     )
 
   val seed = -1157790455010312737L
+
+  val checksCounter = Unsafe.unsafe(implicit u => FiberRef.unsafe.make((0, 0)))
+
+  val resetChecksCounter = checksCounter.set((0, 0))
+
+  val checksCounterAspect = new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+    def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      ZIO
+        .acquireReleaseWith(
+          checksCounter.update { case (before, after) => (before + 1, after) }
+        )(_ => checksCounter.update { case (before, after) => (before, after + 1) })(_ => zio)
+  }
+
+  trait CounterService {
+    def get: UIO[Int]
+    def increment(amount: Int): UIO[Unit]
+    def reset: UIO[Unit]
+  }
+
+  object CounterService {
+    val live: ULayer[CounterService] = ZLayer {
+      for {
+        ref <- Ref.make[Int](0)
+      } yield new CounterService {
+        def get: UIO[Int]                     = ref.get
+        def increment(amount: Int): UIO[Unit] = ref.update(_ + amount)
+        def reset: UIO[Unit]                  = ref.set(0)
+      }
+    }
+  }
+
+  val resetCounterServiceAspect = ZIO.serviceWith[CounterService] { cs =>
+    new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
+      def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace) =
+        zio <* cs.reset
+    }
+  }
 }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -326,13 +326,13 @@ object TestAspect extends TimeoutVariants {
           case Spec.TestCase(oldTest, annotations) =>
             val newTest = makeAspect.mapError(TestFailure.fail).flatMap { aspect =>
               testConfigWith { oldConfig =>
-                val newConfig = new TestConfig {
-                  val repeats              = oldConfig.repeats
-                  val retries              = oldConfig.retries
-                  val samples              = oldConfig.samples
-                  val shrinks              = oldConfig.shrinks
-                  override val checkAspect = oldConfig.checkAspect >>> aspect
-                }
+                val newConfig = TestConfig.TestV2(
+                  repeats = oldConfig.repeats,
+                  retries = oldConfig.retries,
+                  samples = oldConfig.samples,
+                  shrinks = oldConfig.shrinks,
+                  checkAspect = oldConfig.checkAspect >>> aspect
+                )
                 withTestConfig(newConfig)(oldTest)
               }
             }
@@ -798,13 +798,13 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
-          val testConfig = new TestConfig {
-            val repeats              = n
-            val retries              = old.retries
-            val samples              = old.samples
-            val shrinks              = old.shrinks
-            override val checkAspect = old.checkAspect
-          }
+          val testConfig = TestConfig.TestV2(
+            repeats = n,
+            retries = old.retries,
+            samples = old.samples,
+            shrinks = old.shrinks,
+            checkAspect = old.checkAspect
+          )
           withTestConfig(testConfig)(test)
         }
     }
@@ -869,13 +869,13 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
-          val testConfig = new TestConfig {
-            val repeats              = old.repeats
-            val retries              = n
-            val samples              = old.samples
-            val shrinks              = old.shrinks
-            override val checkAspect = old.checkAspect
-          }
+          val testConfig = TestConfig.TestV2(
+            repeats = old.repeats,
+            retries = n,
+            samples = old.samples,
+            shrinks = old.shrinks,
+            checkAspect = old.checkAspect
+          )
           withTestConfig(testConfig)(test)
         }
     }
@@ -908,13 +908,13 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
-          val testConfig = new TestConfig {
-            val repeats              = old.repeats
-            val retries              = old.retries
-            val samples              = n
-            val shrinks              = old.shrinks
-            override val checkAspect = old.checkAspect
-          }
+          val testConfig = TestConfig.TestV2(
+            repeats = old.repeats,
+            retries = old.retries,
+            samples = n,
+            shrinks = old.shrinks,
+            checkAspect = old.checkAspect
+          )
           withTestConfig(testConfig)(test)
         }
     }
@@ -998,13 +998,13 @@ object TestAspect extends TimeoutVariants {
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
-          val testConfig = new TestConfig {
-            val repeats              = old.repeats
-            val retries              = old.retries
-            val samples              = old.samples
-            val shrinks              = n
-            override val checkAspect = old.checkAspect
-          }
+          val testConfig = TestConfig.TestV2(
+            repeats = old.repeats,
+            retries = old.retries,
+            samples = old.samples,
+            shrinks = n,
+            checkAspect = old.checkAspect
+          )
           withTestConfig(testConfig)(test)
         }
     }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -85,7 +85,7 @@ abstract class TestAspect[+LowerR, -UpperR, +LowerE, -UpperE] { self =>
 }
 object TestAspect extends TimeoutVariants {
 
-  type CheckSampleAspect = ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any]
+  type CheckAspect = ZIOAspect[Nothing, Any, Nothing, Any, TestResult, TestResult]
 
   /**
    * An aspect that returns the tests unchanged
@@ -308,7 +308,7 @@ object TestAspect extends TimeoutVariants {
    * }
    * }}}
    */
-  def checks(aspect: CheckSampleAspect): TestAspectPoly = checksZIO(
+  def checks(aspect: CheckAspect): TestAspectPoly = checksZIO(
     ZIO.succeed(aspect)(Trace.empty)
   )
 
@@ -318,7 +318,7 @@ object TestAspect extends TimeoutVariants {
    * each test is run.
    */
   def checksZIO[R, E](
-    makeAspect: ZIO[R, E, CheckSampleAspect]
+    makeAspect: ZIO[R, E, CheckAspect]
   ): TestAspect[Nothing, R, E, Any] =
     new TestAspect[Nothing, R, E, Any] {
       def some[R1 <: R, E1 >: E](spec: Spec[R1, E1])(implicit trace: Trace): Spec[R1, E1] =
@@ -327,11 +327,11 @@ object TestAspect extends TimeoutVariants {
             val newTest = makeAspect.mapError(TestFailure.fail).flatMap { aspect =>
               testConfigWith { oldConfig =>
                 val newConfig = new TestConfig {
-                  val repeats                    = oldConfig.repeats
-                  val retries                    = oldConfig.retries
-                  val samples                    = oldConfig.samples
-                  val shrinks                    = oldConfig.shrinks
-                  override val checkSampleAspect = oldConfig.checkSampleAspect >>> aspect
+                  val repeats              = oldConfig.repeats
+                  val retries              = oldConfig.retries
+                  val samples              = oldConfig.samples
+                  val shrinks              = oldConfig.shrinks
+                  override val checkAspect = oldConfig.checkAspect >>> aspect
                 }
                 withTestConfig(newConfig)(oldTest)
               }
@@ -799,11 +799,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats                    = n
-            val retries                    = old.retries
-            val samples                    = old.samples
-            val shrinks                    = old.shrinks
-            override val checkSampleAspect = old.checkSampleAspect
+            val repeats              = n
+            val retries              = old.retries
+            val samples              = old.samples
+            val shrinks              = old.shrinks
+            override val checkAspect = old.checkAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -870,11 +870,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats                    = old.repeats
-            val retries                    = n
-            val samples                    = old.samples
-            val shrinks                    = old.shrinks
-            override val checkSampleAspect = old.checkSampleAspect
+            val repeats              = old.repeats
+            val retries              = n
+            val samples              = old.samples
+            val shrinks              = old.shrinks
+            override val checkAspect = old.checkAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -909,11 +909,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats                    = old.repeats
-            val retries                    = old.retries
-            val samples                    = n
-            val shrinks                    = old.shrinks
-            override val checkSampleAspect = old.checkSampleAspect
+            val repeats              = old.repeats
+            val retries              = old.retries
+            val samples              = n
+            val shrinks              = old.shrinks
+            override val checkAspect = old.checkAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -999,11 +999,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats                    = old.repeats
-            val retries                    = old.retries
-            val samples                    = old.samples
-            val shrinks                    = n
-            override val checkSampleAspect = old.checkSampleAspect
+            val repeats              = old.repeats
+            val retries              = old.retries
+            val samples              = old.samples
+            val shrinks              = n
+            override val checkAspect = old.checkAspect
           }
           withTestConfig(testConfig)(test)
         }

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -24,7 +24,6 @@ import scala.collection.immutable.SortedSet
 import zio.test.TestAspectPoly
 import zio.System.env
 import zio.test.TestAspectAtLeastR
-import zio.test.TestAspectAtLeastR
 
 /**
  * A `TestAspect` is an aspect that can be weaved into specs. You can think of

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -21,6 +21,10 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.collection.immutable.SortedSet
+import zio.test.TestAspectPoly
+import zio.System.env
+import zio.test.TestAspectAtLeastR
+import zio.test.TestAspectAtLeastR
 
 /**
  * A `TestAspect` is an aspect that can be weaved into specs. You can think of
@@ -80,6 +84,8 @@ abstract class TestAspect[+LowerR, -UpperR, +LowerE, -UpperE] { self =>
     self >>> that
 }
 object TestAspect extends TimeoutVariants {
+
+  type CheckSampleAspect = ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any]
 
   /**
    * An aspect that returns the tests unchanged
@@ -277,6 +283,62 @@ object TestAspect extends TimeoutVariants {
         trace: Trace
       ): ZIO[R, TestFailure[E], TestSuccess] =
         ZIO.blocking(test)
+    }
+
+  /**
+   * An aspect that applies the provided zio aspect to each sample of all checks
+   * in the test.
+   *
+   * i.e.
+   * {{{
+   * test("example") {
+   *   check(Gen.int) { i =>
+   *     ZIO.succeed(assert(i, Assertion.equalTo(1)))
+   *   }
+   * } @@ checks(ZIOAspect.debug)
+   * }}}
+   *
+   * is equivalent to
+   *
+   * {{{
+   * test("example") {
+   *   check(Gen.int) { i =>
+   *     ZIO.succeed(assert(i, Assertion.equalTo(1))) @@ ZIOAspect.debug
+   *   }
+   * }
+   * }}}
+   */
+  def checks(aspect: CheckSampleAspect): TestAspectPoly = checksZIO(
+    ZIO.succeed(aspect)(Trace.empty)
+  )
+
+  /**
+   * An aspect that applies the provided zio aspect to each sample of all checks
+   * in the test. The aspect will be constructed from the provided effect before
+   * each test is run.
+   */
+  def checksZIO[R, E](
+    makeAspect: ZIO[R, E, CheckSampleAspect]
+  ): TestAspect[Nothing, R, E, Any] =
+    new TestAspect[Nothing, R, E, Any] {
+      def some[R1 <: R, E1 >: E](spec: Spec[R1, E1])(implicit trace: Trace): Spec[R1, E1] =
+        spec.transform[R1, E1] {
+          case Spec.TestCase(oldTest, annotations) =>
+            val newTest = makeAspect.mapError(TestFailure.fail).flatMap { aspect =>
+              testConfigWith { oldConfig =>
+                val newConfig = new TestConfig {
+                  val repeats                    = oldConfig.repeats
+                  val retries                    = oldConfig.retries
+                  val samples                    = oldConfig.samples
+                  val shrinks                    = oldConfig.shrinks
+                  override val checkSampleAspect = oldConfig.checkSampleAspect >>> aspect
+                }
+                withTestConfig(newConfig)(oldTest)
+              }
+            }
+            Spec.TestCase(newTest, annotations)
+          case c => c
+        }
     }
 
   /**
@@ -737,10 +799,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats = n
-            val retries = old.retries
-            val samples = old.samples
-            val shrinks = old.shrinks
+            val repeats                    = n
+            val retries                    = old.retries
+            val samples                    = old.samples
+            val shrinks                    = old.shrinks
+            override val checkSampleAspect = old.checkSampleAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -807,10 +870,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats = old.repeats
-            val retries = n
-            val samples = old.samples
-            val shrinks = old.shrinks
+            val repeats                    = old.repeats
+            val retries                    = n
+            val samples                    = old.samples
+            val shrinks                    = old.shrinks
+            override val checkSampleAspect = old.checkSampleAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -845,10 +909,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats = old.repeats
-            val retries = old.retries
-            val samples = n
-            val shrinks = old.shrinks
+            val repeats                    = old.repeats
+            val retries                    = old.retries
+            val samples                    = n
+            val shrinks                    = old.shrinks
+            override val checkSampleAspect = old.checkSampleAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -934,10 +999,11 @@ object TestAspect extends TimeoutVariants {
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
         testConfigWith { old =>
           val testConfig = new TestConfig {
-            val repeats = old.repeats
-            val retries = old.retries
-            val samples = old.samples
-            val shrinks = n
+            val repeats                    = old.repeats
+            val retries                    = old.retries
+            val samples                    = old.samples
+            val shrinks                    = n
+            override val checkSampleAspect = old.checkSampleAspect
           }
           withTestConfig(testConfig)(test)
         }
@@ -1170,5 +1236,4 @@ object TestAspect extends TimeoutVariants {
      */
     type Poly = TestAspect.PerTest[Nothing, Any, Nothing, Any]
   }
-
 }

--- a/test/shared/src/main/scala/zio/test/TestConfig.scala
+++ b/test/shared/src/main/scala/zio/test/TestConfig.scala
@@ -63,10 +63,10 @@ object TestConfig {
 
   val tag: Tag[TestConfig] = Tag[TestConfig]
 
+  @deprecated("use TestV2", "2.1.8")
   final case class Test(repeats: Int, retries: Int, samples: Int, shrinks: Int) extends TestConfig
 
-  // NOTE: Additonal class for backward compatibility. Rename to `Test` and remove the old one in next major version.
-  final case class Test1(
+  final case class TestV2(
     repeats: Int,
     retries: Int,
     samples: Int,
@@ -92,7 +92,7 @@ object TestConfig {
     trace: Trace
   ): ZLayer[Any, Nothing, TestConfig] =
     ZLayer.scoped {
-      val testConfig = Test(repeats, retries, samples, shrinks)
+      val testConfig = TestV2(repeats, retries, samples, shrinks, ZIOAspect.identity)
       withTestConfigScoped(testConfig).as(testConfig)
     }
 
@@ -112,7 +112,7 @@ object TestConfig {
     trace: Trace
   ): ZLayer[Any, Nothing, TestConfig] =
     ZLayer.scoped {
-      val testConfig = Test1(repeats, retries, samples, shrinks, checkAspect)
+      val testConfig = TestV2(repeats, retries, samples, shrinks, checkAspect)
       withTestConfigScoped(testConfig).as(testConfig)
     }
 

--- a/test/shared/src/main/scala/zio/test/TestConfig.scala
+++ b/test/shared/src/main/scala/zio/test/TestConfig.scala
@@ -56,7 +56,7 @@ trait TestConfig extends Serializable {
    * NOTE: default implementation for backward compatibility. Remove in next
    * major version.
    */
-  def checkSampleAspect: TestAspect.CheckSampleAspect = ZIOAspect.identity
+  def checkAspect: TestAspect.CheckAspect = ZIOAspect.identity
 }
 
 object TestConfig {
@@ -71,14 +71,14 @@ object TestConfig {
     retries: Int,
     samples: Int,
     shrinks: Int,
-    override val checkSampleAspect: TestAspect.CheckSampleAspect
+    override val checkAspect: TestAspect.CheckAspect
   ) extends TestConfig
 
   /**
    * Constructs a new `TestConfig` with the default settings.
    */
   val default: ZLayer[Any, Nothing, TestConfig] =
-    live(100, 100, 200, 1000)(Trace.empty)
+    live(100, 100, 200, 1000, ZIOAspect.identity)(Trace.empty)
 
   /**
    * Constructs a new `TestConfig` service with the specified settings.
@@ -107,12 +107,12 @@ object TestConfig {
     retries: Int,
     samples: Int,
     shrinks: Int,
-    checkSampleAspect: TestAspect.CheckSampleAspect
+    checkAspect: TestAspect.CheckAspect
   )(implicit
     trace: Trace
   ): ZLayer[Any, Nothing, TestConfig] =
     ZLayer.scoped {
-      val testConfig = Test1(repeats, retries, samples, shrinks, checkSampleAspect)
+      val testConfig = Test1(repeats, retries, samples, shrinks, checkAspect)
       withTestConfigScoped(testConfig).as(testConfig)
     }
 
@@ -143,6 +143,6 @@ object TestConfig {
   /**
    * Action that should be performed on each check sample.
    */
-  def checkSampleAspect(implicit trace: Trace): URIO[Any, TestAspect.CheckSampleAspect] =
-    testConfigWith(testConfig => ZIO.succeed(testConfig.checkSampleAspect))
+  def checkAspect(implicit trace: Trace): URIO[Any, TestAspect.CheckAspect] =
+    testConfigWith(testConfig => ZIO.succeed(testConfig.checkAspect))
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -1070,7 +1070,7 @@ package object test extends CompileVariants {
       warningEmptyGen(flag) *> shrinkStream {
         stream.zipWithIndex.mapZIO { case (initial, index) =>
           flag.set(true) *> initial.foreach(input =>
-            (test(input) @@ testConfig.checkSampleAspect)
+            (test(input) @@ testConfig.checkAspect)
               .map(_.setGenFailureDetails(GenFailureDetails(initial.value, input, index)))
               .either
           )
@@ -1104,7 +1104,7 @@ package object test extends CompileVariants {
         stream.zipWithIndex
           .mapZIOPar(parallelism) { case (initial, index) =>
             initial.foreach { input =>
-              (test(input) @@ testConfig.checkSampleAspect)
+              (test(input) @@ testConfig.checkAspect)
                 .map(_.setGenFailureDetails(GenFailureDetails(initial.value, input, index)))
                 .either
             // convert test failures to failures to terminate parallel tests on first failure

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -1065,17 +1065,17 @@ package object test extends CompileVariants {
   private def checkStream[R, R1 <: R, E, A](stream: ZStream[R, Nothing, Sample[R, A]])(
     test: A => ZIO[R1, E, TestResult]
   )(implicit trace: Trace): ZIO[R1, E, TestResult] =
-    TestConfig.shrinks.flatMap { s =>
+    testConfigWith { testConfig =>
       val flag = Ref.unsafe.make(false)(Unsafe.unsafe)
       warningEmptyGen(flag) *> shrinkStream {
         stream.zipWithIndex.mapZIO { case (initial, index) =>
           flag.set(true) *> initial.foreach(input =>
-            test(input)
+            (test(input) @@ testConfig.checkSampleAspect)
               .map(_.setGenFailureDetails(GenFailureDetails(initial.value, input, index)))
               .either
           )
         }
-      }(s)
+      }(testConfig.shrinks)
     }
 
   private def shrinkStream[R, R1 <: R, E, A](
@@ -1099,12 +1099,12 @@ package object test extends CompileVariants {
   private def checkStreamPar[R, R1 <: R, E, A](stream: ZStream[R, Nothing, Sample[R, A]], parallelism: Int)(
     test: A => ZIO[R1, E, TestResult]
   )(implicit trace: Trace): ZIO[R1, E, TestResult] =
-    TestConfig.shrinks.flatMap {
+    testConfigWith { testConfig =>
       shrinkStream {
         stream.zipWithIndex
           .mapZIOPar(parallelism) { case (initial, index) =>
             initial.foreach { input =>
-              test(input)
+              (test(input) @@ testConfig.checkSampleAspect)
                 .map(_.setGenFailureDetails(GenFailureDetails(initial.value, input, index)))
                 .either
             // convert test failures to failures to terminate parallel tests on first failure
@@ -1112,7 +1112,7 @@ package object test extends CompileVariants {
           // move failures back into success channel for shrinking logic
           }
           .catchAll(ZStream.succeed(_))
-      }
+      }(testConfig.shrinks)
     }
 
   private def warningEmptyGen(flag: Ref[Boolean])(implicit trace: Trace): UIO[Unit] =


### PR DESCRIPTION
resolves #9046 
/claim #9046 