### PR TITLE
Optimize `ZIO.fail`

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -608,7 +608,6 @@ object Fiber extends FiberPlatformSpecific {
 
     private[zio] def isAlive(): Boolean
 
-
     /**
      * Determines if the specified throwable is fatal, based on the fatal errors
      * tracked by the fiber's state.

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -544,6 +544,13 @@ object Fiber extends FiberPlatformSpecific {
     private[zio] def deleteFiberRef(ref: FiberRef[_]): Unit
 
     /**
+     * Generates a full stack trace from the reified stack.
+     *
+     * '''NOTE''': This method must be invoked by the fiber itself.
+     */
+    private[zio] def generateStackTrace(): StackTrace
+
+    /**
      * Retrieves the current executor that effects are executed on.
      *
      * '''NOTE''': This method is safe to invoke on any fiber, but if not
@@ -600,6 +607,7 @@ object Fiber extends FiberPlatformSpecific {
     private[zio] def getRunningExecutor(): Option[Executor]
 
     private[zio] def isAlive(): Boolean
+
 
     /**
      * Determines if the specified throwable is fatal, based on the fatal errors

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4869,7 +4869,9 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Capture ZIO stack trace at the current point.
    */
   def stackTrace(implicit trace: Trace): UIO[StackTrace] =
-    GenerateStackTrace(trace)
+    ZIO.withFiberRuntime[Any, Nothing, StackTrace] { (state, _) =>
+      Exit.succeed(state.generateStackTrace())
+    }
 
   /**
    * Tags each metric in this effect with the specific tag.
@@ -6143,6 +6145,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A] = f(oldRuntimeFlags)
     }
   }
+  @deprecated("Kept for binary compatibility only", since = "2.1.15")
   private[zio] final case class GenerateStackTrace(trace: Trace) extends ZIO[Any, Nothing, StackTrace]
   private[zio] final case class Stateful[R, E, A](
     trace: Trace,

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -510,7 +510,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def generateStackTrace(): StackTrace = {
+  private[zio] def generateStackTrace(): StackTrace = {
     val builder = stackTraceBuilderPool.get()
 
     val stack = _stack
@@ -1221,13 +1221,13 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 return failure
               }
 
-            case gen0: GenerateStackTrace =>
-              updateLastTrace(gen0.trace)
-              cur = Exit.succeed(generateStackTrace())
-
             case updateRuntimeFlags: UpdateRuntimeFlags =>
               updateLastTrace(updateRuntimeFlags.trace)
               cur = patchRuntimeFlags(updateRuntimeFlags.update, null, Exit.unit)
+
+            case gen0: GenerateStackTrace =>
+              updateLastTrace(gen0.trace)
+              cur = Exit.succeed(generateStackTrace())
 
             // Should be unreachable, but we keep it to be backwards compatible
             case update0: UpdateRuntimeFlagsWithin[Any, Any, Any] =>

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -516,6 +516,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val stack = _stack
     val size  = _stackSize // racy
 
+    builder += _lastTrace
     try {
       if (stack ne null) {
         var i = (if (stack.length < size) stack.length else size) - 1


### PR DESCRIPTION
`ZIO.fail` is commonly used not only for raising errors, but also as shortcut (e.g., `ZIO.fail(None)`). While we're trying to use `Exit.fail` as much as possible when we need to shortcut, there are still quite a lot of usages of `ZIO.fail` both within the core `zio` repo and in `zio-*` libraries.

This PR optimizes `ZIO.fail` so that we get all the info we need to build the failure with 2 iterations of the runloop instead of 4