### PR TITLE
Improve subtype global cache performance

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -283,7 +283,7 @@ final class ZEnvironment[+R] private (
         else value
       }
 
-      private[this] def getUnsafe[A](tag: LightTypeTag)(implicit unsafe: Unsafe): A = {
+      private[this] def getUnsafe[A](tag: LightTypeTag): A = {
         val fromCache = self.cache.get(tag)
         if (fromCache != null)
           fromCache.asInstanceOf[A]
@@ -301,7 +301,7 @@ final class ZEnvironment[+R] private (
             }
           }
           if (service != null) {
-            self.cache.put(tag, service)
+            self.cache.putIfAbsent(tag, service)
           }
           service
         }


### PR DESCRIPTION
While looking into another issue I realised that the performance of `ConcurrentHashMap#computeIfAbsent` degrades quite badly under heavy contention as opposed to using `get`. This seems to affect the global subtype cache quite heavily as it's continuously accessed by multiple threads.

This PR fixes the contention issue by:
1. Using `get` / `putIfAbsent` in favour of `computeIfAbsent` which offers better read performance at the cost of potentially computing `left <:< right` more than once. This is a small price to pay since this should only happen during app warmup
2. Using oversized maps. Larger map sizes have lower chances of hash collisions which offer better read and write performance