### PR TITLE
Bring back the `addMetrics` optimization of `LinkedQueue` to improve performances of  `Queue.unbounded`

### DIFF
--- a/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/MutableConcurrentQueue.scala
@@ -31,8 +31,7 @@ private[zio] object MutableConcurrentQueue {
     if (capacity == 1) new OneElementConcurrentQueue()
     else RingBuffer[A](capacity)
 
-  def unbounded[A]: MutableConcurrentQueue[A] =
-    new LinkedQueue[A]
+  def unbounded[A]: MutableConcurrentQueue[A] = LinkedQueue[A](addMetrics = false)
 
   /**
    * Rounds up to the nearest power of 2 and subtracts 1. e.g.,

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -23,7 +23,19 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicLong
 import scala.annotation.nowarn
 
-private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with Serializable {
+private[zio] final class LinkedQueue[A] private (addMetrics: Boolean)
+    extends MutableConcurrentQueue[A]
+    with Serializable {
+
+  /**
+   * Public constructor to create a new LinkedQueue.
+   *
+   * Required for retrocompatibility. See https://github.com/zio/zio/pull/8784
+   *
+   * Use [[LinkedQueue.apply]] to use a different `addMetrics` value.
+   */
+  def this() = this(addMetrics = true)
+
   override final val capacity = Int.MaxValue
 
   private[this] val jucConcurrentQueue = new ConcurrentLinkedQueue[A]()
@@ -32,32 +44,32 @@ private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with S
    * performance implications. Having a better solution would be
    * desirable.
    */
-  private[this] val enqueuedCounter = new AtomicLong(0)
-  private[this] val dequeuedCounter = new AtomicLong(0)
+  private[this] val enqueuedCounter = if (addMetrics) new AtomicLong(0) else null
+  private[this] val dequeuedCounter = if (addMetrics) new AtomicLong(0) else null
 
   override def size(): Int = jucConcurrentQueue.size()
 
-  override def enqueuedCount(): Long = enqueuedCounter.get()
+  override def enqueuedCount(): Long = if (addMetrics) enqueuedCounter.get() else 0L
 
-  override def dequeuedCount(): Long = dequeuedCounter.get()
+  override def dequeuedCount(): Long = if (addMetrics) dequeuedCounter.get() else 0L
 
   override def offer(a: A): Boolean = {
     val success = jucConcurrentQueue.offer(a)
-    if (success) enqueuedCounter.incrementAndGet()
+    if (addMetrics && success) enqueuedCounter.incrementAndGet()
     success
   }
 
   override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     import collection.JavaConverters._
     jucConcurrentQueue.addAll(as.asJavaCollection): @nowarn("msg=JavaConverters")
-    enqueuedCounter.addAndGet(as.size.toLong)
+    if (addMetrics) enqueuedCounter.addAndGet(as.size.toLong)
     Chunk.empty
   }
 
   override def poll(default: A): A = {
     val polled = jucConcurrentQueue.poll()
     if (polled != null) {
-      dequeuedCounter.incrementAndGet()
+      if (addMetrics) dequeuedCounter.incrementAndGet()
       polled
     } else default
   }
@@ -65,4 +77,8 @@ private[zio] final class LinkedQueue[A] extends MutableConcurrentQueue[A] with S
   override def isEmpty(): Boolean = jucConcurrentQueue.isEmpty
 
   override def isFull(): Boolean = false
+}
+
+object LinkedQueue {
+  def apply[A](addMetrics: Boolean): LinkedQueue[A] = new LinkedQueue[A](addMetrics)
 }

--- a/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
+++ b/core/shared/src/main/scala/zio/internal/impls/LinkedQueue.scala
@@ -49,27 +49,27 @@ private[zio] final class LinkedQueue[A] private (addMetrics: Boolean)
 
   override def size(): Int = jucConcurrentQueue.size()
 
-  override def enqueuedCount(): Long = if (addMetrics) enqueuedCounter.get() else 0L
+  override def enqueuedCount(): Long = if (enqueuedCounter ne null) enqueuedCounter.get() else 0L
 
-  override def dequeuedCount(): Long = if (addMetrics) dequeuedCounter.get() else 0L
+  override def dequeuedCount(): Long = if (dequeuedCounter ne null) dequeuedCounter.get() else 0L
 
   override def offer(a: A): Boolean = {
     val success = jucConcurrentQueue.offer(a)
-    if (addMetrics && success) enqueuedCounter.incrementAndGet()
+    if ((enqueuedCounter ne null) && success) enqueuedCounter.incrementAndGet()
     success
   }
 
   override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
     import collection.JavaConverters._
     jucConcurrentQueue.addAll(as.asJavaCollection): @nowarn("msg=JavaConverters")
-    if (addMetrics) enqueuedCounter.addAndGet(as.size.toLong)
+    if (enqueuedCounter ne null) enqueuedCounter.addAndGet(as.size.toLong)
     Chunk.empty
   }
 
   override def poll(default: A): A = {
     val polled = jucConcurrentQueue.poll()
     if (polled != null) {
-      if (addMetrics) dequeuedCounter.incrementAndGet()
+      if (dequeuedCounter ne null) dequeuedCounter.incrementAndGet()
       polled
     } else default
   }


### PR DESCRIPTION
See also:
- https://github.com/zio/zio/pull/8784
- https://github.com/zio/zio/pull/8745

FYI @ghostdogpr 