### PR TITLE
Remove internal usages of `ZIO.done`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -96,7 +96,7 @@ object FiberRefSpec extends ZIOBaseSpec {
         for {
           child <- FiberRef.make(initial).fork
           // Don't use join as it inherits values from child.
-          fiberRef   <- child.await.flatMap(ZIO.done(_))
+          fiberRef   <- child.await.unexit
           localValue <- fiberRef.locally(update)(fiberRef.get)
           value      <- fiberRef.get
         } yield assert(localValue)(equalTo(update)) && assert(value)(equalTo(initial))
@@ -169,7 +169,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("initial value is always available") {
         for {
           child    <- FiberRef.make(initial).fork
-          fiberRef <- child.await.flatMap(ZIO.done(_))
+          fiberRef <- child.await.unexit
           value    <- fiberRef.get
         } yield assert(value)(equalTo(initial))
       },

--- a/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
@@ -13,7 +13,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
   def spec = suite("ZIOLazinessSpec")(
     test("die")(assertLazy(ZIO.die)),
     test("dieMessage")(assertLazy(ZIO.dieMessage)),
-    test("done")(assertLazy(ZIO.done)),
     test("fail")(assertLazy(ZIO.fail)),
     test("failCause")(assertLazy(ZIO.failCause)),
     test("fromEither")(assertLazy(ZIO.fromEither)),

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1802,11 +1802,8 @@ object ZIOSpec extends ZIOBaseSpec {
         val successes = Gen.successes(smallInts)
         val exits     = Gen.either(causes, successes).map(_.fold(Exit.failCause, Exit.succeed))
         check(exits, exits, exits) { (exit1, exit2, exit3) =>
-          val zio1  = exit1
-          val zio2  = exit2
-          val zio3  = exit3
-          val left  = (zio1 orElse zio2) orElse zio3
-          val right = zio1 orElse (zio2 orElse zio3)
+          val left = (exit1 orElse exit2) orElse exit3
+          val right = exit1 orElse (exit2 orElse exit3)
           for {
             left  <- left.exit
             right <- right.exit

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1802,9 +1802,9 @@ object ZIOSpec extends ZIOBaseSpec {
         val successes = Gen.successes(smallInts)
         val exits     = Gen.either(causes, successes).map(_.fold(Exit.failCause, Exit.succeed))
         check(exits, exits, exits) { (exit1, exit2, exit3) =>
-          val zio1  = ZIO.done(exit1)
-          val zio2  = ZIO.done(exit2)
-          val zio3  = ZIO.done(exit3)
+          val zio1  = exit1
+          val zio2  = exit2
+          val zio3  = exit3
           val left  = (zio1 orElse zio2) orElse zio3
           val right = zio1 orElse (zio2 orElse zio3)
           for {
@@ -2963,7 +2963,7 @@ object ZIOSpec extends ZIOBaseSpec {
                          .catchAllCause(cause => ZIO.succeed(cause))
                          .fork
                      }
-            cause <- ensuring.await *> fiber.interrupt.flatMap(ZIO.done(_))
+            cause <- ensuring.await *> fiber.interrupt.unexit
           } yield assertTrue(cause.defects.length == 1)
         } @@ exceptJS(nonFlaky)
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1802,7 +1802,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val successes = Gen.successes(smallInts)
         val exits     = Gen.either(causes, successes).map(_.fold(Exit.failCause, Exit.succeed))
         check(exits, exits, exits) { (exit1, exit2, exit3) =>
-          val left = (exit1 orElse exit2) orElse exit3
+          val left  = (exit1 orElse exit2) orElse exit3
           val right = exit1 orElse (exit2 orElse exit3)
           for {
             left  <- left.exit

--- a/core/shared/src/main/scala/zio/Cached.scala
+++ b/core/shared/src/main/scala/zio/Cached.scala
@@ -69,7 +69,7 @@ object Cached {
     ref: ScopedRef[Exit[Error, Resource]],
     acquire: ZIO[Scope, Error, Resource]
   ) extends Cached[Error, Resource] {
-    def get(implicit trace: Trace): IO[Error, Resource] = ref.get.flatMap(ZIO.done(_))
+    def get(implicit trace: Trace): IO[Error, Resource] = ref.get.unexit
 
     def refresh(implicit trace: Trace): IO[Error, Unit] = ref.set[Any, Error](acquire.map(Exit.succeed(_)))
   }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -50,7 +50,7 @@ trait Runtime[+R] { self =>
     ZIO.fiberIdWith { fiberId =>
       ZIO.asyncInterrupt[Any, E, A] { callback =>
         val fiber = unsafe.fork(zio)(trace, Unsafe.unsafe)
-        fiber.unsafe.addObserver(exit => callback(ZIO.done(exit)))(Unsafe.unsafe)
+        fiber.unsafe.addObserver(callback(_))(Unsafe.unsafe)
         Left(ZIO.blocking(fiber.interruptAs(fiberId)))
       }
     }

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -349,30 +349,30 @@ object Scope {
                   case ExecutionStrategy.Sequential =>
                     (
                       ZIO
-                        .foreach(fins: Iterable[(Long, Finalizer)]) { case (_, fin) =>
+                        .foreach(fins.values) { fin =>
                           update(fin).apply(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAll(results) getOrElse Exit.unit)),
+                        .flatMap(Exit.collectAllDiscard),
                       Exited(nextKey, exit, update)
                     )
 
                   case ExecutionStrategy.Parallel =>
                     (
                       ZIO
-                        .foreachPar(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
-                          update(finalizer)(exit).exit
+                        .foreachPar(fins.values) { fin =>
+                          update(fin)(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAllPar(results) getOrElse Exit.unit)),
+                        .flatMap(Exit.collectAllParDiscard),
                       Exited(nextKey, exit, update)
                     )
 
                   case ExecutionStrategy.ParallelN(n) =>
                     (
                       ZIO
-                        .foreachPar(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
-                          update(finalizer)(exit).exit
+                        .foreachPar(fins.values) { fin =>
+                          update(fin)(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAllPar(results) getOrElse Exit.unit))
+                        .flatMap(Exit.collectAllParDiscard)
                         .withParallelism(n),
                       Exited(nextKey, exit, update)
                     )

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3181,6 +3181,10 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   /**
    * Returns an effect from a [[zio.Exit]] value.
    */
+  @deprecated(
+    "For suspending a side-effecting method that produces an Exit, use `ZIO.suspendSucceed` instead.",
+    "2.1.14"
+  )
   def done[E, A](r: => Exit[E, A])(implicit trace: Trace): IO[E, A] =
     ZIO.suspendSucceed(r)
 

--- a/core/shared/src/main/scala/zio/ZPool.scala
+++ b/core/shared/src/main/scala/zio/ZPool.scala
@@ -146,7 +146,7 @@ object ZPool {
       }
 
     def toZIO(implicit trace: Trace): ZIO[Any, E, A] =
-      ZIO.done(result)
+      ZIO.suspendSucceed(result)
   }
 
   private final case class DefaultPool[E, A](

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -280,7 +280,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
               releaseThat(e).exit
                 .flatMap(e1 =>
                   releaseSelf(e).exit
-                    .flatMap(e2 => ZIO.done(e1 *> e2))
+                    .flatMap(e2 => e1 *> e2)
                 ),
             b
           )
@@ -522,10 +522,10 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
                                innerReleaseMap
                                  .releaseAll(e, ExecutionStrategy.Sequential)
                                  .exit
-                                 .zipWith(cleanup(exitEA).provideEnvironment(r1).exit)((l, r) => ZIO.done(l *> r))
+                                 .zipWith(cleanup(exitEA).provideEnvironment(r1).exit)((l, r) => l *> r)
                                  .flatten
                              }
-          a <- ZIO.done(exitEA)
+          a <- exitEA
         } yield (releaseMapEntry, a)
       }
     }
@@ -551,11 +551,11 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
                                  .provideEnvironment(r1)
                                  .exit
                                  .zipWith(innerReleaseMap.releaseAll(e, ExecutionStrategy.Sequential).exit)((l, r) =>
-                                   ZIO.done(l *> r)
+                                   l *> r
                                  )
                                  .flatten
                              }
-          a <- ZIO.done(exitEA)
+          a <- exitEA
         } yield (releaseMapEntry, a)
       }
     }
@@ -1525,7 +1525,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                         .foreach(fins: Iterable[(Long, Finalizer)]) { case (_, fin) =>
                           update(fin).apply(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAll(results) getOrElse Exit.unit)),
+                        .flatMap(Exit.collectAllDiscard),
                       Exited(nextKey, exit, update)
                     )
 
@@ -1535,7 +1535,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                         .foreachPar(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
                           update(finalizer)(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAllPar(results) getOrElse Exit.unit)),
+                        .flatMap(Exit.collectAllParDiscard),
                       Exited(nextKey, exit, update)
                     )
 
@@ -1545,7 +1545,7 @@ object ZManaged extends ZManagedPlatformSpecific {
                         .foreachPar(fins: Iterable[(Long, Finalizer)]) { case (_, finalizer) =>
                           update(finalizer)(exit).exit
                         }
-                        .flatMap(results => ZIO.done(Exit.collectAllPar(results) getOrElse Exit.unit))
+                        .flatMap(Exit.collectAllParDiscard)
                         .withParallelism(n),
                       Exited(nextKey, exit, update)
                     )

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1816,7 +1816,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * Returns an effect from a lazily evaluated [[zio.Exit]] value.
    */
   def done[E, A](r: => Exit[E, A])(implicit trace: Trace): ZManaged[Any, E, A] =
-    ZManaged.fromZIO(ZIO.done(r))
+    ZManaged.fromZIO(r)
 
   /**
    * Accesses the whole environment of the effect.

--- a/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZChannelSpec.scala
@@ -310,8 +310,8 @@ object ZChannelSpec extends ZIOBaseSpec {
           val conduit = ZChannel
             .writeAll(1, 2, 3)
             .mergeWith(ZChannel.writeAll(4, 5, 6))(
-              ex => ZChannel.MergeDecision.awaitConst(ZIO.done(ex)),
-              ex => ZChannel.MergeDecision.awaitConst(ZIO.done(ex))
+              ZChannel.MergeDecision.awaitConst,
+              ZChannel.MergeDecision.awaitConst
             )
 
           conduit.runCollect.map { case (chunk, _) =>
@@ -323,8 +323,8 @@ object ZChannelSpec extends ZIOBaseSpec {
           val right = ZChannel.write(2) *> ZChannel.fromZIO(ZIO.attempt(true).refineToOrDie[IllegalStateException])
 
           val merged = left.mergeWith(right)(
-            ex => ZChannel.MergeDecision.await(ex2 => ZIO.done(ex <*> ex2)),
-            ex2 => ZChannel.MergeDecision.await(ex => ZIO.done(ex <*> ex2))
+            ex => ZChannel.MergeDecision.await(ex2 => ex <*> ex2),
+            ex2 => ZChannel.MergeDecision.await(ex => ex <*> ex2)
           )
 
           merged.runCollect.map { case (chunk, result) =>
@@ -337,8 +337,8 @@ object ZChannelSpec extends ZIOBaseSpec {
           val right = ZChannel.write(2) *> ZChannel.fail(true).as(true)
 
           val merged = left.mergeWith(right)(
-            ex => ZChannel.MergeDecision.await(ex2 => ZIO.done(ex).flip.zip(ZIO.done(ex2).flip).flip),
-            ex2 => ZChannel.MergeDecision.await(ex => ZIO.done(ex).flip.zip(ZIO.done(ex2).flip).flip)
+            ex => ZChannel.MergeDecision.await(ex2 => ex.flip.zip(ex2.flip).flip),
+            ex2 => ZChannel.MergeDecision.await(ex => ex.flip.zip(ex2.flip).flip)
           )
 
           merged.runDrain.exit.map(ex => assert(ex)(fails(equalTo(("Boom", true)))))
@@ -351,7 +351,7 @@ object ZChannelSpec extends ZIOBaseSpec {
               val right = ZChannel.write(2) *> ZChannel.fromZIO(latch.await)
 
               val merged = left.mergeWith(right)(
-                ex => ZChannel.MergeDecision.done(ZIO.done(ex)),
+                ex => ZChannel.MergeDecision.done(ex),
                 _ => ZChannel.MergeDecision.done(interrupted.get.map(assert(_)(isTrue)))
               )
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4250,7 +4250,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 fib <- ZStream
                          .fromQueue(c.queue)
                          .tap(_ => c.proceed)
-                         .flatMap(ex => ZStream.fromZIOOption(ZIO.done(ex)))
+                         .flatMap(ex => ZStream.fromZIOOption(ex))
                          .flattenChunks
                          .debounce(200.millis)
                          .interruptWhen(ZIO.never)
@@ -4888,9 +4888,9 @@ object ZStreamSpec extends ZIOBaseSpec {
                 ZStream.fromChunkQueue(left).zipLatest(ZStream.fromChunkQueue(right)).runIntoQueue(out).fork
               _      <- left.offer(Chunk(0))
               _      <- right.offerAll(List(Chunk(0), Chunk(1)))
-              chunk1 <- ZIO.replicateZIO(2)(out.take.flatMap(_.done)).map(_.flatten)
+              chunk1 <- ZIO.replicateZIO(2)(out.take.flatMap(_.exit)).map(_.flatten)
               _      <- left.offerAll(List(Chunk(1), Chunk(2)))
-              chunk2 <- ZIO.replicateZIO(2)(out.take.flatMap(_.done)).map(_.flatten)
+              chunk2 <- ZIO.replicateZIO(2)(out.take.flatMap(_.exit)).map(_.flatten)
             } yield assert(chunk1)(equalTo(List((0, 0), (0, 1)))) && assert(chunk2)(equalTo(List((1, 1), (2, 1))))
           } @@ exceptJS(nonFlaky),
           test("handle empty pulls properly") {

--- a/streams/js/src/main/scala/zio/stream/platform.scala
+++ b/streams/js/src/main/scala/zio/stream/platform.scala
@@ -74,7 +74,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
           lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.unwrap(
               output.take
-                .flatMap(_.done)
+                .flatMap(_.exit)
                 .fold(
                   maybeError =>
                     ZChannel.fromZIO(output.shutdown) *>
@@ -115,7 +115,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
                  if (_)
                    Pull.end
                  else
-                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+                   output.take.flatMap(_.exit).onError(_ => done.set(true) *> output.shutdown)
                }
       } yield pull
     }.flatMap(repeatZIOChunkOption(_))
@@ -144,7 +144,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
     } yield {
       lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = ZChannel.unwrap(
         output.take
-          .flatMap(_.done)
+          .flatMap(_.exit)
           .fold(
             maybeError =>
               ZChannel.fromZIO(output.shutdown) *>

--- a/streams/jvm/src/main/scala/zio/stream/platform.scala
+++ b/streams/jvm/src/main/scala/zio/stream/platform.scala
@@ -90,7 +90,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
           lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.unwrap(
               output.take
-                .flatMap(_.done)
+                .flatMap(_.exit)
                 .fold(
                   maybeError =>
                     ZChannel.fromZIO(output.shutdown) *>
@@ -132,7 +132,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
                  if (_)
                    Pull.end
                  else
-                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+                   output.take.flatMap(_.exit).onError(_ => done.set(true) *> output.shutdown)
                }
       } yield pull
     }.flatMap(repeatZIOChunkOption(_))
@@ -162,7 +162,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
     } yield {
       lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = ZChannel.unwrap(
         output.take
-          .flatMap(_.done)
+          .flatMap(_.exit)
           .foldCauseZIO(
             maybeError =>
               output.shutdown as (maybeError.failureOrCause match {

--- a/streams/native/src/main/scala/zio/stream/platform.scala
+++ b/streams/native/src/main/scala/zio/stream/platform.scala
@@ -84,7 +84,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
           lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.unwrap(
               output.take
-                .flatMap(_.done)
+                .flatMap(_.exit)
                 .fold(
                   maybeError =>
                     ZChannel.fromZIO(output.shutdown) *>
@@ -125,7 +125,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
                  if (_)
                    Pull.end
                  else
-                   output.take.flatMap(_.done).onError(_ => done.set(true) *> output.shutdown)
+                   output.take.flatMap(_.exit).onError(_ => done.set(true) *> output.shutdown)
                }
       } yield pull
     }.flatMap(repeatZIOChunkOption(_))
@@ -154,7 +154,7 @@ private[stream] trait ZStreamPlatformSpecificConstructors {
     } yield {
       lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = ZChannel.unwrap(
         output.take
-          .flatMap(_.done)
+          .flatMap(_.exit)
           .fold(
             maybeError =>
               ZChannel.fromZIO(output.shutdown) *>

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -29,7 +29,7 @@ case class Take[+E, +A](exit: Exit[Option[E], Chunk[A]]) extends AnyVal {
   /**
    * Transforms `Take[E, A]` to `ZIO[R, E, B]`.
    */
-  @deprecated("2.1.14", "use `exit` instead")
+  @deprecated("use `exit` instead", "2.1.14")
   def done[R](implicit trace: Trace): ZIO[R, Option[E], Chunk[A]] =
     ZIO.done(exit)
 

--- a/streams/shared/src/main/scala/zio/stream/Take.scala
+++ b/streams/shared/src/main/scala/zio/stream/Take.scala
@@ -29,6 +29,7 @@ case class Take[+E, +A](exit: Exit[Option[E], Chunk[A]]) extends AnyVal {
   /**
    * Transforms `Take[E, A]` to `ZIO[R, E, B]`.
    */
+  @deprecated("2.1.14", "use `exit` instead")
   def done[R](implicit trace: Trace): ZIO[R, Option[E], Chunk[A]] =
     ZIO.done(exit)
 

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1289,7 +1289,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    * failure terminating the stream.
    */
   def flattenExit[Err, Out](implicit trace: Trace): ZPipeline[Any, Err, Exit[Err, Out], Out] =
-    ZPipeline.mapZIO(ZIO.done(_))
+    ZPipeline.mapZIO(ZIO.identityFn)
 
   /**
    * Creates a pipeline that submerges iterables into the structure of the

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -462,8 +462,8 @@ final class ZSink[-R, +E, -In, +L, +Z] private (val channel: ZChannel[R, ZNothin
     capacity: => Int = 16
   )(implicit trace: Trace): ZSink[R1, E1, In1, L1, Either[Z, Z2]] =
     self.raceWith(that, capacity)(
-      selfDone => ZChannel.MergeDecision.done(ZIO.done(selfDone).map(Left(_))),
-      thatDone => ZChannel.MergeDecision.done(ZIO.done(thatDone).map(Right(_)))
+      selfDone => ZChannel.MergeDecision.done(selfDone.map(Left(_))),
+      thatDone => ZChannel.MergeDecision.done(thatDone.map(Right(_)))
     )
 
   /**
@@ -489,8 +489,8 @@ final class ZSink[-R, +E, -In, +L, +Z] private (val channel: ZChannel[R, ZNothin
                      rightDone
                    )
         channel = reader.mergeWith(writer)(
-                    _ => ZChannel.MergeDecision.await(ZIO.done(_)),
-                    done => ZChannel.MergeDecision.done(ZIO.done(done))
+                    _ => ZChannel.MergeDecision.await(ZIO.identityFn),
+                    done => ZChannel.MergeDecision.done(done)
                   )
       } yield new ZSink[R1, E1, In1, L1, Z2](channel)
     ZSink.unwrapScopedWith(scoped)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4108,8 +4108,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   /**
    * The stream that ends with the [[zio.Exit]] value `exit`.
    */
+  @deprecated("use `ZStream.fromZIO` instead", "2.1.14")
   def done[E, A](exit: => Exit[E, A])(implicit trace: Trace): ZStream[Any, E, A] =
-    fromZIO(ZIO.done(exit))
+    fromZIO(exit)
 
   /**
    * The empty stream

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -472,7 +472,7 @@ private[zio] class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, OutElem, 
       ZIO
         .foreach(finalizers)(_.apply(ex).exit)
         .map(results => Exit.collectAll(results) getOrElse Exit.unit)
-        .flatMap(ZIO.done(_))
+        .unexit
 
   private[this] def runSubexecutor()(implicit trace: Trace): ChannelState[Env, Any] =
     activeSubexecutor match {
@@ -714,7 +714,7 @@ private[zio] object ChannelExecutor {
         val fin2 = parentSubexecutor.close(ex)
 
         if ((fin1 eq null) && (fin2 eq null)) null
-        else if ((fin1 ne null) && (fin2 ne null)) fin1.exit.zipWith(fin2.exit)(_ *> _).flatMap(ZIO.done(_))
+        else if ((fin1 ne null) && (fin2 ne null)) fin1.exit.zipWith(fin2.exit)(_ *> _).unexit
         else if (fin1 ne null) fin1
         else fin2
       }

--- a/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeoutVariants.scala
@@ -53,7 +53,7 @@ trait TimeoutVariants {
     duration: Duration
   )(implicit trace: Trace): ZTest[R, E] =
     test.raceWith(Live.withLive(showWarning(labels, duration))(_.delay(duration)))(
-      (result, fiber) => fiber.interrupt *> ZIO.done(result),
+      (result, fiber) => fiber.interrupt *> result,
       (_, fiber) => fiber.join
     )
 


### PR DESCRIPTION
I'm not entirely sure why `ZIO.done` exists in the first place; my guess is that it's a hangover back from a time that Exit didn't extend ZIO and had to be lifted into one instead.

In any way, this PR removes all internal usages of `ZIO.done` (which are surprisingly many) to avoid the additional allocations and runtime loop iterations