### PR TITLE
Remove mention of discontinued tools

### DIFF
--- a/docs/ecosystem/tools.md
+++ b/docs/ecosystem/tools.md
@@ -3,6 +3,4 @@ id: tools
 title:  "ZIO Tools"
 ---
 
-- [ZIO IntelliJ](https://github.com/zio/zio-intellij) — A complimentary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects
-- [zio-shield](https://github.com/zio/zio-shield) — Enforce best coding practices with ZIO
-- [zio/zio-zmx](https://github.com/zio/zio-zmx) — Monitoring, Metrics and Diagnostics for ZIO
+- [ZIO IntelliJ](https://github.com/zio/zio-intellij) — A complementary, community-developed plugin for IntelliJ IDEA, brings enhancements when using ZIO in your projects


### PR DESCRIPTION
`zio-zmx` and `zio-shield` seem to be dead for 2+ and 3+ years, respectively  
I asked on [discord](https://discord.com/channels/629491597070827530/630498701860929559/1287681555610992661) before creating this PR