### PR TITLE
Use an `Exit` for `Promise.succeed`

### DIFF
--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -279,7 +279,7 @@ final class Promise[E, A] private (
         completeWith(Exit.failCause(e))
 
       def succeed(a: A)(implicit trace: Trace, unsafe: Unsafe): Boolean =
-        completeWith(ZIO.succeed(a))
+        completeWith(Exit.succeed(a))
     }
 
 }


### PR DESCRIPTION
There is no need to suspend the value in `ZIO.succeed` in this case, so we use an Exit to avoid the Function0 allocation