### PR TITLE
Ensure that FiberRuntime auto-yields when evaluating `WhileLoop`s

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -1,0 +1,82 @@
+package zio
+
+import zio.internal.FiberScope
+import zio.test.{TestAspect, assertTrue}
+
+import java.util.concurrent.atomic.AtomicInteger
+
+object FiberRuntimeSpec extends ZIOBaseSpec {
+  private implicit val unsafe: Unsafe = Unsafe.unsafe
+
+  def spec = suite("FiberRuntimeSpec")(
+    suite("whileLoop")(
+      test("auto-yields every 10280 operations when no other yielding is performed") {
+        val nIters       = 50000
+        val nOpsPerYield = 1024 * 10
+        val nOps         = new AtomicInteger(0)
+        val latch        = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val supervisor   = new YieldTrackingSupervisor(latch, nOps)
+        val f            = ZIO.whileLoop(nOps.getAndIncrement() < nIters)(Exit.unit)(_ => ())
+        ZIO
+          .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
+            val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
+            fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
+            fiber.startConcurrently(f)
+            latch.await
+          }
+          .as {
+            assertTrue(
+              supervisor.yieldedAt == List(
+                nIters + 1,
+                nOpsPerYield * 4 - 3,
+                nOpsPerYield * 3 - 2,
+                nOpsPerYield * 2 - 1,
+                nOpsPerYield
+              )
+            )
+          }
+      },
+      test("doesn't auto-yield when effect itself yields") {
+        implicit val unsafe: Unsafe = Unsafe
+        val nIters                  = 50000
+        val nOps                    = new AtomicInteger(0)
+        val latch                   = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val supervisor              = new YieldTrackingSupervisor(latch, nOps)
+        val f                       = ZIO.whileLoop(nOps.getAndIncrement() < nIters)(ZIO.when(nOps.get() % 10000 == 0)(ZIO.yieldNow))(_ => ())
+        ZIO
+          .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
+            val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
+            fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
+            fiber.startConcurrently(f)
+            latch.await
+          }
+          .as {
+            assertTrue(
+              supervisor.yieldedAt == List(nIters + 1, 50000, 40000, 30000, 20000, 10000)
+            )
+          }
+      }
+    )
+  ) @@ TestAspect.timeout(5.seconds)
+
+  private final class YieldTrackingSupervisor(
+    latch: Promise[Nothing, Unit],
+    nOps: AtomicInteger
+  ) extends Supervisor[Unit] {
+    @volatile var yieldedAt: List[Int]          = Nil
+    def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
+    def onStart[R, E, A](
+      environment: ZEnvironment[R],
+      effect: ZIO[R, E, A],
+      parent: Option[Fiber.Runtime[Any, Any]],
+      fiber: Fiber.Runtime[E, A]
+    )(implicit unsafe: Unsafe): Unit = ()
+    override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
+      latch.unsafe.done(Exit.unit)
+    override def onSuspend[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      yieldedAt ::= nOps.get()
+      ()
+    }
+  }
+
+}

--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -1,7 +1,7 @@
 package zio
 
 import zio.internal.FiberScope
-import zio.test.{TestAspect, assertTrue}
+import zio.test._
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -11,70 +11,84 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
   def spec = suite("FiberRuntimeSpec")(
     suite("whileLoop")(
       test("auto-yields every 10280 operations when no other yielding is performed") {
-        val nIters       = 50000
-        val nOpsPerYield = 1024 * 10
-        val nOps         = new AtomicInteger(0)
-        val latch        = Promise.unsafe.make[Nothing, Unit](FiberId.None)
-        val supervisor   = new YieldTrackingSupervisor(latch, nOps)
-        val f            = ZIO.whileLoop(nOps.getAndIncrement() < nIters)(Exit.unit)(_ => ())
-        ZIO
-          .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
-            val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
-            fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
-            fiber.startConcurrently(f)
-            latch.await
-          }
-          .as {
-            assertTrue(
-              supervisor.yieldedAt == List(
-                nIters + 1,
-                nOpsPerYield * 4 - 3,
-                nOpsPerYield * 3 - 2,
-                nOpsPerYield * 2 - 1,
-                nOpsPerYield
+        ZIO.suspendSucceed {
+          val nIters       = 50000
+          val nOpsPerYield = 1024 * 10
+          val nOps         = new AtomicInteger(0)
+          val latch        = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+          val supervisor   = new YieldTrackingSupervisor(latch, nOps)
+          val f            = ZIO.whileLoop(nOps.getAndIncrement() < nIters)(Exit.unit)(_ => ())
+          ZIO
+            .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
+              val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
+              fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
+              fiber.startConcurrently(f)
+              latch.await
+            }
+            .as {
+              val yieldedAt = supervisor.yieldedAt
+              assertTrue(
+                yieldedAt == List(
+                  nIters + 1,
+                  nOpsPerYield * 4 - 3,
+                  nOpsPerYield * 3 - 2,
+                  nOpsPerYield * 2 - 1,
+                  nOpsPerYield
+                )
               )
-            )
-          }
+            }
+        }
       },
       test("doesn't auto-yield when effect itself yields") {
-        implicit val unsafe: Unsafe = Unsafe
-        val nIters                  = 50000
-        val nOps                    = new AtomicInteger(0)
-        val latch                   = Promise.unsafe.make[Nothing, Unit](FiberId.None)
-        val supervisor              = new YieldTrackingSupervisor(latch, nOps)
-        val f                       = ZIO.whileLoop(nOps.getAndIncrement() < nIters)(ZIO.when(nOps.get() % 10000 == 0)(ZIO.yieldNow))(_ => ())
-        ZIO
-          .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
-            val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
-            fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
-            fiber.startConcurrently(f)
-            latch.await
-          }
-          .as {
-            assertTrue(
-              supervisor.yieldedAt == List(nIters + 1, 50000, 40000, 30000, 20000, 10000)
-            )
-          }
+        ZIO.suspendSucceed {
+          val nIters     = 50000
+          val nOps       = new AtomicInteger(0)
+          val latch      = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+          val supervisor = new YieldTrackingSupervisor(latch, nOps)
+          val f =
+            ZIO.whileLoop(nOps.getAndIncrement() < nIters)(ZIO.when(nOps.get() % 10000 == 0)(ZIO.yieldNow))(_ => ())
+          ZIO
+            .withFiberRuntime[Any, Nothing, Unit] { (parentFib, status) =>
+              val fiber = ZIO.unsafe.makeChildFiber(Trace.empty, f, parentFib, status.runtimeFlags, FiberScope.global)
+              fiber.setFiberRef(FiberRef.currentSupervisor, supervisor)
+              fiber.startConcurrently(f)
+              latch.await
+            }
+            .as {
+              val yieldedAt = supervisor.yieldedAt
+              assertTrue(
+                yieldedAt == List(nIters + 1, 50000, 40000, 30000, 20000, 10000)
+              )
+            }
+        }
       }
     )
