### PR TITLE
Optimisation - FiberRuntime: bypass evaluation of `flatmap.first` when possible

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -762,6 +762,8 @@ object Cause extends Serializable {
   def stack[E](cause: Cause[E]): Cause[E]                                              = Stackless(cause, false)
   def stackless[E](cause: Cause[E]): Cause[E]                                          = Stackless(cause, true)
 
+  private[zio] val none: Cause[Option[Nothing]] = fail(None)
+
   trait Folder[-Context, -E, Z] {
     def empty(context: Context): Z
     def failCase(context: Context, error: E, stackTrace: StackTrace): Z

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6834,8 +6834,8 @@ object Exit extends Serializable {
   private[zio] val `false`: Exit[Nothing, Boolean]           = Success(false)
   private[zio] val none: Exit[Nothing, Option[Nothing]]      = Success(None)
   private[zio] val emptyChunk: Exit[Nothing, Chunk[Nothing]] = Success(Chunk.empty)
-  private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.fail(None))
-  private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.fail(()))
+  private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.none)
+  private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.unit)
 
   private[zio] val empty: Exit[Nothing, Nothing] = Exit.failCause[Nothing](Cause.empty)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -24,7 +24,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.function.IntFunction
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
 
@@ -1066,12 +1065,10 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               val first = flatmap.first
 
               if (first eq ZIO.unit) cur = flatmap.successK(())
-              else if (first.isInstanceOf[Success[Any]]) cur = flatmap.successK(first.asInstanceOf[Success[Any]].value)
-              else if (first.isInstanceOf[Failure[Any]]) cur = first
               else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
 
-                val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
+                val result = runLoop(first, stackIndex, stackIndex, currentDepth + 1, ops)
                 ops += 1
 
                 if (null eq result) return null

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1063,23 +1063,26 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             case flatmap: FlatMap[Any, Any, Any, Any] =>
               updateLastTrace(flatmap.trace)
 
-              stackIndex = pushStackFrame(flatmap, stackIndex)
+              val first = flatmap.first
 
-              val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
-              ops += 1
-
-              if (null eq result)
-                return null
+              if (first eq ZIO.unit) cur = flatmap.successK(())
+              else if (first.isInstanceOf[Success[Any]]) cur = flatmap.successK(first.asInstanceOf[Success[Any]].value)
+              else if (first.isInstanceOf[Failure[Any]]) cur = first
               else {
-                stackIndex -= 1
-                popStackFrame(stackIndex)
+                stackIndex = pushStackFrame(flatmap, stackIndex)
 
-                result match {
-                  case s: Success[Any] =>
-                    cur = flatmap.successK(s.value)
+                val result = runLoop(flatmap.first, stackIndex, stackIndex, currentDepth + 1, ops)
+                ops += 1
 
-                  case failure =>
-                    cur = failure
+                if (null eq result) return null
+                else {
+                  stackIndex -= 1
+                  popStackFrame(stackIndex)
+
+                  result match {
+                    case s: Success[Any] => cur = flatmap.successK(s.value)
+                    case failure         => cur = failure
+                  }
                 }
               }
             case stateful: Stateful[Any, Any, Any] =>
@@ -1094,30 +1097,29 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             case fold: FoldZIO[Any, Any, Any, Any, Any] =>
               updateLastTrace(fold.trace)
 
-              stackIndex = pushStackFrame(fold, stackIndex)
+              @inline def exitFailure(cause: Cause[Any]): ZIO.Erased =
+                if (shouldInterrupt()) Exit.Failure(cause.stripFailures) else fold.failureK(cause)
 
-              val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1, ops)
-              ops += 1
+              val first = fold.first
 
-              if (null eq result)
-                return null
+              if (first eq ZIO.unit) cur = fold.successK(())
+              else if (first.isInstanceOf[Success[Any]]) cur = fold.successK(first.asInstanceOf[Success[Any]].value)
+              else if (first.isInstanceOf[Failure[Any]]) cur = exitFailure(first.asInstanceOf[Failure[Any]].cause)
               else {
-                stackIndex -= 1
-                popStackFrame(stackIndex)
+                stackIndex = pushStackFrame(fold, stackIndex)
 
-                result match {
-                  case s: Success[Any] =>
-                    cur = fold.successK(s.value)
+                val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1, ops)
+                ops += 1
 
-                  case f: Failure[Any] =>
-                    val cause = f.cause
-                    if (shouldInterrupt()) {
-                      cur = Exit.Failure(cause.stripFailures)
-                    } else {
-                      val f = fold.failureK
+                if (null eq result) return null
+                else {
+                  stackIndex -= 1
+                  popStackFrame(stackIndex)
 
-                      cur = f(cause)
-                    }
+                  result match {
+                    case s: Success[Any] => cur = fold.successK(s.value)
+                    case f: Failure[Any] => cur = exitFailure(f.cause)
+                  }
                 }
               }
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1075,14 +1075,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 ops += 1
 
                 if (null eq result) return null
-                else {
-                  stackIndex -= 1
-                  popStackFrame(stackIndex)
 
-                  result match {
-                    case s: Success[Any] => cur = flatmap.successK(s.value)
-                    case failure         => cur = failure
-                  }
+                stackIndex -= 1
+                popStackFrame(stackIndex)
+
+                result match {
+                  case s: Success[Any] => cur = flatmap.successK(s.value)
+                  case failure         => cur = failure
                 }
               }
             case stateful: Stateful[Any, Any, Any] =>
@@ -1112,14 +1111,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 ops += 1
 
                 if (null eq result) return null
-                else {
-                  stackIndex -= 1
-                  popStackFrame(stackIndex)
 
-                  result match {
-                    case s: Success[Any] => cur = fold.successK(s.value)
-                    case f: Failure[Any] => cur = exitFailure(f.cause)
-                  }
+                stackIndex -= 1
+                popStackFrame(stackIndex)
+
+                result match {
+                  case s: Success[Any] => cur = fold.successK(s.value)
+                  case f: Failure[Any] => cur = exitFailure(f.cause)
                 }
               }
 
@@ -1168,16 +1166,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 val exit = runLoop(update0.f(oldRuntimeFlags), stackIndex, stackIndex, currentDepth + 1, ops)
                 ops += 1
 
-                if (null eq exit)
-                  return null
-                else {
+                if (null eq exit) return null
 
-                  stackIndex -= 1
-                  popStackFrame(stackIndex)
+                stackIndex -= 1
+                popStackFrame(stackIndex)
 
-                  // Go backward, on the stack:
-                  cur = patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
-                }
+                // Go backward, on the stack:
+                cur = patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
               }
 
             case iterate: WhileLoop[Any, Any, Any] =>


### PR DESCRIPTION
I'd like your opinion on these changes. The goal is to try to reduce the number of recursive calls

It'd, for example, benefit this change: https://github.com/zio/zio/pull/9388