### PR TITLE
Add `ZStream.mapZIOChunked`

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2735,6 +2735,30 @@ object ZStreamSpec extends ZIOBaseSpec {
             )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
+        suite("mapZIOChunked")(
+          test("ZIO#foreach equivalence when error-free") {
+            check(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
+              val s = ZStream.fromIterable(data)
+
+              for {
+                l <- s.mapZIOChunked(f).runCollect
+                r <- ZIO.foreach(data)(f)
+              } yield assert(l.toList)(equalTo(r))
+            }
+          },
+          test("laziness on chunks") {
+            assertZIO(
+              ZStream
+                .fromChunks(Chunk(1), Chunk(2, 3))
+                .mapZIOChunked {
+                  case 3 => ZIO.fail("boom")
+                  case x => ZIO.succeed(x)
+                }
+                .either
+                .runCollect
+            )(equalTo(Chunk(Right(1), Left("boom"))))
+          }
+        ),
         suite("mapZIOPar")(
           test("foreachParN equivalence") {
             checkN(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2754,17 +2754,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               .runCount
               .map(count => assertTrue(count == 1))
           },
-          test("laziness on chunks") {
+          test("retains chunks up to error") {
             assertZIO(
               ZStream
-                .fromChunks(Chunk(1), Chunk(2, 3))
+                .fromChunks(Chunk(1, 2), Chunk(3, 4, 5))
                 .mapZIOChunked {
-                  case 3 => ZIO.fail("boom")
+                  case 4 => ZIO.fail("boom")
                   case x => ZIO.succeed(x)
                 }
                 .either
+                .chunks
                 .runCollect
-            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2)), Chunk(Right(3)), Chunk(Left("boom"))))
           }
         ),
         suite("mapZIOPar")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2746,6 +2746,14 @@ object ZStreamSpec extends ZIOBaseSpec {
               } yield assert(l.toList)(equalTo(r))
             }
           },
+          test("retains chunks") {
+            ZStream
+              .fromChunks(Chunk(1, 2))
+              .mapZIOChunked(ZIO.succeed(_))
+              .chunks
+              .runCount
+              .map(count => assertTrue(count == 1))
+          },
           test("laziness on chunks") {
             assertZIO(
               ZStream
@@ -2756,7 +2764,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 }
                 .either
                 .runCollect
-            )(equalTo(Chunk(Right(1), Left("boom"))))
+            )(equalTo(Chunk(Right(1), Right(2), Left("boom"))))
           }
         ),
         suite("mapZIOPar")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2765,7 +2765,7 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .either
                 .chunks
                 .runCollect
