### PR TITLE
Fix race condition for errors in `ZChannel.mapOutZIOPar*` methods

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2722,7 +2722,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                           .exit
               count <- interrupted.get
             } yield assert(count)(equalTo(2)) && assert(result)(fails(equalTo("Boom")))
-          } @@ exceptJS(nonFlaky),
+          } @@ exceptJS(nonFlaky(500)),
           test("propagates correct error with subsequent mapZIOPar call (#4514)") {
             assertZIO(
               ZStream
@@ -2831,7 +2831,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                           .exit
               count <- interrupted.get
             } yield assert(count)(equalTo(2)) && assert(result)(fails(equalTo("Boom")))
-          } @@ exceptJS(nonFlaky),
+          } @@ exceptJS(nonFlaky(500)),
           test("awaits children fibers properly") {
             assertZIO(
               ZStream

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -671,7 +671,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         _           <- scope.addFinalizer(outgoing.shutdown)
         errorSignal <- Promise.make[Nothing, Unit]
         permits     <- Semaphore.make(n.toLong)
-        failure     <- Ref.make[Cause[OutErr1]](Cause.empty)
+        failure      = Ref.unsafe.make[Cause[OutErr1]](Cause.empty)(Unsafe)
         pull        <- (queueReader >>> self).toPullInAlt(scope)
         childScope  <- scope.fork
         fiberId     <- ZIO.fiberId
@@ -713,11 +713,13 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
             outgoing.take.flatMap(_.await).map {
               case s: Exit.Success[OutElem2] => ZChannel.write(s.value) *> writer
               case f: Exit.Failure[Either[Unit, OutDone]] =>
-                def extractFailures = ZChannel.unwrap(failure.get.map(ZChannel.refailCause(_)))
+                val failure0 = failure.unsafe.get(Unsafe)
                 f.cause.failureOrCause match {
-                  case Left(_: Left[Unit, OutDone])    => extractFailures
-                  case Left(x: Right[Unit, OutDone])   => ZChannel.succeedNow(x.value)
-                  case Right(c) if c.isInterruptedOnly => extractFailures
+                  case Left(_: Left[Unit, OutDone]) => ZChannel.refailCause(failure0)
+                  case Left(x: Right[Unit, OutDone]) =>
+                    if (failure0 eq Cause.empty) ZChannel.succeedNow(x.value)
+                    else ZChannel.refailCause(failure0)
+                  case Right(c) if c.isInterruptedOnly => ZChannel.refailCause(failure0)
                   case Right(cause)                    => ZChannel.refailCause(cause)
                 }
             }
@@ -748,7 +750,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         _           <- scope.addFinalizer(outgoing.shutdown)
         errorSignal <- Promise.make[Nothing, Unit]
         permits     <- Semaphore.make(n.toLong)
-        failure     <- Ref.make[Cause[OutErr1]](Cause.empty)
+        failure      = Ref.unsafe.make[Cause[OutErr1]](Cause.empty)(Unsafe)
         pull        <- (queueReader >>> self).toPullInAlt(scope)
         childScope  <- scope.fork
         fiberId     <- ZIO.fiberId
@@ -791,11 +793,13 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
             outgoing.take.map {
               case s: Exit.Success[OutElem2] => ZChannel.write(s.value) *> writer
               case f: Exit.Failure[Either[Unit, OutDone]] =>
-                def extractFailures = ZChannel.unwrap(failure.get.map(ZChannel.refailCause(_)))
+                val failure0 = failure.unsafe.get(Unsafe)
                 f.cause.failureOrCause match {
-                  case Left(_: Left[Unit, OutDone])    => extractFailures
-                  case Left(x: Right[Unit, OutDone])   => ZChannel.succeedNow(x.value)
-                  case Right(c) if c.isInterruptedOnly => extractFailures
+                  case Left(_: Left[Unit, OutDone]) => ZChannel.refailCause(failure0)
+                  case Left(x: Right[Unit, OutDone]) =>
+                    if (failure0 eq Cause.empty) ZChannel.succeedNow(x.value)
+                    else ZChannel.refailCause(failure0)
+                  case Right(c) if c.isInterruptedOnly => ZChannel.refailCause(failure0)
                   case Right(cause)                    => ZChannel.refailCause(cause)
                 }
             }


### PR DESCRIPTION
There is a rare race condition where the error in `ZChannel.mapOutZIOPar*` methods is not propagated due to a Done signal winning the race against the errorSignal. This PR fixes it by checking that the errors in the `failure` Ref are empty prior to succeeding the ZChannel