### PR TITLE
Ensure `Supervisor#onEnd` is called exactly once

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -1,6 +1,5 @@
 package zio
 
-import zio.Clock.ClockLive
 import zio.internal.FiberScope
 import zio.test._
 
@@ -63,30 +62,8 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
             }
         }
       }
-    ),
-    suite("supervisor")(
-      suite("onStart and onEnd are called exactly once")(
-        test("sync effect") {
-          for {
-            s <- ZIO.succeed(new StartEndTrackingSupervisor)
-            f <- ZIO.unit.fork.supervised(s)
-            _ <- f.await
-            // onEnd might be called after the forked fiber notifies the current fiber
-            _ <- ZIO.succeed(s.onEndCalls).repeatUntil(_ > 0)
-          } yield assertTrue(s.onStartCalls == 1, s.onEndCalls == 1)
-        },
-        test("async effect") {
-          for {
-            s <- ZIO.succeed(new StartEndTrackingSupervisor)
-            f <- ClockLive.sleep(100.micros).fork.supervised(s)
-            _ <- f.await
-            // onEnd might be called after the forked fiber notifies the current fiber
-            _ <- ZIO.succeed(s.onEndCalls).repeatUntil(_ > 0)
-          } yield assertTrue(s.onStartCalls == 1, s.onEndCalls == 1)
-        }
-      ) @@ TestAspect.nonFlaky(100)
     )
-  ) @@ TestAspect.timeout(10.seconds)
+  )
 
   private final class YieldTrackingSupervisor(
     latch: Promise[Nothing, Unit],
@@ -114,30 +91,6 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
       if (onEndCalled) latch.unsafe.done(Exit.unit) // onEnd gets called before onSuspend
       ()
     }
-  }
-
-  private final class StartEndTrackingSupervisor extends Supervisor[Unit] {
-    private val _onStartCalls, _onEndCalls = new AtomicInteger(0)
-
-    def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
-
-    def onStart[R, E, A](
-      environment: ZEnvironment[R],
-      effect: ZIO[R, E, A],
-      parent: Option[Fiber.Runtime[Any, Any]],
-      fiber: Fiber.Runtime[E, A]
-    )(implicit unsafe: Unsafe): Unit = {
-      _onStartCalls.incrementAndGet()
-      ()
-    }
-
-    def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
-      _onEndCalls.incrementAndGet
-      ()
-    }
-
-    def onStartCalls = _onStartCalls.get
-    def onEndCalls   = _onEndCalls.get
   }
 
 }

--- a/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SupervisorSpec.scala
@@ -1,7 +1,10 @@
 package zio
 
+import zio.Clock.ClockLive
 import zio.test.TestAspect.{exceptJS, nonFlaky}
 import zio.test._
+
+import java.util.concurrent.atomic.AtomicInteger
 
 object SupervisorSpec extends ZIOBaseSpec {
 
@@ -31,7 +34,27 @@ object SupervisorSpec extends ZIOBaseSpec {
       DifferSpec.diffLaws(Differ.supervisor)(genSupervisor)((left, right) =>
         Supervisor.toSet(left) == Supervisor.toSet(right)
       )
-    }
+    },
+    suite("onStart and onEnd are called exactly once")(
+      test("sync effect") {
+        for {
+          s <- ZIO.succeed(new StartEndTrackingSupervisor)
+          f <- ZIO.unit.fork.supervised(s)
+          _ <- f.await
+          // onEnd might be called after the forked fiber notifies the current fiber
+          _ <- ZIO.succeed(s.onEndCalls).repeatUntil(_ > 0)
+        } yield assertTrue(s.onStartCalls == 1, s.onEndCalls == 1)
+      },
+      test("async effect") {
+        for {
+          s <- ZIO.succeed(new StartEndTrackingSupervisor)
+          f <- ClockLive.sleep(100.micros).fork.supervised(s)
+          _ <- f.await
+          // onEnd might be called after the forked fiber notifies the current fiber
+          _ <- ZIO.succeed(s.onEndCalls).repeatUntil(_ > 0)
+        } yield assertTrue(s.onStartCalls == 1, s.onEndCalls == 1)
+      }
+    ) @@ TestAspect.nonFlaky(100)
   )
 
   val genSupervisor: Gen[Any, Supervisor[Any]] =