-            )(equalTo(Chunk(Right(1), Right(2)), Chunk(Right(3)), Chunk(Left("boom"))))
+            )(equalTo(Chunk(Chunk(Right(1), Right(2)), Chunk(Right(3)), Chunk(Left("boom")))))
           }
         ),
         suite("mapZIOPar")(

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -483,12 +483,21 @@ final class ZPipeline[-Env, +Err, -In, +Out] private (
     self >>> ZPipeline.mapZIO(f)
 
   /**
-   * Creates a pipeline that maps elements with the specified effectful
-   * function.
+   * Creates a pipeline that maps over elements of the stream with the specified
+   * effectful function.
    *
-   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
-   * element in the middle of a Chunk, the following elements of the chunk are
-   * consumed but not processed; they are lost.
+   * Unlike `mapZIO` processing is done chunk by chunk. This means that
+   * `mapZIOChunked` provides weaker guarantees than `mapZIO`. While
+   * `stream.mapZIO(f).mapZIO(g)` is guaranteed to be equivalent to
+   * `stream.mapZIO(x => f(x).flatMap(g))`, the same is not true for
+   * `mapZIOChunked`. For example, `mapZIO` guarantees that the first element of
+   * a stream will first be processed with `f` and then `g` before the second
+   * element is processed with `f`. `mapZIOChunked` may process the first two
+   * elements with `f` and only then move on to process the first element with
+   * `g`.
+   *
+   * When `f` fails for an element in the middle of a Chunk, the following
+   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[Env2 <: Env, Err2 >: Err, Out2](
     f: Out => ZIO[Env2, Err2, Out2]
@@ -1812,12 +1821,21 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   }
 
   /**
-   * Creates a pipeline that maps elements with the specified effectful
-   * function.
+   * Creates a pipeline that maps over elements of the stream with the specified
+   * effectful function.
    *
-   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
-   * element in the middle of a Chunk, the following elements of the chunk are
-   * consumed but not processed; they are lost.
+   * Unlike `mapZIO` processing is done chunk by chunk. This means that
+   * `mapZIOChunked` provides weaker guarantees than `mapZIO`. While
+   * `stream.mapZIO(f).mapZIO(g)` is guaranteed to be equivalent to
+   * `stream.mapZIO(x => f(x).flatMap(g))`, the same is not true for
+   * `mapZIOChunked`. For example, `mapZIO` guarantees that the first element of
+   * a stream will first be processed with `f` and then `g` before the second
+   * element is processed with `f`. `mapZIOChunked` may process the first two
+   * elements with `f` and only then move on to process the first element with
+   * `g`.
+   *
+   * When `f` fails for an element in the middle of a Chunk, the following
+   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[Env, Err, In, Out](
     f: In => ZIO[Env, Err, Out]
@@ -1831,28 +1849,23 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         ZChannel.unwrap {
           val a = chunkIterator.nextAt(index)
           f(a).foldCause(
-            cause =>
-              if (builder ne null) ZChannel.write(builder.result()) *> ZChannel.refailCause(cause)
-              else ZChannel.refailCause(cause),
+            cause => ZChannel.write(builder.result()) *> ZChannel.refailCause(cause),
             a1 => {
-              val b = if (builder ne null) builder else ChunkBuilder.make[Out](chunkIterator.length)
-              b += a1
-              loop(chunkIterator, index + 1, b)
+              builder += a1
+              loop(chunkIterator, index + 1, builder)
             }
           )
         }
       } else {
-        if (builder ne null) ZChannel.write(builder.result()) *> reader
-        else reader
+        ZChannel.write(builder.result()) *> reader
       }
 
     lazy val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
       ZChannel.readWithCause(
-        elem => loop(elem.chunkIterator, 0, null),
+        elem => if (elem.nonEmpty) loop(elem.chunkIterator, 0, ChunkBuilder.make[Out](elem.size)) else reader,
         err => ZChannel.refailCause(err),
         done => ZChannel.succeed(done)
       )
-
     new ZPipeline(reader)
   }
 

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1836,7 +1836,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
     def writeWithNext(
       builder: ChunkBuilder[Out],
-      next: => ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any]
+      next: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any]
     ): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] = {
       val out = builder.result()
       if (out.nonEmpty) ZChannel.write(out) *> next else next

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -495,9 +495,6 @@ final class ZPipeline[-Env, +Err, -In, +Out] private (
    * element is processed with `f`. `mapZIOChunked` may process the first two
    * elements with `f` and only then move on to process the first element with
    * `g`.
-   *
-   * When `f` fails for an element in the middle of a Chunk, the following
-   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[Env2 <: Env, Err2 >: Err, Out2](
     f: Out => ZIO[Env2, Err2, Out2]
@@ -1833,9 +1830,6 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    * element is processed with `f`. `mapZIOChunked` may process the first two
    * elements with `f` and only then move on to process the first element with
    * `g`.
-   *
-   * When `f` fails for an element in the middle of a Chunk, the following
-   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[Env, Err, In, Out](
     f: In => ZIO[Env, Err, Out]

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -483,6 +483,19 @@ final class ZPipeline[-Env, +Err, -In, +Out] private (
     self >>> ZPipeline.mapZIO(f)
 
   /**
+   * Creates a pipeline that maps elements with the specified effectful
+   * function.
+   *
+   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
+   * element in the middle of a Chunk, the following elements of the chunk are
+   * consumed but not processed; they are lost.
+   */
+  def mapZIOChunked[Env2 <: Env, Err2 >: Err, Out2](
+    f: Out => ZIO[Env2, Err2, Out2]
+  )(implicit trace: Trace): ZPipeline[Env2, Err2, In, Out2] =
+    self >>> ZPipeline.mapZIOChunked(f)
+
+  /**
    * Maps over elements of the stream with the specified effectful function,
    * executing up to `n` invocations of `f` concurrently. Transformed elements
    * will be emitted in the original order.
@@ -1796,6 +1809,51 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         )
 
     new ZPipeline(loop(Chunk.ChunkIterator.empty, 0))
+  }
+
+  /**
+   * Creates a pipeline that maps elements with the specified effectful
+   * function.
+   *
+   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
+   * element in the middle of a Chunk, the following elements of the chunk are
+   * consumed but not processed; they are lost.
+   */
+  def mapZIOChunked[Env, Err, In, Out](
+    f: In => ZIO[Env, Err, Out]
+  )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
+    def loop(
+      chunkIterator: Chunk.ChunkIterator[In],
+      index: Int,
+      builder: ChunkBuilder[Out]
+    ): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
+      if (chunkIterator.hasNextAt(index)) {
+        ZChannel.unwrap {
+          val a = chunkIterator.nextAt(index)
+          f(a).foldCause(
+            cause =>
+              if (builder ne null) ZChannel.write(builder.result()) *> ZChannel.refailCause(cause)
+              else ZChannel.refailCause(cause),
+            a1 => {
+              val b = if (builder ne null) builder else ChunkBuilder.make[Out](chunkIterator.length)
+              b += a1
+              loop(chunkIterator, index + 1, b)
+            }
+          )
+        }
+      } else {
+        if (builder ne null) ZChannel.write(builder.result()) *> reader
+        else reader
+      }
+
+    lazy val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
+      ZChannel.readWithCause(
+        elem => loop(elem.chunkIterator, 0, null),
+        err => ZChannel.refailCause(err),
+        done => ZChannel.succeed(done)
+      )
+
+    new ZPipeline(reader)
   }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1843,7 +1843,11 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         ZChannel.unwrap {
           val a = chunkIterator.nextAt(index)
           f(a).foldCause(
-            cause => ZChannel.write(builder.result()) *> ZChannel.refailCause(cause),
+            cause => {
+              val out = builder.result()
+              if (out.nonEmpty) ZChannel.write(out) *> ZChannel.refailCause(cause)
+              else ZChannel.refailCause(cause)
+            },
             a1 => {
               builder += a1
               loop(chunkIterator, index + 1, builder)

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1834,33 +1834,26 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   def mapZIOChunked[Env, Err, In, Out](
     f: In => ZIO[Env, Err, Out]
   )(implicit trace: Trace): ZPipeline[Env, Err, In, Out] = {
-    def loop(
-      chunkIterator: Chunk.ChunkIterator[In],
-      index: Int,
-      builder: ChunkBuilder[Out]
-    ): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
-      if (chunkIterator.hasNextAt(index)) {
-        ZChannel.unwrap {
-          val a = chunkIterator.nextAt(index)
-          f(a).foldCause(
-            cause => {
-              val out = builder.result()
-              if (out.nonEmpty) ZChannel.write(out) *> ZChannel.refailCause(cause)
-              else ZChannel.refailCause(cause)
-            },
-            a1 => {
-              builder += a1
-              loop(chunkIterator, index + 1, builder)
-            }
-          )
-        }
-      } else {
-        ZChannel.write(builder.result()) *> reader
-      }
+    def writeWithNext(
+      builder: ChunkBuilder[Out],
+      next: => ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any]
+    ): ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] = {
+      val out = builder.result()
+      if (out.nonEmpty) ZChannel.write(out) *> next else next
+    }
 
-    lazy val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
+    val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
       ZChannel.readWithCause(
-        elem => if (elem.nonEmpty) loop(elem.chunkIterator, 0, ChunkBuilder.make[Out](elem.size)) else reader,
+        chunk =>
+          ZChannel.unwrap {
+            val builder = ChunkBuilder.make[Out](chunk.size)
+            chunk
+              .mapZIODiscard(f(_).map(builder += _))
+              .foldCause(
+                cause => writeWithNext(builder, ZChannel.refailCause(cause)),
+                _ => writeWithNext(builder, reader)
+              )
+          },
         err => ZChannel.refailCause(err),
         done => ZChannel.succeed(done)
       )

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1842,7 +1842,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       if (out.nonEmpty) ZChannel.write(out) *> next else next
     }
 
-    val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
+    lazy val reader: ZChannel[Env, Err, Chunk[In], Any, Err, Chunk[Out], Any] =
       ZChannel.readWithCause(
         chunk =>
           ZChannel.unwrap {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1944,6 +1944,15 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   }
 
   /**
+   * Maps over elements of the stream with the specified effectful function.
+   *
+   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
+   * element in the middle of a Chunk, the other elements of the chunk are lost.
+   */
+  def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
+    this.chunksWith(stream => stream.mapZIO(f))
+
+  /**
    * Maps over elements of the stream with the specified effectful function,
    * executing up to `n` invocations of `f` concurrently. Transformed elements
    * will be emitted in the original order.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1944,11 +1944,21 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   }
 
   /**
-   * Maps over elements of the stream with the specified effectful function.
+   * Creates a pipeline that maps over elements of the stream with the specified
+   * effectful function.
    *
-   * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
-   * element in the middle of a Chunk, the following elements of the chunk are
-   * consumed but not processed; they are lost.
+   * Unlike `mapZIO` processing is done chunk by chunk. This means that
+   * `mapZIOChunked` provides weaker guarantees than `mapZIO`. While
+   * `stream.mapZIO(f).mapZIO(g)` is guaranteed to be equivalent to
+   * `stream.mapZIO(x => f(x).flatMap(g))`, the same is not true for
+   * `mapZIOChunked`. For example, `mapZIO` guarantees that the first element of
+   * a stream will first be processed with `f` and then `g` before the second
+   * element is processed with `f`. `mapZIOChunked` may process the first two
+   * elements with `f` and only then move on to process the first element with
+   * `g`.
+   *
+   * When `f` fails for an element in the middle of a Chunk, the following
+   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
     self >>> ZPipeline.mapZIOChunked(f)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1922,6 +1922,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *
    * @note
    *   This combinator destroys the chunking structure.
+   * @see
+   *   [[mapZIOChunked]] for a version that preserves the chunking structure
    */
   def mapZIO[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] = {
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1951,19 +1951,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * consumed but not processed; they are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
-    this.chunks.flatMap { chunk =>
-      val buffer = Chunk.newBuilder[A1]
-      ZStream.unwrap {
-        ZIO
-          .foreachDiscard(chunk) { a =>
-            f(a).tap(a1 => ZIO.succeed(buffer += a1))
-          }
-          .fold(
-            err => ZStream.fromChunk(buffer.result()) ++ ZStream.fail(err),
-            _ => ZStream.fromChunk(buffer.result())
-          )
-      }
-    }
+    self >>> ZPipeline.mapZIOChunked(f)
 
   /**
    * Maps over elements of the stream with the specified effectful function,

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1956,9 +1956,6 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * element is processed with `f`. `mapZIOChunked` may process the first two
    * elements with `f` and only then move on to process the first element with
    * `g`.
-   *
-   * When `f` fails for an element in the middle of a Chunk, the following
-   * elements of the chunk are consumed but not processed; they are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
     self >>> ZPipeline.mapZIOChunked(f)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1950,7 +1950,17 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * element in the middle of a Chunk, the other elements of the chunk are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
-    this.chunksWith(_.mapZIO(c => ZIO.foreach(c)(f)))
+    this.chunks.flatMap { chunk =>
+      val buffer = Chunk.newBuilder[A1]
+      ZStream.unwrap {
+        ZIO.foreachDiscard(chunk) { a =>
+          f(a).tap(a1 => ZIO.succeed(buffer += a1))
+        }.fold(
+          err => ZStream.fromChunk(buffer.result()) ++ ZStream.fail(err),
+          _ => ZStream.fromChunk(buffer.result())
+        )
+      }
+    }
 
   /**
    * Maps over elements of the stream with the specified effectful function,

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1947,18 +1947,21 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * Maps over elements of the stream with the specified effectful function.
    *
    * Unlike `mapZIO` processing is done chunk by chunk. When `f` fails for an
-   * element in the middle of a Chunk, the other elements of the chunk are lost.
+   * element in the middle of a Chunk, the following elements of the chunk are
+   * consumed but not processed; they are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
     this.chunks.flatMap { chunk =>
       val buffer = Chunk.newBuilder[A1]
       ZStream.unwrap {
-        ZIO.foreachDiscard(chunk) { a =>
-          f(a).tap(a1 => ZIO.succeed(buffer += a1))
-        }.fold(
-          err => ZStream.fromChunk(buffer.result()) ++ ZStream.fail(err),
-          _ => ZStream.fromChunk(buffer.result())
-        )
+        ZIO
+          .foreachDiscard(chunk) { a =>
+            f(a).tap(a1 => ZIO.succeed(buffer += a1))
+          }
+          .fold(
+            err => ZStream.fromChunk(buffer.result()) ++ ZStream.fail(err),
+            _ => ZStream.fromChunk(buffer.result())
+          )
       }
     }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1950,7 +1950,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * element in the middle of a Chunk, the other elements of the chunk are lost.
    */
   def mapZIOChunked[R1 <: R, E1 >: E, A1](f: A => ZIO[R1, E1, A1])(implicit trace: Trace): ZStream[R1, E1, A1] =
-    this.chunksWith(stream => stream.mapZIO(f))
+    this.chunksWith(_.mapZIO(c => ZIO.foreach(c)(f)))
 
   /**
    * Maps over elements of the stream with the specified effectful function,


### PR DESCRIPTION
Add `ZStream.mapZIOChunked` as an alternative to `mapZIO` that does not destroy the chunking structure.

Co-authored-by: Matthias Berndt <matthias_berndt@gmx.de>
Co-authored-by: Paul Daniels <paulpdaniels@gmail.com>
Co-authored-by: Regis Kuckaertz <platen-porter0e@icloud.com>