### PR TITLE
Optimize `FiberRef#locally` to restore previous FiberRefs when unmodified

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -576,7 +576,19 @@ object Fiber extends FiberPlatformSpecific {
      * invoked on this fiber, then values derived from the fiber's state
      * (including the log annotations and log level) may not be up-to-date.
      */
-    private[zio] def getFiberRefs(): FiberRefs
+    private[zio] def getFiberRefs(): FiberRefs = getFiberRefs(true)
+
+    /**
+     * Retrieves all fiber refs of the fiber. If `updateRuntimeFlagsWithin` is
+     * set to `false`, the FiberRefs will ''not'' be updated with the Fiber's
+     * current runtime flags. This can help performance for cases that we don't
+     * need to extract the runtime flags from the FiberRefs.
+     *
+     * '''NOTE''': This method is safe to invoke on any fiber, but if not
+     * invoked on this fiber, then values derived from the fiber's state
+     * (including the log annotations and log level) may not be up-to-date.
+     */
+    private[zio] def getFiberRefs(updateRuntimeFlagsWithin: Boolean): FiberRefs
 
     /**
      * Retrieves the executor that this effect is currently executing on.

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -476,14 +476,27 @@ object FiberRef {
 
         override def locally[R, E, A](newValue: Value)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
           ZIO.withFiberRuntime[R, E, A] { (fiberState, _) =>
-            val oldValue = fiberState.getFiberRefOrNull(self)
+            val oldRefs = fiberState.getFiberRefs(false)
+            val newRefs = oldRefs.updatedAs(fiberState.id)(self, newValue)
 
-            fiberState.setFiberRef(self, newValue)
+            if (newRefs eq oldRefs) zio
+            else {
+              fiberState.setFiberRefs(newRefs)
+              zio.onExit { _ =>
+                val currentRefs = fiberState.getFiberRefs(false)
+                if (newRefs eq currentRefs) {
+                  // FiberRefs were not modified, we can just restore the old state
+                  fiberState.setFiberRefs(oldRefs)
+                } else {
+                  // They were modified, we need to update only the current FiberRef
+                  val oldValue = oldRefs.getOrNull(self)
+                  if (oldValue == null) fiberState.resetFiberRef(self)
+                  else fiberState.setFiberRef(self, oldValue)
+                }
+                Exit.unit
+              }
+            }
 
-            zio.ensuring(ZIO.succeed {
-              if (oldValue == null) fiberState.resetFiberRef(self)
-              else fiberState.setFiberRef(self, oldValue)
-            })
           }
 
         override def set(value: Value)(implicit trace: Trace): UIO[Unit] =


### PR DESCRIPTION
As part of an effort to make joining fibers less expensive, this PR changes the logic in `FiberRef#locally` so that the previous instance of `FiberRefs` is restored as-is if no other modification to `FiberRefs` was done in the effect run passed to `locally`. In addition, we can skip the update of the `FiberRefs` altogether if the value passed to `locally` doesn't require the `FiberRefs` to be updated.

Note that this is faster even for cases that we don't need to join any fibers, since we don't need to `delete` the entry from the underlying immutable map and recreate it. This is seen by this simple benchmark, where `locally` has a ~40% increased throughput with these changes:

```scala
  private val ref0          = FiberRef.unsafe.make("foo")
  private val updateLocally = List.fill(10000)(ref0.locally("bar")(ZIO.unit))

  @Benchmark
  @OperationsPerInvocation(10000)
  def locally() = unsafeRun {
    ZIO.setFiberRefs(frs5) *>
      ZIO.collectAllDiscard(updateLocally)
  }
```

```
# series/2.x
[info] Benchmark                    Mode  Cnt      Score      Error   Units
[info] FiberRefsBenchmark.locally  thrpt    6  11209.120 ± 1159.421  ops/ms

# PR
[info] Benchmark                    Mode  Cnt      Score     Error   Units
[info] FiberRefsBenchmark.locally  thrpt    6  15515.414 ± 222.464  ops/ms
```

