### PR TITLE
Fix assert macro throwing missing method error in Scala 3

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -35,7 +35,7 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         } @@ failing,
         test("i9153") {
           val map = Map(1 -> 2)
-          assertTrue(map.view.mapValues(_ + 1).toMap == Map(1 -> 3))
+          assertTrue(map.view.map { case (k, v) => k -> (v + 1) }.toMap == Map(1 -> 3))
         }
       )
     ),

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -32,7 +32,11 @@ object SmartAssertionSpec extends ZIOBaseSpec {
           val a1 = Array(1, 2, 3)
           val a2 = Array(1, 3, 2)
           assertTrue(a1 == a2)
-        } @@ failing
+        } @@ failing,
+        test("i9153") {
+          val map = Map(1 -> 2)
+          assertTrue(map.view.mapValues(_ + 1).toMap == Map(1 -> 3))
+        }
       )
     ),
     test("multiple assertions") {


### PR DESCRIPTION
/fixes #9153
/claim #9153

Issue is that the current macro uses methods that are directly declared in the class. In the case of `.view`, it is declared in a subclass and therefore it cannot be found using `declaredFields` / `declaredMethods`