### PR TITLE
add `stringValue` method to `zio.Config.Secret`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -69,6 +69,11 @@ object ConfigSpec extends ZIOBaseSpec {
         test("toString") {
           assertTrue(Secret("secret").toString() == "Secret(<redacted>)")
         } +
+        test("stringValue") {
+          val string = "secret"
+          val secret = Secret(string)
+          assertTrue(secret.stringValue == string)
+        } +
         test("equals") {
           assertTrue(Secret("secret") == Secret("secret")) &&
           assertTrue(Secret("secret1") != Secret("secret2"))

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -179,6 +179,8 @@ object Config {
     }
 
     def value: Chunk[Char] = Chunk.fromArray(raw)
+
+    def stringValue = new String(raw)
   }
   object Secret extends (Chunk[Char] => Secret) {
     def apply(chunk: Chunk[Char]): Secret = new Secret(chunk.toArray)


### PR DESCRIPTION
Most `Secret`s are probably passwords that are sooner or later needed in String form, hence this method. 