### PR TITLE
Reduce CI test time & optimize zio-test execution

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -218,6 +218,14 @@ object SpecSpec extends ZIOBaseSpec {
       test("some other test") {
         assertCompletes
       }
-    ).provideLayerShared(neverFinalizerLayer)
+    ).provideLayerShared(neverFinalizerLayer) @@ shutdownTimeout(2.seconds)
   )
+
+  private def shutdownTimeout(d: Duration): TestAspectPoly =
+    new PerTest.Poly {
+      def perTest[R, E](
+        test: ZIO[R, TestFailure[E], TestSuccess]
+      )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] =
+        TestExecutor.overrideShutdownTimeout.set(Some(d)) *> test
+    }
 }

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -30,6 +30,11 @@ abstract class TestExecutor[+R, E] {
 }
 object TestExecutor {
 
+  // Used to override the default shutdown for a suite so we don't have to wait 60 seconds in some tests.
+  // Might be useful to make public at some point
+  private[zio] val overrideShutdownTimeout: FiberRef[Option[Duration]] =
+    FiberRef.unsafe.make[Option[Duration]](None)(Unsafe)
+
   def default[R, E](
     sharedSpecLayer: ZLayer[Any, E, R],
     freshLayerPerSpec: ZLayer[Any, Nothing, TestEnvironment with Scope],
@@ -66,14 +71,20 @@ object TestExecutor {
                     scope
                       .extend(managed.flatMap(loop(labels, _, exec, ancestors, sectionId)))
                       .onExit { exit =>
-                        val warning =
-                          "Warning: ZIO Test is attempting to close the scope of suite " +
-                            s"${labels.reverse.mkString(" - ")} in $fullyQualifiedName, " +
-                            "but closing the scope has taken more than 60 seconds to " +
-                            "complete. This may indicate a resource leak."
                         for {
+                          timeout <- overrideShutdownTimeout.get.map(_.getOrElse(60.seconds))
                           warning <-
-                            ZIO.logWarning(warning).delay(60.seconds).withClock(ClockLive).interruptible.forkDaemon
+                            ZIO
+                              .logWarning({
+                                "Warning: ZIO Test is attempting to close the scope of suite " +
+                                  s"${labels.reverse.mkString(" - ")} in $fullyQualifiedName, " +
+                                  s"but closing the scope has taken more than ${timeout.toSeconds} seconds to " +
+                                  "complete. This may indicate a resource leak."
+                              })
+                              .delay(timeout)
+                              .withClock(ClockLive)
+                              .interruptible
+                              .forkDaemon
                           finalizer <- scope.close(exit).ensuring(warning.interrupt).forkDaemon
                           exit      <- warning.await
                           _         <- finalizer.join.when(exit.isInterrupted)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -334,8 +334,9 @@ package object test extends CompileVariants {
                for {
                  fiber <- ZIO
                             .logWarning({
+                              val quotedLabel = "\"" + label + "\""
                               s"Warning: ZIO Test is attempting to interrupt fiber " +
-                                s"${child.id} forked in test \"$label\" due to automatic, " +
+                                s"${child.id} forked in test $quotedLabel due to automatic, " +
                                 "supervision, but interruption has taken more than 10 " +
                                 "seconds to complete. This may indicate a resource leak. " +
                                 "Make sure you are not forking a fiber in an " +

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -328,24 +328,27 @@ package object test extends CompileVariants {
                    )
                    .intoPromise(promise)
                    .forkDaemon
-        result     <- promise.await
-        _          <- child.inheritAll
-        quotedLabel = "\"" + label + "\""
-        warning =
-          s"Warning: ZIO Test is attempting to interrupt fiber " +
-            s"${child.id} forked in test ${quotedLabel} due to automatic, " +
-            "supervision, but interruption has taken more than 10 " +
-            "seconds to complete. This may indicate a resource leak. " +
-            "Make sure you are not forking a fiber in an " +
-            "uninterruptible region."
-        fiber <- ZIO
-                   .logWarning(warning)
-                   .delay(10.seconds)
-                   .withClock(Clock.ClockLive)
-                   .interruptible
-                   .forkDaemon
-                   .onExecutor(Runtime.defaultExecutor)
-        _ <- (child.interrupt *> fiber.interrupt).forkDaemon.onExecutor(Runtime.defaultExecutor)
+        result <- promise.await
+        _      <- child.inheritAll
+        _ <- ZIO.whenDiscard(child.isAlive()) {
+               for {
+                 fiber <- ZIO
+                            .logWarning({
+                              s"Warning: ZIO Test is attempting to interrupt fiber " +
+                                s"${child.id} forked in test \"$label\" due to automatic, " +
+                                "supervision, but interruption has taken more than 10 " +
+                                "seconds to complete. This may indicate a resource leak. " +
+                                "Make sure you are not forking a fiber in an " +
+                                "uninterruptible region."
+                            })
+                            .delay(10.seconds)
+                            .withClock(Clock.ClockLive)
+                            .interruptible
+                            .forkDaemon
+                            .onExecutor(Runtime.defaultExecutor)
+                 _ <- (child.interrupt *> fiber.interrupt).forkDaemon.onExecutor(Runtime.defaultExecutor)
+               } yield ()
+             }
       } yield result
   }
 


### PR DESCRIPTION
There is a test that takes 60 seconds to complete because it awaits for the scoped layer to finalize, which has a `ZIO.never` in it. The timeout is currently hardcoded to 60 seconds, which is a fairly long time for a test to run in CI. With this PR we make it configurable (not exposed publically) so that we can run that test much faster and reduce overall CI time by 1 minute.

In addition, I noticed that in some cases we were forking fibers unnecessarily when executing tests (e.g., interrupting a child that might already be completed). This change might help with reducing test execution time especially on low CPU machines