### PR TITLE
Optimize `Queue#shutdown`

### DIFF
--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -34,7 +34,8 @@ object MimaSettings {
         exclude[NewMixinForwarderProblem]("zio.Exit.mapBoth"),
         exclude[NewMixinForwarderProblem]("zio.Exit.mapError"),
         exclude[NewMixinForwarderProblem]("zio.Exit.mapErrorCause"),
-        exclude[NewMixinForwarderProblem]("zio.Exit.unit")
+        exclude[NewMixinForwarderProblem]("zio.Exit.unit"),
+        exclude[Problem]("zio.Queue#Strategy*.shutdown")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
I noticed that `Queue#shutdown` was quite unoptimized while looking at a different PR.

At the moment `Queue#shutdown` is quite heavy for the calling thread, as it involves a lot of ZIO's in addition to completing Promises in parallel unnecessarily. With this PR we avoid all of this which should make queue shutdowns a lot faster. While most workflows won't see much of a performance benefit from this change, certain workflows  that rely on creation of queues for streams will definitely benefit from these changes.