### PR TITLE
Avoid scheduling non-positive sleep timers

### DIFF
--- a/core/jvm/src/main/scala/zio/Scheduler.scala
+++ b/core/jvm/src/main/scala/zio/Scheduler.scala
@@ -39,17 +39,13 @@ object Scheduler {
       def schedule(task: Runnable, duration: Duration)(implicit unsafe: Unsafe): CancelToken =
         (duration: @unchecked) match {
           case Duration.Infinity => ConstFalse
-          case Duration.Zero =>
+          case d if d.isZero || d.isNegative =>
             task.run()
-
             ConstFalse
-          case Duration.Finite(_) =>
+          case d =>
             val future = service.schedule(
-              new Runnable {
-                def run: Unit =
-                  task.run()
-              },
-              duration.toNanos,
+              task,
+              d.toNanos,
               TimeUnit.NANOSECONDS
             )
 


### PR DESCRIPTION
The current implementation of `ZIO.sleep` / `ZIO#delay` will schedule a task even when the duration is negative / zero. This is an issue on 2 fronts:
1.  Non-determinism: We do not know whether the scheduled callback will be executed before or after asynchronous resumption has taken place
2. Is less performant as we need to create a runnable, schedule the task, maybe switch await the completion of the task asynchronously and then continue

I also noticed a few micro-optimizations that could be done `ClockPlatformSpecific` and `Scheduler` so I did them in this PR as well