### PR TITLE
fix: `ZIO.raceFirst` prevents scope finalisers from running 

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -7,6 +7,8 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{exceptJS, flaky, forked, jvmOnly, nonFlaky, scala2Only, timeout, withLiveClock}
 import zio.test._
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 import scala.annotation.tailrec
 import scala.util.{Failure, Success, Try}
 


### PR DESCRIPTION
/claim #9203
Fixes #9203