### PR TITLE
Fix `IndexOutOfBoundsException` when using `reverseIterator` on `UpdateOrderLinkedMap`

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/UpdateOrderLinkedMapConcurrencyTests.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/UpdateOrderLinkedMapConcurrencyTests.scala
@@ -1,0 +1,47 @@
+package zio.internal
+
+import org.openjdk.jcstress.annotations._
+import org.openjdk.jcstress.infra.results.LL_Result
+
+object UpdateOrderLinkedMapConcurrencyTests {
+
+  /*
+   * Tests that there are no race conditions between publishing and taking..
+   */
+  @JCStressTest
+  @Outcome.Outcomes(
+    Array(
+      new Outcome(id = Array("List(4, 3, 2, 1, 0), List(4, 3, 2, 1, 0)"), expect = Expect.ACCEPTABLE)
+    )
+  )
+  @State
+  class ReverseIteratorTest {
+    val map: UpdateOrderLinkedMap[String, Int] =
+      (0 until 1000).foldLeft(UpdateOrderLinkedMap.empty[String, Int]) { case (m, i) =>
+        val ii = i % 5
+        m.updated(ii.toString, ii)
+      }
+
+    var r1: List[Int] = null
+    var r2: List[Int] = null
+
+    @Actor
+    def actor1(): Unit = {
+      r1 = map.reverseIterator.map(_._2).toList
+      ()
+    }
+
+    @Actor
+    def actor2(): Unit = {
+      r2 = map.reverseIterator.map(_._2).toList
+      ()
+    }
+
+    @Arbiter
+    def arbiter(r: LL_Result): Unit = {
+      r.r1 = r1
+      r.r2 = r2
+    }
+  }
+
+}

--- a/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
@@ -12,12 +12,12 @@ object UpdateOrderLinkedMapSpec extends ZIOBaseSpec {
       assertTrue(m.iterator.toList == List("a" -> 1, "b" -> 2, "c" -> 3))
     },
     test("updating existing elements") {
-      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4)
-      assertTrue(m.iterator.toList == List("a" -> 1, "c" -> 3, "b" -> 4))
+      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4).updated("a" , 5)
+      assertTrue(m.iterator.toList == List("c" -> 3, "b" -> 4, "a" -> 5))
     },
     test("reverseIterator") {
-      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4).updated("d", 5)
-      assertTrue(m.reverseIterator.toList == List("d" -> 5, "b" -> 4, "c" -> 3, "a" -> 1))
+      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4).updated("d", 5).updated("a", 6)
+      assertTrue(m.reverseIterator.toList == List("a" -> 6, "d" -> 5, "b" -> 4, "c" -> 3))
     },
     test("builder") {
       val m =

--- a/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
@@ -12,7 +12,7 @@ object UpdateOrderLinkedMapSpec extends ZIOBaseSpec {
       assertTrue(m.iterator.toList == List("a" -> 1, "b" -> 2, "c" -> 3))
     },
     test("updating existing elements") {
-      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4).updated("a" , 5)
+      val m = empty.updated("a", 1).updated("b", 2).updated("c", 3).updated("b", 4).updated("a", 5)
       assertTrue(m.iterator.toList == List("c" -> 3, "b" -> 4, "a" -> 5))
     },
     test("reverseIterator") {

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -132,7 +132,8 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
   }
 
   private def reverseIterator0: Iterator[(K, V)] = new AbstractIterator[(K, V)] {
-    private[this] var slot = fields.length
+    private[this] var slot      = fields.length
+    private[this] var remaining = underlying.size
 
     @tailrec
     final private[this] def findNextKey(nextSlot: Int): K =
@@ -141,11 +142,12 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
         case Tombstone(d) if d == 1 => findNextKey(nextSlot - 1)
         case Tombstone(d)           => throw new IllegalStateException("tombstone indicate wrong position: " + d)
         case k =>
+          remaining -= 1
           slot = nextSlot
           k.asInstanceOf[K]
       }
 
-    override def hasNext: Boolean = slot > 0
+    override def hasNext: Boolean = remaining > 0
 
     override def next(): (K, V) =
       if (!hasNext) Iterator.empty.next()


### PR DESCRIPTION
/fixes #9237

Issue seems to be present only when using `reverseIterator` for cases that the first entry in the environment was updated, as the `isEmpty` method of the iterator is invalidly returning `false`. This PR fixes the issue which I believe is the root cause of the issue.

Note that when discussing this issue with @ghostdogpr, there were some concerns regarding concurrency so I added stress tests just in case.