### PR TITLE
Ensure that transactions containing both reads and writes are consistent

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/ZSTMSpec.scala
@@ -1239,7 +1239,23 @@ object ZSTMSpec extends ZIOBaseSpec {
         _     <- transaction(ref).commit
         value <- ref.get
       } yield assertTrue(value == 9)
-    } @@ exceptJS(nonFlaky(10000))
+    } @@ exceptJS(nonFlaky(10000)),
+    suite("STM issue 9264")(
+      test("transactions containing both reads and writes are consistent") {
+        for {
+          q1 <- TestQueue.make[String]
+          q2 <- TestQueue.make[String]
+          enq = (q1.enqueue("x") *> q2.enqueue("x")).commit.repeatN(8)
+          deq = (q1.tryDequeue <*> q2.tryDequeue).commit.flatMap {
+                  case (None, None)                     => ZIO.unit
+                  case (Some(v1), Some(v2)) if v1 == v2 => ZIO.unit
+                  case (x, y)                           => ZIO.dieMessage(s"Dequeued values are different: $x != $y")
+                }
+                  .repeatN(8)
+          _ <- ZIO.foreachParDiscard(List(enq, deq, deq))(t => t)
+        } yield assertCompletes
+      } @@ exceptJS(nonFlaky(10000))
+    )
   )
 
   val ExampleError = new Throwable("fail")
@@ -1326,4 +1342,45 @@ object ZSTMSpec extends ZIOBaseSpec {
 
     loop(depth, STM.succeed(0))
   }
+
+  final class TestQueue[A >: Null] private (head: TRef[TestQueue.Node[A]], tail: TRef[TestQueue.Node[A]]) {
+    import TestQueue._
+
+    def enqueue(a: A): USTM[Unit] =
+      for {
+        end <- TRef.make[Elem[A]](End[A]())
+        node = Node(a, end)
+        t   <- tail.get
+        tn  <- t.next.get
+        _ <- tn match {
+               case End() => t.next.set(node).flatMap(_ => tail.set(node))
+               case _     => ZSTM.dieMessage("this should never happen")
+             }
+      } yield ()
+
+    def tryDequeue: USTM[Option[A]] =
+      for {
+        h  <- head.get
+        hn <- h.next.get
+        r <- hn match {
+               case n @ Node(a, _) => head.set(n.copy(data = null)).as(Some(a))
+               case End()          => ZSTM.succeed(None)
+             }
+      } yield r
+  }
+
+  object TestQueue {
+
+    private sealed abstract class Elem[A]
+    private final case class Node[A](data: A, next: TRef[Elem[A]]) extends Elem[A]
+    private final case class End[A]()                              extends Elem[A]
+
+    def make[A >: Null]: UIO[TestQueue[A]] = for {
+      end     <- TRef.makeCommit[Elem[A]](End[A]())
+      sentinel = Node[A](null, end)
+      head    <- TRef.makeCommit[Node[A]](sentinel)
+      tail    <- TRef.makeCommit[Node[A]](sentinel)
+    } yield new TestQueue[A](head, tail)
+  }
+
 }

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1924,15 +1924,16 @@ object ZSTM {
             ZSTMLockSupport.tryLock(missing) {
               loop = !checkAndMaybeCommit(value)
             }
+            if (loop) tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
           }
         } else {
           value = stm.run(journal, fiberId, r)
           ZSTMLockSupport.tryLock(tRefsUnsafe) {
             loop = !checkAndMaybeCommit(value)
           }
+          if (loop && retries >= MaxRetries) tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
         }
 
-        if (loop && retries >= MaxRetries) tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
         retries += 1
       }
 

--- a/core/shared/src/main/scala/zio/stm/ZSTM.scala
+++ b/core/shared/src/main/scala/zio/stm/ZSTM.scala
@@ -1870,8 +1870,32 @@ object ZSTM {
       executor: Executor
     )(implicit unsafe: Unsafe): TryCommit[E, A] = {
       val journal     = new Journal
-      var value       = null.asInstanceOf[TExit[E, A]]
       val stateIsNull = state eq null
+
+      /**
+       * Checks that the value is a success, and commits the changes if the
+       * journal is valid and values have changed. Returns whether the
+       * transaction is valid.
+       *
+       * '''NOTE''': This method MUST be invoked while we hold the lock on the
+       * journal
+       */
+      def checkAndMaybeCommit(value: TExit[E, A]) = {
+        val isSuccess      = value.isInstanceOf[TExit.Succeed[_]]
+        val analysis       = journal.analyze(attemptCommit = isSuccess && stateIsNull)
+        val isJournalValid = analysis != JournalAnalysis.Invalid
+        if (isJournalValid) {
+          if (
+            analysis == JournalAnalysis.ReadWrite &&
+            isSuccess &&
+            (stateIsNull || state.compareAndSet(State.Running, State.done(value)))
+          ) journal.commit()
+          if (value ne TExit.Retry) journal.completeTodos(executor)
+        }
+        isJournalValid
+      }
+
+      var value = null.asInstanceOf[TExit[E, A]]
 
       // Used to store the previous snapshot of TRefs
       var tRefs = immutable.TreeSet.empty[TRef[?]]
@@ -1897,39 +1921,18 @@ object ZSTM {
                In case they changed, try acquiring the lock on them otherwise retry the entire transaction.
              */
             val missing = tRefsUnsafe.diff(tRefs)
-            val acquired = ZSTMLockSupport.tryLock(missing) {
-              if (value.isInstanceOf[TExit.Succeed[?]]) {
-                val isRunning = stateIsNull || state.compareAndSet(State.Running, State.done(value))
-                if (isRunning) journal.commit()
-                loop = false
-              } else if (journal.isValid) {
-                loop = false
-              }
+            ZSTMLockSupport.tryLock(missing) {
+              loop = !checkAndMaybeCommit(value)
             }
-
-            if (!acquired) {
-              tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
-            }
-            if (!loop && (value ne TExit.Retry)) journal.completeTodos(executor)
           }
         } else {
           value = stm.run(journal, fiberId, r)
           ZSTMLockSupport.tryLock(tRefsUnsafe) {
-            val isSuccess = value.isInstanceOf[TExit.Succeed[_]]
-            val analysis  = journal.analyze(attemptCommit = isSuccess && stateIsNull)
-            if (analysis != JournalAnalysis.Invalid) {
-              loop = false
-              if (
-                analysis == JournalAnalysis.ReadWrite &&
-                isSuccess &&
-                (stateIsNull || state.compareAndSet(State.Running, State.done(value)))
-              ) journal.commit()
-              if (value ne TExit.Retry) journal.completeTodos(executor)
-            }
+            loop = !checkAndMaybeCommit(value)
           }
-          if (loop && retries >= MaxRetries) tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
         }
 
+        if (loop && retries >= MaxRetries) tRefs = ZSTMUtils.newImmutableTreeSet(tRefsUnsafe)
         retries += 1
       }
 


### PR DESCRIPTION
/fixes #9264

Issue seems to be in a bug where the commit logic was inconsistent between the two branches in the retry loop (`retries >= MaxRetries`). Fixed it by extracting the logic into a common method for determining whether we commit and/or continue looping