### PR TITLE
test-sbt: [bug] match tests on both short and prefixed names.

### DIFF
--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -143,4 +143,13 @@ object FrameworkSpecInstances {
     )
   }
 
+  object NestedSpec extends ZIOSpecDefault {
+    def spec: Spec[Any, TestFailure[Any]] = zio.test.suite("outer")(
+      zio.test.suite("inner")(
+        test("test") {
+          zio.test.assert(1)(Assertion.equalTo(1))
+        }
+      )
+    )
+  }
 }

--- a/test/shared/src/main/scala/zio/test/FilteredSpec.scala
+++ b/test/shared/src/main/scala/zio/test/FilteredSpec.scala
@@ -29,7 +29,13 @@ private[zio] object FilteredSpec {
     val testSearchedSpec = args.testSearchTerms match {
       case Nil => spec
       case testSearchTerms =>
-        spec.filterLabels(label => testSearchTerms.exists(term => label.contains(term))).getOrElse(Spec.empty)
+        spec
+          .filterLabels(
+            label => testSearchTerms.exists(term => label.contains(term)),
+            prefix = "",
+            accumulatePrefix = true
+          )
+          .getOrElse(Spec.empty)
     }
     val tagIgnoredSpec = args.tagIgnoreTerms match {
       case Nil => testSearchedSpec


### PR DESCRIPTION
If a test is defined as `suite("suite")(test("test"){})`, it seems reasonable that we should be able to ask for it to be executed by either its short name `test` or by its full name `suite - test`.

When outer suite is run via `sbt.testing`  and tests to run specified using `sbt.testing.Test[Wildcard]Selector`, this *can* be achieved by stripping the suite prefix "suite -" from the names in the `Selector`s. However, this approach breaks down in the presence of nested suites; e.g. if a test is defined as `suite("outer")(suite("inner")(test("test"){}))`, when the outer suite is run:
- selector `test` does executes the test - as it should;
- selector `outer - test` _does_ execute the test  (prefix gets wrongly stripped) - but _should not_, since test with such a full name does not exist;
- selector `inner - test` _does not_ execute the test (wrong prefix gets stripped) - but _should_;
- selector `outer - inner - test` _does not_ execute the test (inner prefix does not get stripped) - but _should_.

When outer suite is run directly and tests to run specified using search terms (`-t`):
- search term `inner - test` _does not_ execute the test - but _should_;
- search term `outer - inner - test` _does not_ execute the test - but _should_.

To make this work correctly, an overload of `Spec.filterLabels()` is introduced that keep track of the accumulated suite prefix and matches the search terms against prefixed names. This overload is used in `FilteredSpec`.
