### PR TITLE
Refactor `FiberRefs` shortcut optimizations

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -452,7 +452,56 @@ object FiberRefSpec extends ZIOBaseSpec {
         _        <- promise.succeed(child2)
         value    <- child1.join
       } yield assertTrue(value)
-    }
+    },
+    suite("hasIdentityFork & hasSecondFnJoin")(
+      test("ZIO-provided refs") {
+        val shouldBeTrue = List(
+          FiberRef.currentLogLevel,
+          FiberRef.currentLogSpan,
+          FiberRef.currentLogAnnotations,
+          FiberRef.currentTags,
+          FiberRef.overrideExecutor,
+          FiberRef.currentEnvironment,
+          FiberRef.currentBlockingExecutor,
+          FiberRef.currentFatal,
+          FiberRef.currentFiberIdGenerator,
+          FiberRef.currentLoggers,
+          FiberRef.currentReportFatal,
+          FiberRef.currentRuntimeFlags,
+          FiberRef.currentSupervisor,
+          FiberRef.unhandledErrorLogLevel
+        )
+        val shouldBeFalse = List(
+          FiberRef.forkScopeOverride,
+          FiberRef.interruptedCause
+        )
+        assertTrue(
+          shouldBeTrue.forall(_.hasIdentityFork),
+          shouldBeTrue.forall(_.hasSecondFnJoin),
+          !shouldBeFalse.exists(_.hasIdentityFork),
+          !shouldBeFalse.exists(_.hasSecondFnJoin)
+        )
+      },
+      test("user-defined ref") {
+        implicit val unsafe: Unsafe = Unsafe
+
+        val ref1 = FiberRef.unsafe.make[String]("foo")
+        val ref2 = FiberRef.unsafe.make[String]("foo", fork = _ => "foo")
+        val ref3 = FiberRef.unsafe.make[String]("foo", join = (l, r) => l + r)
+        val ref4 = FiberRef.unsafe.make[String]("foo", fork = _ => "foo", join = (l, r) => l + r)
+
+        assertTrue(
+          ref1.hasIdentityFork,
+          ref1.hasSecondFnJoin,
+          !ref2.hasIdentityFork,
+          ref2.hasSecondFnJoin,
+          ref3.hasIdentityFork,
+          !ref3.hasSecondFnJoin,
+          !ref4.hasIdentityFork,
+          !ref4.hasSecondFnJoin
+        )
+      }
+    )
   ) @@ TestAspect.fromLayer(Runtime.enableCurrentFiber) @@ TestAspect.sequential
 }
 