-  ) @@ TestAspect.timeout(5.seconds)
+  )
 
   private final class YieldTrackingSupervisor(
     latch: Promise[Nothing, Unit],
     nOps: AtomicInteger
   ) extends Supervisor[Unit] {
-    @volatile var yieldedAt: List[Int]          = Nil
+    @volatile var yieldedAt           = List.empty[Int]
+    @volatile private var onEndCalled = false
+
     def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
+
     def onStart[R, E, A](
       environment: ZEnvironment[R],
       effect: ZIO[R, E, A],
       parent: Option[Fiber.Runtime[Any, Any]],
       fiber: Fiber.Runtime[E, A]
     )(implicit unsafe: Unsafe): Unit = ()
-    override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit =
-      latch.unsafe.done(Exit.unit)
+
+    override def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      onEndCalled = true
+      ()
+    }
+
     override def onSuspend[E, A](fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
       yieldedAt ::= nOps.get()
+      if (onEndCalled) latch.unsafe.done(Exit.unit) // onEnd gets called before onSuspend
       ()
     }
   }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1066,6 +1066,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               stackIndex = pushStackFrame(flatmap, stackIndex)
 
               val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
+              ops += 1
 
               if (null eq result)
                 return null
@@ -1096,6 +1097,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               stackIndex = pushStackFrame(fold, stackIndex)
 
               val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1, ops)
+              ops += 1
+
               if (null eq result)
                 return null
               else {
@@ -1161,6 +1164,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 stackIndex = pushStackFrame(k, stackIndex)
 
                 val exit = runLoop(update0.f(oldRuntimeFlags), stackIndex, stackIndex, currentDepth + 1, ops)
+                ops += 1
 
                 if (null eq exit)
                   return null

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -410,7 +410,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
           }
 
           val exit =
-            runLoop(effect, 0, _stackSize, initialDepth).asInstanceOf[Exit[E, A]]
+            runLoop(effect, 0, _stackSize, initialDepth, 0).asInstanceOf[Exit[E, A]]
 
           if (null eq exit) {
             // Terminate this evaluation, async resumption will continue evaluation:
@@ -962,13 +962,14 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     effect: ZIO.Erased,
     minStackIndex: Int,
     startStackIndex: Int,
-    currentDepth: Int
+    currentDepth: Int,
+    currentOps: Int
   ): Exit[Any, Any] = {
     assert(DisableAssertions || running.get)
 
     // Note that assigning `cur` as the result of `try` or `if` can cause Scalac to box local variables.
     var cur        = effect
-    var ops        = 0
+    var ops        = currentOps
     var stackIndex = startStackIndex
 
     if (currentDepth >= FiberRuntime.MaxDepthBeforeTrampoline) {
@@ -1064,7 +1065,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               stackIndex = pushStackFrame(flatmap, stackIndex)
 
-              val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1)
+              val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
 
               if (null eq result)
                 return null
@@ -1094,7 +1095,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               stackIndex = pushStackFrame(fold, stackIndex)
 
-              val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1)
+              val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1, ops)
               if (null eq result)
                 return null
               else {
@@ -1159,7 +1160,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
                 stackIndex = pushStackFrame(k, stackIndex)
 
-                val exit = runLoop(update0.f(oldRuntimeFlags), stackIndex, stackIndex, currentDepth + 1)
+                val exit = runLoop(update0.f(oldRuntimeFlags), stackIndex, stackIndex, currentDepth + 1, ops)
 
                 if (null eq exit)
                   return null
@@ -1191,7 +1192,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               cur = null
 
               while ((cur eq null) && check()) {
-                runLoop(iterate.body(), stackIndex, stackIndex, nextDepth) match {
+                runLoop(iterate.body(), stackIndex, stackIndex, nextDepth, ops) match {
                   case s: Success[Any] =>
                     iterate.process(s.value)
                   case null =>
@@ -1199,6 +1200,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case failure =>
                     cur = failure
                 }
+                ops += 1
               }
 
               stackIndex -= 1


### PR DESCRIPTION
While reviewing #9131 I realised that we're not propagating the number of operations that were evaluated when we re-enter `FiberRuntime#runLoop`. This means that an infinitely running `WhileLoop` will never auto-yield.

Note that the implementation is not strictly correct, as the number of operations executed in "deeper" levels are not propagated backwards. The only way to make this behaviour exact is to use a heap variable or propagate a mutable counter when re-entering `runLoop`. However, since I don't think we need to be very strict with when we auto-yield, this more lightweight implementation should be good enough.

@jdegoes what do you think regarding the above?