### PR TITLE
Implement generic interfaces for non-empty collections (#9559)

### DIFF
--- a/core/shared/src/main/scala/zio/NonEmptyOps.scala
+++ b/core/shared/src/main/scala/zio/NonEmptyOps.scala
@@ -1,0 +1,21 @@
+package zio
+
+trait NonEmptyOps[+A, CC[+_], EC[+_]] {
+  def collect[B](pf: PartialFunction[A, B]): EC[B]
+  def exists(p: A => Boolean): Boolean
+  def filter(p: A => Boolean): EC[A]
+  def filterNot(p: A => Boolean): EC[A]
+  def find(p: A => Boolean): Option[A]
+  def foldLeft[B](z: B)(op: (B, A) => B): B
+  def forall(p: A => Boolean): Boolean
+  def grouped(size: Int): Iterator[CC[A]]
+  def head: A
+  def init: EC[A]
+  def iterator: Iterator[A]
+  def last: A
+  def map[B](f: A => B): CC[B]
+  def reduce[B >: A](op: (B, B) => B): B
+  def tail: EC[A]
+  def zip[B](that: CC[B])(implicit zippable: Zippable[A, B]): CC[zippable.Out]
+  def zipWithIndex: CC[(A, Int)]
+}

--- a/core/shared/src/main/scala/zio/NonEmptySeq.scala
+++ b/core/shared/src/main/scala/zio/NonEmptySeq.scala
@@ -1,0 +1,11 @@
+package zio
+
+trait NonEmptySeq[+A, CC[+_], EC[+_]] extends NonEmptyOps[A, CC, EC] {
+  def appended[B >: A](elem: B): CC[B]
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B]
+  def distinct: CC[A]
+  def prepended[B >: A](elem: B): CC[B]
+  def reverse: CC[A]
+  def sortBy[B](f: A => B)(implicit ord: Ordering[B]): CC[A]
+  def sorted[B >: A](implicit ord: Ordering[B]): CC[B]
+}


### PR DESCRIPTION
fixes #9559
/claim #9559

The idea would be, to use the introduced interfaces also in prelude.

Implementing any useful Scala default collection interface sadly does not work, since they require empty instances in factories.

Cats took a similar approach of having their own [interface](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/data/NonEmptyCollection.scala)

Maybe we should have the other non empty collections in ZIO core?