### PR TITLE
Use simple CSS minifier

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus generate-sidebar; docusaurus start",
-    "build": "docusaurus generate-sidebar; docusaurus build",
+    "build": "docusaurus generate-sidebar; USE_SIMPLE_CSS_MINIFIER=true docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus generate-sidebar; docusaurus deploy",
     "serve": "docusaurus generate-sidebar; docusaurus serve",

--- a/website/postcss.config.js
+++ b/website/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    plugins: [
+        require('@tailwindcss/postcss')
+    ],
+}


### PR DESCRIPTION
Follow-up #9728.

It looks like CSS minification in Docusaurus breaks some style priorities, because the problem only shows up in the production build. There are a couple of issues about this, and the documentation advises using the environment variable `USE_SIMPLE_CSS_MINIFIER=true` in case of minification problems: https://docusaurus.io/docs/cli#docusaurus-build-sitedir.

- https://github.com/facebook/docusaurus/issues/10274
- https://github.com/facebook/docusaurus/issues/7548

And it does fix the issue with the feature cards.

Before:

![Screenshot_20250327_215944](https://github.com/user-attachments/assets/5a61c511-9abb-4ccf-b158-c0fd2df1f6c0)

After (production build with `yarn build`):

![Screenshot_20250327_215047](https://github.com/user-attachments/assets/3439722f-3311-47fe-aed0-1fc463edb9bf)

