### PR TITLE
Update izumi-reflect to v3.0.0

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/OpaqueTypeTagsSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/OpaqueTypeTagsSpec.scala
@@ -1,0 +1,32 @@
+package zio.test
+
+import zio.*
+
+object OpaqueTypeTagsSpec extends ZIOBaseSpec {
+
+  object UserName {
+    opaque type T = String
+    def apply(s: String): T = s"UserName: $s"
+  }
+
+  type UserName = UserName.T
+
+  object UserId {
+    opaque type T = String
+    def apply(s: String): T = s"UserId: $s"
+  }
+
+  type UserId = UserId.T
+
+  def spec =
+    suite("OpaqueTypeTagsSpec")(
+      test("extracts opaque types from environment") {
+        val f = for {
+          n <- ZIO.service[UserName.T]
+          i <- ZIO.service[UserId.T]
+        } yield assertTrue(n.toString == "UserName: foo", i.toString == "UserId: bar")
+
+        f.provide(ZLayer.succeed(UserName("foo")), ZLayer.succeed(UserId("bar")))
+      }
+    )
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   // Runtime dependencies
   val JunitVersion                 = "4.13.2"
   val JunitPlatformEngineVersion   = "1.11.3"
-  val IzumiReflectVersion          = "2.3.10"
+  val IzumiReflectVersion          = "3.0.0"
   val MagnoliaScala2Version        = "1.1.10"
   val MagnoliaScala3Version        = "1.3.8"
   val RefinedVersion               = "0.11.2"


### PR DESCRIPTION
/fixes #8882
/claim #8882

This PR update the izumi-reflect version to v3.0.0 which contains important fixes to tags of opaque types, as demonstrated by #8882.

Note that there is binary incompatibility of tags for opaque types created between versions 2.x and 3.x of izumi-reflect, but the risk is extremely minimal as no `zio-*` library uses opaque types in situations that require an implicit Tag