### PR TITLE
Suppress ExplicitImplicitTypes Wartremover warning in macro

### DIFF
--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -79,8 +79,10 @@ private[zio] trait LayerMacroUtils {
       )
 
       val traceVal = if (usesEnvironment || usesCompose) {
-        val trace = c.freshName(TermName("trace"))
-        List(q"implicit val $trace: ${typeOf[Trace]} = ${reify(Tracer)}.newTrace")
+        val trace       = c.freshName(TermName("trace"))
+        val suppress    = typeOf[SuppressWarnings]
+        val wartRemover = q"""${reify(Array)}("org.wartremover.warts.ExplicitImplicitTypes")"""
+        List(q"@$suppress($wartRemover) implicit val $trace: ${typeOf[Trace]} = ${reify(Tracer)}.newTrace")
       } else {
         Nil
       }


### PR DESCRIPTION
This should fix #9320 