### PR TITLE
Fix typo scala doc classes

### DIFF
--- a/core/shared/src/main/scala-2.12/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.12/zio/ChunkLike.scala
@@ -33,7 +33,7 @@ import scala.reflect.ClassTag
  *
  * Note that `IndexedSeq` is not a referentially transparent interface in that
  * it exposes methods that are partial (e.g. `apply`), allocate mutable state
- * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `Chunk`
+ * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `ChunkLike`
  * extends `IndexedSeq` to provide interoperability with Scala's collection
  * library but users should avoid these methods whenever possible.
  */

--- a/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
+++ b/core/shared/src/main/scala-2.13+/zio/ChunkLike.scala
@@ -32,7 +32,7 @@ import scala.reflect.ClassTag
  *
  * Note that `IndexedSeq` is not a referentially transparent interface in that
  * it exposes methods that are partial (e.g. `apply`), allocate mutable state
- * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `Chunk`
+ * (e.g. `iterator`), or are purely side effecting (e.g. `foreach`). `ChunkLike`
  * extends `IndexedSeq` to provide interoperability with Scala's collection
  * library but users should avoid these methods whenever possible.
  */

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -26,10 +26,10 @@ import scala.math.log
 import scala.reflect.{ClassTag, classTag}
 
 /**
- * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are designed
- * are usually backed by arrays, but expose a purely functional, safe interface
- * to the underlying elements, and they become lazy on operations that would be
- * costly with arrays, such as repeated concatenation.
+ * A `Chunk[A]` represents a chunk of values of type `A`. Chunks are usually
+ * backed by arrays, but expose a purely functional, safe interface to the
+ * underlying elements, and they become lazy on operations that would be costly
+ * with arrays, such as repeated concatenation.
  *
  * The implementation of balanced concatenation is based on the one for
  * Conc-Trees in "Conc-Trees for Functional and Parallel Programming" by


### PR DESCRIPTION
I found some **typos** on scala doc of some traits : **Chunk** and **ChunkLike**