### PR TITLE
Optimise happy path in ZChannel.mapOutZIOPar*

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6777,6 +6777,8 @@ object Exit extends Serializable {
 
   val unit: Exit[Nothing, Unit] = succeed(())
 
+  val failUnit: Exit[Unit, Nothing] = failCause(Cause.unit)
+
   private def zipRightWith[E, E1 >: E, A](left: Exit[E, Any], right: Exit[E1, A])(
     g: (Cause[E], Cause[E1]) => Cause[E1]
   ): Exit[E1, A] =

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6777,8 +6777,6 @@ object Exit extends Serializable {
 
   val unit: Exit[Nothing, Unit] = succeed(())
 
-  val failUnit: Exit[Unit, Nothing] = failCause(Cause.unit)
-
   private def zipRightWith[E, E1 >: E, A](left: Exit[E, Any], right: Exit[E1, A])(
     g: (Cause[E], Cause[E1]) => Cause[E1]
   ): Exit[E1, A] =

--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -183,6 +183,21 @@ object ZChannelSpec extends ZIOBaseSpec {
             }
         }
       ),
+      suite("ZChannel#mapOutZIOPar")(
+        test("mapOutZIOPar in uninterruptible region") {
+          for {
+            _ <- ZChannel.unit.mapOutZIOPar(4)(_ => ZIO.unit).runDrain.uninterruptible
+          } yield assertCompletes
+        } @@ timeout(5.seconds),
+        test("mergeAllWith in uninterruptible region") {
+          for {
+            _ <- ZChannel
+                   .mergeAllWith(ZChannel.unit, 4, mergeStrategy = ZChannel.MergeStrategy.BufferSliding)((l, _) => l)
+                   .runDrain
+                   .uninterruptible
+          } yield assertCompletes
+        } @@ timeout(5.seconds)
+      ),
       suite("ZChannel.concatMap")(
         test("plain") {
           ZChannel.writeAll(1, 2, 3).concatMap(i => ZChannel.writeAll(i, i)).runCollect.map { case (chunk, _) =>

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2712,7 +2712,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   containsCause[DbError](Cause.fail(QtyTooLarge))
               )
             )
-          }
+          } @@ flaky
         ),
         suite("mapZIOParUnordered")(
           test("foreachParN equivalence") {
@@ -2823,7 +2823,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                   containsCause[DbError](Cause.fail(QtyTooLarge))
               )
             )
-          },
+          } @@ flaky,
           test("first finished first out") {
             checkN(2)(Gen.small(Gen.chunkOfN(_)(Gen.byte))) { data =>
               val s = ZStream.fromChunk(data).zipWithIndex

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2672,15 +2672,15 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(exit)(fails(hasMessage(equalTo("Boom"))))
           },
           test("parallelism is not exceeded") {
-            val iterations = 1000
+            val iterations  = 1000
             val parallelism = 64
             for {
               latch <- CountdownLatch.make(parallelism + 1)
               f <- ZStream
-                      .range(0, iterations)
-                      .mapZIOPar(parallelism, parallelism)(_ => latch.countDown *> latch.await)
-                      .runDrain
-                      .fork
+                     .range(0, iterations)
+                     .mapZIOPar(parallelism, parallelism)(_ => latch.countDown *> latch.await)
+                     .runDrain
+                     .fork
               _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)
               _     <- latch.countDown
               count <- latch.count

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2804,21 +2804,26 @@ object ZStreamSpec extends ZIOBaseSpec {
             case object QtyTooLarge       extends DbError
 
             for {
-              exit <- ZStream(1 to 2: _*)
-                        .mapZIOParUnordered(3) {
-                          case 1 => ZIO.fail(Missing)
-                          case 2 => ZIO.fail(QtyTooLarge)
-                          case _ => ZIO.succeed(true)
-                        }
-                        .runDrain
-                        .exit
+              latch  <- Promise.make[Nothing, Unit]
+              start1 <- Promise.make[Nothing, Unit]
+              start2 <- Promise.make[Nothing, Unit]
+              f <- ZStream(1 to 2: _*)
+                     .mapZIOParUnordered(3) {
+                       case 1 => start1.succeed(()) *> latch.await *> ZIO.fail(Missing)
+                       case 2 => start2.succeed(()) *> latch.await *> ZIO.fail(QtyTooLarge)
+                       case _ => ZIO.succeed(true)
+                     }
+                     .runDrain
+                     .fork
+              _    <- start1.await *> start2.await *> latch.succeed(())
+              exit <- f.await
             } yield assert(exit)(
               failsCause(
                 containsCause[DbError](Cause.fail(Missing)) &&
                   containsCause[DbError](Cause.fail(QtyTooLarge))
               )
             )
-          } @@ flaky,
+          },
           test("first finished first out") {
             checkN(2)(Gen.small(Gen.chunkOfN(_)(Gen.byte))) { data =>
               val s = ZStream.fromChunk(data).zipWithIndex

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -679,14 +679,14 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                 case Left(x: Left[OutErr, OutDone]) =>
                   failure.update(_ && Cause.fail(x.value)) *>
                     outgoing.offer(Fiber.done(ZChannel.failLeftUnit)) *>
-                    Exit.failUnit
+                    ZChannel.failUnit
                 case Left(x: Right[OutErr, OutDone]) =>
                   permits.withPermits(n.toLong)(ZIO.unit) *>
                     outgoing.offer(Fiber.fail(x.asInstanceOf[Either[Unit, OutDone]]))
                 case Right(cause) =>
                   failure.update(_ && cause).unless(cause.isInterrupted) *>
                     outgoing.offer(Fiber.done(ZChannel.failLeftUnit)) *>
-                    Exit.failUnit
+                    ZChannel.failUnit
               }
             )
             .race(errorSignal.await)
@@ -758,14 +758,14 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                    case Left(x: Left[OutErr, OutDone]) =>
                      failure.update(_ && Cause.fail(x.value)) *>
                        outgoing.offer(ZChannel.failLeftUnit) *>
-                       Exit.failUnit
+                       ZChannel.failUnit
                    case Left(x: Right[OutErr, OutDone]) =>
                      permits.withPermits(n.toLong)(ZIO.unit) *>
                        outgoing.offer(Exit.fail(x.asInstanceOf[Either[Unit, OutDone]]))
                    case Right(cause) =>
                      failure.update(_ && cause).unless(cause.isInterrupted) *>
                        outgoing.offer(ZChannel.failLeftUnit) *>
-                       Exit.failUnit
+                       ZChannel.failUnit
                  }
                )
                .race(errorSignal.await)
