### PR TITLE
Add internal `Promise#succeedUnit` method to avoid `Exit` allocation when possible

### DIFF
--- a/concurrent/src/main/scala/zio/concurrent/CountdownLatch.scala
+++ b/concurrent/src/main/scala/zio/concurrent/CountdownLatch.scala
@@ -38,7 +38,7 @@ final class CountdownLatch private (_count: Ref[Int], _waiters: Promise[Nothing,
    */
   val countDown: UIO[Unit] = _count.modify {
     case 0 => ZIO.unit             -> 0
-    case 1 => _waiters.succeed(()) -> 0
+    case 1 => _waiters.succeedUnit -> 0
     case n => ZIO.unit             -> (n - 1)
   }.flatten.unit
 

--- a/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
+++ b/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
@@ -29,7 +29,7 @@ final class CyclicBarrier private (
     _lock.get.flatMap(_.fail(()).unit)
 
   private val succeed: UIO[Unit] =
-    _lock.get.flatMap(_.succeed(()).unit)
+    _lock.get.flatMap(_.succeedUnit.unit)
 
   /** The number of parties required to trip this barrier. */
   def parties: Int = _parties

--- a/concurrent/src/main/scala/zio/concurrent/ReentrantLock.scala
+++ b/concurrent/src/main/scala/zio/concurrent/ReentrantLock.scala
@@ -130,7 +130,7 @@ final class ReentrantLock private (fairness: Boolean, state: Ref[ReentrantLock.S
       ZIO.unit -> State(epoch + 1, None, 0, Map.empty)
     else {
       val (fiberId, (_, promise)) = if (fairness) holders.minBy(_._2._1) else pickRandom(holders)
-      promise.succeed(()).unit -> State(epoch + 1, Some(fiberId), 1, holders - fiberId)
+      promise.succeedUnit.unit -> State(epoch + 1, Some(fiberId), 1, holders - fiberId)
     }
 
   private def pickRandom(

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -160,7 +160,7 @@ object Hub {
         ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
-            .whenZIO(shutdownHook.succeed(())) {
+            .whenZIO(shutdownHook.succeedUnit) {
               scope.close(Exit.interrupt(fiberId)) *> strategy.shutdown
             }
             .unit
@@ -229,7 +229,7 @@ object Hub {
         ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
-            .whenZIO(shutdownHook.succeed(())) {
+            .whenZIO(shutdownHook.succeedUnit) {
               ZIO.foreachPar(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
                 ZIO.succeed {
                   subscribers.remove(subscription -> pollers)

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -160,10 +160,9 @@ object Hub {
         ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
-            .whenZIO(shutdownHook.succeedUnit) {
+            .whenZIODiscard(shutdownHook.succeedUnit) {
               scope.close(Exit.interrupt(fiberId)) *> strategy.shutdown
             }
-            .unit
         }.uninterruptible
       def size(implicit trace: Trace): UIO[Int] =
         ZIO.suspendSucceed {
@@ -229,15 +228,14 @@ object Hub {
         ZIO.fiberIdWith { fiberId =>
           shutdownFlag.set(true)
           ZIO
-            .whenZIO(shutdownHook.succeedUnit) {
-              ZIO.foreachPar(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
+            .whenZIODiscard(shutdownHook.succeedUnit) {
+              ZIO.foreachParDiscard(unsafePollAll(pollers))(_.interruptAs(fiberId)) *>
                 ZIO.succeed {
                   subscribers.remove(subscription -> pollers)
                   subscription.unsubscribe()
                   strategy.unsafeOnHubEmptySpace(hub, subscribers)
                 }
             }
-            .unit
         }.uninterruptible
       def size(implicit trace: Trace): UIO[Int] =
         ZIO.suspendSucceed {

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -177,7 +177,8 @@ final class Promise[E, A] private (
     ZIO.succeed(unsafe.succeed(a)(trace, Unsafe.unsafe))
 
   /**
-   * Internally, you can use this method instead of calling `myPromise.succeed(())`
+   * Internally, you can use this method instead of calling
+   * `myPromise.succeed(())`
    *
    * It avoids the `Exit` allocation
    */

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -176,6 +176,14 @@ final class Promise[E, A] private (
   def succeed(a: A)(implicit trace: Trace): UIO[Boolean] =
     ZIO.succeed(unsafe.succeed(a)(trace, Unsafe.unsafe))
 
+  /**
+   * Internally, you can use this method instead of calling `myPromise.succeed(())`
+   *
+   * It avoids the `Exit` allocation
+   */
+  private[zio] def succeedUnit(implicit ev0: A =:= Unit, trace: Trace): UIO[Boolean] =
+    ZIO.succeed(unsafe.succeedUnit(ev0, trace, Unsafe))
+
   private def interruptJoiner(joiner: IO[E, A] => Any)(implicit trace: Trace): UIO[Any] = ZIO.succeed {
     var retry = true
 
@@ -205,6 +213,7 @@ final class Promise[E, A] private (
     def poll(implicit unsafe: Unsafe): Option[IO[E, A]]
     def refailCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean
     def succeed(a: A)(implicit trace: Trace, unsafe: Unsafe): Boolean
+    def succeedUnit(implicit ev0: A =:= Unit, trace: Trace, unsafe: Unsafe): Boolean
   }
 
   private[zio] val unsafe: UnsafeAPI =
@@ -280,6 +289,9 @@ final class Promise[E, A] private (
 
       def succeed(a: A)(implicit trace: Trace, unsafe: Unsafe): Boolean =
         completeWith(Exit.succeed(a))
+
+      override def succeedUnit(implicit ev0: A =:= Unit, trace: Trace, unsafe: Unsafe): Boolean =
+        completeWith(Exit.unit.asInstanceOf[IO[E, A]])
     }
 
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -155,9 +155,9 @@ object Semaphore {
                   case None => acc -> Right(n)
                   case Some(((promise, permits), queue)) =>
                     if (n > permits)
-                      loop(n - permits, Left(queue), acc *> promise.succeed(()))
+                      loop(n - permits, Left(queue), acc *> promise.succeedUnit)
                     else if (n == permits)
-                      (acc *> promise.succeed(())) -> Left(queue)
+                      (acc *> promise.succeedUnit) -> Left(queue)
                     else
                       acc -> Left((promise -> (permits - n)) +: queue)
                 }

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -689,11 +689,11 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 
                            permits
                              .withPermit(
-                               latch.succeed(()) *>
+                               latch.succeedUnit *>
                                  f(outElem)
                                    .catchAllCause(cause =>
                                      failureRef.update(_ && cause).unless(cause.isInterruptedOnly) *>
-                                       errorSignal.succeed(()) *>
+                                       errorSignal.succeedUnit *>
                                        ZChannel.failLeftUnit
                                    )
                              )
@@ -770,11 +770,11 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
             for {
               _ <- permits
                      .withPermit(
-                       latch.succeed(()) *> f(outElem)
+                       latch.succeedUnit *> f(outElem)
                          .foldCauseZIO(
                            cause =>
                              failure.update(_ && cause).unless(cause.isInterruptedOnly) *>
-                               errorSignal.succeed(()) *>
+                               errorSignal.succeedUnit *>
                                outgoing.offer(ZChannel.failLeftUnit),
                            elem => outgoing.offer(Exit.succeed(elem))
                          )
@@ -1248,8 +1248,8 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         fiber          <- restore(run(channelPromise, scopePromise, child)).forkDaemon
         _ <- parent.addFinalizer {
                channelPromise.isDone.flatMap { isDone =>
-                 if (isDone) scopePromise.succeed(()) *> fiber.await *> fiber.inheritAll
-                 else scopePromise.succeed(()) *> fiber.interrupt *> fiber.inheritAll
+                 if (isDone) scopePromise.succeedUnit *> fiber.await *> fiber.inheritAll
+                 else scopePromise.succeedUnit *> fiber.interrupt *> fiber.inheritAll
                }
              }
         done <- restore(channelPromise.await)
@@ -1986,9 +1986,9 @@ object ZChannel {
                     }
                   }
                 case Left(l: Left[OutErr, OutDone]) =>
-                  outgoing.offer(Result.Error(l.value)) *> errorSignal.succeed(()).unit
+                  outgoing.offer(Result.Error(l.value)) *> errorSignal.succeedUnit.unit
                 case Right(cause) =>
-                  outgoing.offer(Result.Fatal(cause)) *> errorSignal.succeed(()).unit
+                  outgoing.offer(Result.Fatal(cause)) *> errorSignal.succeedUnit.unit
               }
             )
 
@@ -2005,7 +2005,7 @@ object ZChannel {
               }
 
             permits
-              .withPermit(latch.succeed(()) *> raceIOs)
+              .withPermit(latch.succeedUnit *> raceIOs)
               .interruptible
               .forkIn(childScope) *> latch.await
           }
@@ -2017,7 +2017,7 @@ object ZChannel {
 
             for {
               size <- cancelers.size
-              _    <- ZIO.when(size >= n0)(cancelers.take.flatMap(_.succeed(())))
+              _    <- ZIO.when(size >= n0)(cancelers.take.flatMap(_.succeedUnit))
               _    <- cancelers.offer(canceler)
               raceIOs =
                 ZIO.scopedWith { scope =>
@@ -2026,7 +2026,7 @@ object ZChannel {
                     .flatMap(evaluatePull(_).race(canceler.await.interruptible))
                 }
               _ <- permits
-                     .withPermit(latch.succeed(()) *> raceIOs)
+                     .withPermit(latch.succeedUnit *> raceIOs)
                      .interruptible
                      .forkIn(childScope)
               _ <- latch.await


### PR DESCRIPTION
Idea comes from @hearnadam's review in this PR: https://github.com/zio/zio/pull/9556