### PR TITLE
Use reference equality in `ZEnvironment` when applying optimizations

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -69,6 +69,32 @@ final class ZEnvironment[+R] private (
   }
 
   /**
+   * Similar to `equals` but uses reference equality on the map's elements.
+   * Therefore, this method might result in false negatives but never in false
+   * positives.
+   *
+   * Useful for cases where failing the equality check will not produce an
+   * invalid state (e.g., applying optimizations) and we want to avoid the
+   * overhead of strict equality.
+   */
+  private def relaxedEquals(that: ZEnvironment[_]): Boolean =
+    if (self eq that) true
+    else if (self.scope ne that.scope) false
+    else if (self.map eq that.map) true
+    else if (self.map.size != that.map.size) false
+    else {
+      // We check in the reverse order since this is an update-ordered map
+      // We could potentially check only the last element but that might result in a false positive so better be safe
+      val l   = self.map.reverseIterator
+      val r   = that.map.reverseIterator
+      var res = true
+      while (l.hasNext && res) {
+        if (l.next() ne r.next()) res = false
+      }
+      res
+    }
+
+  /**
    * Retrieves a service from the environment.
    */
   def get[A >: R](implicit tag: Tag[A]): A =
@@ -184,7 +210,7 @@ final class ZEnvironment[+R] private (
    * the right hand side will be preferred.
    */
   def unionAll[R1](that: ZEnvironment[R1]): ZEnvironment[R with R1] =
-    if (self == that) that.asInstanceOf[ZEnvironment[R with R1]]
+    if (self.relaxedEquals(that)) that.asInstanceOf[ZEnvironment[R with R1]]
     else {
       val newMap = that.map.iterator.foldLeft(self.map) { case (map, (k, v)) =>
         map.updated(k, v)
@@ -395,9 +421,7 @@ object ZEnvironment {
       if (isEmpty) env0
       else {
         val out = loop(environment, self.asInstanceOf[Patch[Any, Any]] :: Nil).asInstanceOf[ZEnvironment[Out]]
-        // Unfortunately we can't rely on eq here. However, the ZEnvironment equals method uses a cached hashCode
-        // so it's pretty fast
-        if (env0 == out) env0 else out
+        if (env0.relaxedEquals(out)) env0 else out
       }
     }
 

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -89,7 +89,9 @@ final class ZEnvironment[+R] private (
       val r   = that.map.reverseIterator
       var res = true
       while (l.hasNext && res) {
-        if (l.next() ne r.next()) res = false
+        val (lk, lv) = l.next().asInstanceOf[(LightTypeTag, AnyRef)]
+        val (rk, rv) = r.next().asInstanceOf[(LightTypeTag, AnyRef)]
+        res = lk == rk && (lv eq rv)
       }
       res
     }


### PR DESCRIPTION
@ghostdogpr identified an issue w.r.t. `ZEnvironment#unionAll` being very expensive for cases that the ZEnvironment contained a single (or few) services that had a very expensive `equals` / `hashCode`.

After thinking a bit about it, I think that for cases where we need to determine whether to apply optimization shortcuts or not, we can use a relaxed variant of `equals` that checks each element of the map using reference equality. While this check might produce false positives in edge-case scenarios, it'll lead to more optimized code for most users that rely on `unionAll` in their code (or when updating `ZEnvironment` in the child fibers)