### PR TITLE
Fix scope propagation for multiple specs #9175

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -79,11 +79,39 @@ object SpecSpec extends ZIOBaseSpec {
           summary <- execute(spec)
         } yield assertTrue(summary.success == 1)
       },
+      test("dependencies of shared service are scoped to lifetime of suite") {
+        trait Service {
+          def open: UIO[Boolean]
+        }
+        object Service {
+          val open: ZIO[Service, Nothing, Boolean] =
+            ZIO.serviceWithZIO(_.open)
+        }
+        val layer =
+          ZLayer {
+            for {
+              ref <- Ref.make(true)
+              _   <- ZIO.addFinalizer(ref.set(false))
+            } yield new Service {
+              def open: UIO[Boolean] =
+                ref.get
+            }
+          }
+        val spec = suite("suite")(
+          test("test1") {
+            assertZIO(Service.open)(isTrue)
+          },
+          test("test2") {
+            assertZIO(Service.open)(isTrue)
+          }
+        ).provideLayerShared(layer).provideLayer(Scope.default) @@ sequential
+        assertZIO(succeeded(spec))(isTrue)
+      },
       test("propagates the scope to multiple tests") {
         def assertion = ZIO.scoped {
           for {
-            value <- Random.nextInt
-          } yield assertTrue(value != -1295463240) // TestRandom.deterministic produces -1295463240
+            rnd <- ZIO.random
+          } yield assertTrue(rnd == Random.RandomLive)
         }
         val spec = suite("suite")(
           test("test1") {
@@ -217,6 +245,24 @@ object SpecSpec extends ZIOBaseSpec {
           }
         ).provideSomeLayerShared[Scope](layer).provideLayer(Scope.default) @@ sequential
         assertZIO(succeeded(spec))(isTrue)
+      },
+      test("propagates the scope to multiple tests") {
+        def assertion = ZIO.scoped {
+          for {
+            rnd <- ZIO.random
+          } yield assertTrue(rnd == Random.RandomLive)
+        }
+        val spec = suite("suite")(
+          test("test1") {
+            assertion
+          },
+          test("test2") {
+            assertion
+          }
+        ).provideSomeLayerShared(ZLayer.scoped(ZIO.withRandomScoped(Random.RandomLive)))
+        for {
+          summary <- execute(spec)
+        } yield assertTrue(summary.success == 2)
       }
     ),
     suite("iterable constructor") {

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -78,6 +78,24 @@ object SpecSpec extends ZIOBaseSpec {
         for {
           summary <- execute(spec)
         } yield assertTrue(summary.success == 1)
+      },
+      test("propagates the scope to multiple tests") {
+        def assertion = ZIO.scoped {
+          for {
+            value <- Random.nextInt
+          } yield assertTrue(value != -1295463240) // TestRandom.deterministic produces -1295463240
+        }
+        val spec = suite("suite")(
+          test("test1") {
+            assertion
+          },
+          test("test2") {
+            assertion
+          }
+        ).provideLayerShared(ZLayer.scoped(ZIO.withRandomScoped(Random.RandomLive)))
+        for {
+          summary <- execute(spec)
+        } yield assertTrue(summary.success == 2)
       }
     ),
     suite("provideSomeLayerShared")(

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -342,7 +342,9 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
         )
       case MultipleCase(specs) =>
         Spec.scoped[R0](
-          layer.memoize.map(layer => Spec.multiple(specs.map(_.provideLayer(layer))))
+          layer.memoize.flatMap(layer =>
+            layer.mapError(TestFailure.fail).build.map(_ => Spec.multiple(specs.map(_.provideLayer(layer))))
+          )
         )
       case TestCase(test, annotations) => Spec.test(test.provideLayer(layer.mapError(TestFailure.fail)), annotations)
     }
@@ -531,10 +533,10 @@ object Spec {
           )
         case MultipleCase(specs) =>
           Spec.scoped[R0](
-            layer
-              .mapError(TestFailure.fail)
-              .build
-              .map(r => Spec.multiple(specs.map(_.provideSomeLayer[R0](ZLayer.succeedEnvironment(r)))))
+            layer.memoize
+              .flatMap(layer =>
+                layer.mapError(TestFailure.fail).build.map(_ => Spec.multiple(specs.map(_.provideSomeLayer[R0](layer))))
+              )
           )
         case TestCase(test, annotations) =>
           Spec.test(test.provideSomeLayer(layer.mapError(TestFailure.fail)), annotations)

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -342,7 +342,7 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
         )
       case MultipleCase(specs) =>
         Spec.scoped[R0](
-          layer.mapError(TestFailure.fail).build.map(r => Spec.multiple(specs.map(_.provideEnvironment(r))))
+          layer.memoize.map(layer => Spec.multiple(specs.map(_.provideLayer(layer))))
         )
       case TestCase(test, annotations) => Spec.test(test.provideLayer(layer.mapError(TestFailure.fail)), annotations)
     }


### PR DESCRIPTION
/claim #9175

I found the commit which introduced the bug https://github.com/zio/zio/commit/ff01fa4994597391d32ed373bf9f18fd93d61d76#diff-ad3f1b449cac121bd82f6d24a2a105e90334bc80deaf7a1fd050ab950b821ac5R345

I don't fully understand why the current implementation fails, so I just reverted the code to when it worked.