### PR TITLE
Prefer `Exit` over `ZIO` in nested effects and other micro-optimizations

### DIFF
--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -276,7 +276,7 @@ final class Promise[E, A] private (
         }
 
       def refailCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean =
-        completeWith(ZIO.refailCause(e))
+        completeWith(Exit.failCause(e))
 
       def succeed(a: A)(implicit trace: Trace, unsafe: Unsafe): Boolean =
         completeWith(ZIO.succeed(a))

--- a/core/shared/src/main/scala/zio/ScopedRef.scala
+++ b/core/shared/src/main/scala/zio/ScopedRef.scala
@@ -88,7 +88,7 @@ object ScopedRef {
             exit     <- newScope.extend[R](acquire).exit
             result <- exit match {
                         case Exit.Failure(cause) =>
-                          newScope.close(Exit.unit).as(ZIO.refailCause(cause) -> (oldScope -> a))
+                          newScope.close(Exit.unit).as(Exit.failCause(cause) -> (oldScope -> a))
                         case Exit.Success(a) => ZIO.succeed(ZIO.unit -> (newScope -> a))
                       }
           } yield result

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1065,7 +1065,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def onError[R1 <: R](cleanup: Cause[E] => URIO[R1, Any])(implicit trace: Trace): ZIO[R1, E, A] =
     onExit {
-      case _: Exit.Success[_]  => Exit.unit
+      case _: Exit.Success[?]  => Exit.unit
       case Exit.Failure(cause) => cleanup(cause)
     }
 
@@ -1120,7 +1120,7 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def onInterrupt[R1 <: R](cleanup: => URIO[R1, Any])(implicit trace: Trace): ZIO[R1, E, A] =
     onExit {
-      case _: Exit.Success[_]  => Exit.unit
+      case _: Exit.Success[?]  => Exit.unit
       case Exit.Failure(cause) => if (cause.isInterruptedOnly) cleanup else Exit.unit
     }
 
@@ -1131,7 +1131,7 @@ sealed trait ZIO[-R, +E, +A]
   final def onInterrupt[R1 <: R](cleanup: Set[FiberId] => URIO[R1, Any])(implicit trace: Trace): ZIO[R1, E, A] =
     // TODO: isInterrupted or isInterruptedOnly?
     onExit {
-      case _: Exit.Success[_]  => Exit.unit
+      case _: Exit.Success[?]  => Exit.unit
       case Exit.Failure(cause) => if (cause.isInterruptedOnly) cleanup(cause.interruptors) else Exit.unit
     }
 
