### PR TITLE
Avoid excessive filesystem read/writes during test execution

### DIFF
--- a/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
+++ b/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 object ResultFileOpsJsonSpec extends ZIOBaseSpec {
   def spec = suite("ResultFileOpsJsonSpec")(
-    test("writes lines within the result array sequentially")(
+    test("trailing comma from last entry is removed")(
       for {
         path    <- writeToTestFile(parallel = false)("\naaa", "\nbbb", "\nccc")
         results <- readFile(path)
@@ -16,6 +16,20 @@ object ResultFileOpsJsonSpec extends ZIOBaseSpec {
         results(1) == "  \"results\": [",
         results(2) == "aaa",
         results(3) == "bbb",
+        results(4) == "ccc",
+        results(5) == "  ]",
+        results(6) == "}"
+      )
+    ),
+    test("trailing comma from last entry is removed")(
+      for {
+        path    <- writeToTestFile(parallel = false)("\naaa,", "\nbbb,", "\nccc,")
+        results <- readFile(path)
+      } yield assertTrue(
+        results(0) == "{",
+        results(1) == "  \"results\": [",
+        results(2) == "aaa,",
+        results(3) == "bbb,",
         results(4) == "ccc",
         results(5) == "  ]",
         results(6) == "}"

--- a/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
+++ b/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
@@ -7,66 +7,42 @@ import java.nio.file.Path
 
 object ResultFileOpsJsonSpec extends ZIOBaseSpec {
   def spec = suite("ResultFileOpsJsonSpec")(
-    test("simple write")(
+    test("writes lines within the result array sequentially")(
       for {
-        _       <- writeToTestFile("a")
-        results <- readFile
-      } yield assertTrue(results == List("a"))
-    ).provide(test, Scope.default),
-    test("clobbered concurrent writes") {
-      val linesToWrite =
-        List(
-          "a",
-          "b",
-          "c",
-          "d",
-          "e"
-        ).map(_ * 100)
-      for {
-        _ <-
-          ZIO.foreachPar(
-            linesToWrite
-          )(writeToTestFile)
-        results <- readFile
-      } yield assertTrue(linesToWrite.forall(results.contains(_)))
-    }
-      .provide(test, Scope.default)
-      @@ TestAspect.nonFlaky,
-    test("generated concurrent writes clean") {
-      checkN(10)(Gen.listOfN(3)(Gen.alphaNumericStringBounded(0, 700))) { linesToWrite =>
+        path    <- writeToTestFile(parallel = false)("\naaa", "\nbbb", "\nccc")
+        results <- readFile(path)
+      } yield assertTrue(
+        results(0) == "{",
+        results(1) == "  \"results\": [",
+        results(2) == "aaa",
+        results(3) == "bbb",
+        results(4) == "ccc",
+        results(5) == "  ]",
+        results(6) == "}"
+      )
+    ),
+    test("is thread safe") {
+      checkN(10)(Gen.setOfN(100)(Gen.alphaNumericStringBounded(1, 10))) { linesToWrite =>
         for {
-          _ <-
-            ZIO.foreachPar(
-              linesToWrite
-            )(writeToTestFile)
-          results <- readFile
-        } yield assertTrue(linesToWrite.forall(results.contains(_)))
+          path    <- writeToTestFile(parallel = true)(linesToWrite.toList.map("\n" + _): _*)
+          results <- readFile(path).map(_.toSet)
+          union    = linesToWrite.intersect(results)
+        } yield assertTrue(union == linesToWrite)
       }
-    }.provide(test, Scope.default)
+    }
   )
 
-  private def writeToTestFile(content: String) =
-    ZIO.serviceWithZIO[ResultFileOps](_.write(content + "\n", append = true))
+  private def writeToTestFile(parallel: Boolean)(content: String*): Task[Path] =
+    ZIO.scoped(for {
+      path   <- ZIO.attemptBlocking(java.nio.file.Files.createTempFile("zio-test", ".json"))
+      writer <- ResultFileOps.Json(path.toString)
+      _ <-
+        if (parallel) ZIO.foreachParDiscard(content)(writer.write(_))
+        else ZIO.foreachDiscard(content)(writer.write(_))
+    } yield path)
 
-  val readFile: ZIO[Path with Scope, Nothing, List[String]] =
-    for {
-      tmpFilePath <- ZIO.service[Path]
-      source       = scala.io.Source.fromFile(tmpFilePath.toString)
-      _           <- ZIO.addFinalizer(ZIO.succeed(source.close()))
-      lines <- ZIO.attempt {
-                 source.getLines().toList
-               }.orDie
-    } yield lines
-
-  val test: ZLayer[Any, Throwable, Path with ResultFileOps.Json] =
-    ZLayer.fromZIO {
-      for {
-        fileLock <- Ref.Synchronized.make[Unit](())
-        result <- ZIO
-                    .attempt(
-                      java.nio.file.Files.createTempFile("zio-test", ".json")
-                    )
-                    .map(path => (path, ResultFileOps.Json(path.toString, fileLock)))
-      } yield result
-    }.flatMap(tup => ZLayer.succeed(tup.get._1) ++ ZLayer.succeed(tup.get._2))
+  def readFile(path: Path): Task[Vector[String]] =
+    ZIO.acquireReleaseWith(ZIO.succeed(scala.io.Source.fromFile(path.toString)))(s => ZIO.succeed(s.close)) { s =>
+      ZIO.succeed(s.getLines().toVector)
+    }
 }

--- a/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
+++ b/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
@@ -2,83 +2,67 @@ package zio.test.results
 
 import zio._
 
-import java.io.IOException
-import scala.io.Source
+import java.util.concurrent.ConcurrentLinkedQueue
 
 private[test] trait ResultFileOps {
-  def write(content: => String, append: Boolean): ZIO[Any, IOException, Unit]
+  def write(content: => String): UIO[Unit]
 }
 
 private[test] object ResultFileOps {
   val live: ZLayer[Any, Nothing, ResultFileOps] =
-    ZLayer.scoped(
-      Json.apply
-    )
+    ZLayer.scoped(Json.apply)
 
-  private[test] case class Json(resultPath: String, lock: Ref.Synchronized[Unit]) extends ResultFileOps {
-    def write(content: => String, append: Boolean): ZIO[Any, IOException, Unit] =
-      lock.updateZIO(_ =>
-        ZIO
-          .acquireReleaseWith(ZIO.attemptBlockingIO(new java.io.FileWriter(resultPath, append)))(f =>
-            ZIO.attemptBlocking(f.close()).orDie
-          ) { f =>
-            ZIO.attemptBlockingIO(f.append(content))
-          }
-          .ignore
-      )
+  private[test] class Json private (resultPath: String) extends ResultFileOps {
+    private val queue = new ConcurrentLinkedQueue[String]()
 
-    private val makeOutputDirectory = ZIO.attempt {
+    def write(content: => String): UIO[Unit] =
+      ZIO.succeed {
+        queue.offer(content)
+        ()
+      }
+
+    private def close: UIO[Unit] =
+      ZIO.attemptBlocking {
+        makeOutputDirectory()
+        flushUnsafe()
+      }.orDie
+
+    private def makeOutputDirectory(): Unit = {
       import java.nio.file.{Files, Paths}
 
       val fp = Paths.get(resultPath)
       Files.createDirectories(fp.getParent)
-    }.unit
+      ()
+    }
 
-    private def closeJson: ZIO[Scope, Throwable, Unit] =
-      removeLastComma *>
-        write("\n  ]\n}", append = true).orDie
+    private def flushUnsafe(): Unit = {
+      val file = new java.io.FileWriter(resultPath, false)
+      try {
+        file.write("""|{
+                      |  "results": [""".stripMargin)
 
-    private def writeJsonPreamble: URIO[Any, Unit] =
-      write(
-        """|{
-           |  "results": [""".stripMargin,
-        append = false
-      ).orDie
-
-    private val removeLastComma =
-      for {
-        source <- ZIO.succeed(Source.fromFile(resultPath))
-        updatedLines = {
-          val lines = source.getLines().toList
-          if (lines.nonEmpty && lines.last.endsWith(",")) {
-            val lastLine    = lines.last
-            val newLastLine = lastLine.dropRight(1)
-            lines.init :+ newLastLine
+        var next = queue.poll()
+        while (next ne null) {
+          val current = next
+          next = queue.poll()
+          if ((next eq null) && current.endsWith(",")) {
+            file.write(current.dropRight(1))
           } else {
-            lines
+            file.write(current)
           }
         }
-        _ <- ZIO.when(updatedLines.nonEmpty) {
-               val firstLine :: rest = updatedLines
-               for {
-                 _ <- write(firstLine + "\n", append = false)
-                 _ <- ZIO.foreach(rest)(line => write(line + "\n", append = true))
-                 _ <- ZIO.addFinalizer(ZIO.attempt(source.close()).orDie)
-               } yield ()
-             }
-      } yield ()
-
+        file.write("\n  ]\n}")
+      } finally {
+        file.close()
+      }
+    }
   }
 
   object Json {
+    def apply(filename: String): ZIO[Scope, Nothing, Json] =
+      ZIO.acquireRelease(ZIO.succeed(new Json(filename)))(_.close)
+
     def apply: ZIO[Scope, Nothing, Json] =
-      ZIO.acquireRelease(
-        for {
-          fileLock <- Ref.Synchronized.make[Unit](())
-          instance  = Json("target/test-reports-zio/output.json", fileLock)
-          _        <- instance.makeOutputDirectory.orDie
-          _        <- instance.writeJsonPreamble
-        } yield instance
-      )(instance => instance.closeJson.orDie)
+      apply("target/test-reports-zio/output.json")
   }
 }

--- a/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
+++ b/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
@@ -12,7 +12,7 @@ private[test] object ResultFileOps {
   val live: ZLayer[Any, Nothing, ResultFileOps] =
     ZLayer.scoped(Json.apply)
 
-  private[test] class Json private (resultPath: String) extends ResultFileOps {
+  private[test] final class Json private (resultPath: String) extends ResultFileOps {
     private val queue = new ConcurrentLinkedQueue[String]()
 
     def write(content: => String): UIO[Unit] =

--- a/test/jvm-native/src/main/scala/zio/test/results/ResultPrinterJson.scala
+++ b/test/jvm-native/src/main/scala/zio/test/results/ResultPrinterJson.scala
@@ -8,13 +8,11 @@ private[test] object ResultPrinterJson {
     ZLayer.make[ResultPrinter](
       ResultSerializer.live,
       ResultFileOps.live,
-      ZLayer.fromFunction(
-        LiveImpl(_, _)
-      )
+      ZLayer.fromFunction(LiveImpl.apply _)
     )
 
   private case class LiveImpl(serializer: ResultSerializer, resultFileOps: ResultFileOps) extends ResultPrinter {
     override def print[E](event: ExecutionEvent.Test[E]): ZIO[Any, Nothing, Unit] =
-      resultFileOps.write(serializer.render(event), append = true).orDie
+      resultFileOps.write(serializer.render(event))
   }
 }

--- a/test/shared/src/main/scala/zio/test/results/ResultSerializer.scala
+++ b/test/shared/src/main/scala/zio/test/results/ResultSerializer.scala
@@ -13,7 +13,7 @@ object ResultSerializer {
   object Json extends ResultSerializer {
     def render[E](executionEvent: ExecutionEvent.Test[E]): String =
       executionEvent match {
-        case ExecutionEvent.Test(labelsReversed, test, annotations, ancestors, duration, id, fullyQualifiedName) =>
+        case ExecutionEvent.Test(labelsReversed, test, annotations, _, duration, _, fullyQualifiedName) =>
           s"""
              |    {
              |       "name" : "$fullyQualifiedName/${labelsReversed.reverse
@@ -28,12 +28,7 @@ object ResultSerializer {
       }
 
     private def render[E](test: Either[TestFailure[E], TestSuccess]): String =
-      test match {
-        case Left(value) =>
-          "Failure"
-        case Right(value) =>
-          "Success"
-      }
+      if (test.isRight) "Success" else "Failure"
 
     private[results] def render(testAnnotationMap: TestAnnotationMap): String =
       TestAnnotationRenderer.default


### PR DESCRIPTION
/fixes #9783

Currently we're appending the result of each test to a file. When test execution finishes, we load up the entire file, and then write each line by opening / closing a new `java.io.FileWriter`. This is very inefficient especially for large test suites.

With this PR we store all the writes in a queue which we then drain and write its contents to the FS once we close `ResultFileOps`.

Previously, running `coreTestsJVM/test` locally required 10 seconds (!!!) for the test reports to be written to the file, whereas now it's done in a matter of milliseconds.