### PR TITLE
Fix #9642 Compare operations of ops classes in assertTrue

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -252,6 +252,13 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       assertTrue(b > aL) && assertTrue(bL > a) &&
       assertTrue(b >= aL) && assertTrue(bL >= a)
     },
+    test("comparison compiles when comparing types with ops implicit class containing compare operation") {
+      import java.time.temporal.ChronoUnit._
+
+      val duration = Duration(500, MILLIS)
+      assertTrue(duration < Duration(1, SECONDS)) &&
+      assertTrue("testing" > "test")
+    },
     test("exists must succeed when at least one element of iterable satisfy specified assertion") {
       assertTrue(Seq(1, 42, 5).exists(_ == 42))
     },

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -165,7 +165,7 @@ object SmartAssertMacros {
         val arrow                 = Inlined(a, b, transform(expr.asExprOf[A]).asTerm).asExprOf[zio.test.TestArrow[Any, A]]
         '{ $arrow.span($preMacroExpansionSpan) }
 
-      case Unseal(Apply(Select(lhs, op @ (">" | ">=" | "<" | "<=")), List(rhs))) =>
+      case Unseal(tree @ Apply(Select(lhs, op @ (">" | ">=" | "<" | "<=")), List(rhs))) =>
         def tpesPriority(tpe: TypeRepr): Int =
           tpe.toString match {
             case "Byte"   => 0
@@ -263,6 +263,9 @@ object SmartAssertMacros {
                             .span($span)
                         }.asExprOf[TestArrow[Any, A]]
                     }
+                  case (None, _) =>
+                    val span = getSpan(tree)
+                    '{ TestArrow.succeed($expr).span($span) }
                   case _ => throw new Error("NO")
                 }
             }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -229,7 +229,10 @@ object SmartAssertMacros {
                             .span($span)
                         }.asExprOf[TestArrow[Any, A]]
                     }
-                  case _ => throw new Error("NO")
+                  case _ =>
+                    throw new IllegalArgumentException(
+                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
+                    )
                 }
             }
           case Some(false) =>
@@ -266,7 +269,10 @@ object SmartAssertMacros {
                   case (None, _) =>
                     val span = getSpan(tree)
                     '{ TestArrow.succeed($expr).span($span) }
-                  case _ => throw new Error("NO")
+                  case _ =>
+                    throw new IllegalArgumentException(
+                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
+                    )
                 }
             }
           case None =>
@@ -300,7 +306,10 @@ object SmartAssertMacros {
                             .span($span)
                         }.asExprOf[TestArrow[Any, A]]
                     }
-                  case _ => throw new Error("NO")
+                  case _ =>
+                    throw new IllegalArgumentException(
+                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
+                    )
                 }
             }
         }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -61,6 +61,12 @@ object SmartAssertMacros {
     def apply(using Quotes)(term: quotes.reflect.Term) = new PositionContext(term.pos.start)
   }
 
+  def unsupportedOperationErrorExpr(using Quotes) = '{
+    scala.compiletime.error(
+      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
+    )
+  }
+
   def transformAs[Start: Type, End: Type](
     expr: Expr[TestLens[End]]
   )(start: Expr[TestArrow[Any, Start]])(using PositionContext, Quotes): Expr[TestArrow[Any, End]] = {
@@ -229,10 +235,7 @@ object SmartAssertMacros {
                             .span($span)
                         }.asExprOf[TestArrow[Any, A]]
                     }
-                  case _ =>
-                    throw new IllegalArgumentException(
-                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
-                    )
+                  case _ => unsupportedOperationErrorExpr
                 }
             }
           case Some(false) =>
@@ -269,10 +272,7 @@ object SmartAssertMacros {
                   case (None, _) =>
                     val span = getSpan(tree)
                     '{ TestArrow.succeed($expr).span($span) }
-                  case _ =>
-                    throw new IllegalArgumentException(
-                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
-                    )
+                  case _ => unsupportedOperationErrorExpr
                 }
             }
           case None =>
@@ -306,10 +306,7 @@ object SmartAssertMacros {
                             .span($span)
                         }.asExprOf[TestArrow[Any, A]]
                     }
-                  case _ =>
-                    throw new IllegalArgumentException(
-                      "Unsupported operation in 'assertTrue'\nPlease open an issue: https://github.com/zio/zio/issues/new"
-                    )
+                  case _ => unsupportedOperationErrorExpr
                 }
             }
         }


### PR DESCRIPTION
Fix #9642

This PR fixes an issue in `assertTrue` macro that did not allow using compare operation (>, >=, <, <=) inside of it when they were extension methods.

The problem was that when the macro matched a tree with such an operation it always "tried" to summon an instance of `Ordering[l]` where `l` is the type of lhs. However, sometimes when having an ops class and implicit conversions to its instance does not mean that there is an `Ordering` instance for the type (actually I believe it's always the case). In other words, it is just an extension method that's why the macro would never work in Scala 3.

I have only changed the logic when `implicitConversionDirection` value is `Some(false)` (direction from the type on the rigth to the one on left) since all the comparison operators are left associative.