### PR TITLE
Add `Cause::foldFailureOrCause` method and use it to replace `f.failureOrCause.fold(..., ...)`

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -133,6 +133,17 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
   }
 
   /**
+   * Calls the `failure` function with the first checked error if available, if
+   * there are no checked errors, calls the `cause` function with the rest of
+   * the `Cause` that is known to contain only `Die` or `Interrupt` causes.
+   */
+  final def foldFailureOrCause[Z](failure: E => Z, cause: Cause[Nothing] => Z): Z =
+    failureOption match {
+      case Some(error) => failure(error)
+      case None        => cause(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    }
+
+  /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -370,7 +370,7 @@ sealed abstract class ZManaged[-R, +E, +A] extends ZManagedVersionSpecific[R, E,
     failure: E => ZManaged[R1, E2, B],
     success: A => ZManaged[R1, E2, B]
   )(implicit ev: CanFail[E], trace: Trace): ZManaged[R1, E2, B] =
-    foldCauseManaged(_.failureOrCause.fold(failure, ZManaged.failCause(_)), success)
+    foldCauseManaged(_.foldFailureOrCause(failure, ZManaged.failCause(_)), success)
 
   /**
    * Creates a `ZManaged` value that acquires the original resource in a fiber,

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -138,7 +138,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
   ](
     f: OutErr => ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1]
   )(implicit trace: Trace): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr2, OutElem1, OutDone1] =
-    catchAllCause((cause: Cause[OutErr]) => cause.failureOrCause.fold(f(_), ZChannel.refailCause))
+    catchAllCause((cause: Cause[OutErr]) => cause.foldFailureOrCause(f(_), ZChannel.refailCause))
 
   /**
    * Returns a new channel that is the same as this one, except if this channel
@@ -2126,7 +2126,7 @@ object ZChannel {
     error: InErr => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
     done: InDone => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone]
   )(implicit trace: Trace): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-    readWithCause(in, (c: Cause[InErr]) => c.failureOrCause.fold(error, ZChannel.refailCause(_)), done)
+    readWithCause(in, (c: Cause[InErr]) => c.foldFailureOrCause(error, ZChannel.refailCause(_)), done)
 
   def readOrFail[E, In](e: => E)(implicit trace: Trace): ZChannel[Any, Any, In, Any, E, Nothing, In] =
     Read[Any, Any, In, Any, Any, E, Nothing, Nothing, In, In](

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -595,7 +595,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def catchAll[R1 <: R, E2, A1 >: A](
     f: E => ZStream[R1, E2, A1]
   )(implicit ev: CanFail[E], trace: Trace): ZStream[R1, E2, A1] =
-    catchAllCause(_.failureOrCause.fold(f, ZStream.failCause(_)))
+    catchAllCause(_.foldFailureOrCause(f, ZStream.failCause(_)))
 
   /**
    * Switches over to the stream produced by the provided function in case this
@@ -3269,7 +3269,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def tapError[R1 <: R, E1 >: E](
     f: E => ZIO[R1, E1, Any]
   )(implicit ev: CanFail[E], trace: Trace): ZStream[R1, E1, A] =
-    tapErrorCause(_.failureOrCause.fold(f, _ => ZIO.unit))
+    tapErrorCause(_.foldFailureOrCause(f, _ => ZIO.unit))
 
   /**
    * Returns a stream that effectfully "peeks" at the cause of failure of the


### PR DESCRIPTION
Avoids the allocation of an intermediate, immediately discarded, `Either`