### PR TITLE
Implement NIO scheduler

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/NIOSchedulerBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/internal/NIOSchedulerBenchmarks.scala
@@ -1,0 +1,96 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio._
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 15, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(value = 3)
+class NIOSchedulerBenchmarks {
+  val nioScheduler: zio.Executor = Executor.makeNIOScheduler()
+
+  @Benchmark
+  def zioSchedulerChainedFork(): Int =
+    zioChainedFork(nioScheduler)
+
+  @Benchmark
+  def zioSchedulerForkMany(): Int =
+    zioForkMany(nioScheduler)
+
+  @Benchmark
+  def zioSchedulerPingPong(): Int =
+    zioPingPong((nioScheduler))
+
+  @Benchmark
+  def zioSchedulerYieldMany(): Int =
+    zioYieldMany(nioScheduler)
+
+  def zioChainedFork(executor: zio.Executor): Int = {
+
+    def iterate(promise: Promise[Nothing, Unit], n: Int): UIO[Any] =
+      if (n <= 0) promise.succeed(())
+      else ZIO.unit.flatMap(_ => iterate(promise, n - 1).forkDaemon)
+
+    val io = for {
+      promise <- Promise.make[Nothing, Unit]
+      _       <- iterate(promise, 1000).forkDaemon
+      _       <- promise.await
+    } yield 0
+
+    unsafeRun(io.onExecutor(executor))
+  }
+
+  def zioForkMany(executor: zio.Executor): Int = {
+
+    val io = for {
+      promise <- Promise.make[Nothing, Unit]
+      ref     <- Ref.make(10000)
+      effect   = ref.modify(n => (if (n == 1) promise.succeed(()) else ZIO.unit, n - 1)).flatten
+      _       <- repeat(10000)(effect.forkDaemon)
+      _       <- promise.await
+    } yield 0
+
+    unsafeRun(io.onExecutor(executor))
+  }
+
+  def zioPingPong(executor: zio.Executor): Int = {
+
+    def iterate(promise: Promise[Nothing, Unit], n: Int): UIO[Any] =
+      for {
+        ref   <- Ref.make(n)
+        queue <- Queue.bounded[Unit](1)
+        effect = queue.offer(()).forkDaemon *>
+                   queue.take *>
+                   ref.modify(n => (if (n == 1) promise.succeed(()) else ZIO.unit, n - 1)).flatten
+        _ <- repeat(1000)(effect.forkDaemon)
+      } yield ()
+
+    val io = for {
+      promise <- Promise.make[Nothing, Unit]
+      _       <- iterate(promise, 1000).forkDaemon
+      _       <- promise.await
+    } yield 0
+
+    unsafeRun(io.onExecutor(executor))
+  }
+
+  def zioYieldMany(executor: zio.Executor): Int = {
+
+    val io = for {
+      promise <- Promise.make[Nothing, Unit]
+      ref     <- Ref.make(200)
+      effect =
+        repeat(1000)(ZIO.yieldNow) *> ref.modify(n => (if (n == 1) promise.succeed(()) else ZIO.unit, n - 1)).flatten
+      _ <- repeat(200)(effect.forkDaemon)
+      _ <- promise.await
+    } yield 0
+
+    unsafeRun(io.onExecutor(executor))
+  }
+}

