### PR TITLE
Make metrics names compatible with Prometheus Java library

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/MetricsSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/MetricsSpec.scala
@@ -11,7 +11,7 @@ object MetricsSpec extends ZIOBaseSpec {
         val run =
           for {
             latch <- Promise.make[Nothing, Unit]
-            frk    = (latch.succeed(()) *> ZIO.never).provideLayer(DefaultJvmMetrics.live.unit)
+            frk    = (latch.succeed(()) *> ZIO.never).provideLayer(DefaultJvmMetrics.liveV2.unit)
             _     <- frk.forkDaemon.flatMap(f => latch.await *> f.interrupt *> f.await)
           } yield ()
 

--- a/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
@@ -9,17 +9,33 @@ import zio._
 trait DefaultJvmMetrics {
   protected def jvmMetricsSchedule: ULayer[JvmMetricsSchedule]
 
+  @deprecated(
+    "This app exposes JVM metrics with the non-OpenMetrics-compliant names used in prometheus client_java 0.16: https://github.com/prometheus/client_java/blob/main/docs/content/migration/simpleclient.md#jvm-metrics. Use `appV2` instead, it uses names compatible with the client_java 1.0 library"
+  )
+  lazy val app   = withMetrics(live)
+  lazy val appV2 = withMetrics(liveV2)
+
   /** A ZIO application that periodically updates the JVM metrics */
-  lazy val app: ZIOAppDefault = new ZIOAppDefault {
-    override val bootstrap: ZLayer[ZIOAppArgs, Any, Any]         = live
+  private def withMetrics(metricsLayer: ZLayer[Any, Any, Any]): ZIOAppDefault = new ZIOAppDefault {
+    override val bootstrap: ZLayer[ZIOAppArgs, Any, Any]         = metricsLayer
     override def run: ZIO[Environment with ZIOAppArgs, Any, Any] = ZIO.unit
   }
+
+  @deprecated(
+    "This layer exposes JVM metrics with the non-OpenMetrics-compliant names used in prometheus client_java 0.16: https://github.com/prometheus/client_java/blob/main/docs/content/migration/simpleclient.md#jvm-metrics. Use the `liveV2` layer instead, it uses names compatible with the client_java 1.0 library"
+  )
+  lazy val live
+    : ZLayer[Any, Throwable, Reloadable[BufferPools] with ClassLoading with GarbageCollector with MemoryAllocation with MemoryPools with Standard with Thread with VersionInfo] =
+    withMemoryPoolsLayer(MemoryPools.live)
+  lazy val liveV2
+    : ZLayer[Any, Throwable, Reloadable[BufferPools] with ClassLoading with GarbageCollector with MemoryAllocation with MemoryPools with Standard with Thread with VersionInfo] =
+    withMemoryPoolsLayer(MemoryPools.liveV2)
 
   /**
    * Layer that starts collecting the same JVM metrics as the Prometheus Java
    * client's default exporters
    */
-  lazy val live: ZLayer[
+  def withMemoryPoolsLayer(memoryPools: ZLayer[JvmMetricsSchedule, Throwable, MemoryPools]): ZLayer[
     Any,
     Throwable,
     Reloadable[BufferPools]
@@ -36,7 +52,7 @@ trait DefaultJvmMetrics {
         ClassLoading.live ++
         GarbageCollector.live ++
         MemoryAllocation.live ++
-        MemoryPools.live ++
+        memoryPools ++
         Standard.live ++
         Thread.live ++
         VersionInfo.live)

--- a/examples/jvm/src/main/scala/zio/examples/metrics/JvmMetricAppExample.scala
+++ b/examples/jvm/src/main/scala/zio/examples/metrics/JvmMetricAppExample.scala
@@ -26,6 +26,6 @@ object JvmMetricAppExample extends ZIOAppDefault {
       ZLayer.succeed(MetricsConfig(5.seconds)),
 
       // Default JVM Metrics
-      DefaultJvmMetrics.live.unit
+      DefaultJvmMetrics.liveV2.unit
     )
 }


### PR DESCRIPTION
Hi there,

When the Default JVM metrics were initially added to ZIO, they were written to be compatible with the metrics in the Prometheus  simpleclient library.
That library has since been replaced by the Prometheus client_java library, which has changed the names of a dozen metrics:

https://github.com/prometheus/client_java/blob/main/docs/content/migration/simpleclient.md#jvm-metrics

This PR intends to make ZIO compatible with the Prometheus library and the OpenMetrics specification once more.
Since changing metrics names is an incompatible change that will break everybody's monitoring, I have left the existing layers in place, deprecated them and added new `V2` layers that do the same thing but use the new names. I'm open to other suggestions, but I do think it's important to keep the metrics stable. 