### PR TITLE
Provide a more sensible default `.jvmopts`

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,1 +1,5 @@
 -Dcats.effect.stackTracingMode=full
+-Dfile.encoding=UTF8
+-Xms256M
+-Xmx6G
+-XX:+UseG1GC


### PR DESCRIPTION
Let's be honest, ZIO doesn't compile with the current `.jvmopts`
The JVM will OOM way before finishing to compile ZIO code
I feel like it can be an issue for more beginner engineers who'd want to contribute and wouldn't know how to fix this sbt issue