### PR TITLE
Make `val`s non-transient in ZIO services

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -43,7 +43,7 @@ trait Clock extends Serializable { self =>
 
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit]
 
-  trait UnsafeAPI {
+  trait UnsafeAPI extends Serializable {
     def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long
     def currentTime(unit: ChronoUnit)(implicit unsafe: Unsafe): Long
     def currentDateTime()(implicit unsafe: Unsafe): OffsetDateTime
@@ -105,7 +105,7 @@ object Clock extends ClockPlatformSpecific with Serializable {
     def scheduler(implicit trace: Trace): UIO[Scheduler] =
       ClockLive.scheduler
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long = {
           val inst = instant()
@@ -184,7 +184,7 @@ object Clock extends ClockPlatformSpecific with Serializable {
       ZIO.succeed(JavaClock(ZoneId.systemDefault))
     }
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long = {
           val inst = instant()

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -16,8 +16,6 @@
 
 package zio
 
-import zio.Console.ConsoleLive
-import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.{EOFException, IOException, PrintStream}
@@ -38,7 +36,7 @@ trait Console extends Serializable { self =>
   def readLine(prompt: String)(implicit trace: Trace): IO[IOException, String] =
     print(prompt) *> readLine
 
-  trait UnsafeAPI {
+  trait UnsafeAPI extends Serializable {
     def print(line: Any)(implicit unsafe: Unsafe): Unit
     def printError(line: Any)(implicit unsafe: Unsafe): Unit
     def printLine(line: Any)(implicit unsafe: Unsafe): Unit
@@ -86,7 +84,7 @@ object Console extends Serializable {
     def readLine(implicit trace: Trace): IO[IOException, String] =
       ZIO.attemptBlockingInterrupt(unsafe.readLine()(Unsafe.unsafe)).refineToOrDie[IOException]
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def print(line: Any)(implicit unsafe: Unsafe): Unit =
           print(SConsole.out)(line)

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -194,7 +194,7 @@ final class Promise[E, A] private (
     }
   }
 
-  private[zio] trait UnsafeAPI {
+  private[zio] trait UnsafeAPI extends Serializable {
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
@@ -207,7 +207,7 @@ final class Promise[E, A] private (
     def succeed(a: A)(implicit trace: Trace, unsafe: Unsafe): Boolean
   }
 
-  @transient private[zio] val unsafe: UnsafeAPI =
+  private[zio] val unsafe: UnsafeAPI =
     new UnsafeAPI {
       def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean = {
         var action: () => Boolean = null.asInstanceOf[() => Boolean]

--- a/core/shared/src/main/scala/zio/Random.scala
+++ b/core/shared/src/main/scala/zio/Random.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.UUID
@@ -45,7 +44,7 @@ trait Random extends Serializable { self =>
     trace: Trace
   ): UIO[Collection[A]]
 
-  trait UnsafeAPI {
+  trait UnsafeAPI extends Serializable {
     def nextBoolean()(implicit unsafe: Unsafe): Boolean
     def nextBytes(length: Int)(implicit unsafe: Unsafe): Chunk[Byte]
     def nextDouble()(implicit unsafe: Unsafe): Double
@@ -207,7 +206,7 @@ object Random extends Serializable {
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
       ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
           scala.util.Random.nextBoolean()
@@ -335,7 +334,7 @@ object Random extends Serializable {
     )(implicit bf: BuildFrom[Collection[A], A, Collection[A]], trace: Trace): UIO[Collection[A]] =
       ZIO.succeed(unsafe.shuffle(collection)(bf, Unsafe.unsafe))
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def nextBoolean()(implicit unsafe: Unsafe): Boolean =
           random.nextBoolean()

--- a/core/shared/src/main/scala/zio/System.scala
+++ b/core/shared/src/main/scala/zio/System.scala
@@ -16,7 +16,6 @@
 
 package zio
 
-import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.{System => JSystem}
@@ -46,7 +45,7 @@ trait System extends Serializable { self =>
     trace: Trace
   ): IO[Throwable, Option[String]]
 
-  trait UnsafeAPI {
+  trait UnsafeAPI extends Serializable {
     def env(variable: String)(implicit unsafe: Unsafe): Option[String]
     def envOrElse(variable: String, alt: => String)(implicit unsafe: Unsafe): String
     def envOrOption(variable: String, alt: => Option[String])(implicit unsafe: Unsafe): Option[String]
@@ -137,7 +136,7 @@ object System extends SystemPlatformSpecific {
     ): IO[Throwable, Option[String]] =
       ZIO.attempt(unsafe.propertyOrOption(prop, alt)(Unsafe.unsafe))
 
-    @transient override val unsafe: UnsafeAPI =
+    override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def env(variable: String)(implicit unsafe: Unsafe): Option[String] =
           environmentProvider.env(variable)


### PR DESCRIPTION
Followup of #9344 

`val`s should never be marked as `@transient` as their value is set to `null` when deserialized. This was probably never an issue since I highly doubt users are serializing ZIO's services, but might as well have it implemented properly