### PR TITLE
Increase timeout for `broadcastDynamic` tests

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -576,7 +576,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               cleaned     <- finalized.get
             } yield assertTrue(cleaned)
           }
-        ) @@ TestAspect.timeout(5.seconds),
+        ) @@ TestAspect.timeout(20.seconds),
         suite("buffer")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
             assertZIO(


### PR DESCRIPTION
Test seems to be flaky in CI but can't replicate locally. I'm suspecting it might be related to test scheduling so I'm increasing the timeout _just in case_.

Will look into it if the issue persists after the timeout has been increased