### PR TITLE
Fix interruption propagation in `ZChannel#mapOutPar*` methods

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2725,7 +2725,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               count <- latch.count
               _     <- f.join
             } yield assertTrue(count == 0)
-          } @@ TestAspect.jvmOnly @@ nonFlaky(5),
+          } @@ TestAspect.jvmOnly @@ nonFlaky,
           test("accumulates parallel errors") {
             sealed abstract class DbError extends Product with Serializable
             case object Missing           extends DbError

--- a/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/CheckSpec.scala
@@ -1,7 +1,7 @@
 package zio.test
 
 import zio.test.Assertion._
-import zio.test.TestAspect.failing
+import zio.test.TestAspect._
 import zio.{Chunk, Random, Ref, ZIO}
 
 object CheckSpec extends ZIOBaseSpec {
@@ -88,6 +88,9 @@ object CheckSpec extends ZIOBaseSpec {
       checkAllPar(Gen.int, 2) { _ =>
         assertZIO(ZIO.unit)(equalTo(()))
       }
-    }
+    },
+    test("i9303") {
+      checkAllPar(Gen.int, 4)(_ => assertCompletes)
+    } @@ jvm(nonFlaky(1000))
   )
 }


### PR DESCRIPTION
/fixes #9303
/cc @regiskuckaertz

> [!NOTE]
> A large number of changes in this PR are due to whitespaces. Make sure to review it with whitespace diff ignored

A previous PR (https://github.com/zio/zio/pull/9123) introduced some flakiness in a number of tests where `ZChannel#mapOutPar*` methods are involved. After some extensive investigation, the issue is due to race conditions in the propagation of interruption from the parent fiber to the forked fibers.

This PR fixes it through these main changes:

1. Create a fork of the parent scope and fork worker fibers using `forkIn(childScope)`. If the `errorSignal` succeeds, then close the child scope. This ensures that all in-progress worker fibers are interrupted prior to closing the stream. This is the same behaviour as with the previous implementation, but without using `race` for each forked worker to await on the error signal.
2. Use `onExit` rather than `catchAllCause` when handling errors in the main loop. We need to do this because `catchAllCause` will not be executed in cases that we're within an interruptible region and the parent fiber is interrupted.