### PR TITLE
Use an `inline given` for CanFail evidence in Scala 3

### DIFF
--- a/core/shared/src/main/scala-3/zio/CanFail.scala
+++ b/core/shared/src/main/scala-3/zio/CanFail.scala
@@ -34,11 +34,16 @@ import scala.util.NotGiven
 )
 sealed abstract class CanFail[-E]
 
-object CanFail extends CanFail[Any] {
-
+object CanFail extends CanFail[Any] with CanFailLowPriority {
   inline given canFail[E](using inline ev: NotGiven[E =:= Nothing]): CanFail[E] = CanFail
 
   @targetName("canFail")
   @deprecated("Kept for binary compatibility only, do not use", "2.1.16")
   private[zio] def _canFailCompat[E](implicit ev: NotGiven[E =:= Nothing]): CanFail[E] = CanFail
+}
+
+private[zio] transparent trait CanFailLowPriority { self: CanFail.type =>
+  // In some extremely extremely rare case the type inference prior to macro expansion doesn't work,
+  // so we need a non-inlined low priority as a fallback
+  implicit def canFailLowPriority[E](implicit ev: NotGiven[E =:= Nothing]): CanFail[E] = self
 }

--- a/core/shared/src/main/scala-3/zio/CanFail.scala
+++ b/core/shared/src/main/scala-3/zio/CanFail.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.annotation.implicitNotFound
+import scala.annotation.{implicitNotFound, targetName}
 import scala.util.NotGiven
 
 /**

--- a/core/shared/src/main/scala-3/zio/CanFail.scala
+++ b/core/shared/src/main/scala-3/zio/CanFail.scala
@@ -35,5 +35,10 @@ import scala.util.NotGiven
 sealed abstract class CanFail[-E]
 
 object CanFail extends CanFail[Any] {
-  implicit def canFail[E](implicit ev: NotGiven[E =:= Nothing]): CanFail[E] = CanFail
+
+  inline given canFail[E](using inline ev: NotGiven[E =:= Nothing]): CanFail[E] = CanFail
+
+  @targetName("canFail")
+  @deprecated("Kept for binary compatibility only, do not use", "2.1.16")
+  private[zio] def _canFailCompat[E](implicit ev: NotGiven[E =:= Nothing]): CanFail[E] = CanFail
 }

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1373,8 +1373,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           case ChannelState.Emit =>
             Exit.succeed(exec.getEmit)
           case ChannelState.Effect(zio) =>
-            zio.asInstanceOf[ZIO[Any, OutErr, Any]].mapError(Left(_)) *>
-              interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+            zio.mapError(Left(_)) *> interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
           case r @ ChannelState.Read(upstream, onEffect, onEmit, onDone) =>
             ChannelExecutor.readUpstream[Env, OutErr, Either[OutErr, OutDone], OutElem](
               r.asInstanceOf[ChannelState.Read[Env, OutErr]],

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1373,7 +1373,8 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           case ChannelState.Emit =>
             Exit.succeed(exec.getEmit)
           case ChannelState.Effect(zio) =>
-            zio.mapError(Left(_)) *> interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
+            zio.asInstanceOf[ZIO[Any, OutErr, Any]].mapError(Left(_)) *>
+              interpret(exec.run().asInstanceOf[ChannelState[Env, OutErr]])
           case r @ ChannelState.Read(upstream, onEffect, onEmit, onDone) =>
             ChannelExecutor.readUpstream[Env, OutErr, Either[OutErr, OutDone], OutElem](
               r.asInstanceOf[ChannelState.Read[Env, OutErr]],


### PR DESCRIPTION
When looking at some decompiled code for Scala 3, I realised that the `CanFail` evidence implicit required 2 method invocations; one for `CanFail.canFail` and one for `NotGiven.value`. By inlining the evidence and the implicit parameter, we avoid these 2 method invocations and `CanFail` is inlined at the callsite during compile time (if the `NotGiven` predicate is satisfied that's it).

Note that we keep the old method as a normal `def` with a `targetName` annotation and as package-private in order to maintain binary compatibility for code compiled with older ZIO versions.