### PR TITLE
Fix memory leak in `ZKeydPool#invalidate`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
@@ -57,7 +57,7 @@ object ZKeyedPoolSpec extends ZIOBaseSpec {
               )
           }
           .as(assertCompletes)
-      }
+      } @@ jvmOnly
     ) @@ exceptJS
 
 }

--- a/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
@@ -206,6 +206,12 @@ object ZPoolSpec extends ZIOBaseSpec {
             _         <- ZIO.scoped(ZPool.make(incCounter <* ZIO.fail("oh no"), 10))
             _         <- latch.await
           } yield assertCompletes
-        } @@ exceptJS(nonFlaky(1000))
+        } @@ exceptJS(nonFlaky(1000)) +
+        test("calling invalidate with items not in the pool doesn't cause memory leaks") {
+          for {
+            pool <- ZPool.make(ZIO.succeed(Array.empty[Int]), 1)
+            _    <- ZIO.foreachDiscard(1 to 1000)(_ => pool.invalidate(Array.ofDim[Int](10000000)))
+          } yield assertCompletes
+        }
     }.provideLayer(Scope.default) @@ timeout(30.seconds)
 }

--- a/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZPoolSpec.scala
@@ -212,6 +212,6 @@ object ZPoolSpec extends ZIOBaseSpec {
             pool <- ZPool.make(ZIO.succeed(Array.empty[Int]), 1)
             _    <- ZIO.foreachDiscard(1 to 1000)(_ => pool.invalidate(Array.ofDim[Int](10000000)))
           } yield assertCompletes
-        }
+        } @@ jvmOnly
     }.provideLayer(Scope.default) @@ timeout(30.seconds)
 }

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -17,7 +17,9 @@ object MimaSettings {
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.todo"),
         exclude[DirectMissingMethodProblem]("zio.stm.TRef.versioned_="),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned"),
-        exclude[ReversedMissingMethodProblem]("zio.Fiber#Runtime#UnsafeAPI.zio$Fiber$Runtime$UnsafeAPI$$$outer")
+        exclude[ReversedMissingMethodProblem]("zio.Fiber#Runtime#UnsafeAPI.zio$Fiber$Runtime$UnsafeAPI$$$outer"),
+        exclude[FinalClassProblem]("zio.ZPool$DefaultPool"),
+        exclude[DirectMissingMethodProblem]("zio.ZPool#DefaultPool.invalidated")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
/fixes #9306

The current behaviour of `ZPool#invalidate` is to add the invalidated item in a set which we then use to determine if an item that should be removed from the pool. This usage pattern can result in a memory leak when `invalidate` is called on items that are not present in the pool as they'll never be removed from the `invalidated` set.

I considered a few different implementations for this, but I ended up going with the simplest one I could think of
- Instead of using a set to track the invalidated items, we use one to track the allocated items.
- When we invalidate an item, we remove it from this set.
- When we return / get an item from the pool, we check if the item is present in the `allocated` set, and if not that means it's been invalidated, so we remove it from the pool altogether

PS: I realised that the implementation of ZPool is rather inefficient at this moment and can be optimized. Since it's heavily used by ZIO HTTP's Client, I'll create a followup PR to optimize it