### PR TITLE
Reduce number of CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 0
+          fetch-depth: 500
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -58,8 +58,6 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
       - name: Mima Checks
         run: sbt --client -v "++${{ matrix.scala }}; mimaChecks"
       - name: publishLocal 2.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC # Needed for sbt
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:
@@ -32,45 +32,8 @@ jobs:
         check-latest: true
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
-    - name: Install libuv
-      run: sudo apt-get update && sudo apt-get install -y libuv1-dev
     - name: Lint code
       run: sbt "++2.13; check; ++3.3; check"
-
-  compile:
-    runs-on: ubuntu-20.04
-    timeout-minutes: 120
-    if: ${{ ((github.event_name != 'repository_dispatch') && (github.event.action != 'update-docs')) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        scala: ['2.12.x', '2.13.x', '3.x']
-    steps:
-      - name: Checkout current branch
-        uses: actions/checkout@v4.1.1
-      - name: Setup Java
-        uses: actions/setup-java@v4.2.1
-        with:
-          distribution: temurin
-          java-version: 17
-          check-latest: true
-      - name: Cache scala dependencies
-        uses: coursier/cache-action@v6
-      - name: Install libuv
-        run: sudo apt-get update && sudo apt-get install -y libuv1-dev
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 7
-      - name: Test/compile 2.12
-        if: ${{ startsWith(matrix.scala, '2.12.') }}
-        run: free --si -tmws 10 & sbt -v ++${{ matrix.scala }} root212/Test/compile
-      - name: Test/compile 2.13
-        if: ${{ startsWith(matrix.scala, '2.13.') }}
-        run: free --si -tmws 10 & sbt -v ++${{ matrix.scala }} root213/Test/compile
-      - name: Test/compile 3
-        if: ${{ startsWith(matrix.scala, '3.') }}
-        run: free --si -tmws 10 & sbt -v ++${{ matrix.scala }} root3/Test/compile
 
   publishLocal:
     runs-on: ubuntu-20.04
@@ -85,6 +48,8 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -95,15 +60,17 @@ jobs:
         uses: coursier/cache-action@v6
       - name: Install libuv
         run: sudo apt-get update && sudo apt-get install -y libuv1-dev
+      - name: Mima Checks
+        run: sbt --client -v "++${{ matrix.scala }}; mimaChecks"
       - name: publishLocal 2.12
         if: ${{ startsWith(matrix.scala, '2.12.') }}
-        run: sbt -v ++${{ matrix.scala }} root212/publishLocal
+        run: sbt --client -v "root212/Test/compile; root212/publishLocal"
       - name: publishLocal 2.13
         if: ${{ startsWith(matrix.scala, '2.13.') }}
-        run: sbt -v ++${{ matrix.scala }} root213/publishLocal
+        run: sbt --client -v "root213/Test/compile; root213/publishLocal"
       - name: publishLocal 3
         if: ${{ startsWith(matrix.scala, '3.') }}
-        run: sbt -v ++${{ matrix.scala }} root3/publishLocal
+        run: sbt --client -v "root3/Test/compile; root3/publishLocal"
 
   build-website:
     runs-on: ubuntu-20.04
@@ -128,8 +95,7 @@ jobs:
       - name: Compile Docs
         run: |
           while true; do free -h; sleep 5; done &
-          sbt -mem 6144 docs/mdoc -verbose
-          sbt -mem 6144 docs/unidoc -verbose
+          sbt -v "docs/mdoc; docs/unidoc"
 
       - name: Build The Website
         working-directory: ./website
@@ -160,8 +126,6 @@ jobs:
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v4.1.1
-      with:
-        fetch-depth: 0
     - name: Setup Java
       uses: actions/setup-java@v4.2.1
       with:
@@ -170,9 +134,6 @@ jobs:
         check-latest: true
     - name: Cache scala dependencies
       uses: coursier/cache-action@v6
-    - name: Mima Checks
-      # Enable optimizers as inlining might affect binary compatibility in rare cases
-      run: CI_RELEASE_MODE=1 sbt -v ++${{ matrix.scala }} mimaChecks
     - name: Test 2.12
       if: ${{ startsWith(matrix.scala, '2.12.') }}
       run: sbt -v ++${{ matrix.scala }} test${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 env:
-  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
-  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx8G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
+  JDK_JAVA_OPTIONS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # JDK_JAVA_OPTIONS is _the_ env. variable to use for modern Java
+  SBT_OPTS: -XX:+PrintCommandLineFlags -Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M # Needed for sbt
   NODE_OPTIONS: --max_old_space_size=6144
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
         with:
+          fetch-depth: 1000
           fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.2.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,7 @@ jobs:
 
   ci:
     runs-on: ubuntu-20.04
-    needs: [lint, compile, publishLocal, build-website, test, testJvms, testPlatforms]
+    needs: [lint, publishLocal, build-website, test, testJvms, testPlatforms]
     steps:
       - name: Aggregate of lint, mdoc and all tests
         run: echo "ci passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 500
+          fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,17 +59,19 @@ jobs:
           check-latest: true
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
-      - name: Mima Checks
-        run: sbt --client -v "++${{ matrix.scala }}; mimaChecks"
       - name: publishLocal 2.12
         if: ${{ startsWith(matrix.scala, '2.12.') }}
-        run: sbt --client -v "root212/Test/compile; root212/publishLocal"
+        run: sbt --client -v "++${{ matrix.scala }}; root212/Test/compile; root212/publishLocal"
       - name: publishLocal 2.13
         if: ${{ startsWith(matrix.scala, '2.13.') }}
-        run: sbt --client -v "root213/Test/compile; root213/publishLocal"
+        run: sbt --client -v "++${{ matrix.scala }}; root213/Test/compile; root213/publishLocal"
       - name: publishLocal 3
         if: ${{ startsWith(matrix.scala, '3.') }}
-        run: sbt --client -v "root3/Test/compile; root3/publishLocal"
+        run: sbt --client -v "++${{ matrix.scala }}; root3/Test/compile; root3/publishLocal"
+      - name: Mima Checks
+        run: sbt --client mimaChecks
+      - name: Shutdown SBT server
+        run: sbt --client shutdown
 
   build-website:
     runs-on: ubuntu-20.04
@@ -78,7 +80,8 @@ jobs:
       - name: Checkout Current Branch
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: '0'
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Setup Scala and Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -248,7 +251,8 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:
@@ -274,7 +278,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - uses: actions/download-artifact@v3
         with:
           name: website-artifact


### PR DESCRIPTION
We have a finite number of runners shared across all of `zio/` codebases. When multiple PRs are being tested across different repos, in some cases we end up waiting a long time for runners to become available.

This PR improves CI by:
1. Reducing the number of workflows by 3 by pushing the `Test/compile` task into `publishLocal`. It also moves MiMa checks to the `publishLocal` workflow since it's shorter and I think it makes more sense to be there.
2. Using `fetch-depth: 1000` along `fetch-tags: true`. This reduces the execution time by ~2 minutes for workflows that previously used `fetch-depth: 0`. Note that in the past we unsuccessfully attempted to limit `fetch-depth`, but that caused CI failures because we didn't include `fetch-tags: true`, which is needed for any workflow that needs to list recent tags (e.g., the `publish` workflow)

Note that we also use the `--client` CLI argument to SBT wherever possible to reuse the warmed up JVM instance instead of discarding it