### PR TITLE
Optimisation: Eager eval `flatmap.first` and `fold.first` when possible

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -762,6 +762,8 @@ object Cause extends Serializable {
   def stack[E](cause: Cause[E]): Cause[E]                                              = Stackless(cause, false)
   def stackless[E](cause: Cause[E]): Cause[E]                                          = Stackless(cause, true)
 
+  private[zio] val none: Cause[Option[Nothing]] = fail(None)
+
   trait Folder[-Context, -E, Z] {
     def empty(context: Context): Z
     def failCase(context: Context, error: E, stackTrace: StackTrace): Z

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6834,8 +6834,7 @@ object Exit extends Serializable {
   private[zio] val `false`: Exit[Nothing, Boolean]           = Success(false)
   private[zio] val none: Exit[Nothing, Option[Nothing]]      = Success(None)
   private[zio] val emptyChunk: Exit[Nothing, Chunk[Nothing]] = Success(Chunk.empty)
-  private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.fail(None))
-  private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.fail(()))
+  private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.none)
+  private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.unit)
 
-  private[zio] val empty: Exit[Nothing, Nothing] = Exit.failCause[Nothing](Cause.empty)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1063,7 +1063,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             case flatmap: FlatMap[Any, Any, Any, Any] =>
               updateLastTrace(flatmap.trace)
 
-              if ((flatmap.first eq Exit.unit) || (flatmap.first eq ZIO.unit)) flatmap.successK(())
+              val first = flatmap.first
+
+              if ((first eq Exit.unit) || (first eq ZIO.unit)) flatmap.successK(())
+              else if (first eq Exit.none) flatmap.successK(None)
+              else if (first eq Exit.`false`) flatmap.successK(false)
+              else if (first eq Exit.`true`) flatmap.successK(true)
+              else if (first eq Exit.emptyChunk) flatmap.successK(Chunk.empty)
               else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
 
@@ -1281,6 +1287,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     assert(DisableAssertions, "runLoop must exit with a return statement from within the while loop.")
     null
   }
+
 
   private def sendInterruptSignalToAllChildren(
     children: JavaSet[Fiber.Runtime[_, _]]

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1074,7 +1074,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 stackIndex = pushStackFrame(flatmap, stackIndex)
 
                 val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
-
                 ops += 1
 
                 if (null eq result)


### PR DESCRIPTION
I'd like your opinion on these changes. The goal is to try to reduce the number of recursive calls

It'd, for example, benefit this change: https://github.com/zio/zio/pull/9388