--- a/core/jvm-native/src/main/scala/zio/internal/DefaultExecutors.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/DefaultExecutors.scala
@@ -28,6 +28,8 @@ private[zio] abstract class DefaultExecutors {
   final def makeDefault(autoBlocking: Boolean): zio.Executor =
     new ZScheduler(autoBlocking)
 
+  final def makeNIOScheduler(): zio.Executor = new NIOScheduler()
+
   final def fromThreadPoolExecutor(
     es: ThreadPoolExecutor
   ): zio.Executor =

--- a/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
@@ -84,25 +84,7 @@ private final class NIOScheduler extends Executor {
     true
   }
 
-  private def leastLoadedWorker(): Worker = {
-    var minWorker = workers(0)
-    var minLoad   = minWorker.localQueue.size()
-
-    var i = 1
-    while (i < workers.length) {
-      val currentWorker = workers(i)
-      val currentLoad   = currentWorker.localQueue.size()
-
-      if (currentLoad < minLoad) {
-        minWorker = currentWorker
-        minLoad = currentLoad
-      }
-
-      i += 1
-    }
-
-    minWorker
-  }
+  private def leastLoadedWorker(): Worker = workers.minBy(_.localQueue.size())
 
   private[this] def makeWorker(): NIOScheduler.Worker =
     new NIOScheduler.Worker {
@@ -122,7 +104,7 @@ private final class NIOScheduler extends Executor {
               cache.offer(self)
             }
 
-            while (!active && !isInterrupted) {
+            while (localQueue.size() == 0 && !isInterrupted) {
               LockSupport.park()
             }
           } else {
@@ -190,7 +172,7 @@ private final class NIOScheduler extends Executor {
             }
             workerId += 1
           }
-          val deadline = java.lang.System.currentTimeMillis() + 1000
+          val deadline = java.lang.System.currentTimeMillis() + 100
           var loop     = true
           while (loop) {
             LockSupport.parkUntil(deadline)

--- a/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
@@ -9,6 +9,8 @@ private final class NIOScheduler extends Executor {
   import NIOScheduler.poolSize
   import NIOScheduler.Worker
 
+  private[this] val globalQueue = new ConcurrentLinkedQueue[Runnable]()
+
   private[this] val workers = Array.ofDim[NIOScheduler.Worker](poolSize)
   private[this] val cache   = new ConcurrentLinkedQueue[NIOScheduler.Worker]()
 
@@ -79,6 +81,8 @@ private final class NIOScheduler extends Executor {
         worker.active = true
         LockSupport.unpark(worker)
       }
+    } else {
+      globalQueue.offer(runnable)
     }
 
     true
@@ -96,7 +100,10 @@ private final class NIOScheduler extends Executor {
 
         while (!isInterrupted) {
           currentBlocking = blocking
-          runnable = localQueue.poll(null)
+          runnable = globalQueue.poll()
+          if (runnable eq null) {
+            runnable = localQueue.poll(null)
+          }
 
           if (runnable eq null) {
             active = false

--- a/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
@@ -9,8 +9,6 @@ private final class NIOScheduler extends Executor {
   import NIOScheduler.poolSize
   import NIOScheduler.Worker
 
-  private[this] val globalQueue = new ConcurrentLinkedQueue[Runnable]()
-
   private[this] val workers = Array.ofDim[NIOScheduler.Worker](poolSize)
   private[this] val cache   = new ConcurrentLinkedQueue[NIOScheduler.Worker]()
 
@@ -81,14 +79,33 @@ private final class NIOScheduler extends Executor {
         worker.active = true
         LockSupport.unpark(worker)
       }
-    } else {
-      globalQueue.offer(runnable)
     }
 
     true
   }
 
-  private def leastLoadedWorker(): Worker = workers.minBy(_.localQueue.size())
+  private def leastLoadedWorker(): Worker = {
+    var bestWorker: Worker        = null
+    var leastLoadedWorker: Worker = null
+    var minLoad                   = Int.MaxValue
+    var minOverallLoad            = Int.MaxValue
+
+    workers.foreach { worker =>
+      val queueSize = worker.localQueue.size()
+
+      if (worker.active && queueSize <= 128 && queueSize < minLoad) {
+        minLoad = queueSize
+        bestWorker = worker
+      }
+
+      if (queueSize < minOverallLoad) {
+        minOverallLoad = queueSize
+        leastLoadedWorker = worker
+      }
+    }
+
+    if (bestWorker != null) bestWorker else leastLoadedWorker
+  }
 
   private[this] def makeWorker(): NIOScheduler.Worker =
     new NIOScheduler.Worker {
@@ -100,10 +117,8 @@ private final class NIOScheduler extends Executor {
 
         while (!isInterrupted) {
           currentBlocking = blocking
-          runnable = globalQueue.poll()
-          if (runnable eq null) {
-            runnable = localQueue.poll(null)
-          }
+
+          runnable = localQueue.poll(null)
 
           if (runnable eq null) {
             active = false
@@ -131,7 +146,7 @@ private final class NIOScheduler extends Executor {
           blocking = true
           val idx = workers.indexOf(self)
           if (idx >= 0) {
-            val runnables = self.localQueue.pollUpTo(256)
+            val runnables = self.localQueue.pollUpTo(512)
             val worker    = cache.poll()
             if (worker eq null) {
               val worker = makeWorker()
@@ -242,7 +257,7 @@ private object NIOScheduler {
      * The local work queue for this worker.
      */
     val localQueue: RingBufferPow2[Runnable] =
-      RingBufferPow2[Runnable](256)
+      RingBufferPow2[Runnable](512)
 
     /**
      * The number of tasks that have been executed by this worker.

--- a/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/NIOScheduler.scala
@@ -1,0 +1,277 @@
+package zio.internal
+
+import zio.{Executor, Unsafe}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.locks.LockSupport
+
+private final class NIOScheduler extends Executor {
+  import NIOScheduler.poolSize
+  import NIOScheduler.Worker
+
+  private[this] val workers = Array.ofDim[NIOScheduler.Worker](poolSize)
+  private[this] val cache   = new ConcurrentLinkedQueue[NIOScheduler.Worker]()
+
+  (0 until poolSize).foreach { workerId =>
+    val worker = makeWorker()
+    worker.setName(workerId)
+    worker.setDaemon(true)
+    workers(workerId) = worker
+  }
+  workers.foreach(_.start())
+
+  // The NIOScheduler cannot detect blocking on its own.
+  // Therefore, a supervisor is required to handle it.
+  private[this] val supervisor: NIOScheduler.Supervisor = makeSupervisor()
+  supervisor.setName("NIOScheduler-Supervisor")
+  supervisor.setDaemon(true)
+  supervisor.start()
+
+  def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = {
+    val metrics = new ExecutionMetrics {
+      def capacity: Int =
+        Int.MaxValue
+      def concurrency: Int =
+        poolSize
+      def dequeuedCount: Long = {
+        var dequeued = 0L
+        var i        = 0
+        while (i != poolSize) {
+          val worker = workers(i)
+          dequeued += worker.opCount
+          i += 1
+        }
+        dequeued
+      }
+      def enqueuedCount: Long = {
+        var enqueued = 0L
+        var i        = 0
+        while (i != poolSize) {
+          val worker = workers(i)
+          enqueued += worker.opCount
+          enqueued += worker.localQueue.size()
+          i += 1
+        }
+        enqueued
+      }
+      def size: Int = {
+        var i    = 0
+        var size = 0
+        while (i != poolSize) {
+          val worker = workers(i)
+          size += worker.localQueue.size()
+          i += 1
+        }
+        size
+      }
+      def workersCount: Int = poolSize
+    }
+    Some(metrics)
+  }
+
+  /**
+   * Submits an effect for execution.
+   */
+  def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+    val worker = leastLoadedWorker()
+    if (worker.localQueue.offer(runnable)) {
+      if (!worker.active) {
+        worker.active = true
+        LockSupport.unpark(worker)
+      }
+    }
+
+    true
+  }
+
+  private def leastLoadedWorker(): Worker = {
+    var minWorker = workers(0)
+    var minLoad   = minWorker.localQueue.size()
+
+    var i = 1
+    while (i < workers.length) {
+      val currentWorker = workers(i)
+      val currentLoad   = currentWorker.localQueue.size()
+
+      if (currentLoad < minLoad) {
+        minWorker = currentWorker
+        minLoad = currentLoad
+      }
+
+      i += 1
+    }
+
+    minWorker
+  }
+
+  private[this] def makeWorker(): NIOScheduler.Worker =
+    new NIOScheduler.Worker {
+      self =>
+      override def run(): Unit = {
+        var currentOpCount     = 0L
+        var runnable: Runnable = null
+        var currentBlocking    = false
+
+        while (!isInterrupted) {
+          currentBlocking = blocking
+          runnable = localQueue.poll(null)
+
+          if (runnable eq null) {
+            active = false
+            if (currentBlocking) {
+              cache.offer(self)
+            }
+
+            while (!active && !isInterrupted) {
+              LockSupport.park()
+            }
+          } else {
+            currentRunnable = runnable
+            runnable.run()
+            runnable = null
+            currentRunnable = null
+            currentOpCount += 1
+            opCount = currentOpCount
+          }
+        }
+      }
+
+      def markAsBlocking(): Unit = synchronized {
+        if (blocking) ()
+        else {
+          blocking = true
+          val idx = workers.indexOf(self)
+          if (idx >= 0) {
+            val runnables = self.localQueue.pollUpTo(256)
+            val worker    = cache.poll()
+            if (worker eq null) {
+              val worker = makeWorker()
+              worker.setName(idx)
+              worker.setDaemon(true)
+              worker.localQueue.offerAll(runnables)
+              workers(idx) = worker
+              worker.start()
+            } else {
+              worker.setName(idx)
+              worker.localQueue.offerAll(runnables)
+              workers(idx) = worker
+              worker.blocking = false
+              worker.active = true
+              LockSupport.unpark(worker)
+            }
+          }
+        }
+      }
+    }
+
+  private[this] def makeSupervisor(): NIOScheduler.Supervisor =
+    new NIOScheduler.Supervisor {
+      override def run(): Unit = {
+        val previousOpCounts = Array.fill(poolSize)(-1L)
+        while (!isInterrupted) {
+          var workerId = 0
+          while (workerId < poolSize) {
+            val currentWorker = workers(workerId)
+            if (currentWorker.active) {
+              val currentOpCount  = currentWorker.opCount
+              val previousOpCount = previousOpCounts(workerId)
+              if (currentOpCount == previousOpCount) {
+                previousOpCounts(workerId) = -1L
+                currentWorker.markAsBlocking()
+              } else {
+                previousOpCounts(workerId) = currentOpCount
+              }
+            } else {
+              if (currentWorker.localQueue.size() > 0) {
+                currentWorker.active = true
+                LockSupport.unpark(currentWorker)
+              }
+              previousOpCounts(workerId) = -1L
+            }
+            workerId += 1
+          }
+          val deadline = java.lang.System.currentTimeMillis() + 1000
+          var loop     = true
+          while (loop) {
+            LockSupport.parkUntil(deadline)
+            loop = java.lang.System.currentTimeMillis() < deadline
+          }
+        }
+      }
+    }
+}
+
+private object NIOScheduler {
+  private val poolSize = java.lang.Runtime.getRuntime.availableProcessors
+
+  def markCurrentWorkerAsBlocking(): Unit = {
+    val worker = workerOrNull()
+    if (worker ne null) {
+      worker.markAsBlocking()
+    } else {
+      ()
+    }
+  }
+
+  /**
+   * If the current thread is a [[NIOScheduler.Worker]] then it is returned,
+   * otherwise returns null
+   */
+  private def workerOrNull(): NIOScheduler.Worker =
+    Thread.currentThread() match {
+      case w: NIOScheduler.Worker => w
+      case _                      => null
+    }
+
+  /**
+   * A `Supervisor` is a `Thread` that is responsible for monitoring workers and
+   * shifting tasks from workers that are blocking to new workers.
+   */
+  private sealed abstract class Supervisor extends Thread
+
+  /**
+   * A `Worker` is a `Thread` that is responsible for executing actions
+   * submitted to the scheduler.
+   */
+  private sealed abstract class Worker extends Thread {
+
+    /**
+     * Whether this worker is currently active.
+     */
+    @volatile
+    var active: Boolean =
+      true
+
+    /**
+     * The current task being executed by this worker.
+     */
+    @volatile
+    var currentRunnable: Runnable =
+      null
+
+    /**
+     * The local work queue for this worker.
+     */
+    val localQueue: RingBufferPow2[Runnable] =
+      RingBufferPow2[Runnable](256)
+
+    /**
+     * The number of tasks that have been executed by this worker.
+     */
+    @volatile
+    var opCount: Long =
+      0L
+
+    final def setName(i: Int): Unit =
+      setName(s"NIOScheduler-Worker-$i")
+
+    def markAsBlocking(): Unit
+
+    /**
+     * Whether this worker is currently blocking.
+     */
+    @volatile
+    var blocking: Boolean =
+      false
+  }
+}


### PR DESCRIPTION
This PR introduces an `NIOScheduler` for ZIO. To validate its implementation, I replaced the following lines with `NIOScheduler`:  

- [Blocking.scala#L53](https://github.com/zio/zio/blob/99dc49cd6b9089b7506ece326dce85b3379bc8d8/core/jvm-native/src/main/scala/zio/internal/Blocking.scala#L53)  
- [DefaultExecutors.scala#L29](https://github.com/zio/zio/blob/99dc49cd6b9089b7506ece326dce85b3379bc8d8/core/jvm-native/src/main/scala/zio/internal/DefaultExecutors.scala#L29)  

All tests passed successfully.

/claim #9356  