### PR TITLE
Fix #9505 Constructors in assertTrue (Scala 3)

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -87,6 +87,19 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         assertTrue(zio.Duration.fromNanos(1000) == zio.Duration.Zero)
       }
     ) @@ failing,
+    suite("class constructors")(
+      test("string constructor") {
+        val bytes: Array[Byte] = "test".getBytes
+        assertTrue(new String(bytes) == "test")
+      },
+      test("class constructor") {
+        assertTrue(new Service("serviceName").name == "serviceName")
+      },
+      test("generic class contructor") {
+        assertTrue(new GenericService[Int](52).value == 52) &&
+        assertTrue(new GenericService(52).value == 52)
+      }
+    ),
     suite("contains")(
       test("Option") {
         assertTrue(company.users.head.posts.head.publishDate.contains(LocalDateTime.MAX))

--- a/test-tests/shared/src/test/scala/zio/test/SmartTestTypes.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartTestTypes.scala
@@ -15,4 +15,8 @@ object SmartTestTypes {
 
   case class Company(name: String, users: List[User])
 
+  class Service(val name: String)
+
+  class GenericService[A](val value: A)
+
 }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -46,11 +46,13 @@ object SmartAssertMacros {
     ): Option[(quotes.reflect.Term, String, List[quotes.reflect.TypeRepr], Option[List[quotes.reflect.Term]])] = {
       import quotes.reflect._
       tree match {
-        case Select(lhs, name)                               => Some((lhs, name, List.empty, None))
-        case TypeApply(Select(lhs, name), tpes)              => Some((lhs, name, tpes.map(_.tpe), None))
-        case Apply(Select(lhs, name), args)                  => Some((lhs, name, List.empty, Some(args)))
-        case Apply(TypeApply(Select(lhs, name), tpes), args) => Some((lhs, name, tpes.map(_.tpe), Some(args)))
-        case _                                               => None
+        case Select(lhs, name)                  => Some((lhs, name, List.empty, None))
+        case TypeApply(Select(lhs, name), tpes) => Some((lhs, name, tpes.map(_.tpe), None))
+        case Apply(select @ Select(lhs, name), args) if !select.symbol.isClassConstructor =>
+          Some((lhs, name, List.empty, Some(args)))
+        case Apply(TypeApply(select @ Select(lhs, name), tpes), args) if !select.symbol.isClassConstructor =>
+          Some((lhs, name, tpes.map(_.tpe), Some(args)))
+        case _ => None
       }
     }
   }


### PR DESCRIPTION
Fix #9505

This PR fixes a bug in assertTrue macro that did not allow using class constructors (in lhs) inside of it.

The problem was that this macro seemed to be originally written in Scala 2 and the `MethodCall` extractor object does not extact constructors. However, in Scala 3 it does. I have added a guard using `isClassConstructor` on Select symbol which does not allow future "decomposing" of the tree. 

Sorry, if what I have described is not understandable, I do not have much experience in contributing to such big projects, so do not hesitate to ask questions. I will try my best to answer them.