### PR TITLE
[9102] - add awaiting function to Semaphore

### DIFF
--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -40,15 +40,15 @@ object SemaphoreSpec extends ZIOBaseSpec {
         _         <- semaphore.withPermit(promise.await).fork
         _         <- ZIO.foreach(List.fill(10)(()))(_ => semaphore.withPermit(ZIO.unit).fork)
         waitingStart <- semaphore.awaiting
-          .flatMap(awaiting => if (awaiting < 10) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
-          .retryUntil(_ == 10)
-          .catchAll(n => ZIO.succeed(n))
+                          .flatMap(awaiting => if (awaiting < 10) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
+                          .retryUntil(_ == 10)
+                          .catchAll(n => ZIO.succeed(n))
         _ <- promise.succeed(())
 
         waitingEnd <- semaphore.awaiting
-          .flatMap(awaiting => if (awaiting > 0) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
-          .retryUntil(_ == 0)
-          .catchAll(n => ZIO.succeed(n))
+                        .flatMap(awaiting => if (awaiting > 0) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
+                        .retryUntil(_ == 0)
+                        .catchAll(n => ZIO.succeed(n))
       } yield assertTrue(waitingStart == 10) && assertTrue(waitingEnd == 0)
     }
   )

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -32,6 +32,24 @@ object SemaphoreSpec extends ZIOBaseSpec {
         _         <- ZIO.scoped(semaphore.withPermitsScoped(2))
         permits   <- semaphore.available
       } yield assertTrue(permits == 2L)
+    },
+    test("awaiting returns the count of waiting fibers") {
+      for {
+        semaphore <- Semaphore.make(1)
+        promise   <- Promise.make[Nothing, Unit]
+        _         <- semaphore.withPermit(promise.await).fork
+        _         <- ZIO.foreach(List.fill(10)(()))(_ => semaphore.withPermit(ZIO.unit).fork)
+        waitingStart <- semaphore.awaiting
+          .flatMap(awaiting => if (awaiting < 10) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
+          .retryUntil(_ == 10)
+          .catchAll(n => ZIO.succeed(n))
+        _ <- promise.succeed(())
+
+        waitingEnd <- semaphore.awaiting
+          .flatMap(awaiting => if (awaiting > 0) ZIO.fail(awaiting) else ZIO.succeed(awaiting))
+          .retryUntil(_ == 0)
+          .catchAll(n => ZIO.succeed(n))
+      } yield assertTrue(waitingStart == 10) && assertTrue(waitingEnd == 0)
     }
   )
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -40,8 +40,8 @@ sealed trait Semaphore extends Serializable {
   def available(implicit trace: Trace): UIO[Long]
 
   /**
-   * Returns the number of tasks currently waiting for permits.
-   * The default implementation returns 0.
+   * Returns the number of tasks currently waiting for permits. The default
+   * implementation returns 0.
    */
   def awaiting(implicit trace: Trace): UIO[Long] = ZIO.succeed(0L)
 
@@ -95,7 +95,7 @@ object Semaphore {
         override def awaiting(implicit trace: Trace): UIO[Long] =
           ref.get.map {
             case Left(queue) => queue.size.toLong
-            case Right(_) => 0L
+            case Right(_)    => 0L
           }
 
         def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -40,6 +40,12 @@ sealed trait Semaphore extends Serializable {
   def available(implicit trace: Trace): UIO[Long]
 
   /**
+   * Returns the number of tasks currently waiting for permits.
+   * The default implementation returns 0.
+   */
+  def awaiting(implicit trace: Trace): UIO[Long] = ZIO.succeed(0L)
+
+  /**
    * Executes the specified workflow, acquiring a permit immediately before the
    * workflow begins execution and releasing it immediately after the workflow
    * completes execution, whether by success, failure, or interruption.
@@ -84,6 +90,12 @@ object Semaphore {
           ref.get.map {
             case Left(_)        => 0L
             case Right(permits) => permits
+          }
+
+        override def awaiting(implicit trace: Trace): UIO[Long] =
+          ref.get.map {
+            case Left(queue) => queue.size.toLong
+            case Right(_) => 0L
           }
 
         def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -40,10 +40,9 @@ sealed trait Semaphore extends Serializable {
   def available(implicit trace: Trace): UIO[Long]
 
   /**
-   * Returns the number of tasks currently waiting for permits. The default
-   * implementation returns 0.
+   * Returns the number of tasks currently waiting for permits.
    */
-  def awaiting(implicit trace: Trace): UIO[Long] = ZIO.succeed(0L)
+  def awaiting(implicit trace: Trace): UIO[Long]
 
   /**
    * Executes the specified workflow, acquiring a permit immediately before the

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -40,9 +40,10 @@ sealed trait Semaphore extends Serializable {
   def available(implicit trace: Trace): UIO[Long]
 
   /**
-   * Returns the number of tasks currently waiting for permits.
+   * Returns the number of tasks currently waiting for permits. The default
+   * implementation returns 0.
    */
-  def awaiting(implicit trace: Trace): UIO[Long]
+  def awaiting(implicit trace: Trace): UIO[Long] = ZIO.succeed(0L)
 
   /**
    * Executes the specified workflow, acquiring a permit immediately before the
@@ -91,7 +92,7 @@ object Semaphore {
             case Right(permits) => permits
           }
 
-        def awaiting(implicit trace: Trace): UIO[Long] =
+        override def awaiting(implicit trace: Trace): UIO[Long] =
           ref.get.map {
             case Left(queue) => queue.size.toLong
             case Right(_)    => 0L

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -91,7 +91,7 @@ object Semaphore {
             case Right(permits) => permits
           }
 
-        override def awaiting(implicit trace: Trace): UIO[Long] =
+        def awaiting(implicit trace: Trace): UIO[Long] =
           ref.get.map {
             case Left(queue) => queue.size.toLong
             case Right(_)    => 0L

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,7 +14,6 @@ object MimaSettings {
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),
-        exclude[ReversedMissingMethodProblem]("zio.Semaphore.awaiting"),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.todo"),
         exclude[DirectMissingMethodProblem]("zio.stm.TRef.versioned_="),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned")

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,6 +14,7 @@ object MimaSettings {
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),
+        exclude[Problem]("zio.Semaphore.internal*"),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.todo"),
         exclude[DirectMissingMethodProblem]("zio.stm.TRef.versioned_="),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned")

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,7 +14,7 @@ object MimaSettings {
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),
-        exclude[Problem]("zio.Semaphore.internal*"),
+        exclude[ReversedMissingMethodProblem]("zio.Semaphore.awaiting"),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.todo"),
         exclude[DirectMissingMethodProblem]("zio.stm.TRef.versioned_="),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned")


### PR DESCRIPTION
Added awaiting function to Semaphore object to expose the size of the queue waiting for a semaphore to resolve issue [9102](https://github.com/zio/zio/issues/9102)