### PR TITLE
Optimizations for Java Future interop methods

### DIFF
--- a/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/FiberPlatformSpecific.scala
@@ -37,17 +37,16 @@ private[zio] trait FiberPlatformSpecific {
           if (cf.isDone) {
             ZIO
               .isFatalWith(isFatal => javaz.unwrapDone(isFatal)(cf))
-              .fold(Exit.fail, Exit.succeed)
-              .map(Some(_))
+              .fold(e => Some(Exit.fail(e)), v => Some(Exit.succeed(v)))
           } else {
-            ZIO.succeed(None)
+            Exit.none
           }
         }
 
       def id: FiberId = FiberId.None
 
       final def interruptAsFork(id: FiberId)(implicit trace: Trace): UIO[Unit] =
-        ZIO.succeed(cs.toCompletableFuture.cancel(false)).unit
+        ZIO.succeed(cs.toCompletableFuture.cancel(false): Unit)
 
       final def inheritAll(implicit trace: Trace): UIO[Unit] = ZIO.unit
     }
@@ -72,17 +71,16 @@ private[zio] trait FiberPlatformSpecific {
           if (ftr.isDone) {
             ZIO
               .isFatalWith(isFatal => javaz.unwrapDone(isFatal)(ftr))
-              .fold(Exit.fail, Exit.succeed)
-              .map(Some(_))
+              .fold(e => Some(Exit.fail(e)), v => Some(Exit.succeed(v)))
           } else {
-            ZIO.none
+            Exit.none
           }
         }
 
       def id: FiberId = FiberId.None
 
       def interruptAsFork(id: FiberId)(implicit trace: Trace): UIO[Unit] =
-        ZIO.succeed(ftr.cancel(false)).unit
+        ZIO.succeed(ftr.cancel(false): Unit)
 
       def inheritAll(implicit trace: Trace): UIO[Unit] = ZIO.unit
     }

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -76,7 +76,7 @@ private[zio] object javaz {
             val cancel = ZIO.succeed(cf.cancel(false))
             restore {
               ZIO.asyncInterrupt[Any, Throwable, A] { cb =>
-                val _ = cs.handle[Unit] { (v: A, t: Throwable) =>
+                cs.handle[Unit] { (v: A, t: Throwable) =>
                   val io =
                     if (t eq null) Exit.succeed(v)
                     else catchFromGet(isFatal).applyOrElse(t, (d: Throwable) => ZIO.die(d))
@@ -84,7 +84,7 @@ private[zio] object javaz {
                 }
                 Left(cancel)
               }
-            }.onInterrupt(cancel)
+            }
           }
         }
       }
@@ -102,8 +102,11 @@ private[zio] object javaz {
             unwrapDone(isFatal)(future)
           } else {
             restore {
-              ZIO.blocking(ZIO.suspend(unwrapDone(isFatal)(future)))
-            }.onInterrupt(ZIO.succeed(future.cancel(false)))
+              ZIO.blocking(unwrapDone(isFatal)(future))
+            }.catchAllCause { c =>
+              if (c.isInterruptedOnly) future.cancel(false)
+              Exit.failCause(c)
+            }
           }
         }
       }

--- a/core/jvm/src/main/scala/zio/interop/javaz.scala
+++ b/core/jvm/src/main/scala/zio/interop/javaz.scala
@@ -73,7 +73,6 @@ private[zio] object javaz {
           if (cf.isDone) {
             unwrapDone(isFatal)(cf)
           } else {
-            val cancel = ZIO.succeed(cf.cancel(false))
             restore {
               ZIO.asyncInterrupt[Any, Throwable, A] { cb =>
                 cs.handle[Unit] { (v: A, t: Throwable) =>
@@ -82,7 +81,7 @@ private[zio] object javaz {
                     else catchFromGet(isFatal).applyOrElse(t, (d: Throwable) => ZIO.die(d))
                   cb(io)
                 }
-                Left(cancel)
+                Left(ZIO.succeed(cf.cancel(false)))
               }
             }
           }


### PR DESCRIPTION
Main optimization / fix here is that previously in `fromCompletionStage` we would be handling interruption twice, once as part of `asyncInterrupt` and another one when calling `onInterrupt`. I'm somewhat certain this wouldn't cause bugs because it's OK to call `future.cancel` twice, but still not ideal since it adds a fair bit of overhead to this method