### PR TITLE
add support for Junit5 tags with zio tests

### DIFF
--- a/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/TaggedSpec.scala
+++ b/test-junit-engine-tests/maven/src/test/scala/zio/test/junit/maven/TaggedSpec.scala
@@ -1,0 +1,22 @@
+package zio.test.junit.maven
+
+import zio.test.junit._
+import zio.test._
+import zio.test.Assertion._
+
+object TaggedSpec extends ZIOSpecDefault {
+  override def spec = suite("TaggedSpec")(
+    test("should run for tag tagged") {
+      assert(12)(equalTo(12))
+    },
+    test("should run for tag a and tagged") {
+      assert(12)(equalTo(12))
+    } @@ TestAspect.tag("a"),
+    test("should run for tag b and tagged") {
+      assert(12)(equalTo(12))
+    } @@ TestAspect.tag("b"),
+    test("should run for tag a b tagged") {
+      assert(12)(equalTo(12))
+    } @@ TestAspect.tag("a")  @@ TestAspect.tag("b"),
+  ) @@ TestAspect.tag("tagged")
+}

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestDescriptor.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestDescriptor.scala
@@ -16,9 +16,12 @@
 
 package zio.test.junit
 
-import org.junit.platform.engine.{TestDescriptor, UniqueId}
 import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor
-import zio.test.TestAnnotationMap
+import org.junit.platform.engine.{TestDescriptor, TestTag, UniqueId}
+import zio.test.{TestAnnotation, TestAnnotationMap}
+
+import java.util
+import scala.jdk.CollectionConverters._
 
 /**
  * Describes a JUnit 5 test descriptor for a single ZIO tests.
@@ -45,6 +48,9 @@ class ZIOTestDescriptor(
 ) extends AbstractTestDescriptor(uniqueId, label, ZIOTestSource(testClass, annotations)) {
   setParent(parent)
   override def getType: TestDescriptor.Type = TestDescriptor.Type.TEST
+
+  override def getTags: util.Set[TestTag] =
+    annotations.get(TestAnnotation.tagged).map(TestTag.create).asJava
 }
 
 object ZIOTestDescriptor {


### PR DESCRIPTION
This change exposes zio test `TestAnnotation.tagged` to junit5 via the `org.junit.platform.engine.TestDescriptor#getTags` method