### PR TITLE
Allow creation of child fibers within uninterruptible regions on interrupted fibers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1626,10 +1626,11 @@ object ZIOSpec extends ZIOBaseSpec {
           isInterupted <- Promise.make[Nothing, Boolean]
           parent <- ZIO.never.onInterrupt {
                       for {
-                        child <- ZIO.unit.fork
+                        latch <- Promise.make[Nothing, Unit]
+                        child <- latch.await.fork
                         _     <- ZIO.sleep(10.millis)
                         _     <- isInterupted.done(Exit.succeed(child.asInstanceOf[FiberRuntime[?, ?]].isInterrupted()))
-                        _     <- child.interrupt
+                        _     <- latch.done(Exit.unit)
                       } yield ()
                     }.forkDaemon
           _   <- parent.interrupt.delay(10.millis)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2,9 +2,9 @@ package zio
 
 import zio.Cause._
 import zio.LatchOps._
-import zio.internal.Platform
+import zio.internal.{FiberRuntime, Platform}
 import zio.test.Assertion._
-import zio.test.TestAspect.{exceptJS, flaky, forked, jvmOnly, nonFlaky, scala2Only}
+import zio.test.TestAspect.{exceptJS, flaky, forked, jvmOnly, nonFlaky, scala2Only, withLiveClock}
 import zio.test._
 
 import scala.annotation.tailrec
@@ -1620,7 +1620,22 @@ object ZIOSpec extends ZIOBaseSpec {
           _     <- latch.await
           exit  <- fiber.interrupt.map(_.mapErrorCauseExit((cause: Cause[Nothing]) => cause.untraced))
         } yield assert(exit)(isInterrupted)
-      } @@ exceptJS(nonFlaky)
+      } @@ exceptJS(nonFlaky),
+      test("child fibers can be created on interrupted parents within unininterruptible regions") {
+        for {
+          isInterupted <- Promise.make[Nothing, Boolean]
+          parent <- ZIO.never.onInterrupt {
+                      for {
+                        child <- ZIO.never.interruptible.fork
+                        _     <- ZIO.sleep(10.millis)
+                        _     <- isInterupted.done(Exit.succeed(child.asInstanceOf[FiberRuntime[?, ?]].isInterrupted()))
+                        _     <- child.interrupt
+                      } yield ()
+                    }.forkDaemon
+          _   <- parent.interrupt.delay(10.millis)
+          res <- isInterupted.await
+        } yield assertTrue(!res)
+      } @@ withLiveClock @@ exceptJS(nonFlaky(10)) @@ zioTag(interruption)
     ),
     suite("negate")(
       test("on true returns false") {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1626,7 +1626,7 @@ object ZIOSpec extends ZIOBaseSpec {
           isInterupted <- Promise.make[Nothing, Boolean]
           parent <- ZIO.never.onInterrupt {
                       for {
-                        child <- ZIO.never.interruptible.fork
+                        child <- ZIO.unit.fork
                         _     <- ZIO.sleep(10.millis)
                         _     <- isInterupted.done(Exit.succeed(child.asInstanceOf[FiberRuntime[?, ?]].isInterrupted()))
                         _     <- child.interrupt

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -158,7 +158,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       if (isAlive()) {
         getChildren().add(child)
 
-        if (isInterrupted())
+        if (shouldInterrupt())
           child.tellInterrupt(getInterruptedCause())
       } else {
         child.tellInterrupt(getInterruptedCause())
@@ -170,7 +170,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     if (isAlive()) {
       val childs = getChildren()
 
-      if (isInterrupted()) {
+      if (shouldInterrupt()) {
         val cause = getInterruptedCause()
         while (iter.hasNext) {
           val child = iter.next()


### PR DESCRIPTION
/fixes #9288

After thinking about it quite extensively, I think we should allow the creation of child fibers when the parent is interrupted but we're within an uninterruptible region (e.g., in finalizers). Any child fibers that are created during this time will still be interrupted when the interrupted parent fiber exits, so we're not risking leaking resources.

I believe that this change brings better alignment of the semantics of finalizers and uninterruptible regions between effects that do/don't require additional fibers to be created as part of their finalization, as evident by in the linked issue.