### PR TITLE
Print interruptions in `ZIO#debug`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -455,9 +455,12 @@ sealed trait ZIO[-R, +E, +A]
    * Prefixes the output with the given message.
    */
   final def debug(prefix: => String)(implicit trace: Trace): ZIO[R, E, A] =
-    self
-      .tap(value => ZIO.succeed(println(s"$prefix: $value")))
-      .tapErrorCause(error => ZIO.succeed(println(s"<FAIL> $prefix: $error")))
+    ZIO.uninterruptibleMask { restore =>
+      restore(self).exitWith {
+        case exit @ Exit.Success(value) => println(s"$prefix: $value"); exit
+        case exit @ Exit.Failure(cause) => println(s"<FAIL> $prefix: $error"); exit
+      }
+    }
 
   /**
    * Returns an effect that is delayed from this effect by the specified

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -458,7 +458,7 @@ sealed trait ZIO[-R, +E, +A]
     ZIO.uninterruptibleMask { restore =>
       restore(self).exitWith {
         case exit @ Exit.Success(value) => println(s"$prefix: $value"); exit
-        case exit @ Exit.Failure(cause) => println(s"<FAIL> $prefix: $error"); exit
+        case exit @ Exit.Failure(error) => println(s"<FAIL> $prefix: $error"); exit
       }
     }
 


### PR DESCRIPTION
Currently `ZIO#debug` doesn't print anything when the effect is interrupted, which can be annoying if using this method to debug issues