### PR TITLE
Ensure `ZStream` scope is properly closed

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4903,7 +4903,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Prefix form of `ZIO#uninterruptible`.
    */
   def uninterruptible[R, E, A](zio: => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-    ZIO.suspendSucceed(zio.uninterruptible)
+    ZIO.suspendSucceed(zio).uninterruptible
 
   /**
    * Makes the effect uninterruptible, but passes it a restore function that can

--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -141,7 +141,7 @@ object ZChannelSpec extends ZIOBaseSpec {
         test("finalizer ordering 2") {
           for {
             effects <- Ref.make(List[String]())
-            push     = (i: String) => ZIO.debug(i) *> effects.update(i :: _)
+            push     = (i: String) => effects.update(i :: _)
             _ <- ZChannel
                    .writeAll(1, 2)
                    .mapOutZIO(n => push(s"pulled $n").as(n))


### PR DESCRIPTION
/fixes #9052
/claim #9052

Issue is that when we pull from a child, when `onDone` is run we store the finalizers in the `closeLastSubstream` var. However, if the upstream is interrupted before the next time we pull from the child, we're not running the finalizers.

This PR fixes it by:
1. Ensuring that the `closeLastSubstream` is set to `null` only when the effect is run
2. When running `onClose`, we also check if the `closeLastSubstream != null` and add those finalizers to the effect 