### PR TITLE
fix broken links in docs

### DIFF
--- a/docs/contributing-to-zio-ecosystem-projects.md
+++ b/docs/contributing-to-zio-ecosystem-projects.md
@@ -96,7 +96,7 @@ Inside the `index.md` file, the `sidebar_title` field is used to set the name of
 
 Also, we can use `@‎PROJECT_BADGES@` placeholder to add badges to the documentation. The `@‎PROJECT_BADGES@` placeholder will be replaced with the badges of the library. Also, the `@‎VERSION@` placeholder will be replaced with the latest version of the library.
 
-The `index.md` file is the primary source for generating the `README.md` file of the library. Further details on this process will be discussed in the [Generating README File](#generating-readme-file) section.
+The `index.md` file is the primary source for generating the `README.md` file of the library. Further details on this process will be discussed in the [ZIO SBT Website Plugin](#zio-sbt-website-plugin) section.
 
 ### The `sidebars.js` File
 

--- a/docs/guides/interop/with-javascript.md
+++ b/docs/guides/interop/with-javascript.md
@@ -16,7 +16,7 @@ println(s"""```""")
 
 ## Example
 
-Your main function can extend [`ZIOAppDefault`](../../core/zioapp.md) as follows.
+Your main function can extend [`ZIOAppDefault`](../../reference/core/zioapp.md) as follows.
 
 This example uses [scala-js-dom](https://github.com/scala-js/scala-js-dom) to access the DOM; to run the example you
 will need to add that library as a dependency to your `build.sbt`.


### PR DESCRIPTION
Ideally we'd run `docs/mdoc` with the `--check-link-hygiene` flag in CI to turn broken links into errors.
But unfortunately, it emits a lot of false positives for the documents in the `guides/tutorials` directory. 