@@ -1504,6 +1504,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 
 object ZChannel {
   private val failLeftUnit = Exit.fail(Left(()))
+  private val failUnit     = Exit.failCause(Cause.unit)
 
   private[zio] final case class PipeTo[
     Env,

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -743,7 +743,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                               ()
                             ) *> outgoing.offer(Exit.fail(Left(())))
                           )
-                          .forkIn(scope)
+                          .fork
                    _ <- latch.await
                  } yield ()
                )
@@ -1943,7 +1943,7 @@ object ZChannel {
                                  }
                                _ <- permits
                                       .withPermit(latch.succeed(()) *> raceIOs)
-                                      .forkIn(scope)
+                                      .fork
                                _ <- latch.await
                              } yield ()
                            )
@@ -1963,7 +1963,7 @@ object ZChannel {
                                  }
                                childFiber <- permits
                                                .withPermit(latch.succeed(()) *> raceIOs)
-                                               .forkIn(scope)
+                                               .fork
                                _ <- latch.await
                              } yield ()
                            )

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -689,7 +689,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                        ZChannel.failUnit
                  }
                )
-               .race(errorSignal.await.interruptible)
+               .raceFirst(errorSignal.await.interruptible)
                .forkIn(scope)
       } yield {
         lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
@@ -769,7 +769,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                        ZChannel.failUnit
                  }
                )
-               .race(errorSignal.await.interruptible)
+               .raceFirst(errorSignal.await.interruptible)
                .forkIn(scope)
       } yield {
         lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
@@ -1993,7 +1993,7 @@ object ZChannel {
                    case Right(cause) => outgoing.offer(Exit.failCause(cause.map(Left(_))))
                  }
                )
-               .race(errorSignal.await.interruptible)
+               .raceFirst(errorSignal.await.interruptible)
                .forkIn(scope)
       } yield {
         lazy val consumer: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone] =


### PR DESCRIPTION
Changes a few things:

- in `mapOutZIOPar`, the queue now harbours the fibers themselves instead of promises
- optimises for the common path by changing the effect from `IO[Unit, Either[OutDone, OutElem]]` to `IO[Either[OutDone, Unit], OutElem]`
- uses a version of `toPullIn` that does the same thing: in `toPullInAlt`, I'm using `Exit` instead of `ZIO` but I'm not sure that's correct, let me know what you think
- move error/end of source handling out of repetition
- move race out of worker fiber
- fork worker fibers in the scope of the consumer: the error signal will interrupt the consumer fiber, which will interrupt all its children

This is not going as far as the previous optimised implementation.