### PR TITLE
[WIP] ZStream.groupedWithin works in unexpected way for infinite stream #8686

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1714,13 +1714,14 @@ object ZStreamSpec extends ZIOBaseSpec {
           testM("group based on time passed (#8686)") {
             assertM(for {
               q <- Queue.unbounded[Chunk[Int]]
-              resF <- ZStream.fromChunkQueue(q)
-                .groupedWithin(3, 2.seconds)
-                .provideCustomLayer(Clock.live)
-                .take(1)
-                .runCollect
-                .fork
-              _ <- (q.offer(Chunk(1, 2)) *> q.offer(Chunk()).forever).fork
+              resF <- ZStream
+                        .fromChunkQueue(q)
+                        .groupedWithin(3, 2.seconds)
+                        .provideCustomLayer(Clock.live)
+                        .take(1)
+                        .runCollect
+                        .fork
+              _   <- (q.offer(Chunk(1, 2)) *> q.offer(Chunk()).forever).fork
               res <- resF.join
             } yield res)(equalTo(Chunk(Chunk(1, 2))))
           } @@ timeout(4.seconds) @@ repeats(5),


### PR DESCRIPTION
/claim https://github.com/zio/zio/issues/8686
If I understand correctly, the issue could happen when producer is fast, in such cases schedule could be ignored in function `aggregateAsyncWithinEither`. I think it happens because in this code `waitForSchedule.raceWith(waitForProducer)` there is no guarantee that `waitForSchedule` fiber would win race with `waitForProducer` even if scheduler had already signaled. 
Added test reproduces original behavior on my system, it uses `Clock.live`, I couldn't make it work with `TestClock`

These issues could also be related:

- https://github.com/zio/zio/issues/4061
- https://github.com/zio/zio/issues/3639