### PR TITLE
Fix make macro

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -160,7 +160,7 @@ private[zio] trait LayerMacroUtils {
 
     intersectionTypes
       .map(_.dealias)
-      .filterNot(t => typeOf[Any] <:< t)
+      .filterNot(t => typeOf[Object] <:< t || typeOf[Any] <:< t)
       .distinct
   }
 

--- a/core/shared/src/main/scala/zio/internal/macros/RenderedGraph.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/RenderedGraph.scala
@@ -25,7 +25,7 @@ private[macros] object RenderedGraph {
     override def >>>(that: RenderedGraph): RenderedGraph =
       that match {
         case Value(string, children) => Value(string, self +: children)
-        case Row(_)                  => throw new Error("NOT LIKE THIS")
+        case Row(values)             => Row(self +: values)
       }
 
     override def render(depth: Int): String = {
@@ -72,7 +72,7 @@ private[macros] object RenderedGraph {
     override def >>>(that: RenderedGraph): RenderedGraph =
       that match {
         case Value(string, children) => Value(string, self.values ++ children)
-        case Row(_)                  => throw new Error("NOT LIKE THIS")
+        case Row(values2)            => Row(values ++ values2)
       }
 
     override def render(depth: Int): String =


### PR DESCRIPTION
`Graph` implementation using a `List` instead of a `Map` so that possible differences in how scala registers as keys the types are not a problem. I think this should be somewhat faster and could potentially use more memory if there is a lot of redundancy.

@kyri-petrou, @RobVermazeren, @strokyl, I don't know if this fixes #9145 because I can't reproduce the issue. The tests for zio and zio-test were passing and I haven't been able to reproduce the issue locally with non-zio repositories. If someone of you could either open a repository with a working example of the issue so I can check what's happening or try this version locally, that would be really helpful! 

Respect to the @butcherless issue, your error can only appear once the layer construction has been correct, so it isn't entirely related. I have added a fix for that. I don't know if it's the more appropriate as the layer construction is a bit more complex than before and can't be printed in such a nice way.