### PR TITLE
Add junit 5 engine for zio tests. Resolves zio/zio#6724

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ addCommandAlias(
 )
 addCommandAlias(
   "testJVM",
-  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRefinedJVM/test;testRunnerJVM/test;testRunnerJVM/Test/run;examplesJVM/Test/compile;benchmarks/Test/compile;macrosTestsJVM/test;testJunitRunnerTests/test;concurrentJVM/test;managedTestsJVM/test"
+  ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRefinedJVM/test;testRunnerJVM/test;testRunnerJVM/Test/run;examplesJVM/Test/compile;benchmarks/Test/compile;macrosTestsJVM/test;testJunitRunnerTests/test;testJunitEngineTests/test;concurrentJVM/test;managedTestsJVM/test"
 )
 addCommandAlias(
   "testJVMNoBenchmarks",
@@ -97,6 +97,8 @@ lazy val rootJVM213 = project
       scalafixTests,
       testJunitRunner,
       testJunitRunnerTests,
+      testJunitEngine,
+      testJunitEngineTests,
       testMagnolia.jvm,
       testMagnoliaTests.jvm,
       testRefined.jvm,
@@ -111,7 +113,9 @@ lazy val rootJVM3 = project
   .aggregate(
     List[ProjectReference](
       testJunitRunner,
+      testJunitEngine,
 //      testJunitRunnerTests, TODO: fix test
+      testJunitEngineTests,
       testMagnolia.jvm,
       testMagnoliaTests.jvm,
       testRefined.jvm,
@@ -161,7 +165,9 @@ lazy val root213 = project
         benchmarks,
         scalafixTests,
         testJunitRunner,
-        testJunitRunnerTests
+        testJunitEngine,
+        testJunitRunnerTests,
+        testJunitEngineTests
       )) *
   )
 
@@ -180,7 +186,9 @@ lazy val root3 = project
       ).flatMap(p => List[ProjectReference](p.jvm, p.js)) ++
       List[ProjectReference](
         testJunitRunner,
-        testJunitRunnerTests
+        testJunitEngine,
+        testJunitRunnerTests,
+        testJunitEngineTests
       )) *
   )
 
@@ -494,7 +502,7 @@ lazy val testScalaCheck = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(crossProjectSettings)
   .settings(
     libraryDependencies ++= Seq(
-      ("org.scalacheck" %%% "scalacheck" % "1.18.0")
+      "org.scalacheck" %%% "scalacheck" % "1.18.0"
     )
   )
   .jsSettings(jsSettings)
@@ -578,6 +586,62 @@ lazy val testJunitRunnerTests = project.module
     Test / Keys.test :=
       (Test / Keys.test)
         .dependsOn(testJunitRunner / publishM2)
