### PR TITLE
[Issue #8571] Fix spans in TestResults with inlined code

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/AssertTrueWithMacroCodeSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/AssertTrueWithMacroCodeSpec.scala
@@ -1,0 +1,50 @@
+package zio
+
+import zio.test.*
+import zio.test.TestArrow.Meta
+import zio.test.TestArrow.TestArrowF
+import zio.test.TestArrow.AndThen
+import zio.test.TestArrow.And
+import zio.test.TestArrow.Or
+import zio.test.TestArrow.Not
+import zio.test.TestArrow.Suspend
+import zio.test.TestArrow.Span
+
+object AssertTrueWithMacroCodeSpec extends ZIOBaseSpec {
+
+  def spec: Spec[TestEnvironment & Scope, Any] =
+    test(
+      "[Issue #8571] the span of an inline definition is correct in relation to its actual sourcecode (and not to its macro-expanded form)"
+    ) {
+      val arrow = assertTrue(expandMe == 3).arrow
+      val spans = collectSpans(arrow)
+      // 0 - 8 maps to the code string of 'expandMe', 12 - 13 maps to the code string of '3'
+      val expectedSpans = Span(0, 8) :: Span(12, 13) :: Nil
+      assertTrue(spans == expectedSpans)
+    }
+
+  private def collectSpans(arrow: TestArrow[Any, ?]) = {
+    def recurse(accumulator: List[Span], stack: List[TestArrow[Any, ?]]): List[Span] =
+      stack match {
+        case Nil => accumulator
+        case head :: next =>
+          head match {
+            case Meta(arrow, span, parentSpan, code, location, completeCode, customLabel, genFailureDetails) =>
+              recurse(accumulator ::: span.toList ::: parentSpan.toList, arrow :: next)
+            case TestArrowF(f)    => recurse(accumulator, next)
+            case AndThen(f, g)    => recurse(accumulator, f :: g.asInstanceOf[TestArrow[Any, ?]] :: next)
+            case And(left, right) => recurse(accumulator, left :: right :: next)
+            case Or(left, right)  => recurse(accumulator, left :: right :: next)
+            case Not(arrow)       => recurse(accumulator, arrow :: next)
+            case Suspend(f)       => recurse(accumulator, f(()) :: next)
+          }
+      }
+    recurse(Nil, arrow :: Nil)
+  }
+
+  private inline def expandMe = {
+    val arbritraryDef  = "I'm an arbitrary definition!"
+    val arbritraryDef2 = "I'm an arbitrary definition too!"
+    1
+  }
+}


### PR DESCRIPTION
closes #8571 

/claim #8571 

First of all, a reproduction: 

```scala
package zio

import zio.test.*
import zio.test.TestArrow.Meta

object AssertTrueWithMacroCodeSpec extends ZIOBaseSpec {

  def spec: Spec[TestEnvironment & Scope, Any] =
    test(
      "[Issue #8571] the span of an inline definition is correct in relation to its actual sourcecode (and not to its macro-expanded form)"
    ) {
      assertTrue(expandMe == 3)
    }

  private inline def expandMe = {
    val arbritraryDef  = "I'm an arbitrary definition!"
    val arbritraryDef2 = "I'm an arbitrary definition too!"
    1
  }
}
```

This actually works on HEAD due to this change: https://github.com/zio/zio/pull/9285 but as @kyri-petrou pointed out in a discussion on that ticket, it was merely addressing the symptom and not the cause, which now manifests in a slightly off rendering of the code in a test error message:
<img width="1497" alt="Screenshot 2024-12-02 at 15 27 26" src="https://github.com/user-attachments/assets/74aa20f4-852d-4b72-be55-d81d6a7e987d">

comparing it to the fixed version (as of this PR):
<img width="1495" alt="Screenshot 2024-12-02 at 15 26 45" src="https://github.com/user-attachments/assets/3b585ce7-db60-43e8-89c1-6b40a97ff450">

We can see that it actually renders the inlined code properly as opposed to outputting an empty string.

What's more, if we undo the changes introduced in #9285 we can once again reproduce the original issue:
<img width="1493" alt="Screenshot 2024-12-02 at 15 28 59" src="https://github.com/user-attachments/assets/0ca19a4e-ec49-4e9f-bf01-cc3f8ff6fdc3">

...which is now fixed!
<img width="1482" alt="Screenshot 2024-12-02 at 15 29 48" src="https://github.com/user-attachments/assets/cc308212-855a-4980-b416-a3b21aa6a966">

I guess one last question here is how to properly test it in-code or is a comment and a couple of screenshots enough? Alternatively we could revert #9285 because it can now actually give us a false sense of security (I wouldn't bother with this tbh, since the error messages shown after 9285 are much much much much better that a stack trace!) - so yeah, looking forward to your suggestions :)

