### PR TITLE
Config.Secret's length leak

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -7,6 +7,36 @@ import zio.Config.Secret
 
 object ConfigSpec extends ZIOBaseSpec {
 
+  def boxTest[A](slow: ZIO[Any, Throwable, A], fast: ZIO[Any, Throwable, A]): ZIO[Any, Throwable, Boolean] = {
+
+    //Box test from "Opportunities and Limits of Remote Timing Attacks", Scott A. Crosby, Dan S. Wallach, Rudolf H. Riedi
+    val i = 0.03
+    val j = 0.06
+
+    val nOfTries = 1000
+
+    def statistics[A](a: ZIO[Any, Throwable, A]): ZIO[Any, Throwable, (Long, Long)] =
+      ZIO.loop(0)(_ < nOfTries, _ + 1)(_ => measure(a)).map { sampleUnsorted =>
+        val sample = sampleUnsorted.sorted
+        val tail   = sample.drop((nOfTries * i).round.toInt)
+        val low    = tail.head
+        val high   = tail.drop((nOfTries * (j - i)).round.toInt).head
+        (low, high)
+      }
+
+    def measure[A](f: ZIO[Any, Throwable, A]): ZIO[Any, Throwable, Long] =
+      for {
+        before <- Clock.nanoTime
+        _      <- f
+        after  <- Clock.nanoTime
+      } yield after - before
+
+    for {
+      statisticsA <- statistics(slow)
+      statisticsB <- statistics(fast)
+    } yield !(statisticsB._2 < statisticsA._1)
+  }
+
   def secretSuite =
     suite("Secret")(
       test("Chunk constructor") {
@@ -49,7 +79,32 @@ object ConfigSpec extends ZIOBaseSpec {
           secret.unsafe.wipe(Unsafe.unsafe)
 
           assertTrue(secret.hashCode == Chunk.fill[Char]("secret".length)(0).hashCode)
-        }
+        } +
+        suite("timing vulnerabilities")(
+          test("doesn't leak length") {
+            val secret          = zio.Config.Secret("some-secret" * 1000)
+            val differentLength = zio.Config.Secret("some-secre" * 1000)
+            val sameLength      = zio.Config.Secret("some-secrez" * 1000)
+            assertZIO(boxTest(ZIO.attempt(secret equals sameLength), ZIO.attempt(secret equals differentLength)))(
+              equalTo(true)
+            )
+          },
+          test("leak length inverted") {
+            val secret          = zio.Config.Secret("some-secret" * 1000)
+            val differentLength = zio.Config.Secret("some-secre" * 1000)
+            val sameLength      = zio.Config.Secret("some-secrez" * 1000)
+            assertZIO(boxTest(ZIO.attempt(sameLength equals secret), ZIO.attempt(differentLength equals secret)))(
+              equalTo(false)
+            )
+          },
+          test("doesn't leak char") {
+            val secret     = zio.Config.Secret("some-secret" * 1000)
+            val sameLength = zio.Config.Secret("some-secrez" * 1000)
+            assertZIO(boxTest(ZIO.attempt(secret equals secret), ZIO.attempt(secret equals sameLength)))(
+              equalTo(true)
+            )
+          }
+        ) @@ TestAspect.sequential @@ TestAspect.withLiveClock @@ TestAspect.flaky
     )
 
   def withDefaultSuite =

--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -90,7 +90,7 @@ object ConfigSpec extends ZIOBaseSpec {
             val secret          = zio.Config.Secret("some-secret" * 1000)
             val differentLength = zio.Config.Secret("some-secre" * 1000)
             val sameLength      = zio.Config.Secret("some-secrez" * 1000)
-            assertZIO(boxTest(ZIO.attempt(secret equals sameLength), ZIO.attempt(secret equals differentLength)), 0.9)(
+            assertZIO(boxTest(ZIO.attempt(secret equals sameLength), ZIO.attempt(secret equals differentLength), 0.9))(
               equalTo(true)
             )
           },
@@ -105,7 +105,7 @@ object ConfigSpec extends ZIOBaseSpec {
           test("doesn't leak char") {
             val secret     = zio.Config.Secret("some-secret" * 1000)
             val sameLength = zio.Config.Secret("some-secrez" * 1000)
-            assertZIO(boxTest(ZIO.attempt(secret equals secret), ZIO.attempt(secret equals sameLength)), 0.9)(
+            assertZIO(boxTest(ZIO.attempt(secret equals secret), ZIO.attempt(secret equals sameLength), 0.9))(
               equalTo(true)
             )
           }

--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -10,8 +10,8 @@ object ConfigSpec extends ZIOBaseSpec {
   def boxTest[A](slow: ZIO[Any, Throwable, A], fast: ZIO[Any, Throwable, A]): ZIO[Any, Throwable, Boolean] = {
 
     //Box test from "Opportunities and Limits of Remote Timing Attacks", Scott A. Crosby, Dan S. Wallach, Rudolf H. Riedi
-    val i = 0.03
-    val j = 0.06
+    val i = 0.02
+    val j = 0.2
 
     val nOfTries = 1000
 

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -154,11 +154,15 @@ object Config {
   final class Secret private (private val raw: Array[Char]) { self =>
     override def equals(that: Any): Boolean =
       that match {
-        case that: Secret =>
-          self.raw.length == that.raw.length &&
-            (0 until raw.length).foldLeft(true) { (b, i) =>
-              self.raw(i) == that.raw(i) && b
-            }
+        case that: Secret => {
+          val selfLength = self.raw.length
+          val thatLength = that.raw.length
+          val isEqual    = if (selfLength == thatLength) 0 else 1
+          (0 until selfLength).foldLeft(isEqual) { (b, i) =>
+            val char = if (i >= thatLength) "a".head else that.raw(i)
+            b | (self.raw(i) ^ char)
+          } == 0
+        }
         case _ => false
       }
 

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -159,7 +159,7 @@ object Config {
           val thatLength = that.raw.length
           val isEqual    = if (selfLength == thatLength) 0 else 1
           (0 until selfLength).foldLeft(isEqual) { (b, i) =>
-            val char = if (i >= thatLength) "a".head else that.raw(i)
+            val char = if (i >= thatLength) 'a' else that.raw(i)
             b | (self.raw(i) ^ char)
           } == 0
         }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -158,9 +158,11 @@ object Config {
           val selfLength = self.raw.length
           val thatLength = that.raw.length
           var isEqual    = if (selfLength == thatLength) 0 else 1
-          for (i <- 0 until selfLength) {
+          var i          = 0
+          while (i < selfLength) {
             val char = if (i >= thatLength) 'a' else that.raw(i)
             isEqual = isEqual | (self.raw(i) ^ char)
+            i += 1
           }
           isEqual == 0
         }

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -157,11 +157,12 @@ object Config {
         case that: Secret => {
           val selfLength = self.raw.length
           val thatLength = that.raw.length
-          val isEqual    = if (selfLength == thatLength) 0 else 1
-          (0 until selfLength).foldLeft(isEqual) { (b, i) =>
+          var isEqual    = if (selfLength == thatLength) 0 else 1
+          for (i <- 0 until selfLength) {
             val char = if (i >= thatLength) 'a' else that.raw(i)
-            b | (self.raw(i) ^ char)
-          } == 0
+            isEqual = isEqual | (self.raw(i) ^ char)
+          }
+          isEqual == 0
         }
         case _ => false
       }


### PR DESCRIPTION
When the lengths of the secrets differ, it returns inmediately, which could theoretically leak the length of the secret. Also, using bit-wise operations might help avoiding potential optimizations. See zio/zio-http#3039.