--- a/core/shared/src/main/scala/zio/FiberRefs.scala
+++ b/core/shared/src/main/scala/zio/FiberRefs.scala
@@ -56,15 +56,15 @@ final class FiberRefs private (
    * invocation of [[forkAs]] when we already know that the map will not be
    * transformed
    */
-  private var needsTransformWhenForked: Boolean = true
+  private[this] lazy val needsTransformWhenForked: Boolean =
+    !fiberRefLocals.keysIterator.forall(_.hasIdentityFork)
 
   /**
    * Boolean flag which indicates whether this FiberRefs requires a transform on
    * the values when joining with its own self (as determined by `eq`).
-   *
-   * Note that this should the case with all ZIO-provided `FiberRef`.
    */
-  private[this] var needsTransformWhenJoinEq: Boolean = true
+  private[this] lazy val needsTransformWhenJoinEq: Boolean =
+    !fiberRefLocals.keysIterator.forall(_.hasSecondFnJoin)
 
   /**
    * Forks this collection of fiber refs as the specified child fiber id. This
@@ -74,15 +74,14 @@ final class FiberRefs private (
   def forkAs(childId: FiberId.Runtime): FiberRefs =
     if (needsTransformWhenForked) {
       val childMap = fiberRefLocals.transform { (fiberRef, entry) =>
-        val fork = fiberRef.fork
-        if (fork.asInstanceOf[AnyRef] eq ZIO.identityFn[Any]) {
+        if (fiberRef.hasIdentityFork) {
           entry
         } else {
           import entry.{depth, stack}
 
           type T = fiberRef.Value & AnyRef
           val oldValue = stack.head.value.asInstanceOf[T]
-          val newValue = fiberRef.patch(fork)(oldValue).asInstanceOf[T]
+          val newValue = fiberRef.patch(fiberRef.fork)(oldValue).asInstanceOf[T]
           if (eqWithBoxedNumericEquality(oldValue, newValue)) entry
           else {
 
@@ -101,10 +100,7 @@ final class FiberRefs private (
       }
 
       if (childMap ne fiberRefLocals) FiberRefs(childMap)
-      else {
-        needsTransformWhenForked = false
-        self
-      }
+      else self
     } else self
 
   /**
@@ -152,15 +148,13 @@ final class FiberRefs private (
    * preservation of maximum information from both child and parent refs.
    */
   def joinAs(fiberId: FiberId.Runtime)(that: FiberRefs): FiberRefs = {
-    val areEqual = self eq that
-
-    // First attempt at shortcut when the two objects are the same, and we already know that we don't need to transform
-    if (areEqual && !needsTransformWhenJoinEq) {
-      return self
-    }
-
     val childFiberRefs  = that.fiberRefLocals
     var fiberRefLocals0 = self.fiberRefLocals
+
+    // First attempt at shortcut when the two objects are the same, and we already know that we don't need to transform
+    if ((childFiberRefs eq fiberRefLocals0) && !needsTransformWhenJoinEq) {
+      return self
+    }
 
     val it = childFiberRefs.asInstanceOf[Map[FiberRef[AnyRef], Value]].iterator
     while (it.hasNext) {
@@ -178,7 +172,7 @@ final class FiberRefs private (
           val newValue = ref.join(initial, childValue)
           // Attempt to shortcut in case that the value after the join is the same as the initial one
           if (!eqWithBoxedNumericEquality(newValue, initial)) {
-            val v = Value(::(StackEntry(fiberId, newValue, 0), List.empty), 1)
+            val v = Value(::(StackEntry(fiberId, newValue, 0), Nil), 1)
             fiberRefLocals0 = fiberRefLocals0.updated(ref, v)
           }
         } else {
@@ -217,10 +211,8 @@ final class FiberRefs private (
       }
     }
 
-    if (self.fiberRefLocals eq fiberRefLocals0) {
-      if (areEqual) needsTransformWhenJoinEq = false
-      self
-    } else FiberRefs(fiberRefLocals0)
+    if (self.fiberRefLocals eq fiberRefLocals0) self
+    else FiberRefs(fiberRefLocals0)
   }
 
   @tailrec
@@ -269,7 +261,7 @@ final class FiberRefs private (
     val oldEntry = fiberRefLocals.getOrElse(fiberRef, null)
     val newEntry =
       if (oldEntry eq null) {
-        Value(::(StackEntry(fiberId, value, 0), List.empty), 1)
+        Value(::(StackEntry(fiberId, value, 0), Nil), 1)
       } else {
         val oldStack = oldEntry.stack.asInstanceOf[::[StackEntry[A]]]
         val oldDepth = oldEntry.depth
@@ -303,7 +295,7 @@ final class FiberRefs private (
     val oldEntry = fiberRefLocals.getOrElse(currentRuntimeFlags, null)
     val newEntry =
       if (oldEntry eq null)
-        Value(::(StackEntry(fiberId, value, 0), List.empty), 1)
+        Value(::(StackEntry(fiberId, value, 0), Nil), 1)
       else {
         val oldStack = oldEntry.stack.asInstanceOf[::[StackEntry[Int]]]
         val oldDepth = oldEntry.depth

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -411,9 +411,9 @@ object ZEnvironment {
         if (patches eq Nil) env
         else
           patches.head match {
-            case AddService(service, tag) => loop(env.unsafe.addService(tag, service)(Unsafe.unsafe), patches.tail)
+            case AddScope(scope)          => loop(env.unsafe.addScope(scope)(Unsafe), patches.tail)
+            case AddService(service, tag) => loop(env.unsafe.addService(tag, service)(Unsafe), patches.tail)
             case AndThen(first, second)   => loop(env, erase(first) :: erase(second) :: patches.tail)
-            case AddScope(scope)          => loop(env.unsafe.addScope(scope)(Unsafe.unsafe), patches.tail)
             case _: Empty[?]              => loop(env, patches.tail)
             case _: RemoveService[?, ?]   => loop(env, patches.tail)
             case _: UpdateService[?, ?]   => loop(env, patches.tail)


### PR DESCRIPTION
Followup of #9327

Currently `FiberRefs` utilize 2 internal vars to determine whether to optimize `FiberRefs#forkAs` and `FiberRefs#joinAs` in common usecases. However, the way that we currently determine the value of these flags requires the forkAs / joinAs methods to execute at least once, and are not propagated whenever we create a new instance of `FiberRefs`, so we cannot apply these optimizations efficiently in cases that we update a `FiberRef` a lot (e.g., code that relies heavily on `ZIO.scoped`).

While working on #9327 I realised that when we create a new `FiberRef`, we already have all the information necessary to determine whether it requires transformations on fork/join. So in this PR we add flags to `FiberRef`, so then in `FiberRefs` we simply iterate over the Map keys to determine the values of the optimization flags.

Note that this PR contains 1-2 other unrelated small optimizations that I noticed while working on it (e.g., the change in the pat-mat ordering in ZEnvironment) and it didn't seem substantial enough to create a new PR for