### PR TITLE
Add test for `ZStream#dropWhileZIO`

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1220,6 +1220,25 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(isRight(isUnit))
           }
         ),
+        suite("dropWhileZIO")(
+          test("dropWhileZIO")(
+            check(pureStreamOfInts, Gen.function(Gen.boolean)) { (s, p) =>
+              for {
+                res1 <- s.dropWhileZIO(v => ZIO.succeed(p(v))).runCollect
+                res2 <- s.runCollect.flatMap(_.dropWhileZIO(v => ZIO.succeed(p(v))))
+              } yield assert(res1)(equalTo(res2))
+            }
+          ),
+          test("short circuits") {
+            assertZIO(
+              (ZStream(1) ++ ZStream.fail("Ouch"))
+                .take(1)
+                .dropWhileZIO(_ => ZIO.succeed(true))
+                .runDrain
+                .either
+            )(isRight(isUnit))
+          }
+        ),
         test("either") {
           val s = ZStream(1, 2, 3) ++ ZStream.fail("Boom")
           s.either.runCollect


### PR DESCRIPTION
This operator is not being tested in the ZStream suite. Adding test cases for it based on the `ZStream#dropWhile` suite