### PR TITLE
Reduce parallelism of `ZStreamSpec`

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5795,7 +5795,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           } yield assertTrue(output == Vector("acquire outer", "release outer"))
         }
       )
-    ) @@ TestAspect.timed @@ TestAspect.fibers
+    ) @@ TestAspect.timed @@ TestAspect.fibers @@ TestAspect.parallelN(2)
 
   trait ChunkCoordination[A] {
     def queue: Queue[Exit[Option[Nothing], Chunk[A]]]


### PR DESCRIPTION
/fixes #9443

Issue seems to be related to the heavy usage of `TestClock` in `ZStreamSpec`. Because parallelism is applied per-suite, in cases of nested suites (which `ZStreamSpec` contains a lot of!) with the default parallelism of 4 the number of suites running in parallel can be up to 4 x 4 x 4 = 64.

This causes issues with `TestClock` because it "awaits" (using `sleep`) for all the fibers spawned within the test to be suspended. However, when there is a large number of suites running in parallel, it might falsely determine that a fiber has suspended when it hasn't started running yet. This can cause the suite to deadlock as some test is awaiting for the `TestClock` to advance, when it already has