### PR TITLE
Optimise `Secret` creation from `String`

### DIFF
--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -176,9 +176,9 @@ object Config {
   object Secret extends (Chunk[Char] => Secret) {
     def apply(chunk: Chunk[Char]): Secret = new Secret(chunk.toArray)
 
-    def apply(cs: CharSequence): Secret = Secret(cs.toString())
+    def apply(cs: CharSequence): Secret = Secret(cs.toString)
 
-    def apply(s: String): Secret = Secret(Chunk.fromArray(s.toCharArray))
+    def apply(s: String): Secret = new Secret(s.toCharArray)
 
     def unapply(secret: Secret): Some[Chunk[Char]] = Some(secret.value)
   }


### PR DESCRIPTION
Before it was:
1. transforming the `String` to a `Arrar[Char]`
2. Wrapping this `Array[Char]` in a `CharArray`
3. Calling `.toArray` on this `CharArray` which creates a new `Array[Char]` and copy the value from the initial `Array[Char]` to this new `Array[Char]`