@@ -1143,7 +1143,7 @@ sealed trait ZIO[-R, +E, +A]
     cleanup: Cause[Nothing] => URIO[R1, Any]
   )(implicit trace: Trace): ZIO[R1, E, A] =
     onExit {
-      case _: Exit.Success[_] => Exit.unit
+      case _: Exit.Success[?] => Exit.unit
       case Exit.Failure(cause) =>
         if (cause.isFailure) Exit.unit
         else cleanup(cause.asInstanceOf[Cause[Nothing]])
@@ -1467,7 +1467,7 @@ sealed trait ZIO[-R, +E, +A]
     self.raceFibersWith(that)(
       (winner, loser) =>
         winner.await.flatMap {
-          case exit: Exit.Success[_] =>
+          case exit: Exit.Success[?] =>
             winner.inheritAll.flatMap(_ => leftDone(exit, loser))
           case exit: Exit.Failure[_] =>
             leftDone(exit, loser)

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -341,7 +341,7 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] { self =>
   final def tapErrorCause[RIn1 <: RIn, E1 >: E](f: Cause[E] => ZIO[RIn1, E1, Any])(implicit
     trace: Trace
   ): ZLayer[RIn1, E1, ROut] =
-    catchAllCause(e => ZLayer.fromZIO[RIn1, E1, Nothing](f(e) *> ZIO.refailCause(e)))
+    catchAllCause(e => ZLayer.fromZIO[RIn1, E1, Nothing](f(e) *> Exit.failCause(e)))
 
   /**
    * A named alias for `>>>`.
@@ -868,7 +868,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * Constructs a layer that refails with the specified cause.
    */
   def refailCause[E](cause: Cause[E])(implicit trace: Trace): Layer[E, Nothing] =
-    ZLayer(ZIO.refailCause(cause))
+    ZLayer(Exit.failCause(cause))
 
   /**
    * Constructs a layer from the specified scoped effect.

--- a/core/shared/src/main/scala/zio/metrics/Metric.scala
+++ b/core/shared/src/main/scala/zio/metrics/Metric.scala
@@ -204,7 +204,7 @@ trait Metric[+Type, -In, +Out] extends ZIOAspect[Nothing, Any, Nothing, Any, Not
     new ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] {
       def apply[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
         zio.foldCauseZIO(
-          cause => update(in) *> ZIO.refailCause(cause),
+          cause => update(in) *> Exit.failCause(cause),
           a => update(in) *> ZIO.succeed(a)
         )
     }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -935,7 +935,7 @@ object ZSTM {
                     commitEffects(onCommit) *> exit
                   case _ =>
                     onInterrupt()
-                    ZIO.refailCause(cause)
+                    Exit.failCause(cause)
                 }
               },
               s => {
@@ -1516,18 +1516,18 @@ object ZSTM {
               state match {
                 case State.Done(Exit.Success(a), _) =>
                   release(a).foldCauseZIO(
-                    cause2 => ZIO.refailCause(cause ++ cause2),
-                    _ => ZIO.refailCause(cause)
+                    cause2 => Exit.failCause(cause ++ cause2),
+                    _ => Exit.failCause(cause)
                   )
-                case _ => ZIO.refailCause(cause)
+                case _ => Exit.failCause(cause)
               }
             },
             a =>
               restore(use(a)).foldCauseZIO(
                 cause =>
                   release(a).foldCauseZIO(
-                    cause2 => ZIO.refailCause(cause ++ cause2),
-                    _ => ZIO.refailCause(cause)
+                    cause2 => Exit.failCause(cause ++ cause2),
+                    _ => Exit.failCause(cause)
                   ),
                 b => release(a) *> ZIO.succeed(b)
               )

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -642,7 +642,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
                           c =>
                             releaseMap
                               .releaseAll(Exit.fail(c), ExecutionStrategy.Sequential) *>
-                              ZIO.refailCause(c),
+                              Exit.failCause(c),
                           { case (release, a) =>
                             ZIO.succeed(
                               ZManaged {

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -656,18 +656,18 @@ final class ZSink[-R, +E, -In, +L, +Z] private (val channel: ZChannel[R, ZNothin
   )(f: (Z, Z1) => Z2)(implicit trace: Trace): ZSink[R1, E1, In1, L1, Z2] =
     self.raceWith(that)(
       {
-        case Exit.Failure(err) => ZChannel.MergeDecision.done(ZIO.refailCause(err))
+        case Exit.Failure(err) => ZChannel.MergeDecision.done(Exit.failCause(err))
         case Exit.Success(lz) =>
           ZChannel.MergeDecision.await {
-            case Exit.Failure(cause) => ZIO.refailCause(cause)
+            case Exit.Failure(cause) => Exit.failCause(cause)
             case Exit.Success(rz)    => ZIO.succeed(f(lz, rz))
           }
       },
       {
-        case Exit.Failure(err) => ZChannel.MergeDecision.done(ZIO.refailCause(err))
+        case Exit.Failure(err) => ZChannel.MergeDecision.done(Exit.failCause(err))
         case Exit.Success(rz) =>
           ZChannel.MergeDecision.await {
-            case Exit.Failure(cause) => ZIO.refailCause(cause)
+            case Exit.Failure(cause) => Exit.failCause(cause)
             case Exit.Success(lz)    => ZIO.succeed(f(lz, rz))
           }
       }

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -80,7 +80,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
   final def execute(defExec: ExecutionStrategy)(implicit
     trace: Trace
   ): ZIO[R with Scope, Nothing, Spec[Any, E]] =
-    ZIO.environmentWithZIO(provideEnvironment(_).foreachExec(defExec)(ZIO.refailCause(_), ZIO.succeed(_)))
+    ZIO.environmentWithZIO(provideEnvironment(_).foreachExec(defExec)(Exit.failCause, ZIO.successFn))
 
   /**
    * Returns a new spec with only those tests with annotations satisfying the
@@ -158,7 +158,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
       case LabeledCase(label, spec) => spec.foldScoped[R1, E1, Z](defExec)(f).flatMap(z => f(LabeledCase(label, z)))
       case ScopedCase(scoped) =>
         scoped.foldCauseZIO(
-          c => f(ScopedCase(ZIO.refailCause(c))),
+          c => f(ScopedCase(Exit.failCause(c))),
           spec => spec.foldScoped[R1, E1, Z](defExec)(f).flatMap(z => f(ScopedCase(ZIO.succeed(z))))
         )
       case MultipleCase(specs) =>


### PR DESCRIPTION
Main changes:
1. Use `Exit.unit` over `ZIO.unit` whenever laziness is already guaranteed via an outer effect
2. Use `Exit.succeed` instead of `ZIO.succeed` within `ZIO.withFiberRuntime` functions
3. Use `Exit.failCause` instead of `ZIO.refailCause`. These two methods have the exact same implementation (`Exit.Failure(cause)`). However, `ZIO.refailCause` requires an _unused_ implicit `Trace` which causes closures in lambdas
4. Use `case _: Success[?]` instead of `case Success(_)` and `case s: Success[A] => s` over `case s @ Success(_)` when pattern-matching which are cheaper