### PR TITLE
Fix Span Substring Bounds Handling 

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
@@ -133,6 +133,32 @@ object TestArrowSpec extends ZIOBaseSpec {
             meta.meta(genFailureDetails = genFailureDetails2).asInstanceOf[Meta[Any, Nothing]].genFailureDetails
           assertTrue(res1.map(_.iterations == 1).getOrElse(false) && res2.map(_.iterations == 2).getOrElse(false))
         }
+      ),
+      suite("Span substring bounds")(
+        test("correctly handles valid span bounds within string length") {
+          val span = Span(0, 3)
+          assertTrue(span.substring("foo bar baz") == "foo")
+        },
+        test("clamps start when it is out of bounds") {
+          val span = Span(-3, 3)
+          assertTrue(span.substring("foo bar baz") == "foo")
+        },
+        test("clamps end when it exceeds string length") {
+          val span = Span(0, 10)
+          assertTrue(span.substring("foo") == "foo")
+        },
+        test("clamps both start and end when both are out of bounds") {
+          val span = Span(-5, 10)
+          assertTrue(span.substring("baz") == "baz")
+        },
+        test("returns empty string when start equals end") {
+          val span = Span(3, 3)
+          assertTrue(span.substring("foo bar baz") == "")
+        },
+        test("returns empty string when start is greater than end") {
+          val span = Span(4, 2)
+          assertTrue(span.substring("foo bar baz") == "")
+        }
       )
     )
 

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -288,7 +288,11 @@ object TestArrow {
   }
 
   case class Span(start: Int, end: Int) {
-    def substring(str: String): String = str.substring(start, end)
+    def substring(str: String): String = {
+      val safeStart = math.max(0, math.min(start, str.length))
+      val safeEnd   = math.max(safeStart, math.min(end, str.length))
+      str.substring(safeStart, safeEnd)
+    }
   }
 
   sealed case class Meta[-A, +B](


### PR DESCRIPTION
```
                at zio.test.TestArrow$Span.substring(TestArrow.scala:291)
```
Here the error arised because the `Span.substring` in TestArrow.scala throws an IndexOutOfBoundsException when the specified start and end values exceed the length of the target string. This issue affects the rendering of error messages for failed assertions. To fix this behaviour seen I have added clamping for out-of-bounds start and end indices in Span substring and tests to verify for the same

/claim #9209 