### PR TITLE
Use an improved eq in `FiberRefs` and add shortcut for `join`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -83,10 +83,10 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
       assertTrue(env1.hashCode != env2.hashCode)
     },
     test("diff on two equal environments should return an empty patch") {
-      val env1 = ZEnvironment("foo", 42)
-      val env2 = ZEnvironment("foo", 42)
+      val env1  = ZEnvironment("foo", 42)
+      val env2  = ZEnvironment("foo", 42)
       val patch = ZEnvironment.Patch.diff(env1, env2)
       assertTrue(patch.isEmpty)
-    },
+    }
   )
 }

--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -61,6 +61,32 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
     test("get[Any] on an empty ZEnvironment returns Unit") {
       val value = ZEnvironment.empty.get[Any]
       assertTrue(value.isInstanceOf[Unit])
-    }
+    },
+    test("equality") {
+      val env1 = ZEnvironment("foo", 42)
+      val env2 = ZEnvironment("foo", 42)
+      assertTrue(env1 == env2)
+    },
+    test("equality takes into account order") {
+      val env1 = ZEnvironment("foo", 42)
+      val env2 = ZEnvironment(42, "foo")
+      assertTrue(env1 != env2)
+    },
+    test("hashCode") {
+      val env1 = ZEnvironment("foo", 42)
+      val env2 = ZEnvironment("foo", 42)
+      assertTrue(env1.hashCode == env2.hashCode)
+    },
+    test("hashCode takes into account order") {
+      val env1 = ZEnvironment("foo", 42)
+      val env2 = ZEnvironment(42, "foo")
+      assertTrue(env1.hashCode != env2.hashCode)
+    },
+    test("diff on two equal environments should return an empty patch") {
+      val env1 = ZEnvironment("foo", 42)
+      val env2 = ZEnvironment("foo", 42)
+      val patch = ZEnvironment.Patch.diff(env1, env2)
+      assertTrue(patch.isEmpty)
+    },
   )
 }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -440,7 +440,7 @@ object FiberRef {
       initialValue0: Value0,
       differ: Differ[Value0, Patch0],
       fork0: Patch0,
-      join0: (Value0, Value0) => Value0 = (_: Value0, newValue: Value0) => newValue
+      join0: (Value0, Value0) => Value0 = ZIO.secondFn[Value0]
     )(implicit unsafe: Unsafe): FiberRef.WithPatch[Value0, Patch0] =
       new FiberRef[Value0] {
         self =>
@@ -560,7 +560,7 @@ object FiberRef {
     FiberRef.unsafe.makeSupervisor(Runtime.defaultSupervisor)(Unsafe.unsafe)
 
   private[zio] val unhandledErrorLogLevel: FiberRef[Option[LogLevel]] =
-    FiberRef.unsafe.make[Option[LogLevel]](Some(LogLevel.Debug), identity(_), (_, child) => child)(Unsafe.unsafe)
+    FiberRef.unsafe.make[Option[LogLevel]](Some(LogLevel.Debug))(Unsafe.unsafe)
 
   private def makeWith[Value, Patch](
     ref: => FiberRef.WithPatch[Value, Patch]

--- a/core/shared/src/main/scala/zio/FiberRefs.scala
+++ b/core/shared/src/main/scala/zio/FiberRefs.scala
@@ -20,6 +20,7 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.annotation.tailrec
+import scala.runtime.BoxesRunTime
 
 /**
  * `FiberRefs` is a data type that represents a collection of `FiberRef` values.
@@ -30,7 +31,7 @@ final class FiberRefs private (
   private[zio] val fiberRefLocals: Map[FiberRef[_], FiberRefs.Value]
 ) { self =>
   import FiberRef.currentRuntimeFlags
-  import zio.FiberRefs.{StackEntry, Value}
+  import zio.FiberRefs.{StackEntry, Value, improvedEq}
 
   /**
    * Returns a new fiber refs with the specified ref deleted from it.
@@ -58,6 +59,14 @@ final class FiberRefs private (
   private var needsTransformWhenForked: Boolean = true
 
   /**
+   * Boolean flag which indicates whether this FiberRefs requires a transform on
+   * the values when joining with its own self (as determined by `eq`).
+   *
+   * Note that this should the case with all ZIO-provided `FiberRef`.
+   */
+  private[this] var needsTransformWhenJoinEq: Boolean = true
+
+  /**
    * Forks this collection of fiber refs as the specified child fiber id. This
    * will potentially modify the value of the fiber refs, as determined by the
    * individual fiber refs that make up the collection.
@@ -74,7 +83,7 @@ final class FiberRefs private (
           type T = fiberRef.Value & AnyRef
           val oldValue = stack.head.value.asInstanceOf[T]
           val newValue = fiberRef.patch(fork)(oldValue).asInstanceOf[T]
-          if (oldValue eq newValue) entry
+          if (improvedEq(oldValue, newValue)) entry
           else Value(::(StackEntry(childId, newValue, 0), stack), depth + 1)
         }
       }
@@ -131,6 +140,13 @@ final class FiberRefs private (
    * preservation of maximum information from both child and parent refs.
    */
   def joinAs(fiberId: FiberId.Runtime)(that: FiberRefs): FiberRefs = {
+    val areEqual = self eq that
+
+    // First attempt at shortcut when the two objects are the same, and we already know that we don't need to transform
+    if (areEqual && !needsTransformWhenJoinEq) {
+      return self
+    }
+
     val childFiberRefs  = that.fiberRefLocals
     var fiberRefLocals0 = self.fiberRefLocals
 
@@ -140,7 +156,7 @@ final class FiberRefs private (
       val childStack    = value0.stack
       val childHead     = childStack.head
 
-      // First shortcut: The last time this ref was updated was by the parent, so we just keep it as is
+      // Second shortcut: The last time this ref was updated was by the parent, so we just keep it as is
       if (childHead.id ne fiberId) {
         val value1     = fiberRefLocals0.getOrElse(ref, null)
         val childValue = childHead.value.asInstanceOf[ref.Value]
@@ -149,7 +165,7 @@ final class FiberRefs private (
           val initial  = ref.initial
           val newValue = ref.join(initial, childValue)
           // Attempt to shortcut in case that the value after the join is the same as the initial one
-          if (newValue ne initial) {
+          if (!improvedEq(newValue, initial)) {
             val v = Value(::(StackEntry(fiberId, newValue, 0), List.empty), 1)
             fiberRefLocals0 = fiberRefLocals0.updated(ref, v)
           }
@@ -174,7 +190,7 @@ final class FiberRefs private (
           }
 
           val newValue = ref.join(oldValue, newValue0)
-          if (oldValue ne newValue) {
+          if (!improvedEq(oldValue, newValue)) {
             val parentFiberId = parentHead.id
             val parentVersion = parentHead.version
             val newEntry = {
@@ -189,8 +205,10 @@ final class FiberRefs private (
       }
     }
 
-    if (self.fiberRefLocals eq fiberRefLocals0) self
-    else FiberRefs(fiberRefLocals0)
+    if (self.fiberRefLocals eq fiberRefLocals0) {
+      if (areEqual) needsTransformWhenJoinEq = false
+      self
+    } else FiberRefs(fiberRefLocals0)
   }
 
   @tailrec
@@ -310,6 +328,31 @@ object FiberRefs {
 
   private[zio] def apply(fiberRefLocals: Map[FiberRef[_], Value]): FiberRefs =
     new FiberRefs(fiberRefLocals)
+
+  /**
+   * Similar to `eq`, improved for cases that the type is a boxed integer.
+   *
+   * @note
+   *   Normally we need to be performing a 2nd type check whether the type is a
+   *   `java.lang.Character`, but since ZIO doesn't define any `FiberRef[Char]`
+   *   we can skip it and let the runtime assertion fail in case we ever add it.
+   *
+   * @note
+   *   The assertion disappears when compiling with `CI_RELEASE_MODE=1`. If this
+   *   method shows up in benchmarks, make sure to compile the code with the
+   *   envvar set.
+   */
+  private def improvedEq[A <: AnyRef](x: A, y: A): Boolean = {
+    val isEq = x match {
+      case x0: java.lang.Number => BoxesRunTime.equalsNumObject(x0, y)
+      case _                    => x eq y
+    }
+    assert(
+      BuildInfo.optimizationsEnabled || isEq || x != y,
+      s"FiberRef.improvedEq reference equality returned false but equals returned true for value of class ${x.getClass.getName}"
+    )
+    isEq
+  }
 
   /**
    * A `Patch` captures the changes in `FiberRef` values made by a single fiber

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -60,7 +60,8 @@ final class ZEnvironment[+R] private (
 
   override def equals(that: Any): Boolean = that match {
     case that: ZEnvironment[_] =>
-      if (self.scope ne that.scope) false
+      if (self eq that) true
+      else if (self.scope ne that.scope) false
       else if (self.map eq that.map) true
       else if (self.map.size != that.map.size) false
       else self.hashCode == that.hashCode

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -391,7 +391,7 @@ object ZEnvironment {
           }
 
       val env0 = environment.asInstanceOf[ZEnvironment[Out]]
-      if (self eq empty0) env0
+      if (isEmpty) env0
       else {
         val out = loop(environment, self.asInstanceOf[Patch[Any, Any]] :: Nil).asInstanceOf[ZEnvironment[Out]]
         // Unfortunately we can't rely on eq here, but this is still better than destroying the FiberRefs optimizations
@@ -406,7 +406,10 @@ object ZEnvironment {
     def combine[Out2](that: Patch[Out, Out2]): Patch[In, Out2] =
       AndThen(self, that)
 
-    def isEmpty: Boolean = false
+    /**
+     * Boolean flag indicating whether the patch is empty.
+     */
+    def isEmpty: Boolean = self.isInstanceOf[Empty]
   }
 
   object Patch {
@@ -474,9 +477,7 @@ object ZEnvironment {
       }
 
     private val empty0 = Empty()
-    private final case class Empty[Env]() extends Patch[Env, Env] {
-      override def isEmpty: Boolean = true
-    }
+    private final case class Empty[Env]() extends Patch[Env, Env]
 
     private final case class AddScope[Env, Service](scope: Scope) extends Patch[Env, Env with Scope]
     private final case class AddService[Env, Service](service: Service, tag: LightTypeTag)

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -410,7 +410,7 @@ object ZEnvironment {
     /**
      * Boolean flag indicating whether the patch is empty.
      */
-    def isEmpty: Boolean = self.isInstanceOf[Empty]
+    def isEmpty: Boolean = self.isInstanceOf[Empty[?]]
   }
 
   object Patch {

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -394,7 +394,8 @@ object ZEnvironment {
       if (isEmpty) env0
       else {
         val out = loop(environment, self.asInstanceOf[Patch[Any, Any]] :: Nil).asInstanceOf[ZEnvironment[Out]]
-        // Unfortunately we can't rely on eq here, but this is still better than destroying the FiberRefs optimizations
+        // Unfortunately we can't rely on eq here. However, the ZEnvironment equals method uses a cached hashCode
+        // so it's pretty fast
         if (env0 == out) env0 else out
       }
     }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4973,7 +4973,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * higher-performance variant, see `ZIO#withRuntimeFlags`.
    */
   def updateRuntimeFlags(patch: RuntimeFlags.Patch)(implicit trace: Trace): ZIO[Any, Nothing, Unit] =
-    if (patch == RuntimeFlags.Patch.empty) ZIO.unit
+    if (patch == RuntimeFlags.Patch.empty) Exit.unit
     else ZIO.UpdateRuntimeFlags(trace, patch)
 
   /**

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -107,17 +107,20 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       val parentFiberId      = parentFiber.id
       val parentFiberRefs    = parentFiber.getFiberRefs()
       val parentRuntimeFlags = parentStatus.runtimeFlags
+      val childFiberRefs     = self.getFiberRefs() // Inconsistent snapshot
 
-      val childFiberRefs   = self.getFiberRefs() // Inconsistent snapshot
       val updatedFiberRefs = parentFiberRefs.joinAs(parentFiberId)(childFiberRefs)
+      if (updatedFiberRefs ne parentFiberRefs) {
+        parentFiber.setFiberRefs(updatedFiberRefs)
 
-      parentFiber.setFiberRefs(updatedFiberRefs)
+        val updatedRuntimeFlags = updatedFiberRefs.getRuntimeFlags(Unsafe.unsafe)
 
-      val updatedRuntimeFlags = updatedFiberRefs.getRuntimeFlags(Unsafe.unsafe)
-
-      // Do not inherit WindDown or Interruption!
-      val patch = FiberRuntime.patchExcludeNonInheritable(RuntimeFlags.diff(parentRuntimeFlags, updatedRuntimeFlags))
-      ZIO.updateRuntimeFlags(patch)
+        // Do not inherit WindDown or Interruption!
+        val patch = FiberRuntime.patchExcludeNonInheritable(RuntimeFlags.diff(parentRuntimeFlags, updatedRuntimeFlags))
+        ZIO.updateRuntimeFlags(patch)
+      } else {
+        Exit.unit
+      }
     }
 
   def interruptAsFork(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =


### PR DESCRIPTION
One of the things I didn't account for in #8989 is that `eq` on boxed primitives returns false even if the underlying integer is the same 🫠. The fix is rather simple; typecheck the value and if it's a `java.lang.Number` then unbox it and compare it (via `BoxesRunTime.equalsNumObject`.

While I was doing this, I thought to also do the following:
1. To add an assertion that our now `improvedEq` produces the same outcome as `==` (note that this assertion does not exist in the published artifacts!).
2. To add a shortcut when we join on 2 `FiberRefs` which are equal according to `eq`. This is a very common case especially when we do `ZIO.foreachPar`, since in most cases we won't be modifying any of the FiberRefs in any of the effects run in parallel. Therefore, `inheritAll` then becomes much cheaper, which overall improves the performance of `foreachPar` quite substantially: 

series/2.x
```
[info] Benchmark                                      Mode  Cnt     Score    Error  Units
[info] ForeachParDiscardBenchmark.foreachParDiscard  thrpt    5  1179.541 ± 42.125  ops/s
```

PR
```
[info] Benchmark                                      Mode  Cnt     Score     Error  Units
[info] ForeachParDiscardBenchmark.foreachParDiscard  thrpt    5  1463.919 ± 104.970  ops/s
```

Note that in some rare cases, the `ZEnvironment.Patch.diff` will return a Patch that when applied, it will result having the same services in the environment. To avoid this, I added a guard against this by checking that the resulting ZEnvironment is indeed different (as determined by `==`). I think that since our equals method on `ZEnvironment` is fairly well optimized, I'm thinking it's better not to risk destroying the `FiberRefs` optimizations and perform this check. Thoughts?