### PR TITLE
Fix timeouts in ZStream test

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2400,9 +2400,9 @@ object ZStreamSpec extends ZIOBaseSpec {
                      .runDrain
                      .fork
               _ <- requestQueue.offer("some message").forever.fork
-              _ <- counter.get.repeatUntil(_ >= 10)
+              _ <- (ZIO.yieldNow *> counter.get).repeatUntil(_ >= 10)
             } yield assertCompletes
-          } @@ exceptJS(nonFlaky) @@ TestAspect.timeout(10.seconds)
+          } @@ exceptJS(nonFlaky) @@ TestAspect.timeout(30.seconds)
         ),
         suite("interruptAfter")(
           test("interrupts after given duration") {


### PR DESCRIPTION
Seems to happen on Scala Native only. Adding manual yielding and increased timeout to resolve the issue