### PR TITLE
Fix flaky `WeakConcurrentBagSpec` test

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
@@ -54,7 +54,7 @@ object WeakConcurrentBagSpec extends ZIOBaseSpec {
           bag.gc()
 
           assertTrue(bag.size == 50)
-        } +
+        } @@ flaky +
         test("auto gc") {
           val bag = WeakConcurrentBag[Wrapper[String]](100)
 


### PR DESCRIPTION
/fixes #9087

Since there's no way to guarantee that GC will be performed on the WCB, it's OK to use the `flaky` annotation