### PR TITLE
Allow all types of statements within `suiteAll` for Scala 3

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SuiteAllSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SuiteAllSpec.scala
@@ -36,6 +36,26 @@ object SuiteAllSpec extends ZIOBaseSpec {
         } @@ ignore
       }
 
+      suiteAll("statements within suite") {
+        case class Foo(value: Int)
+        val one = 1
+        def two = 2
+        val foo = Foo(3)
+
+        test("val") {
+          assertTrue(one == 1)
+        }
+
+        test("def") {
+          assertTrue(two == 2)
+        }
+
+        test("case class") {
+          assertTrue(foo == Foo(3))
+        }
+
+      }
+
     }
       .provide(ZLayer.succeed(123))
 

--- a/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/ZIOSpecVersionSpecific.scala
@@ -25,11 +25,11 @@ object ZIOSpecVersionSpecificMacros {
         case Block(stats, expr) =>
           stats.flatMap(collectTests) ++ collectTests(expr)
 
-        case vd @ ValDef(_, _, _) =>
-          List(TestOrStatement.StatementCase(vd))
-
         case spec: Term if spec.tpe <:< TypeRepr.of[Spec[_, _]] =>
           List(TestOrStatement.SpecCase(spec))
+
+        case vd: Statement =>
+          List(TestOrStatement.StatementCase(vd))
 
         case other =>
           throw new Error("UNHANDLED: " + other)


### PR DESCRIPTION
/fixes #9271

While working on this, I also realised that other kinds of statements (e.g., case class definitions) wouldn't work either. This change fixes that also.