### PR TITLE
Mark `Fiber` as sealed

### DIFF
--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -42,7 +42,7 @@ import zio.internal.WeakConcurrentBag
  *   } yield (a, b)
  * }}}
  */
-abstract class Fiber[+E, +A] { self =>
+sealed abstract class Fiber[+E, +A] { self =>
 
   /**
    * Same as `zip` but discards the output of the left hand side.
@@ -742,11 +742,11 @@ object Fiber extends FiberPlatformSpecific {
   }
 
   sealed trait Status { self =>
-    def isDone: Boolean = self match { case Status.Done => true; case _ => false }
+    def isDone: Boolean = self.isInstanceOf[Status.Done.type]
 
-    def isRunning: Boolean = self match { case _: Status.Running => true; case _ => false }
+    def isRunning: Boolean = self.isInstanceOf[Status.Running]
 
-    def isSuspended: Boolean = self match { case _: Status.Suspended => true; case _ => false }
+    def isSuspended: Boolean = self.isInstanceOf[Status.Suspended]
   }
   object Status {
     sealed trait Unfinished extends Status {
@@ -763,7 +763,7 @@ object Fiber extends FiberPlatformSpecific {
     final case class Running(runtimeFlags: RuntimeFlags, trace: Trace) extends Unfinished {
       override def toString(): String = {
         val currentLocation =
-          if (trace == Trace.empty) "<trace unavailable>"
+          if (trace eq Trace.empty) "<trace unavailable>"
           else trace
 
         s"Running(${RuntimeFlags.render(runtimeFlags)}, ${currentLocation})"
@@ -776,7 +776,7 @@ object Fiber extends FiberPlatformSpecific {
     ) extends Unfinished {
       override def toString(): String = {
         val currentLocation =
-          if (trace == Trace.empty) "<trace unavailable>"
+          if (trace eq Trace.empty) "<trace unavailable>"
           else trace
 
         s"Suspended(${RuntimeFlags.render(runtimeFlags)}, ${currentLocation}, ${blockingOn})"

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -742,7 +742,7 @@ object Fiber extends FiberPlatformSpecific {
   }
 
   sealed trait Status { self =>
-    def isDone: Boolean = self.isInstanceOf[Status.Done.type]
+    def isDone: Boolean = self eq Status.Done
 
     def isRunning: Boolean = self.isInstanceOf[Status.Running]
 
@@ -763,7 +763,7 @@ object Fiber extends FiberPlatformSpecific {
     final case class Running(runtimeFlags: RuntimeFlags, trace: Trace) extends Unfinished {
       override def toString(): String = {
         val currentLocation =
-          if (trace eq Trace.empty) "<trace unavailable>"
+          if ((trace eq Trace.empty) || (trace eq null)) "<trace unavailable>"
           else trace
 
         s"Running(${RuntimeFlags.render(runtimeFlags)}, ${currentLocation})"
@@ -776,7 +776,7 @@ object Fiber extends FiberPlatformSpecific {
     ) extends Unfinished {
       override def toString(): String = {
         val currentLocation =
-          if (trace eq Trace.empty) "<trace unavailable>"
+          if ((trace eq Trace.empty) || (trace eq null)) "<trace unavailable>"
           else trace
 
         s"Suspended(${RuntimeFlags.render(runtimeFlags)}, ${currentLocation}, ${blockingOn})"


### PR DESCRIPTION
- Simplify `Status` methods
- use reference equality for trace