### PR TITLE
Fix flaky test in SemaphoreSpec

### DIFF
--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -36,7 +36,7 @@ object SemaphoreSpec extends ZIOBaseSpec {
       for {
         semaphore    <- Semaphore.make(1)
         promise      <- Promise.make[Nothing, Unit]
-        _            <- ZIO.foreach(1 to 11)(_ => semaphore.withPermit(promise.await).fork)
+        _            <- ZIO.foreachDiscard(1 to 11)(_ => semaphore.withPermit(promise.await).fork)
         waitingStart <- semaphore.awaiting.repeatUntil(_ == 10)
         _            <- promise.succeed(())
         waitingEnd   <- semaphore.awaiting.repeatUntil(_ == 0)


### PR DESCRIPTION
I'm actually surprised this test hasn't been flaky more often. Since the first invocation of `semaphore.withPermit(promise.await)` was forked, if the forking in the line below won the race then the test would never complete.

Fixed it by making all of semaphore.await on the promise, so that we can guarantee none of them wins the race and completes. Also annotated the entire suite with `nonFlaky` just in case