### PR TITLE
Make `TMap#toMap` idempotent

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -421,6 +421,47 @@ object TMapSpec extends ZIOBaseSpec {
           res <- map.get("foo").commit
         } yield assertTrue(res.contains(n))
       }
+    ),
+    suite("collection transformation transactions are idempotent")(
+      test("toMap") {
+        for {
+          state <- TMap.empty[String, Int].commit
+          a      = state.toMap.commit
+          _     <- state.put("a", 2).commit
+          s1    <- a
+          _     <- state.delete("a").commit
+          s2    <- a
+        } yield assertTrue(
+          s1 == Map("a" -> 2),
+          s2 == Map.empty[String, Int]
+        )
+      },
+      test("toList") {
+        for {
+          state <- TMap.empty[String, Int].commit
+          a      = state.toList.commit
+          _     <- state.put("a", 2).commit
+          s1    <- a
+          _     <- state.delete("a").commit
+          s2    <- a
+        } yield assertTrue(
+          s1 == List("a" -> 2),
+          s2 == List.empty[(String, Int)]
+        )
+      },
+      test("toChunk") {
+        for {
+          state <- TMap.empty[String, Int].commit
+          a      = state.toChunk.commit
+          _     <- state.put("a", 2).commit
+          s1    <- a
+          _     <- state.delete("a").commit
+          s2    <- a
+        } yield assertTrue(
+          s1 == Chunk("a" -> 2),
+          s2 == Chunk.empty[(String, Int)]
+        )
+      }
     )
   ) @@ exceptJS(nonFlaky)
 

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -526,8 +526,9 @@ final class TMap[K, V] private (
   /**
    * Collects all bindings into a map.
    */
-  def toMap: USTM[Map[K, V]] =
+  def toMap: USTM[Map[K, V]] = ZSTM.suspend {
     fold(Map.newBuilder[K, V])(_ += _).map(_.result())
+  }
 
   /**
    * Atomically updates all bindings using a pure function.


### PR DESCRIPTION
@ghostdogpr identified an issue with `TMap#toMap` where the transaction returned by `toMap` was retaining the state of the map at the time that it was created instead of the time that it's executed. e.g., this test would previously fail with `s2 == Map("a" -> 2)` even though the `a` key was deleted prior to running the transaction.

```scala
      test("toMap") {
        for {
          state <- TMap.empty[String, Int].commit
          a      = state.toMap.commit
          _     <- state.put("a", 2).commit
          s1    <- a
          _     <- state.delete("a").commit
          s2    <- a
        } yield assertTrue(
          s1 == Map("a" -> 2),
          s2 == Map.empty[String, Int]
        )
      }
```

Note that while only `toMap` was affected by this bug, I added tests for `toList` and `toChunk` as well just as a sanity check