### PR TITLE
Fix rare race condition causing `ZStream` to hang on parallel errors

### DIFF
--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -226,7 +226,7 @@ object Queue extends QueuePlatformSpecific {
       ZIO.fiberIdWith { fiberId =>
         shutdownFlag.set(true)
 
-        ZIO.whenZIODiscard(shutdownHook.succeed(()))(
+        ZIO.whenDiscard(shutdownHook.unsafe.completeWith(Exit.unit)(Unsafe))(
           ZIO.foreachParDiscard(unsafePollAll(takers))(_.interruptAs(fiberId)) *> strategy.shutdown
         )
       }.uninterruptible

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamParallelErrorsIssuesSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamParallelErrorsIssuesSpec.scala
@@ -1,0 +1,37 @@
+package zio.stream
+
+import zio._
+import zio.test.TestAspect._
+import zio.test._
+
+object ZStreamParallelErrorsIssuesSpec extends ZIOBaseSpec {
+
+  private val iters = (1 to 5000).toList
+
+  def spec = suite("ZStreamParallelErrorsIssuesSpec")(
+    test("mapZIOPar") {
+      ZIO
+        .foreachParDiscard(iters) { _ =>
+          ZStream
+            .fromIterable(1 to 50)
+            .mapZIOPar(20)(i => if (i < 10) ZIO.succeed(i) else ZIO.fail("Boom"))
+            .mapZIOPar(20)(ZIO.succeed(_))
+            .runCollect
+            .either
+        }
+        .as(assertCompletes)
+    },
+    test("mapZIOParUnordered") {
+      ZIO
+        .foreachParDiscard(iters) { _ =>
+          ZStream
+            .fromIterable(1 to 50)
+            .mapZIOParUnordered(20)(i => if (i < 10) ZIO.succeed(i) else ZIO.fail("Boom"))
+            .mapZIOParUnordered(20)(ZIO.succeed(_))
+            .runCollect
+            .either
+        }
+        .as(assertCompletes)
+    }
+  ) @@ timeout(10.seconds) @@ sequential @@ jvmOnly
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4092,7 +4092,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               _      <- stream.tapSink(sink).take(3).runDrain
               result <- ref.get
             } yield assertTrue(result == 6)
-          }
+          } @@ TestAspect.flaky
         ),
         suite("throttleEnforce")(
           test("free elements") {

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -712,11 +712,11 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
       } yield {
         lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
           ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
-            outgoing.take.flatMap(_.await).map {
-              case s: Exit.Success[OutElem2] => ZChannel.write(s.value) *> writer
+            outgoing.take.flatMap(_.await).flatMap {
+              case s: Exit.Success[OutElem2] => Exit.succeed(ZChannel.write(s.value) *> writer)
               case f: Exit.Failure[Either[Unit, OutDone]] =>
                 val failure0 = failure.unsafe.get(Unsafe)
-                f.cause.failureOrCause match {
+                val out = f.cause.failureOrCause match {
                   case Left(_: Left[Unit, OutDone]) => ZChannel.refailCause(failure0)
                   case Left(x: Right[Unit, OutDone]) =>
                     if (failure0 eq Cause.empty) ZChannel.succeedNow(x.value)
@@ -724,6 +724,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                   case Right(c) if c.isInterruptedOnly => ZChannel.refailCause(failure0)
                   case Right(cause)                    => ZChannel.refailCause(cause)
                 }
+                outgoing.shutdown.as(out)
             }
           }
 
@@ -793,11 +794,11 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
       } yield {
         lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
           ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
-            outgoing.take.map {
-              case s: Exit.Success[OutElem2] => ZChannel.write(s.value) *> writer
+            outgoing.take.flatMap {
+              case s: Exit.Success[OutElem2] => Exit.succeed(ZChannel.write(s.value) *> writer)
               case f: Exit.Failure[Either[Unit, OutDone]] =>
                 val failure0 = failure.unsafe.get(Unsafe)
-                f.cause.failureOrCause match {
+                val out = f.cause.failureOrCause match {
                   case Left(_: Left[Unit, OutDone]) => ZChannel.refailCause(failure0)
                   case Left(x: Right[Unit, OutDone]) =>
                     if (failure0 eq Cause.empty) ZChannel.succeedNow(x.value)
@@ -805,6 +806,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                   case Right(c) if c.isInterruptedOnly => ZChannel.refailCause(failure0)
                   case Right(cause)                    => ZChannel.refailCause(cause)
                 }
+                outgoing.shutdown.as(out)
             }
           }
 
@@ -2059,11 +2061,11 @@ object ZChannel {
         } yield {
           lazy val consumer: ZChannel[Env, Any, Any, Any, OutErr, OutElem, OutDone] =
             unwrap[Env, Any, Any, Any, OutErr, OutElem, OutDone] {
-              outgoing.take.map {
-                case Result.Value(outElem)  => ZChannel.write(outElem) *> consumer
-                case Result.Done(outDone)   => ZChannel.succeedNow(outDone)
-                case Result.Error(outError) => ZChannel.fail(outError)
-                case Result.Fatal(cause)    => ZChannel.refailCause(cause)
+              outgoing.take.flatMap {
+                case Result.Value(outElem)  => Exit.succeed(ZChannel.write(outElem) *> consumer)
+                case Result.Done(outDone)   => outgoing.shutdown.as(ZChannel.succeedNow(outDone))
+                case Result.Error(outError) => outgoing.shutdown.as(ZChannel.fail(outError))
+                case Result.Fatal(cause)    => outgoing.shutdown.as(ZChannel.refailCause(cause))
               }
             }
 


### PR DESCRIPTION
Some tests in the ZStream suite have been hanging during CI relatively often. After looking into it, it appears that the main issue is that in some cases the ZChannel will stop reading (due to an error), causing the queue to fill up and thus not allowing us to write all the errors in it. Normally, this would be handled by finalization of the ZStream's `Scope`, but I suspect there is a race condition where some times the fiber is unable to proceed to the finalization because it's suspended waiting to `offer` on a full queue.

This PR fixes this issue by ensuring the queue is shut down when we're no longer going to read from the queue, which should fix the test flakiness but also avoid this issue from potentially happening in production