### PR TITLE
Fix ZIO#timeoutTo inheriting wrong value from FiberRef#locally (#9693)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -104,7 +104,7 @@ object FiberRefSpec extends ZIOBaseSpec {
       test("`locally` restores parent's value after timeout") {
         for {
           fiberRef <- FiberRef.make(initial)
-          child    <- fiberRef.locally(update)(ZIO.sleep(10.seconds)).timeout(1.second).fork
+          child    <- fiberRef.locally(update)(ZIO.never).timeout(1.second).fork
           _        <- TestClock.adjust(1.second)
           _        <- child.join
           value    <- fiberRef.get

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -101,6 +101,15 @@ object FiberRefSpec extends ZIOBaseSpec {
           value      <- fiberRef.get
         } yield assert(localValue)(equalTo(update)) && assert(value)(equalTo(initial))
       },
+      test("`locally` restores parent's value after timeout") {
+        for {
+          fiberRef <- FiberRef.make(initial)
+          child    <- fiberRef.locally(update)(ZIO.sleep(10.seconds)).timeout(1.second).fork
+          _        <- TestClock.adjust(1.second)
+          _        <- child.join
+          value    <- fiberRef.get
+        } yield assert(value)(equalTo(initial))
+      },
       test("`modify` changes value") {
         for {
           fiberRef <- FiberRef.make(initial)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5603,14 +5603,14 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
           (winner, loser) =>
             winner.await.flatMap { exit =>
-              winner.inheritAll *> loser.interruptAs(parentFiberId) *> exit.mapExit(f)
+              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
             },
           (winner, loser) =>
             winner.await.flatMap {
               case e: Exit.Failure[Nothing] =>
-                loser.inheritAll *> loser.interruptAs(parentFiberId) *> e
+                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
               case _ =>
-                loser.inheritAll *> loser.interruptAs(parentFiberId).as(b())
+                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
             },
           null,
           FiberScope.global


### PR DESCRIPTION
Fixes #9693. The cause of this issue is that current `timeoutTo`  implementation inherits `FiberRef` values from winner / loser before interruption - not catching  reset  to original value in `FiberRef#locally`. This PR moves `inheritAll` after `interruptAs`