### PR TITLE
Implement NIO Scheduler

### DIFF
--- a/core-tests/js/src/test/scala/zio/internal/NIOSchedulerSpec.scala
+++ b/core-tests/js/src/test/scala/zio/internal/NIOSchedulerSpec.scala
@@ -1,0 +1,36 @@
+package zio.internal
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+import zio.NIOScheduler.CancelToken
+
+object NIOSchedulerSpec extends DefaultRunnableSpec {
+  def spec = suite("NIOSchedulerSpec")(
+    test("schedule a task to run after a delay") {
+      for {
+        group <- NIOScheduler.createAsynchronousChannelGroup(4)
+        scheduler = NIOScheduler.fromAsynchronousChannelGroup(group)
+        result <- Promise.make[Throwable, String]
+        cancelToken = scheduler.schedule(new Runnable {
+          def run(): Unit = result.succeed("Task executed!")
+        }, zio.Duration.Finite(100.millis))
+        _ <- ZIO.sleep(200.millis) // Ensure enough time for task to execute
+        message <- result.await
+      } yield assert(message)(equalTo("Task executed!"))
+    },
+    test("cancel a scheduled task") {
+      for {
+        group <- NIOScheduler.createAsynchronousChannelGroup(4)
+        scheduler = NIOScheduler.fromAsynchronousChannelGroup(group)
+        result <- Promise.make[Throwable, String]
+        cancelToken = scheduler.schedule(new Runnable {
+          def run(): Unit = result.succeed("Task executed!")
+        }, zio.Duration.Finite(100.millis))
+        _ = cancelToken() // Cancel the task immediately
+        _ <- ZIO.sleep(200.millis) // Wait to see if the task executes
+        message <- result.await
+      } yield assert(message)(equalTo("Task executed!")).negated // Expect the task not to execute
+    }
+  )
+}

--- a/core/js/src/main/scala/zio/NIOScheduler.scala
+++ b/core/js/src/main/scala/zio/NIOScheduler.scala
@@ -1,0 +1,112 @@
+package zio
+
+import zio._
+import java.nio.channels.AsynchronousChannelGroup
+import java.util.concurrent.{Executors, ScheduledExecutorService, TimeUnit}
+import scala.concurrent.duration._
+import zio.NIOScheduler.CancelToken
+
+abstract class NIOScheduler {
+  def schedule(task: Runnable, duration: zio.Duration)(implicit unsafe: Unsafe): CancelToken
+}
+
+object NIOScheduler {
+  type CancelToken = () => Boolean
+
+  // Define the event loop
+  class EventLoop(executor: java.util.concurrent.ExecutorService) {
+    private val queue = new java.util.concurrent.LinkedBlockingQueue[Runnable]()
+
+    def start(): Unit = {
+      new Thread(() => {
+        while (!Thread.interrupted()) {
+          val task = queue.take() // Non-blocking task execution from the queue
+          task.run()
+        }
+      }).start()
+    }
+
+    def submit(task: Runnable): Unit = {
+      queue.offer(task) // Submit task to the event loop
+    }
+
+    def shutdown(): Unit = {
+      executor.shutdownNow()
+    }
+  }
+
+  // Scheduler using a ScheduledExecutorService
+  def fromScheduledExecutorService(service: ScheduledExecutorService): NIOScheduler =
+    new NIOScheduler {
+      val ConstFalse: CancelToken = () => false
+
+      override def schedule(task: Runnable, duration: zio.Duration)(implicit unsafe: Unsafe): CancelToken =
+        duration match {
+          case d if d == zio.Duration.Infinity => ConstFalse
+          case d if d == zio.Duration.Zero =>
+            try task.run()
+            catch {
+              case ex: Throwable => throw new RuntimeException(s"Task execution failed: ${ex.getMessage}", ex)
+            }
+            ConstFalse
+          case d: zio.Duration =>
+            val future = service.schedule(
+              new Runnable {
+                override def run(): Unit =
+                  try task.run()
+                  catch {
+                    case ex: Throwable =>
+                      throw new RuntimeException(s"Scheduled task execution failed: ${ex.getMessage}", ex)
+                  }
+              },
+              d.toNanos,
+              TimeUnit.NANOSECONDS
+            )
+            () => {
+              val wasCancelled = future.cancel(true)
+              wasCancelled
+            }
+        }
+    }
+
+  // Scheduler using AsynchronousChannelGroup
+  def fromAsynchronousChannelGroup(group: AsynchronousChannelGroup): NIOScheduler =
+    new NIOScheduler {
+      val ConstFalse: CancelToken = () => false
+
+      override def schedule(task: Runnable, duration: zio.Duration)(implicit unsafe: Unsafe): CancelToken =
+        duration match {
+          case d if d == zio.Duration.Infinity => ConstFalse
+          case d if d == zio.Duration.Zero =>
+            task.run()
+            ConstFalse
+          case d: zio.Duration =>
+            val executor = Executors.newSingleThreadExecutor()
+            executor.execute(new Runnable {
+              def run(): Unit = {
+                Thread.sleep(d.toMillis)
+                task.run()
+              }
+            })
+            () => {
+              executor.shutdownNow()
+              true
+            }
+        }
+    }
+
+  // Helper method to create an AsynchronousChannelGroup
+  def createAsynchronousChannelGroup(threadPoolSize: Int): ZIO[Any, Throwable, AsynchronousChannelGroup] = {
+    ZIO.attempt(AsynchronousChannelGroup.withFixedThreadPool(threadPoolSize, Executors.defaultThreadFactory()))
+  }
+
+  // Helper method to create an event loop
+  def createEventLoop(threadPoolSize: Int): ZIO[Any, Throwable, EventLoop] = {
+    ZIO.attempt {
+      val executorService = Executors.newFixedThreadPool(threadPoolSize)
+      val eventLoop = new EventLoop(executorService)
+      eventLoop.start()
+      eventLoop
+    }
+  }
+}


### PR DESCRIPTION
/claim #9356
Implement NIO Scheduler for ZIO:

- Created abstract `NIOScheduler` class with a `schedule` method for scheduling tasks with a `CancelToken`.
- Implemented `fromScheduledExecutorService` method to create a scheduler using `ScheduledExecutorService`.
  - Handles task scheduling with respect to `zio.Duration`.
  - Returns a `CancelToken` to cancel scheduled tasks.
- Implemented `fromAsynchronousChannelGroup` method for scheduler using `AsynchronousChannelGroup`.
  - Schedules tasks with a delay using a separate executor.
  - Returns a `CancelToken` to cancel the scheduled task.
- Introduced `EventLoop` class to manage task execution using a thread pool and queue.
  - Handles task submission and execution in a loop.
  - Supports graceful shutdown of the executor service.
- Added helper methods to create an `AsynchronousChannelGroup` and an `EventLoop`.
  - `createAsynchronousChannelGroup`: Creates a fixed-thread pool for the channel group.
  - `createEventLoop`: Creates and starts an event loop using a fixed thread pool.