### PR TITLE
Fix zio-kafka regression caused by ZStream changes

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -705,6 +705,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                 failure.update(_ && cause).unless(cause.isInterruptedOnly) *>
                   outgoing.offer(Fiber.done(ZChannel.failLeftUnit))
             })
+            .ignore
             .raceFirst(ZChannel.awaitErrorSignal(childScope, fiberId)(errorSignal))
             .forkIn(scope)
       } yield {
@@ -783,6 +784,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                 failure.update(_ && cause).unless(cause.isInterruptedOnly) *>
                   outgoing.offer(ZChannel.failLeftUnit)
             })
+            .ignore
             .raceFirst(ZChannel.awaitErrorSignal(childScope, fiberId)(errorSignal))
             .forkIn(scope)
       } yield {
@@ -2021,7 +2023,7 @@ object ZChannel {
                              }
                        }
         _ <- pullStrategy(fiberId).forever
-               .onError(cause =>
+               .catchAllCause(cause =>
                  cause.failureOrCause match {
                    case Left(_: Left[OutErr, OutDone]) => outgoing.offer(Exit.failCause(cause))
                    case Left(x: Right[OutErr, OutDone]) =>


### PR DESCRIPTION
/fixes #9324

Main change in this PR is the change from `onError` to `catchAllCause`. Frankly, I really don't know why propagating the interruption (same way that we do in `mapZIOPar` and `mapZIOParUnbounded`) causes issues in the `flatMapPar` method for zio-kafka. I also failed to create a reproducer after many hours of trying different things / combinations.

At this stage I'm not even sure whether this is an issue in zio-kafka that it's only been surfaced that the recent ZIO change, but in order to play it safe I reverted the behaviour to be the same as pre-v2.1.13 while I try to get to the bottom of this