+        .dependsOn(tests.jvm / publishM2)
+        .dependsOn(core.jvm / publishM2)
+        .dependsOn(internalMacros.jvm / publishM2)
+        .dependsOn(streams.jvm / publishM2)
+        .dependsOn(stacktracer.jvm / publishM2)
+        .value
+  )
+
+lazy val testJunitEngine = project.module
+  .in(file("test-junit-engine"))
+  .settings(stdSettings("zio-test-junit-engine"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.junit.platform"      % "junit-platform-engine"   % "1.11.0",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0"
+    )
+  )
+  .dependsOn(tests.jvm)
+
+lazy val testJunitEngineTests = project.module
+  .in(file("test-junit-engine-tests"))
+  .settings(stdSettings("test-junit-engine-tests"))
+  .settings(Test / fork := true)
+  .settings(Test / javaOptions ++= {
+    Seq(
+      s"-Dproject.dir=${baseDirectory.value}",
+      s"-Dproject.version=${version.value}",
+      s"-Dscala.version=${scalaVersion.value}",
+      s"-Dscala.compat.version=${scalaBinaryVersion.value}"
+    )
+  })
+  .settings(publish / skip := true)
+  .settings(
+    libraryDependencies ++= Seq(
+      "junit"                   % "junit"     % "4.13.2" % Test,
+      "org.scala-lang.modules" %% "scala-xml" % "2.2.0"  % Test,
+      // required to run embedded maven in the tests
+      "org.apache.maven"          % "maven-embedder"                 % "3.9.6"  % Test,
+      "org.apache.maven"          % "maven-compat"                   % "3.9.6"  % Test,
+      "com.google.inject"         % "guice"                          % "4.0"    % Test,
+      "org.eclipse.sisu"          % "org.eclipse.sisu.inject"        % "0.3.5"  % Test,
+      "org.apache.maven.resolver" % "maven-resolver-connector-basic" % "1.9.18" % Test,
+      "org.apache.maven.resolver" % "maven-resolver-transport-http"  % "1.9.18" % Test,
+      "org.codehaus.plexus"       % "plexus-component-annotations"   % "2.2.0"  % Test,
+      "org.slf4j"                 % "slf4j-simple"                   % "1.7.36" % Test
+    )
+  )
+  .dependsOn(
+    tests.jvm,
+    testRunner.jvm
+  )
+  // publish locally so embedded maven runs against locally compiled zio
+  .settings(
+    Test / Keys.test :=
+      (Test / Keys.test)
+        .dependsOn(testJunitEngine / publishM2)
         .dependsOn(tests.jvm / publishM2)
         .dependsOn(core.jvm / publishM2)
         .dependsOn(internalMacros.jvm / publishM2)
@@ -881,6 +945,7 @@ lazy val docs = project.module
     concurrent.jvm,
     tests.jvm,
     testJunitRunner,
+    testJunitEngine,
     testMagnolia.jvm,
     testRefined.jvm,
     testScalaCheck.jvm,

--- a/test-junit-engine-tests/maven/pom.xml
+++ b/test-junit-engine-tests/maven/pom.xml
@@ -1,0 +1,123 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dev.zio</groupId>
+    <version>1.0</version>
+    <artifactId>zio_test_junit_engine_test</artifactId>
+    <packaging>pom</packaging>
+    <name>${project.artifactId}</name>
+    <description>Testing ZIO Test Junit engine test project</description>
+    <inceptionYear>2024</inceptionYear>
+
+    <properties>
+        <encoding>UTF-8</encoding>
+        <scala.version>2.13.13</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
+        <zio.version>2.0.22</zio.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio-test_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.zio</groupId>
+            <artifactId>zio-test-junit-engine_${scala.compat.version}</artifactId>
+            <version>${zio.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>scala2</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala-library</artifactId>
+                    <version>${scala.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>scala3</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.scala-lang</groupId>
+                    <artifactId>scala3-library_${scala.compat.version}</artifactId>
+                    <version>${scala.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- see http://davidb.github.com/scala-maven-plugin -->
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <version>4.8.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <configuration>
+                            <args>
+                                <!--<arg>-make:transitive</arg>-->
+                                <arg>-dependencyfile</arg>
+                                <arg>${project.build.directory}/.scala_dependencies</arg>
+                                <arg>-Ywarn-value-discard</arg>
+                            </args>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <goal>test</goal>
+                    <parallel>methods</parallel>
+                    <threadCount>10</threadCount>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>
+

--- a/test-junit-engine-tests/maven/settings.xml
+++ b/test-junit-engine-tests/maven/settings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+</settings>

--- a/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/DefectSpec.scala
+++ b/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/DefectSpec.scala
@@ -1,0 +1,38 @@
+package zio.test.junit.maven
+
+import zio.test.Assertion.equalTo
+import zio.test.{Spec, TestEnvironment, assert, ZIOSpecDefault}
+import zio.{Scope, Task, ZIO, ZLayer}
+
+trait Ops {
+ def targetHost: String
+}
+
+object OpsTest extends Ops {
+  override def targetHost: String = null
+}
+
+trait MyService {
+  def readData : Task[List[String]]
+}
+
+class MyServiceTest(targetHostName: String) extends MyService {
+
+  val url = s"https://${targetHostName.toLowerCase}/ws" // <- null pointer exception here
+
+  override def readData: Task[List[String]] = {
+    ZIO.succeed(List("a","b"))
+  }
+}
+
+object DefectSpec extends ZIOSpecDefault {
+  override def spec: Spec[TestEnvironment with Scope, Any] = suite("nul test")(
+    test("test with defect") {
+      for {
+        ms <- ZIO.service[MyService]
+        result <- ms.readData
+      }
+      yield assert(result.size)(equalTo(2))
+    }.provideLayer(ZLayer.succeed(new MyServiceTest(OpsTest.targetHost)))
+  )
+}

--- a/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/FailingSpec.scala
+++ b/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/FailingSpec.scala
@@ -1,0 +1,19 @@
+package zio.test.junit.maven
+
+import zio.test.junit._
+import zio.test._
+import zio.test.Assertion._
+
+object FailingSpec extends ZIOSpecDefault {
+  override def spec = suite("FailingSpec")(
+    test("should fail") {
+      assert(11)(equalTo(12))
+    },
+    test("should fail - isSome") {
+      assert(Some(11))(isSome(equalTo(12)))
+    },
+    test("should succeed") {
+      assert(12)(equalTo(12))
+    }
+  )
+}

--- a/test-junit-engine-tests/src/test/scala/zio/test/junit/MavenJunitSpec.scala
+++ b/test-junit-engine-tests/src/test/scala/zio/test/junit/MavenJunitSpec.scala
@@ -1,0 +1,121 @@
+package zio.test.junit
+
+import org.apache.maven.cli.MavenCli
+import zio.test.Assertion._
+import zio.test.{ZIOSpecDefault, _}
+import zio.{System => _, ZIO, Task}
+
+import java.io.File
+import scala.collection.immutable
+import scala.xml.XML
+
+/**
+ * when running from IDE run `sbt publishM2`, copy the snapshot version the
+ * artifacts were published under (something like:
+ * `1.0.2+0-37ee0765+20201006-1859-SNAPSHOT`) and put this into `VM Parameters`:
+ * `-Dproject.dir=\$PROJECT_DIR\$/test-junit-tests/jvm
+ * -Dproject.version=\$snapshotVersion`
+ */
+object MavenJunitSpec extends ZIOSpecDefault {
+
+  def spec = suite("MavenJunitSpec")(
+    test("Spec results are properly reported") {
+      for {
+        mvn          <- makeMaven
+        mvnResult    <- mvn.clean() *> mvn.test()
+        report       <- mvn.parseSurefireReport("zio.test.junit.maven.FailingSpec")
+        reportDefect <- mvn.parseSurefireReport("zio.test.junit.maven.DefectSpec")
+      } yield {
+        assert(mvnResult)(not(equalTo(0))) &&
+        assert(report)(
+          containsFailure(
+            "should fail",
+            "11 was not equal to 12"
+          ) &&
+            containsFailure(
+              "should fail - isSome",
+              "11 was not equal to 12"
+            ) &&
+            containsSuccess("should succeed")
+        ) &&
+        assertTrue(reportDefect.length == 1) // spec with defect is reported
+      }
+    }
+  ) @@ TestAspect.sequential /*@@
+    // flaky: sometimes maven fails to download dependencies in CI
+    TestAspect.flaky(3)*/
+
+  def makeMaven: ZIO[Any, AssertionError, MavenDriver] = for {
+    projectDir <-
+      ZIO
+        .fromOption(sys.props.get("project.dir"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.dir system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.dir=$PROJECT_DIR$/test-junit-tests/jvm`"
+          )
+        )
+    projectVer <-
+      ZIO
+        .fromOption(sys.props.get("project.version"))
+        .orElseFail(
+          new AssertionError(
+            "Missing project.version system property\n" +
+              "when running from IDE put this into `VM Parameters`: `-Dproject.version=<current zio version>`"
+          )
+        )
+    scalaVersion       = sys.props.get("scala.version").getOrElse("2.12.10")
+    scalaCompatVersion = sys.props.get("scala.compat.version").getOrElse("2.12")
+  } yield new MavenDriver(projectDir, projectVer, scalaVersion, scalaCompatVersion)
+
+  class MavenDriver(projectDir: String, projectVersion: String, scalaVersion: String, scalaCompatVersion: String) {
+    val mvnRoot: String = new File(s"$projectDir/maven").getCanonicalPath
+    private val cli     = new MavenCli
+    java.lang.System.setProperty("maven.multiModuleProjectDirectory", mvnRoot)
+
+    def clean(): Task[Int] = run("clean")
+
+    def test(): Task[Int] = run(
+      "test",
+      s"-Dzio.version=$projectVersion",
+      s"-Dscala.version=$scalaVersion",
+      s"-Dscala.compat.version=$scalaCompatVersion",
+      s"-Pscala${scalaVersion(0)}"
+    )
+    def run(command: String*): Task[Int] = ZIO.attemptBlocking(
+      cli.doMain(command.toArray, mvnRoot, System.out, System.err)
+    )
+
+    def parseSurefireReport(testFQN: String): Task[immutable.Seq[TestCase]] =
+      ZIO
+        .attemptBlocking(
+          XML.load(scala.xml.Source.fromFile(new File(s"$mvnRoot/target/surefire-reports/TEST-$testFQN.xml")))
+        )
+        .map { report =>
+          (report \ "testcase").map { tcNode =>
+            TestCase(
+              tcNode \@ "name",
+              (tcNode \ "error").headOption
+                .map(error => TestError(error.text.linesIterator.map(_.trim).mkString("\n"), error \@ "type")),
+              (tcNode \ "failure").headOption
+                .map(error => TestError(error.text.linesIterator.map(_.trim).mkString("\n"), error \@ "type"))
+            )
+          }
+        }
+  }
+
+  def containsSuccess(label: String): Assertion[Iterable[TestCase]]                = containsResult(label, error = None)
+  def containsFailure(label: String, error: String): Assertion[Iterable[TestCase]] = containsResult(label, Some(error))
+  def containsResult(label: String, error: Option[String]): Assertion[Iterable[TestCase]] =
+    exists(assertion(s"check $label") { testCase =>
+      testCase.name == label &&
+      error
+        .map(err => testCase.errorAndFailure.exists(_.message.contains(err)))
+        .getOrElse(testCase.errorAndFailure.isEmpty)
+    })
+
+  case class TestCase(name: String, error: Option[TestError], failure: Option[TestError]) {
+    lazy val errorAndFailure: Seq[TestError] = (error ++ failure).toSeq
+  }
+  case class TestError(message: String, `type`: String)
+}

--- a/test-junit-engine/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
+++ b/test-junit-engine/src/main/resources/META-INF/services/org.junit.platform.engine.TestEngine
@@ -1,0 +1,1 @@
+zio.test.junit.ZIOTestEngine

--- a/test-junit-engine/src/main/scala/zio/test/junit/ReflectionUtils.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ReflectionUtils.scala
@@ -1,0 +1,23 @@
+package zio.test.junit
+
+import scala.util.Try
+
+private[zio] object ReflectionUtils {
+
+  /**
+   * Retrieves the companion object of the specified class, if it exists. Here
+   * we use plain java reflection as runtime reflection is not available for
+   * scala 3
+   *
+   * @param klass
+   *   The class for which to retrieve the companion object.
+   * @return
+   *   the optional companion object.
+   */
+  def getCompanionObject(klass: Class[_]): Option[Any] =
+    Try {
+      (if (klass.getName.endsWith("$")) klass else getClass.getClassLoader.loadClass(klass.getName + "$"))
+        .getDeclaredField("MODULE$")
+        .get(null)
+    }.toOption
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/TestFailed.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/TestFailed.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.opentest4j.AssertionFailedError
+
+/**
+ * Represents a failure of a test assertion. It needs to extend
+ * AssertionFailedError for Junit5 platform to mark it as failure
+ *
+ * @param message
+ *   A description of the failure.
+ * @param cause
+ *   The underlying cause of the failure, if any.
+ */
+class TestFailed(message: String, cause: Throwable = null) extends AssertionFailedError(message, cause)

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOSuiteTestDescriptor.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOSuiteTestDescriptor.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
+import org.junit.platform.engine.{TestDescriptor, UniqueId}
+
+/**
+ * Describes a JUnit 5 test descriptor for a suite of ZIO tests.
+ *
+ * @constructor
+ *   Creates an instance of ZIOSuiteTestDescriptor.
+ * @param parent
+ *   The parent TestDescriptor.
+ * @param uniqueId
+ *   The unique identifier for this test descriptor.
+ * @param label
+ *   The display name of this test descriptor.
+ * @param testClass
+ *   The class representing the suite of tests.
+ */
+class ZIOSuiteTestDescriptor(
+  parent: TestDescriptor,
+  uniqueId: UniqueId,
+  label: String,
+  testClass: Class[_]
+) extends AbstractTestDescriptor(uniqueId, label, ZIOTestSource(testClass)) {
+  setParent(parent)
+  override def getType: TestDescriptor.Type = TestDescriptor.Type.CONTAINER
+}
+
+object ZIOSuiteTestDescriptor {
+  val segmentType = "suite"
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassDescriptor.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassDescriptor.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
+import org.junit.platform.engine.{TestDescriptor, UniqueId}
+import zio._
+import zio.test._
+import zio.test.junit.ReflectionUtils._
+
+/**
+ * Represents a JUnit 5 test descriptor for a ZIO-based test class
+ *
+ * @param parent
+ *   The parent TestDescriptor.
+ * @param uniqueId
+ *   A unique identifier for this TestDescriptor.
+ * @param testClass
+ *   The class representing the test.
+ */
+class ZIOTestClassDescriptor(parent: TestDescriptor, uniqueId: UniqueId, val testClass: Class[_])
+    extends AbstractTestDescriptor(uniqueId, testClass.getName.stripSuffix("$"), ZIOTestSource(testClass)) {
+
+  setParent(parent)
+  val className: String = testClass.getName
+
+  // reflection to get the spec implementation
+  // by default, it would be an object, extending ZIOSpecDefault
+  // but this also support class that needs to be instantiated
+  val spec: ZIOSpecAbstract = getCompanionObject(testClass)
+    .getOrElse(testClass.getDeclaredConstructor().newInstance())
+    .asInstanceOf[ZIOSpecAbstract]
+
+  def traverse[R, E](
+    spec: Spec[R, E],
+    description: TestDescriptor,
+    path: Vector[String] = Vector.empty
+  ): ZIO[R with Scope, Any, Unit] =
+    spec.caseValue match {
+      case Spec.ExecCase(_, spec: Spec[R, E]) => traverse(spec, description, path)
+      case Spec.LabeledCase(label, spec: Spec[R, E]) =>
+        traverse(spec, description, path :+ label)
+      case Spec.ScopedCase(scoped) => scoped.flatMap((s: Spec[R, E]) => traverse(s, description, path))
+      case Spec.MultipleCase(specs) =>
+        val suiteDesc = new ZIOSuiteTestDescriptor(
+          description,
+          description.getUniqueId.append(ZIOSuiteTestDescriptor.segmentType, path.lastOption.getOrElse("")),
+          path.lastOption.getOrElse(""),
+          testClass
+        )
+        ZIO.succeed(description.addChild(suiteDesc)) *>
+          ZIO.foreach(specs)((s: Spec[R, E]) => traverse(s, suiteDesc, path)).ignore
+      case Spec.TestCase(_, annotations) =>
+        ZIO.succeed(
+          description.addChild(
+            new ZIOTestDescriptor(
+              description,
+              description.getUniqueId.append(ZIOTestDescriptor.segmentType, path.lastOption.getOrElse("")),
+              path.lastOption.getOrElse(""),
+              testClass,
+              annotations
+            )
+          )
+        )
+    }
+
+  lazy val scoped: ZIO[spec.Environment with TestEnvironment, Any, Unit] =
+    ZIO.scoped[spec.Environment with TestEnvironment](
+      traverse(spec.spec, this)
+    )
+
+  Unsafe.unsafe { implicit unsafe =>
+    Runtime.default.unsafe
+      .run(
+        scoped
+          .provide(
+            Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+            spec.bootstrap
+          )
+      )
+      .getOrThrowFiberFailure()
+  }
+
+  override def getType: TestDescriptor.Type = TestDescriptor.Type.CONTAINER
+}
+
+object ZIOTestClassDescriptor {
+  val segmentType = "class"
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassRunner.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassRunner.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.engine.{EngineExecutionListener, TestDescriptor, TestExecutionResult}
+import zio.test.render.ConsoleRenderer
+import zio.test.render.ExecutionResult.ResultType.Test
+import zio.test.render.ExecutionResult.Status.Failed
+import zio.test.render.LogLine.Message
+import zio.test._
+import zio._
+
+import scala.jdk.OptionConverters._
+
+/**
+ * The `ZIOTestClassRunner` is responsible for running ZIO tests within a test
+ * class and reporting their results using the given JUnit 5
+ * `EngineExecutionListener`.
+ *
+ * @param descriptor
+ *   The ZIO test class JUnit 5 descriptor
+ */
+class ZIOTestClassRunner(descriptor: ZIOTestClassDescriptor) {
+  private val spec = descriptor.spec
+
+  def run(notifier: EngineExecutionListener): IO[Any, Summary] = {
+    def instrumentedSpec[R, E](zspec: Spec[R, E]) = {
+      def loop(
+        spec: Spec[R, E],
+        description: TestDescriptor,
+        path: Vector[String] = Vector.empty
+      ): Spec.SpecCase[R, E, Spec[R, E]] =
+        spec.caseValue match {
+          case Spec.ExecCase(exec, spec: Spec[R, E]) => Spec.ExecCase(exec, Spec(loop(spec, description, path)))
+          case Spec.LabeledCase(label, spec) =>
+            Spec.LabeledCase(label, Spec(loop(spec, description, path :+ label)))
+          case Spec.ScopedCase(scoped) =>
+            Spec.ScopedCase[R, E, Spec[R, E]](scoped.map(spec => Spec(loop(spec, description, path))))
+          case Spec.MultipleCase(specs) =>
+            val uniqueId =
+              description.getUniqueId.append(ZIOSuiteTestDescriptor.segmentType, path.lastOption.getOrElse(""))
+            descriptor
+              .findByUniqueId(uniqueId)
+              .toScala
+              .map(suiteDescription => Spec.MultipleCase(specs.map(spec => Spec(loop(spec, suiteDescription, path)))))
+              .getOrElse(
+                // filtered out
+                Spec.MultipleCase(Chunk.empty)
+              )
+          case Spec.TestCase(test, annotations) =>
+            val uniqueId = description.getUniqueId.append(ZIOTestDescriptor.segmentType, path.lastOption.getOrElse(""))
+            descriptor
+              .findByUniqueId(uniqueId)
+              .toScala
+              .map(_ => Spec.TestCase(test, annotations))
+              .getOrElse(
+                // filtered out
+                Spec.TestCase(ZIO.succeed(TestSuccess.Ignored()), annotations)
+              )
+        }
+
+      Spec(loop(zspec, descriptor))
+    }
+
+    def testDescriptorFromReversedLabel(labelsReversed: List[String]): Option[TestDescriptor] = {
+      val uniqueId = labelsReversed.reverse.zipWithIndex.foldLeft(descriptor.getUniqueId) {
+        case (uid, (label, labelIdx)) if labelIdx == labelsReversed.length - 1 =>
+          uid.append(ZIOTestDescriptor.segmentType, label)
+        case (uid, (label, _)) => uid.append(ZIOSuiteTestDescriptor.segmentType, label)
+      }
+      descriptor.findByUniqueId(uniqueId).toScala
+    }
+
+    def notifyTestFailure(testDescriptor: TestDescriptor, failure: TestFailure[_]): Unit = failure match {
+      case TestFailure.Assertion(result, _) =>
+        notifier.executionFinished(
+          testDescriptor,
+          TestExecutionResult.failed(
+            new TestFailed(renderToString(renderFailureDetails(testDescriptor, result)))
+          )
+        )
+      case TestFailure.Runtime(cause, _) =>
+        notifier.executionFinished(
+          testDescriptor,
+          TestExecutionResult.failed(cause.squashWith {
+            case t: Throwable => t
+            case _            => new TestFailed(renderToString(ConsoleRenderer.renderCause(cause, 0)))
+          })
+        )
+    }
+
+    val instrumented: Spec[spec.Environment with TestEnvironment with Scope, Any] = instrumentedSpec(spec.spec)
+
+    val eventHandler: ZTestEventHandler = {
+      case ExecutionEvent.TestStarted(labelsReversed, _, _, _, _) =>
+        ZIO.succeed(testDescriptorFromReversedLabel(labelsReversed).foreach(notifier.executionStarted))
+      case ExecutionEvent.Test(labelsReversed, test, _, _, _, _, _) =>
+        ZIO.succeed(testDescriptorFromReversedLabel(labelsReversed).foreach { testDescriptor =>
+          test match {
+            case Left(failure: TestFailure[_]) =>
+              notifyTestFailure(testDescriptor, failure)
+            case Right(TestSuccess.Succeeded(_)) =>
+              notifier.executionFinished(testDescriptor, TestExecutionResult.successful())
+            case Right(TestSuccess.Ignored(_)) =>
+              notifier.executionSkipped(testDescriptor, "Test skipped")
+          }
+        })
+      case ExecutionEvent.RuntimeFailure(_, labelsReversed, failure, _) =>
+        ZIO.succeed(testDescriptorFromReversedLabel(labelsReversed).foreach(notifyTestFailure(_, failure)))
+      case _ => ZIO.unit // unhandled events linked to the suite level
+    }
+
+    spec
+      .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive, eventHandler)
+      .provide(
+        Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+        spec.bootstrap
+      )
+  }
+
+  private def renderFailureDetails(descriptor: TestDescriptor, result: TestResult): Message =
+    Message(
+      ConsoleRenderer
+        .rendered(
+          Test,
+          descriptor.getDisplayName,
+          Failed,
+          0,
+          ConsoleRenderer.renderAssertionResult(result.result, 0).lines: _*
+        )
+        .streamingLines
+    )
+
+  private def renderToString(message: Message) =
+    message.lines
+      .map(_.fragments.map(_.text).fold("")(_ + _))
+      .mkString("\n")
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassSelectorResolver.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassSelectorResolver.scala
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.commons.support.ReflectionSupport
+import org.junit.platform.commons.util.ReflectionUtils.{isAbstract, isAssignableTo, isInnerClass, isPublic}
+import org.junit.platform.engine.TestDescriptor
+import org.junit.platform.engine.discovery.{ClassSelector, ClasspathRootSelector, ModuleSelector, PackageSelector}
+import org.junit.platform.engine.support.discovery.SelectorResolver
+import org.junit.platform.engine.support.discovery.SelectorResolver.{Match, Resolution}
+import zio.test._
+import zio.test.junit.ReflectionUtils._
+
+import java.util.Optional
+import java.util.function.Predicate
+import java.util.stream.Collectors
+import scala.jdk.CollectionConverters._
+
+/**
+ * JUnit 5 platform test class resolver for ZIO test implementation
+ */
+class ZIOTestClassSelectorResolver extends SelectorResolver {
+  private val isSuitePredicate: Predicate[Class[_]] = { (testClass: Class[_]) =>
+    // valid test class are ones directly extending ZIOSpecAbstract or whose companion object
+    // extends ZIOSpecAbstract
+    isPublic(testClass) && !isAbstract(testClass) && !isInnerClass(testClass) &&
+    (isAssignableTo(testClass, classOf[ZIOSpecAbstract]) || getCompanionObject(testClass).exists(
+      _.isInstanceOf[ZIOSpecAbstract]
+    ))
+  }
+
+  private val alwaysTruePredicate: Predicate[String] = _ => true
+
+  private def classDescriptorFunction(
+    testClass: Class[_]
+  ): java.util.function.Function[TestDescriptor, Optional[ZIOTestClassDescriptor]] =
+    (parentTestDescriptor: TestDescriptor) => {
+      val suiteUniqueId =
+        parentTestDescriptor.getUniqueId.append(ZIOTestClassDescriptor.segmentType, testClass.getName.stripSuffix("$"))
+      val newChild = parentTestDescriptor.getChildren.asScala.find(_.getUniqueId == suiteUniqueId) match {
+        case Some(_) => Optional.empty[ZIOTestClassDescriptor]()
+        case None    => Optional.of(new ZIOTestClassDescriptor(parentTestDescriptor, suiteUniqueId, testClass))
+      }
+      newChild
+    }
+
+  private val toMatch: java.util.function.Function[TestDescriptor, java.util.stream.Stream[Match]] =
+    (td: TestDescriptor) => java.util.stream.Stream.of[Match](Match.exact(td))
+
+  private def addToParentFunction(
+    context: SelectorResolver.Context
+  ): java.util.function.Function[Class[_], java.util.stream.Stream[Match]] = (aClass: Class[_]) => {
+    context
+      .addToParent(classDescriptorFunction(aClass))
+      .map[java.util.stream.Stream[Match]](toMatch)
+      .orElse(java.util.stream.Stream.empty())
+  }
+
+  override def resolve(
+    selector: ClasspathRootSelector,
+    context: SelectorResolver.Context
+  ): SelectorResolver.Resolution = {
+    val matches =
+      ReflectionSupport
+        .findAllClassesInClasspathRoot(selector.getClasspathRoot, isSuitePredicate, alwaysTruePredicate)
+        .stream()
+        .flatMap(addToParentFunction(context))
+        .collect(Collectors.toSet())
+    Resolution.matches(matches)
+  }
+
+  override def resolve(selector: PackageSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
+    val matches =
+      ReflectionSupport
+        .findAllClassesInPackage(selector.getPackageName, isSuitePredicate, alwaysTruePredicate)
+        .stream()
+        .flatMap(addToParentFunction(context))
+        .collect(Collectors.toSet())
+    Resolution.matches(matches)
+  }
+
+  override def resolve(selector: ModuleSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
+    val matches =
+      ReflectionSupport
+        .findAllClassesInModule(selector.getModuleName, isSuitePredicate, alwaysTruePredicate)
+        .stream()
+        .flatMap(addToParentFunction(context))
+        .collect(Collectors.toSet())
+    Resolution.matches(matches)
+  }
+
+  override def resolve(selector: ClassSelector, context: SelectorResolver.Context): SelectorResolver.Resolution = {
+    val testClass = selector.getJavaClass
+    if (isSuitePredicate.test(testClass)) {
+      context
+        .addToParent(classDescriptorFunction(testClass))
+        .map[Resolution]((td: TestDescriptor) => Resolution.`match`(Match.exact(td)))
+        .orElse(Resolution.unresolved())
+    } else {
+      Resolution.unresolved()
+    }
+  }
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestDescriptor.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestDescriptor.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.engine.{TestDescriptor, UniqueId}
+import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
+import zio.test.TestAnnotationMap
+
+/**
+ * Describes a JUnit 5 test descriptor for a single ZIO tests.
+ *
+ * @constructor
+ *   Creates a new ZIOTestDescriptor instance.
+ * @param parent
+ *   The parent descriptor of this test descriptor.
+ * @param uniqueId
+ *   A unique identifier for this test descriptor.
+ * @param label
+ *   The display name or label for this test descriptor.
+ * @param testClass
+ *   The test class associated with this descriptor.
+ * @param annotations
+ *   A map of annotations applied to this test descriptor.
+ */
+class ZIOTestDescriptor(
+  parent: TestDescriptor,
+  uniqueId: UniqueId,
+  label: String,
+  testClass: Class[_],
+  annotations: TestAnnotationMap
+) extends AbstractTestDescriptor(uniqueId, label, ZIOTestSource(testClass, annotations)) {
+  setParent(parent)
+  override def getType: TestDescriptor.Type = TestDescriptor.Type.TEST
+}
+
+object ZIOTestDescriptor {
+  val segmentType = "test"
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestEngine.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestEngine.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import org.junit.platform.engine.{
+  EngineDiscoveryRequest,
+  ExecutionRequest,
+  TestDescriptor,
+  TestEngine,
+  TestExecutionResult,
+  UniqueId
+}
+import org.junit.platform.engine.support.descriptor.EngineDescriptor
+import org.junit.platform.engine.support.discovery.EngineDiscoveryRequestResolver
+import zio._
+
+import scala.jdk.CollectionConverters._
+
+/**
+ * A JUnit platform test engine implementation designed for running ZIO tests.
+ */
+class ZIOTestEngine extends TestEngine {
+
+  override def getId: String = "zio"
+
+  private lazy val discoverer = EngineDiscoveryRequestResolver
+    .builder[EngineDescriptor]()
+    .addSelectorResolver(new ZIOTestClassSelectorResolver)
+    .build()
+
+  override def discover(discoveryRequest: EngineDiscoveryRequest, uniqueId: UniqueId): TestDescriptor = {
+    val engineDesc = new EngineDescriptor(uniqueId, "ZIO EngineDescriptor")
+    discoverer.resolve(discoveryRequest, engineDesc)
+    engineDesc
+  }
+
+  override def execute(request: ExecutionRequest): Unit =
+    Unsafe.unsafe { implicit unsafe =>
+      Runtime.default.unsafe.run {
+        val engineDesc = request.getRootTestDescriptor
+        val listener   = request.getEngineExecutionListener
+        ZIO.logInfo("Start tests execution...") *> ZIO.foreachDiscard(engineDesc.getChildren.asScala) {
+          case clzDesc: ZIOTestClassDescriptor =>
+            ZIO.logInfo(s"Start execution of test class ${clzDesc.className}...") *> ZIO.succeed(
+              listener.executionStarted(clzDesc)
+            ) *> new ZIOTestClassRunner(clzDesc).run(listener) *> ZIO.succeed(
+              listener.executionFinished(clzDesc, TestExecutionResult.successful())
+            )
+          case otherDesc =>
+            // Do nothing for other descriptor, just log it.
+            ZIO.logWarning(s"Found test descriptor $otherDesc that is not supported, skipping.")
+
+        } *> ZIO.succeed(listener.executionFinished(engineDesc, TestExecutionResult.successful())) *> ZIO.logInfo(
+          "Completed tests execution."
+        )
+      }
+        .getOrThrowFiberFailure()
+    }
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestSource.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestSource.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024-2024 Vincent Raman and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.test.junit
+
+import zio.test._
+
+import java.io.File
+import org.junit.platform.engine.TestSource
+import org.junit.platform.engine.support.descriptor.{ClassSource, FilePosition, FileSource}
+
+/**
+ * ZIOTestSource is an object responsible for creating instances of JUnit
+ * TestSource based on provided test class and optional annotations.
+ */
+object ZIOTestSource {
+  def apply(testClass: Class[_], annotations: Option[TestAnnotationMap]): TestSource =
+    annotations
+      .map(_.get(TestAnnotation.trace))
+      .collect { case location :: _ =>
+        FileSource.from(new File(location.path), FilePosition.from(location.line))
+      }
+      .getOrElse(ClassSource.from(testClass))
+
+  def apply(testClass: Class[_]): TestSource = ZIOTestSource(testClass, None)
+
+  def apply(testClass: Class[_], annotations: TestAnnotationMap): TestSource =
+    ZIOTestSource(testClass, Some(annotations))
+}


### PR DESCRIPTION
/closes #6724

Aim of this development is to provide a junit engine working directly with junit 5 platform without the need of exteding ZTestJUnitRunner and using the junit-vintage engine