### PR TITLE
Fix leak of finalizers in `ZKeyedPool`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
@@ -57,7 +57,18 @@ object ZKeyedPoolSpec extends ZIOBaseSpec {
               )
           }
           .as(assertCompletes)
-      } @@ jvmOnly
+      } @@ jvmOnly,
+      test("finalizers of a resource don't leak to the pool's scope") {
+        ZIO.scoped(
+          ZKeyedPool
+            .make[String, Scope, Nothing, Unit](_ => Scope.addFinalizer(ZIO.unit).as(()), size = 1)
+            .flatMap { pool =>
+              ZIO.scoped(pool.get("key0").flatMap(pool.invalidate(_))).replicateZIODiscard(1000)
+            }
+            .flatMap(_ => ZIO.scope.map(_.size))
+            .map(v => assertTrue(v <= 10L)) // We expect a few finalizers managing the pool itself but not too many
+        )
+      }
     ) @@ exceptJS
 
 }

--- a/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZKeyedPoolSpec.scala
@@ -61,12 +61,12 @@ object ZKeyedPoolSpec extends ZIOBaseSpec {
       test("finalizers of a resource don't leak to the pool's scope") {
         ZIO.scoped(
           ZKeyedPool
-            .make[String, Scope, Nothing, Unit](_ => Scope.addFinalizer(ZIO.unit).as(()), size = 1)
+            .make[String, Scope, Nothing, Unit]((_: String) => Scope.addFinalizer(ZIO.unit).as(()), size = 1)
             .flatMap { pool =>
               ZIO.scoped(pool.get("key0").flatMap(pool.invalidate(_))).replicateZIODiscard(1000)
             }
-            .flatMap(_ => ZIO.scope.map(_.size))
-            .map(v => assertTrue(v <= 10L)) // We expect a few finalizers managing the pool itself but not too many
+            .flatMap(_ => ZIO.scope.map(_.asInstanceOf[Scope.Closeable].size))
+            .map(v => assertTrue(v == 1)) // Pool's finalizer
         )
       }
     ) @@ exceptJS

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -72,12 +72,6 @@ trait Scope extends Serializable { self =>
    */
   final def fork(implicit trace: Trace): UIO[Scope.Closeable] =
     forkWith(executionStrategy)
-
-  /**
-   * Returns the number of finalizers that have been added to this scope and not
-   * yet finalized.
-   */
-  def size: Int
 }
 
 object Scope {
@@ -89,6 +83,12 @@ object Scope {
      * have been added to the scope.
      */
     def close(exit: => Exit[Any, Any])(implicit trace: Trace): UIO[Unit]
+
+    /**
+     * Returns the number of finalizers that have been added to this scope and
+     * not yet finalized.
+     */
+    def size: Int
 
     /**
      * Uses the scope by providing it to a `ZIO` workflow that needs a scope,

--- a/core/shared/src/main/scala/zio/ZKeyedPool.scala
+++ b/core/shared/src/main/scala/zio/ZKeyedPool.scala
@@ -123,7 +123,7 @@ object ZKeyedPool {
                                       .extend(
                                         ZPool
                                           .make(
-                                            get(key).provideEnvironment(environment),
+                                            get(key).provideSomeEnvironment[Scope](environment.union[Scope](_)),
                                             range(key),
                                             ttl(key).getOrElse(Duration.Infinity)
                                           )

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -19,7 +19,9 @@ object MimaSettings {
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned"),
         exclude[ReversedMissingMethodProblem]("zio.Fiber#Runtime#UnsafeAPI.zio$Fiber$Runtime$UnsafeAPI$$$outer"),
         exclude[FinalClassProblem]("zio.ZPool$DefaultPool"),
-        exclude[DirectMissingMethodProblem]("zio.ZPool#DefaultPool.invalidated")
+        exclude[DirectMissingMethodProblem]("zio.ZPool#DefaultPool.invalidated"),
+        exclude[ReversedMissingMethodProblem]("zio.Scope#ReleaseMap.size"),
+        exclude[ReversedMissingMethodProblem]("zio.Scope#Closeable.size")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
This issue was [reported by a user](https://discord.com/channels/629491597070827530/819703129267372113/1309454293270790246) in zio-http's Discord channel.

In short, the current implementation of `ZKeyedPool` incorrectly attaches finalizers from the acquisition of a resource to the scope of the `ZKeyedPool`. So when items are removed from the pool, their finalizers remain in the Scope of the pool itself which causes a memory leak as the items are not garbage collected and the `ReleaseMap` in the `Scope` itself keeps growing.

Note that ZPool has the exact same implementation as the fix in this PR. I suspect this was reported for `ZPool` at some point and it was fixed, but wasn't subsequently fixed for `ZKeyedPool`