@@ -105,4 +128,29 @@ object SupervisorSpec extends ZIOBaseSpec {
           promise.unsafe.done(ZIO.succeed(ref.unsafe.get))
       }
     }
+
+  private final class StartEndTrackingSupervisor extends Supervisor[Unit] {
+    private val _onStartCalls, _onEndCalls = new AtomicInteger(0)
+
+    def value(implicit trace: Trace): UIO[Unit] = ZIO.unit
+
+    def onStart[R, E, A](
+      environment: ZEnvironment[R],
+      effect: ZIO[R, E, A],
+      parent: Option[Fiber.Runtime[Any, Any]],
+      fiber: Fiber.Runtime[E, A]
+    )(implicit unsafe: Unsafe): Unit = {
+      _onStartCalls.incrementAndGet()
+      ()
+    }
+
+    def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      _onEndCalls.incrementAndGet
+      ()
+    }
+
+    def onStartCalls = _onStartCalls.get
+    def onEndCalls   = _onEndCalls.get
+  }
+
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -153,8 +153,6 @@ trait Runtime[+R] { self =>
 
       if (supervisor ne Supervisor.none) {
         supervisor.onStart(environment, zio, None, fiber)
-
-        fiber.addObserver(exit => supervisor.onEnd(exit, fiber))
       }
 
       val exit = fiber.start[R](zio)
@@ -201,8 +199,6 @@ trait Runtime[+R] { self =>
 
       if (supervisor ne Supervisor.none) {
         supervisor.onStart(environment, zio, None, fiber)
-
-        fiber.addObserver(exit => supervisor.onEnd(exit, fiber))
       }
 
       fiber

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -2698,8 +2698,6 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
           Some(parentFiber),
           childFiber
         )
-
-        childFiber.addObserver(exit => supervisor.onEnd(exit, childFiber))
       }
 
       val parentScope =

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -424,7 +424,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               if (inbox.isEmpty) {
                 finalExit = exit
 
-                supervisor.onEnd(finalExit, self)(Unsafe)
+                if (supervisor ne Supervisor.none) supervisor.onEnd(finalExit, self)(Unsafe)
 
                 // No more messages to process, so we will allow the fiber to end life:
                 self.setExitValue(exit)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -396,10 +396,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     if (supervisor ne Supervisor.none) supervisor.onResume(self)(Unsafe)
     if (_stack eq null) _stack = new Array[Continuation](FiberRuntime.InitialStackSize)
 
-    var finalExit = null.asInstanceOf[Exit[E, A]]
-
     try {
-      var effect = effect0
+      var effect    = effect0
+      var finalExit = null.asInstanceOf[Exit[E, A]]
 
       while (effect ne null) {
         try {
@@ -426,6 +425,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 finalExit = exit
 
                 supervisor.onEnd(finalExit, self)(Unsafe)
+
                 // No more messages to process, so we will allow the fiber to end life:
                 self.setExitValue(exit)
               } else {

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -425,6 +425,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               if (inbox.isEmpty) {
                 finalExit = exit
 
+                supervisor.onEnd(finalExit, self)(Unsafe)
                 // No more messages to process, so we will allow the fiber to end life:
                 self.setExitValue(exit)
               } else {
@@ -455,10 +456,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
       val supervisor = getSupervisor()
 
-      if (supervisor ne Supervisor.none) {
-        if (finalExit ne null) supervisor.onEnd(finalExit, self)(Unsafe)
-        supervisor.onSuspend(self)(Unsafe)
-      }
+      if (supervisor ne Supervisor.none) supervisor.onSuspend(self)(Unsafe)
     }
   }
 


### PR DESCRIPTION
/fixes #9494

It seems that in in ZIO 2.0.x we were relying on calling `onEnd` only by adding an observer when we forked the fiber. Some time in the development of ZIO 2.1 the `onEnd` method was also being called within the `FiberRuntime.evaluateEffect`, causing it to be called twice.

This PR delegates the responsibility of calling `onEnd` entirely to the `FiberRuntime` instead of relying on externally adding an observer.