### PR TITLE
Update Scala Native to 0.5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,9 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4.1.1
+      - name: Install Boehm GC
+        if: ${{ startsWith(matrix.platform, 'Native') }}
+        run: sudo apt-get update && sudo apt-get install -y libgc-dev
       - name: Setup Java
         uses: actions/setup-java@v4.2.1
         with:

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -6,7 +6,7 @@ import sbtbuildinfo.*
 import sbtbuildinfo.BuildInfoKeys.*
 import sbtcrossproject.CrossPlugin.autoImport.*
 
-import scala.scalanative.build.Mode
+import scala.scalanative.build.{GC, Mode}
 import scala.scalanative.sbtplugin.ScalaNativePlugin.autoImport.*
 
 object BuildHelper {
@@ -247,7 +247,7 @@ object BuildHelper {
       val os = System.getProperty("os.name").toLowerCase
       // For some unknown reason, we can't run the test suites in debug mode on MacOS
       if (os.contains("mac")) cfg.withMode(Mode.releaseFast)
-      else cfg
+      else cfg.withGC(GC.boehm) // See https://github.com/scala-native/scala-native/issues/4032
     },
     scalacOptions += "-P:scalanative:genStaticForwardersForNonTopLevelObjects",
     Test / fork := crossProjectPlatform.value == JVMPlatform // set fork to `true` on JVM to improve log readability, JS and Native need `false`

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossprojec
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.16.0")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.5.4")
-addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.5.4")
+addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.5.5")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.5.2")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.7")


### PR DESCRIPTION
Note that the GC change is only needed for 1 test which is memory intensive, so users / libraries don't need to do the same. Once / if that's fixed upstream I think we can remove that config