### PR TITLE
Add `.devcontainer` config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,8 +3,7 @@
 ARG JAVA_VERSION="17"
 FROM mcr.microsoft.com/vscode/devcontainers/java:${JAVA_VERSION}
 
-# Install Coursier, SBT and Scala
-RUN curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
-RUN cs setup
+# Install SBT
+RUN sdk install sbt
 
 CMD ["sbt"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,0 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/java/.devcontainer/base.Dockerfile
-
-ARG JAVA_VERSION="17"
-FROM mcr.microsoft.com/vscode/devcontainers/java:${JAVA_VERSION}
-
-# Install SBT
-RUN sdk install sbt
-
-CMD ["sbt"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,8 +4,7 @@ ARG JAVA_VERSION="17"
 FROM mcr.microsoft.com/vscode/devcontainers/java:${JAVA_VERSION}
 
 # Install Coursier, SBT and Scala
-RUN \
-    curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs && \
-    cs setup
+RUN curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs
+RUN cs setup
 
 CMD ["sbt"]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/java/.devcontainer/base.Dockerfile
+
+ARG JAVA_VERSION="17"
+FROM mcr.microsoft.com/vscode/devcontainers/java:${JAVA_VERSION}
+
+# Install Coursier, SBT and Scala
+RUN \
+    curl -fL "https://github.com/coursier/launchers/raw/master/cs-x86_64-pc-linux.gz" | gzip -d > cs && \
+    cs setup
+
+CMD ["sbt"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,5 +26,13 @@
   // "postCreateCommand": "java -version",
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-  "remoteUser": "root"
+  "remoteUser": "root",
+  
+  // Envvar to enable optimizations when building ZIO
+  "containerEnv": {
+    "CI_RELEASE_MODE": "1"
+  },
+  "remoteEnv": {
+    "CI_RELEASE_MODE": "1"
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-   "postCreateCommand": "sbt",
+   "postCreateCommand": "sbt clean",
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  // "postCreateCommand": "java -version",
+   "postCreateCommand": "sbt",
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
       ]
     }
   },
+  "remoteUser": "root",
   "features": {
     "git": "latest"
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,37 +1,30 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/java
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/java
 {
   "name": "Scala",
-  "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      // Update the VARIANT arg to pick a Java version: 11, 17
-      // Append -bullseye or -buster to pin to an OS version.
-      // Use the -bullseye variants on local arm64/Apple Silicon.
-      "JAVA_VERSION": "17"
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "image": "mcr.microsoft.com/devcontainers/java:17",
+  "features": {
+    "ghcr.io/ebaskoro/devcontainer-features/scala:1": {
+      "installSbt": true
     }
   },
   // Configure tool-specific properties.
   "customizations": {
     // Configure properties specific to VS Code.
     "vscode": {
-      // Set *default* container specific settings.json values on container create.
       "settings": {
       },
-      // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
-        "vscjava.vscode-java-pack"
       ]
     }
   },
-  "remoteUser": "root",
-  "features": {
-    "git": "latest"
-  },
-  "containerEnv": {
-    "CI_RELEASE_MODE": "1"
-  },
-  "remoteEnv": {
-    "CI_RELEASE_MODE": "1"
-  }
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  // "postCreateCommand": "java -version",
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  "remoteUser": "root"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,16 +24,18 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-   "postCreateCommand": "sbt update",
-
+  "postCreateCommand": "sbt update",
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "root",
-  
-  // Envvar to enable optimizations when building ZIO
+  // Envvar to enable optimizations when building ZIO and set sensible JVM values
   "containerEnv": {
-    "CI_RELEASE_MODE": "1"
+    "CI_RELEASE_MODE": "1",
+    "JDK_JAVA_OPTIONS": "-Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M",
+    "SBT_OPTS": "-Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M"
   },
   "remoteEnv": {
-    "CI_RELEASE_MODE": "1"
+    "CI_RELEASE_MODE": "1",
+    "JDK_JAVA_OPTIONS": "-Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M",
+    "SBT_OPTS": "-Xms6G -Xmx6G -Xss4M -XX:+UseG1GC -XX:ReservedCodeCacheSize=512M -XX:NonProfiledCodeHeapSize=256M"
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.238.1/containers/java
+{
+  "name": "Scala",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Update the VARIANT arg to pick a Java version: 11, 17
+      // Append -bullseye or -buster to pin to an OS version.
+      // Use the -bullseye variants on local arm64/Apple Silicon.
+      "JAVA_VERSION": "17"
+    }
+  },
+  // Configure tool-specific properties.
+  "customizations": {
+    // Configure properties specific to VS Code.
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "vscjava.vscode-java-pack"
+      ]
+    }
+  },
+  "features": {
+    "git": "latest"
+  },
+  "containerEnv": {
+    "CI_RELEASE_MODE": "1",
+  },
+  "remoteEnv": {
+    "CI_RELEASE_MODE": "1"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
       "settings": {
       },
       "extensions": [
+        "scalameta.metals"
       ]
     }
   },
@@ -23,7 +24,7 @@
   // "forwardPorts": [],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-   "postCreateCommand": "sbt clean",
+   "postCreateCommand": "sbt update",
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   "remoteUser": "root",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
     "git": "latest"
   },
   "containerEnv": {
-    "CI_RELEASE_MODE": "1",
+    "CI_RELEASE_MODE": "1"
   },
   "remoteEnv": {
     "CI_RELEASE_MODE": "1"


### PR DESCRIPTION
Adding a `.devcontainer` config file so that we can run benchmarks on codespaces. This is better than running benchmarks locally as different CPU architectures / OS might benefit more/less from specific optimizations than Linux x86-64 which is the most common setup for production applications