### PR TITLE
Revert Scala Native version to 0.5.6

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "org.scala-native", artifactId="sbt-scala-native", version = "0.5.7" }
+]

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.portable-scala"                % "sbt-scala-native-crossprojec
 addSbtPlugin("org.portable-scala"                % "sbt-scalajs-crossproject"      % "1.3.2")
 addSbtPlugin("org.scala-js"                      % "sbt-scalajs"                   % "1.18.2")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"                      % "2.6.4")
-addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.5.7")
+addSbtPlugin("org.scala-native"                  % "sbt-scala-native"              % "0.5.6")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"                  % "2.5.4")
 addSbtPlugin("pl.project13.scala"                % "sbt-jcstress"                  % "0.2.0")
 addSbtPlugin("pl.project13.scala"                % "sbt-jmh"                       % "0.4.7")


### PR DESCRIPTION
Seems that CI is _very_ flaky after upgrading Scala Native to 0.5.7. I'll try to followup with the SN team on what might be causing the issue but until then we revert it to 0.5.6 so that CI is working as expected again