### PR TITLE
Use `-Ybackend-parallelism:4` when compiling Scala 2.13 with optimization enabled

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -56,9 +56,14 @@ object BuildHelper {
         case "zio-test"    => Nil
         case _             => List("zio.internal.**")
       }
-      // We get some weird errors when trying to inline Scala 2.12 std lib
-      val inlineScala = if (isScala213) Seq("-opt-inline-from:scala.**") else Nil
-      inlineScala ++ Seq(
+      val scala213Flags =
+        if (isScala213)
+          Seq(
+            "-opt-inline-from:scala.**", // We get some weird errors when trying to inline Scala 2.12 std lib
+            "-Ybackend-parallelism:4"
+          )
+        else Nil
+      scala213Flags ++ Seq(
         "-opt:l:method",
         "-opt:l:inline",
         // To remove calls to `assert` in releases. Assertions are level 2000


### PR DESCRIPTION
This should help speed up CI as the optimization phase will use all available threads to compile the code.