### PR TITLE
streams_timeout_bench: introducing benchmarks for stream.timeout (hap…

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/StreamParBenchmark.scala
@@ -8,11 +8,13 @@ import cats.effect.{IO => CatsIO}
 import fs2.{Chunk => FS2Chunk, Stream => FS2Stream}
 import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio.BenchmarkUtil._
+import zio.stream.ZChannel.MergeStrategy
+import zio.stream.ZStream.HaltStrategy
 import zio.stream._
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration => ScalaDuration}
-import scala.concurrent.{Await, ExecutionContextExecutor, Future}
+import scala.concurrent.{Await, ExecutionContextExecutor, Future, TimeoutException}
 
 @State(JScope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -246,4 +248,244 @@ class StreamParBenchmark {
       .covary[CatsIO]
       .unsafeRunSync()
   }*/
+
+  @Benchmark
+  def zioBaseStream : Long = {
+    val strm = ZStream
+      .fromIterable(zioChunks)
+      .flattenChunks
+
+    val result = strm
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioStreamWithTimeout : Long = {
+    val strm = ZStream
+      .fromIterable(zioChunks)
+      .flattenChunks
+
+    val result = strm
+      .timeoutFail(new TimeoutException("nah!"))(100.minutes)
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioStreamWithBetterTimeout : Long = {
+    val strm = ZStream
+      .fromIterable(zioChunks)
+      .flattenChunks
+
+    val strmTO = ZStream.unwrapScoped[Any] {
+      val s2 = ZStream.never.timeoutFail(new TimeoutException("nah!"))(100.minutes)
+
+      for{
+        q <- zio.Queue.bounded[zio.stream.Take[Throwable, Int]](1)
+        _ <- strm.runIntoQueueScoped(q).forkScoped
+        _ <- s2.runIntoQueueScoped(q).forkScoped
+      } yield {
+        ZStream
+          .fromQueue(q)
+          .flattenTake
+      }
+    }
+
+    val result = strmTO
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioStreamWithBetter2Timeout : Long = {
+    val strm = ZStream
+      .fromIterable(zioChunks)
+      .flattenChunks
+    val s2 = ZStream.never.timeoutFail(new TimeoutException("nah!"))(100.minutes)
+
+    val strmTO = {
+      StreamParBenchmark.betterTimeout(strm, 100.minutes)
+    }
+
+    val result = strmTO
+      .runCount
+      //.provideLayer(zio.Runtime.enableCurrentFiber)
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def zioStreamWithRubbishTimeout : Long = {
+    val strm = ZStream
+      .fromIterable(zioChunks)
+      .flattenChunks
+    val s2 = ZStream.never.timeoutFail(new TimeoutException("nah!"))(100.minutes)
+
+    case class Slot(res : zio.Promise[Option[Nothing], Res])
+    case class Res(chunk : Chunk[Int],
+              next : zio.Promise[Nothing, Slot])
+
+    def upstream(pull :  ZIO[Any, Option[Nothing], Chunk[Int]])(slot : Slot) : ZIO[Any, Nothing, Any] =
+      pull
+        .foldCauseZIO(
+          c => {
+            slot.res.failCause(c)
+          },
+          chunk => zio
+            .Promise.make[Nothing, Slot]
+            .flatMap{ next =>
+              slot.res.succeed(Res(chunk, next))  *>
+              next.await
+            }
+            .flatMap(upstream(pull))
+        )
+        .onInterrupt(slot.res.interrupt)
+
+    def downstream(slot : Slot) : ZChannel[Any, Any, Any, Any, Throwable, Chunk[Int], Any] =
+      ZChannel
+        .fromZIO(slot.res.await)
+        .foldCauseChannel(
+          c => {
+            Cause.flipCauseOption(c).fold(ZChannel.unit)(ZChannel.refailCause(_))
+          },
+          {
+            case Res(chunk, next) =>
+              ZChannel.write(chunk) *>
+              ZChannel.unwrap {
+                zio
+                  .Promise
+                  .make[Option[Nothing], Res]
+                  .flatMap{ p =>
+                    val nextSlot = Slot(p)
+                    next
+                      .succeed(nextSlot)
+                      .as(downstream(nextSlot))
+                  }
+              }
+          }
+        )
+
+    val strmTO = ZStream.unwrapScoped[Any] {
+      for {
+        pull <- strm.toPull
+        prom0 <- zio.Promise.make[Option[Nothing], Res]
+        slot0 = Slot(prom0)
+        fib <- upstream(pull)(slot0).forkScoped
+      } yield {
+        downstream(slot0).toStream
+      }
+    }
+
+
+    val result = strmTO
+      .runCount
+
+    unsafeRun(result)
+  }
+
+  @Benchmark
+  def akkaBaseline: Long = {
+    val src = AkkaSource
+      .fromIterator(() => akkaChunks.iterator.flatten)
+    val program = src
+      .toMat(AkkaSink.fold(0L)((c, ignored) => c + 1L))(Keep.right)
+    Await.result(program.run(), ScalaDuration.Inf)
+  }
+
+  @Benchmark
+  def akkaTimeout: Long = {
+    val src = AkkaSource
+      .fromIterator(() => akkaChunks.iterator.flatten)
+    val program = src
+      .completionTimeout(scala.concurrent.duration.FiniteDuration(100, TimeUnit.MINUTES))
+      .toMat(AkkaSink.fold(0L)((c, ignored) => c + 1L))(Keep.right)
+    Await.result(program.run(), ScalaDuration.Inf)
+  }
+}
+
+object StreamParBenchmark {
+  def main(args : Array[String]): Unit = {
+    val inst = new StreamParBenchmark
+    try {
+      inst.chunkCount = 10000
+      inst.chunkSize = 5000
+      inst.parChunkSize = 50
+      inst.setup()
+
+      //val l = inst.zioStreamWithBetter2Timeout
+      //println(l)
+      unsafeRun{
+        val timedOut = ZStream.never.timeoutFail(new TimeoutException)(0.second).debug("timedout")
+        val combined =
+          ZStream
+            .fromIterable(inst.zioChunks)
+            .flattenChunks
+            .concat(timedOut)
+            .take(200000)
+
+        //combined.runCount.debug("count")
+        val longTo = betterTimeout(
+          ZStream
+            .fromIterable(inst.zioChunks)
+            .flattenChunks,
+          5.minutes
+        )
+
+        longTo.runCount.debug("count")
+      }
+    }
+    inst.shutdown()
+  }
+
+  def betterTimeout(strm : ZStream[Any, Nothing, Int], to : zio.Duration) = {
+
+    ZStream
+      .unwrapScoped[Any]{
+        for {
+          ref <- zio.Ref.make[AnyRef] (null)
+          pull <- strm.toPull
+          timeoutFib <- ZIO
+            .sleep(to)
+            .zipRight{
+              ref.modify{
+                  case null =>
+                    ZIO.unit -> Left(new TimeoutException)
+                  case fib : zio.Fiber.Runtime[_, _] =>
+                    fib.interrupt -> Left(new TimeoutException)
+              }
+              .flatten
+            }
+            .forkScoped
+
+          pull2 = ZIO.withFiberRuntime{(fibRt : zio.Fiber.Runtime[Option[Nothing], Chunk[Int]], r)=>
+            ZIO.acquireReleaseWith{
+              ref
+                .modify{
+                  case null =>
+                    ZIO.unit -> fibRt
+                  case l @ Left(err) =>
+                    ZIO.interrupt -> l
+                }
+                .flatten
+            } {
+              _ => ref.modify {
+                  case `fibRt` =>
+                    ZIO.unit -> null
+                  case l @ Left(err) =>
+                    ZIO.interrupt -> l
+                }
+                .flatten
+            } { _ =>
+              pull
+            }
+          }
+        } yield {
+          ZStream.repeatZIOChunkOption(pull2)
+        }
+      }
+  }
 }


### PR DESCRIPTION
…py case) and starting to play around with an alternative implementation.

initial benchmarks results:

```
sbt 'benchmarks/jmh:run zio.StreamParBenchmark.(zioBaseStream|zioStreamWithTimeout|zioStreamWithBetterTimeout|zioStreamWithBetter2Timeout|akkaBaseline|akkaTimeout)'

[info] modes can be very significant. Please make sure you use the consistent Blackhole mode for comparisons.
[info] Benchmark                                       (chunkCount)  (chunkSize)  (parChunkSize)   Mode  Cnt     Score    Error  Units
[info] StreamParBenchmark.akkaBaseline                        10000         5000              50  thrpt   15    42.994 ±  0.223  ops/s
[info] StreamParBenchmark.akkaTimeout                         10000         5000              50  thrpt   15    38.291 ±  0.929  ops/s
[info] StreamParBenchmark.zioBaseStream                       10000         5000              50  thrpt   15  1137.631 ± 11.122  ops/s
[info] StreamParBenchmark.zioStreamWithBetter2Timeout         10000         5000              50  thrpt   15   182.103 ± 11.687  ops/s
[info] StreamParBenchmark.zioStreamWithBetterTimeout          10000         5000              50  thrpt   15    55.533 ±  2.963  ops/s
[info] StreamParBenchmark.zioStreamWithTimeout                10000         5000              50  thrpt   15    19.368 ±  2.564  ops/s
[success] Total time: 226 s (03:46), completed 19 Sept 2024, 19:43:22
```