### PR TITLE
Use GitHub App Token to Create PRs of New Documentation Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,10 +300,17 @@ jobs:
           git add package.json
           commit_message="Update $package_name to $package_version"
           git commit -m "$commit_message" || echo "No changes to commit"
-
-      - name: Create Pull Request to Update Docs
-        uses: peter-evans/create-pull-request@v4.2.4
+      - name: Generate a token
+        id: generate-tokens
+        uses: actions/create-github-app-token@v1.11.1
         with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_SECRET }}
+          owner: ${{ github.repository_owner }}
+      - name: Create Pull Request to Update Docs
+        uses: peter-evans/create-pull-request@v7.0.6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
           body: |-
             The new version of ${{ github.event.client_payload.package_name }} was released.
             Let's update the zio.dev to reflect the latest docs. 


### PR DESCRIPTION
Currently, after receiving the dispatch event, we make a new PR to update new documentation of projects. Doing so with `GITHUB_TOKEN` doesn't trigger the CI to run and needs manual intervention.

With this change, with the help of [this documentation](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs), I changed the default token from `GITHUB_TOKEN` to GitHub App Token, which triggers the CI after making a pull request.