### PR TITLE
Optimize Ref.Atomic

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RefSpec.scala
@@ -1,18 +1,12 @@
 package zio
 
 import zio.test.Assertion._
-import zio.test.TestAspect.{exceptJS, nonFlaky}
 import zio.test._
 
 object RefSpec extends ZIOBaseSpec {
 
   def spec = suite("RefSpec")(
     suite("Atomic")(
-      test("race") {
-        for {
-          _ <- ZIO.unit.race(ZIO.unit)
-        } yield assertCompletes
-      } @@ exceptJS(nonFlaky),
       test("get") {
         for {
           ref   <- Ref.make(current)
@@ -82,7 +76,7 @@ object RefSpec extends ZIOBaseSpec {
         } yield assert(value)(equalTo(update))
       },
       test("toString") {
-        assertZIO(Ref.make(42).map(_.toString))(equalTo("Ref(42)"))
+        assertZIO(Ref.make(42).map(_.toString))(equalTo("Ref.Atomic(initial = 42)"))
       },
       test("update") {
         for {

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicReference
  * concurrent access. If you do need to use a mutable value `Ref.Synchronized`
  * will guarantee that access to the value is properly synchronized.
  */
-abstract class Ref[A] extends Serializable {
+sealed abstract class Ref[A] extends Serializable {
 
   /**
    * Reads the value from the `Ref`.
@@ -189,8 +189,7 @@ object Ref extends Serializable {
     ZIO.succeed(unsafe.make(a)(Unsafe))
 
   object unsafe {
-    def make[A](a: A)(implicit unsafe: Unsafe): Ref.Atomic[A] =
-      Atomic(new AtomicReference(a))
+    def make[A](a: A)(implicit unsafe: Unsafe): Ref.Atomic[A] = new Atomic[A](a)
   }
 
   /**
@@ -320,11 +319,8 @@ object Ref extends Serializable {
       }
     }
   }
-
-  private[zio] final case class Atomic[A](value: AtomicReference[A]) extends Ref[A] {
-    self =>
-
-    def get(implicit trace: Trace): UIO[A] =
+  private[zio] final class Atomic[A](initial: A) extends Ref[A] { self =>
+    override def get(implicit trace: Trace): UIO[A] =
       ZIO.succeed(unsafe.get(Unsafe))
 
     override def getAndSet(a: A)(implicit trace: Trace): UIO[A] =
@@ -336,16 +332,16 @@ object Ref extends Serializable {
     override def getAndUpdateSome(pf: PartialFunction[A, A])(implicit trace: Trace): UIO[A] =
       ZIO.succeed(unsafe.getAndUpdateSome(pf)(Unsafe))
 
-    def modify[B](f: A => (B, A))(implicit trace: Trace): UIO[B] =
+    override def modify[B](f: A => (B, A))(implicit trace: Trace): UIO[B] =
       ZIO.succeed(unsafe.modify(f)(Unsafe))
 
     override def modifySome[B](default: B)(pf: PartialFunction[A, (B, A)])(implicit trace: Trace): UIO[B] =
       ZIO.succeed(unsafe.modifySome(default)(pf)(Unsafe))
 
-    def set(a: A)(implicit trace: Trace): UIO[Unit] =
+    override def set(a: A)(implicit trace: Trace): UIO[Unit] =
       ZIO.succeed(unsafe.set(a)(Unsafe))
 
-    def setAsync(a: A)(implicit trace: Trace): UIO[Unit] =
+    override def setAsync(a: A)(implicit trace: Trace): UIO[Unit] =
       ZIO.succeed(unsafe.setAsync(a)(Unsafe))
 
     override def update(f: A => A)(implicit trace: Trace): UIO[Unit] =
@@ -360,8 +356,7 @@ object Ref extends Serializable {
     override def updateSomeAndGet(pf: PartialFunction[A, A])(implicit trace: Trace): UIO[A] =
       ZIO.succeed(unsafe.updateSomeAndGet(pf)(Unsafe))
 
-    override def toString: String =
-      s"Ref(${value.get})"
+    override def toString: String = s"Ref.Atomic(initial = $initial)"
 
     trait UnsafeAPI extends Serializable {
       def get(implicit unsafe: Unsafe): A
@@ -379,50 +374,29 @@ object Ref extends Serializable {
     }
 
     val unsafe: UnsafeAPI =
-      new UnsafeAPI {
+      new AtomicReference[A](initial) with UnsafeAPI { ref: AtomicReference[A] =>
         def get(implicit unsafe: Unsafe): A =
-          value.get
+          ref.asInstanceOf[AtomicReference[A]].get
 
-        def getAndSet(a: A)(implicit unsafe: Unsafe): A = {
-          var loop       = true
-          var current: A = null.asInstanceOf[A]
-          while (loop) {
-            current = value.get
-            loop = !value.compareAndSet(current, a)
-          }
-          current
-        }
+        def getAndSet(a: A)(implicit unsafe: Unsafe): A =
+          ref.asInstanceOf[AtomicReference[A]].getAndSet(a)
 
-        def getAndUpdate(f: A => A)(implicit unsafe: Unsafe): A = {
-          var loop       = true
-          var current: A = null.asInstanceOf[A]
-          while (loop) {
-            current = value.get
-            val next = f(current)
-            loop = !value.compareAndSet(current, next)
-          }
-          current
-        }
+        def getAndUpdate(f: A => A)(implicit unsafe: Unsafe): A =
+          ref.asInstanceOf[AtomicReference[A]].getAndUpdate(f.apply)
 
-        def getAndUpdateSome(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): A = {
-          var loop       = true
-          var current: A = null.asInstanceOf[A]
-          while (loop) {
-            current = value.get
-            val next = pf.applyOrElse(current, (_: A) => current)
-            loop = !value.compareAndSet(current, next)
-          }
-          current
-        }
+        def getAndUpdateSome(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): A =
+          ref
+            .asInstanceOf[AtomicReference[A]]
+            .getAndUpdate((current: A) => pf.applyOrElse(current, (_: Any) => current))
 
         def modify[B](f: A => (B, A))(implicit unsafe: Unsafe): B = {
           var loop = true
           var b: B = null.asInstanceOf[B]
           while (loop) {
-            val current = value.get
+            val current = ref.asInstanceOf[AtomicReference[A]].get
             val tuple   = f(current)
             b = tuple._1
-            loop = !value.compareAndSet(current, tuple._2)
+            loop = !ref.compareAndSet(current, tuple._2)
           }
           b
         }
@@ -431,63 +405,35 @@ object Ref extends Serializable {
           var loop = true
           var b: B = null.asInstanceOf[B]
           while (loop) {
-            val current = value.get
-            val tuple   = pf.applyOrElse(current, (_: A) => (default, current))
+            val current = ref.asInstanceOf[AtomicReference[A]].get
+            val tuple   = pf.applyOrElse(current, (_: Any) => (default, current))
             b = tuple._1
-            loop = !value.compareAndSet(current, tuple._2)
+            loop = !ref.compareAndSet(current, tuple._2)
           }
           b
         }
 
         def set(a: A)(implicit unsafe: Unsafe): Unit =
-          value.set(a)
+          ref.asInstanceOf[AtomicReference[A]].set(a)
 
         def setAsync(a: A)(implicit unsafe: Unsafe): Unit =
-          value.lazySet(a)
+          ref.lazySet(a)
 
-        def update(f: A => A)(implicit unsafe: Unsafe): Unit = {
-          var loop    = true
-          var next: A = null.asInstanceOf[A]
-          while (loop) {
-            val current = value.get
-            next = f(current)
-            loop = !value.compareAndSet(current, next)
-          }
-          ()
-        }
+        def update(f: A => A)(implicit unsafe: Unsafe): Unit =
+          ref.asInstanceOf[AtomicReference[A]].updateAndGet(f.apply)
 
-        def updateAndGet(f: A => A)(implicit unsafe: Unsafe): A = {
-          var loop    = true
-          var next: A = null.asInstanceOf[A]
-          while (loop) {
-            val current = value.get
-            next = f(current)
-            loop = !value.compareAndSet(current, next)
-          }
-          next
-        }
+        def updateAndGet(f: A => A)(implicit unsafe: Unsafe): A =
+          ref.asInstanceOf[AtomicReference[A]].updateAndGet(f.apply)
 
-        def updateSome(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): Unit = {
-          var loop    = true
-          var next: A = null.asInstanceOf[A]
-          while (loop) {
-            val current = value.get
-            next = pf.applyOrElse(current, (_: A) => current)
-            loop = !value.compareAndSet(current, next)
-          }
-          ()
-        }
+        def updateSome(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): Unit =
+          ref
+            .asInstanceOf[AtomicReference[A]]
+            .updateAndGet((current: A) => pf.applyOrElse(current, (_: Any) => current))
 
-        def updateSomeAndGet(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): A = {
-          var loop    = true
-          var next: A = null.asInstanceOf[A]
-          while (loop) {
-            val current = value.get
-            next = pf.applyOrElse(current, (_: A) => current)
-            loop = !value.compareAndSet(current, next)
-          }
-          next
-        }
+        def updateSomeAndGet(pf: PartialFunction[A, A])(implicit unsafe: Unsafe): A =
+          ref
+            .asInstanceOf[AtomicReference[A]]
+            .updateAndGet((current: A) => pf.applyOrElse(current, (_: Any) => current))
       }
   }
 }

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -319,6 +319,9 @@ object Ref extends Serializable {
       }
     }
   }
+
+  @deprecated("Kept for binary compatibility only. Do not use", "2.1.15")
+  private[zio] object Atomic {}
   private[zio] final class Atomic[A](initial: A) extends Ref[A] { self =>
     override def get(implicit trace: Trace): UIO[A] =
       ZIO.succeed(unsafe.get(Unsafe))
@@ -435,5 +438,8 @@ object Ref extends Serializable {
             .asInstanceOf[AtomicReference[A]]
             .updateAndGet((current: A) => pf.applyOrElse(current, (_: Any) => current))
       }
+
+    @deprecated("Kept for binary compatibility only. Do not use", "2.1.15")
+    private[zio] def value: AtomicReference[A] = unsafe.asInstanceOf[AtomicReference[A]]
   }
 }

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -41,7 +41,8 @@ object ThreadLocalBridge {
 
   private class FiberRefTrackingSupervisor extends Supervisor[Unit] {
 
-    private val trackedRefs: Ref.Atomic[Set[(FiberRef[_], Any => Unit)]] = Ref.Atomic(new AtomicReference(Set.empty))
+    private val trackedRefs: Ref.Atomic[Set[(FiberRef[_], Any => Unit)]] =
+      Ref.unsafe.make(Set.empty[(FiberRef[_], Any => Unit)])(Unsafe)
 
     override def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
 

--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -23,7 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A `SubscriptionRef[A]` is a `Ref` that can be subscribed to in order to
  * receive the current value as well as all changes to the value.
  */
-trait SubscriptionRef[A] extends Ref.Synchronized[A] {
+sealed trait SubscriptionRef[A] extends Ref.Synchronized[A] {
 
   /**
    * A stream containing the current value of the `Ref` as well as all changes


### PR DESCRIPTION
1. Initialize the `UnsafeAPI`  with the `AtomicRef` class to avoid pointer chasing within `UnsafeAPI` methods, as well as allocated space
2. reuse implementations from `AtomicRef` where possible - reducing generated bytecode size

Benchmark shows minor improvement, but it's just using `update`:

https://jmh.morethan.io/?gists=a2e47cdd533e03f456ad1210fefd7172,07a439a09644cedac645fedaf3fe8de6

I don't have time to add other benchmarks now, but I suspect this will be an improvement all around.

Other notes:
- I marked `Ref` and `SubscriptionRef` as sealed, which should be binary compatible...
- I removed the usage of `.get` in `toString`. I think it's unnecessary and not suspended, so probably not worth exposing.

