### PR TITLE
Change FiberRef patching for Supervisor

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -218,7 +218,7 @@ object Runtime extends RuntimePlatformSpecific {
     ZLayer.scoped(ZIO.withLoggerScoped(logger))
 
   def addSupervisor(supervisor: Supervisor[Any])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
-    ZLayer.scoped(FiberRef.currentSupervisor.locallyScopedWith(_ ++ supervisor))
+    ZLayer.scoped(FiberRef.currentSupervisor.locallyScopedWith(_.addToSet(supervisor)))
 
   /**
    * Builds a new runtime given an environment `R` and a [[zio.FiberRefs]].


### PR DESCRIPTION
Using `Runtime.addSupervisor` to install a custom supervisor as a layer works fine when the layer is added as a leaf of the layer graph.

However, if `Runtime.addSupervisor` is used in a base layer that other layers depend on, then the same supervisor instance will likely appear in the supervisor `FiberRef` multiple times. In the production code where I encountered this the same supervisor instance was in the `FiberRef` four times. This is unworkable as the supervisor receives four `onStart`/`onEnd`/etc calls for every fiber.

I found it useful to arrange the layers this way as I had a base layer that uses a supervisor to provide some of its functionality. A work-around is for the base layer to expose the supervisor it builds in its output and then have the application code call `Runtime.addSupervisor` on that supervisor value, after wiring all the layers. But this requires every user of the layer to manually deal with the fact it needs a supervisor to be installed.

The layer produced by `Runtime.addSupervisor` is only executed once, as expected. The thing that causes the supervisor to be added multiple times is the way the `Supervisor.Patch.AddSupervisor` patching is performed as part of `FiberRefs#joinAs`. This uses `Supervisor` `++` to add to the existing supervisor, which works by making a `Zip` of the two supervisors.

Certain layer arrangements can result in an `AddSupervisor(x)` patch being applied to a fiber ref that already contains the `x` supervisor. I guess this is because layer construction can be run concurrently in multiple fibers? I think this is not unexpected?

My proposed fix here is to change `AddSupervisor` patching so that adding a supervisor instance that is already in the fiber ref becomes a no-op. I've done this by using a set of supervisors in the fiber ref instead of using `Supervisor.Zip`, but maybe someone has a better idea.

The tests I've written seem a little clunky, let me know if there's a nicer way to check this.
