### PR TITLE
Fixes #9181 + added tests

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -282,7 +282,23 @@ object ZPipelineSpec extends ZIOBaseSpec {
           }
           .runCollect
           .map(assert(_)(equalTo(Chunk.range(1, 21))))
-      }
+      },
+      suite("intersperse")(
+        test("it intersperses elements") {
+          assertZIO(
+            ZStream('a', 'b', 'c').via(ZPipeline.intersperse(',')).runCollect
+          )(equalTo(Chunk('a', ',', 'b', ',', 'c'))
+          )
+        },
+        test("it intersperses elements with prefix and suffix") {
+          assertZIO(
+            ZStream('a', 'b', 'c').via(ZPipeline.intersperse('[', ',', ']')).runCollect
+          )(equalTo(Chunk('[', 'a', ',', 'b', ',', 'c', ']'))
+          )
+        },
+      )
+
+
     )
 
   val weirdStringGenForSplitLines: Gen[Any, Chunk[String]] = Gen

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -287,18 +287,14 @@ object ZPipelineSpec extends ZIOBaseSpec {
         test("it intersperses elements") {
           assertZIO(
             ZStream('a', 'b', 'c').via(ZPipeline.intersperse(',')).runCollect
-          )(equalTo(Chunk('a', ',', 'b', ',', 'c'))
-          )
+          )(equalTo(Chunk('a', ',', 'b', ',', 'c')))
         },
         test("it intersperses elements with prefix and suffix") {
           assertZIO(
             ZStream('a', 'b', 'c').via(ZPipeline.intersperse('[', ',', ']')).runCollect
-          )(equalTo(Chunk('[', 'a', ',', 'b', ',', 'c', ']'))
-          )
-        },
+          )(equalTo(Chunk('[', 'a', ',', 'b', ',', 'c', ']')))
+        }
       )
-
-
     )
 
   val weirdStringGenForSplitLines: Gen[Any, Chunk[String]] = Gen

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -24,15 +24,7 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import zio.stream.internal.SingleProducerAsyncInput
 
 import java.nio.{Buffer, ByteBuffer, CharBuffer}
-import java.nio.charset.{
-  CharacterCodingException,
-  Charset,
-  CharsetDecoder,
-  CoderResult,
-  MalformedInputException,
-  StandardCharsets,
-  UnmappableCharacterException
-}
+import java.nio.charset.{CharacterCodingException, Charset, CharsetDecoder, CoderResult, MalformedInputException, StandardCharsets, UnmappableCharacterException}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 /**
@@ -1679,7 +1671,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     )
 
   def intersperse[In](start: => In, middle: => In, end: => In)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    ZPipeline.prepend(Chunk.single(start)) >>> ZPipeline.intersperse(middle) >>> ZPipeline.append(Chunk.single(end))
+    ZPipeline.intersperse(middle) >>> ZPipeline.prepend(Chunk.single(start)) >>> ZPipeline.append(Chunk.single(end))
 
   /**
    * Creates a pipeline that converts a stream of bytes into a stream of strings

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -24,7 +24,15 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import zio.stream.internal.SingleProducerAsyncInput
 
 import java.nio.{Buffer, ByteBuffer, CharBuffer}
-import java.nio.charset.{CharacterCodingException, Charset, CharsetDecoder, CoderResult, MalformedInputException, StandardCharsets, UnmappableCharacterException}
+import java.nio.charset.{
+  CharacterCodingException,
+  Charset,
+  CharsetDecoder,
+  CoderResult,
+  MalformedInputException,
+  StandardCharsets,
+  UnmappableCharacterException
+}
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 
 /**


### PR DESCRIPTION
Fixes `ZPipeline.intersperse[In](start: => In, middle: => In, end: => In)`