### PR TITLE
Change iterableFactory from val to def in ChunkLike

### DIFF
--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -111,8 +111,7 @@ trait ChunkLike[+A]
    * exposes a `newBuilder` method that is not referentially transparent because
    * it allocates mutable state.
    */
-  @transient
-  override val iterableFactory: SeqFactory[Chunk] =
+  override def iterableFactory: SeqFactory[Chunk] =
     Chunk
 
   /**

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -111,7 +111,8 @@ trait ChunkLike[+A]
    * exposes a `newBuilder` method that is not referentially transparent because
    * it allocates mutable state.
    */
-  override def iterableFactory: SeqFactory[Chunk] =
+  @transient
+  override val iterableFactory: SeqFactory[Chunk] =
     Chunk
 
   /**

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -42,6 +42,10 @@ trait ChunkLike[+A]
     with StrictOptimizedSeqOps[A, Chunk, Chunk[A]]
     with IterableFactoryDefaults[A, Chunk] { self: Chunk[A] =>
 
+  // this weird () is there to trigger the create of synthetic method $init$ and maintain binary compatibility
+  // removing it should trigger a mima failure
+  ()
+
   override final def appended[A1 >: A](a1: A1): Chunk[A1] =
     append(a1)
 

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -111,7 +111,7 @@ trait ChunkLike[+A]
    * exposes a `newBuilder` method that is not referentially transparent because
    * it allocates mutable state.
    */
-  override val iterableFactory: SeqFactory[Chunk] =
+  override def iterableFactory: SeqFactory[Chunk] =
     Chunk
 
   /**


### PR DESCRIPTION
While using Scala version 3.6.3, ZIO version 2.1.16, and altoo-ag/scala-kryo-serialization version 1.2.0

I encountered the following error when serializing NonEmptyChunk[A] with Kryo:

This issue possibly stems from an initialization order problem.
To avoid the NullPointerException, this PR changes val to def, ensuring proper initialization.

```
  Caused by java.lang.NullPointerException: Cannot invoke "scala.collection.IterableFactory.newBuilder()" because the return value of "scala.collection.Iterable.iterableFactory()" is null
    io.altoo.serialization.kryo.scala.serializer.ScalaCollectionSerializer.read(ScalaCollectionSerializer.scala:34)
    io.altoo.serialization.kryo.scala.serializer.ScalaCollectionSerializer.read(ScalaCollectionSerializer.scala:31)
    com.esotericsoftware.kryo.kryo5.Kryo.readObject(Kryo.java:796)
    com.esotericsoftware.kryo.kryo5.serializers.ReflectField.read(ReflectField.java:124)
    com.esotericsoftware.kryo.kryo5.serializers.FieldSerializer.read(FieldSerializer.java:130)
    com.esotericsoftware.kryo.kryo5.Kryo.readObjectOrNull(Kryo.java:847)
    com.esotericsoftware.kryo.kryo5.serializers.ReflectField.read(ReflectField.java:133)
    com.esotericsoftware.kryo.kryo5.serializers.FieldSerializer.read(FieldSerializer.java:130)
    com.esotericsoftware.kryo.kryo5.Kryo.readObject(Kryo.java:796)
    com.esotericsoftware.kryo.kryo5.serializers.ReflectField.read(ReflectField.java:124)
    com.esotericsoftware.kryo.kryo5.serializers.FieldSerializer.read(FieldSerializer.java:130)
    com.esotericsoftware.kryo.kryo5.Kryo.readClassAndObject(Kryo.java:877)
    io.altoo.serialization.kryo.scala.KryoSerializerBackend.fromBinary(KryoSerializerBackend.scala:61)
    io.altoo.serialization.kryo.scala.KryoSerializer.fromBinaryInternal(KryoSerializer.scala:183)
    io.altoo.serialization.kryo.scala.ScalaKryoSerializer.deserialize$$anonfun$1(ScalaKryoSerializer.scala:23)
    scala.util.Try$.apply(Try.scala:217)
    io.altoo.serialization.kryo.scala.ScalaKryoSerializer.deserialize(ScalaKryoSerializer.scala:23)
    com.devsisters.shardcake.KryoSerialization$$anon$1.decode$$anonfun$1(KryoSerialization.scala:29)
    zio.ZIO$.fromTry$$anonfun$1(ZIO.scala:3871)
    zio.ZIOCompanionVersionSpecific.attempt$$anonfun$1(ZIOCompanionVersionSpecific.scala:108)
    zio.ZIO$.suspendSucceed$$anonfun$1(ZIO.scala:4864)
    zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1063)
    zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
    zio.internal.FiberRuntime.runLoop(FiberRuntime.scala:1067)
    zio.internal.FiberRuntime.evaluateEffect(FiberRuntime.scala:412)
    zio.internal.FiberRuntime.evaluateMessageWhileSuspended(FiberRuntime.scala:487)
    zio.internal.FiberRuntime.drainQueueOnCurrentThread(FiberRuntime.scala:249)
    zio.internal.FiberRuntime.run(FiberRuntime.scala:137)
    zio.internal.ZScheduler$$anon$3.run(ZScheduler.scala:380)
```