### PR TITLE
Introducing ZIO Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 | --- | --- | --- | --- | --- |
 | [![Project stage][Badge-Stage]][Badge-Stage-Page] | ![CI][Badge-CI] | [![Release Artifacts][Badge-SonatypeReleases]][Link-SonatypeReleases] | [![Snapshot Artifacts][Badge-SonatypeSnapshots]][Link-SonatypeSnapshots] | [![Average time to resolve an issue][Badge-IsItMaintained]][Link-IsItMaintained] |
 
-| Scaladoc | Scaladex | Discord | Twitter | Gitpod |
-| --- | --- | --- | --- | --- |
-| [Scaladoc][Link-Scaladoc] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] | [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/zio/zio) |
+| Scaladoc | Scaladex | Discord | Twitter | Gitpod | Gurubase |
+| --- | --- | --- | --- | --- | --- |
+| [Scaladoc][Link-Scaladoc] | [![Badge-Scaladex-page]][Link-Scaladex-page] | [![Badge-Discord]][Link-Discord] | [![Badge-Twitter]][Link-Twitter] | [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/zio/zio) | [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20ZIO%20Guru-006BFF)](https://gurubase.io/g/zio) |
 
 # Welcome to ZIO
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [ZIO Guru](https://gurubase.io/g/zio) to Gurubase. ZIO Guru uses the data from this repo and data from the [docs](https://zio.dev/) to answer questions by leveraging the LLM.

In this PR, I showcased the "ZIO Guru", which highlights that ZIO now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable ZIO Guru in Gurubase, just let me know that's totally fine.
