### PR TITLE
Fix flaky `ZLayer` test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -543,7 +543,7 @@ object ZLayerSpec extends ZIOBaseSpec {
         val layer3   = liveEnvironment >>> TestEnvironment.live
         val combined = layer1 ++ layer2 ++ layer3
         for {
-          exit <- ZIO.scoped(combined.build).exit
+          exit <- ZIO.scoped(combined.build).uninterruptible.exit
         } yield assert(exit)(failsCause(containsCause(Cause.fail("fail"))))
       } @@ jvm(nonFlaky),
       test("fiberRef changes are memoized") {


### PR DESCRIPTION
In some rare cases, the failure triggers an interruption which wins a race over the failure. This PR fixes it by making the effect uninterruptible.

Tested it locally by setting `nonFlaky(100000)` and the test succeeded, whereas before it was guaranteed to fail < 10k iterations.