### PR TITLE
Mark traits+abstract classes as sealed

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -5,7 +5,7 @@ import cats.effect.{Fiber => CFiber, IO => CIO}
 
 import scala.concurrent.ExecutionContext
 
-object BenchmarkUtil extends Runtime[Any] { self =>
+object BenchmarkUtil extends Runtime.Internal[Any] { self =>
   val environment = Runtime.default.environment
 
   val fiberRefs = Runtime.default.fiberRefs
@@ -39,7 +39,7 @@ object BenchmarkUtil extends Runtime[Any] { self =>
     Unsafe.unsafe(implicit unsafe => rt.unsafe.run(zio).getOrThrowFiberFailure())
   }
 
-  private object NoFiberRootsRuntime extends Runtime[Any] {
+  private object NoFiberRootsRuntime extends Runtime.Internal[Any] {
     val environment  = Runtime.default.environment
     val fiberRefs    = Runtime.default.fiberRefs
     val runtimeFlags = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)

--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -5,7 +5,7 @@ import cats.effect.{Fiber => CFiber, IO => CIO}
 
 import scala.concurrent.ExecutionContext
 
-object BenchmarkUtil extends Runtime.Internal[Any] { self =>
+object BenchmarkUtil extends Runtime[Any] { self =>
   val environment = Runtime.default.environment
 
   val fiberRefs = Runtime.default.fiberRefs
@@ -39,7 +39,7 @@ object BenchmarkUtil extends Runtime.Internal[Any] { self =>
     Unsafe.unsafe(implicit unsafe => rt.unsafe.run(zio).getOrThrowFiberFailure())
   }
 
-  private object NoFiberRootsRuntime extends Runtime.Internal[Any] {
+  private object NoFiberRootsRuntime extends Runtime[Any] {
     val environment  = Runtime.default.environment
     val fiberRefs    = Runtime.default.fiberRefs
     val runtimeFlags = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)

--- a/core/js/src/main/scala/zio/ClockPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ClockPlatformSpecific.scala
@@ -21,7 +21,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import scala.scalajs.js
 
 private[zio] trait ClockPlatformSpecific {
-  private[zio] val globalScheduler = new Scheduler {
+  private[zio] val globalScheduler = new Scheduler.Internal {
     import Scheduler.CancelToken
 
     private[this] val ConstFalse = () => false

--- a/core/js/src/main/scala/zio/ClockPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ClockPlatformSpecific.scala
@@ -21,7 +21,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import scala.scalajs.js
 
 private[zio] trait ClockPlatformSpecific {
-  private[zio] val globalScheduler = new Scheduler.Internal {
+  private[zio] val globalScheduler: Scheduler = new Scheduler.Internal {
     import Scheduler.CancelToken
 
     private[this] val ConstFalse = () => false

--- a/core/js/src/main/scala/zio/Scheduler.scala
+++ b/core/js/src/main/scala/zio/Scheduler.scala
@@ -21,12 +21,14 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
 
-abstract class Scheduler {
+sealed abstract class Scheduler {
   def schedule(task: Runnable, duration: Duration)(implicit unsafe: Unsafe): CancelToken
 }
 
 object Scheduler {
   type CancelToken = () => Boolean
+
+  private[zio] abstract class Internal extends Scheduler
 
   def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler =
     new Scheduler {

--- a/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
@@ -24,7 +24,7 @@ import java.util.concurrent._
 private[zio] trait ClockPlatformSpecific {
   import Scheduler.CancelToken
 
-  private[zio] val globalScheduler = new Scheduler {
+  private[zio] val globalScheduler = new Scheduler.Internal {
 
     private[this] val service = makeService()
 

--- a/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
@@ -24,7 +24,7 @@ import java.util.concurrent._
 private[zio] trait ClockPlatformSpecific {
   import Scheduler.CancelToken
 
-  private[zio] val globalScheduler = new Scheduler.Internal {
+  private[zio] val globalScheduler: Scheduler = new Scheduler.Internal {
 
     private[this] val service = makeService()
 

--- a/core/jvm-native/src/main/scala/zio/Scheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/Scheduler.scala
@@ -21,13 +21,15 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
 
-abstract class Scheduler {
+sealed abstract class Scheduler {
   def asScheduledExecutorService: ScheduledExecutorService
   def schedule(task: Runnable, duration: Duration)(implicit unsafe: Unsafe): CancelToken
 }
 
 object Scheduler {
   type CancelToken = () => Boolean
+
+  private[zio] abstract class Internal extends Scheduler
 
   def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler =
     new Scheduler {

--- a/core/shared/src/main/scala/zio/Cached.scala
+++ b/core/shared/src/main/scala/zio/Cached.scala
@@ -19,7 +19,7 @@ package zio
  * A [[Cached]] is a possibly resourceful value that is loaded into memory, and
  * which can be refreshed either manually or automatically.
  */
-trait Cached[+Error, +Resource] {
+sealed trait Cached[+Error, +Resource] {
 
   /**
    * Retrieves the current value stored in the cache.

--- a/core/shared/src/main/scala/zio/Dequeue.scala
+++ b/core/shared/src/main/scala/zio/Dequeue.scala
@@ -19,7 +19,7 @@ package zio
 /**
  * A queue that can only be dequeued.
  */
-trait Dequeue[+A] extends Serializable {
+sealed trait Dequeue[+A] extends Serializable {
 
   /**
    * Waits until the queue is shutdown. The `IO` returned by this method will
@@ -113,4 +113,7 @@ trait Dequeue[+A] extends Serializable {
    */
   def poll(implicit trace: Trace): UIO[Option[A]] =
     takeUpTo(1).map(_.headOption)
+}
+private[zio] object Dequeue {
+  private[zio] abstract class Internal[+A] extends Dequeue[A]
 }

--- a/core/shared/src/main/scala/zio/Enqueue.scala
+++ b/core/shared/src/main/scala/zio/Enqueue.scala
@@ -19,7 +19,7 @@ package zio
 /**
  * A queue that can only be enqueued.
  */
-trait Enqueue[-A] extends Serializable {
+sealed trait Enqueue[-A] extends Serializable {
 
   /**
    * Waits until the queue is shutdown. The `IO` returned by this method will
@@ -86,4 +86,7 @@ trait Enqueue[-A] extends Serializable {
    */
   def isFull(implicit trace: Trace): UIO[Boolean] =
     size.map(_ >= capacity)
+}
+private[zio] object Enqueue {
+  private[zio] trait Internal[-A] extends Enqueue[A]
 }

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -53,7 +53,7 @@ import zio.metrics.MetricLabel
  * Here `value` will be 2 as the value in the joined fiber is lower and we
  * specified `max` as our combining function.
  */
-trait FiberRef[A] extends Serializable { self =>
+sealed trait FiberRef[A] extends Serializable { self =>
 
   /**
    * The type of the value of the `FiberRef`.

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * A `Hub` is an asynchronous message hub. Publishers can offer messages to the
  * hub and subscribers can subscribe to take messages from the hub.
  */
-abstract class Hub[A] extends Enqueue[A] {
+sealed abstract class Hub[A] extends Enqueue.Internal[A] {
 
   /**
    * Publishes a message to the hub, returning whether the message was published
@@ -213,7 +213,7 @@ object Hub {
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
   ): Dequeue[A] =
-    new Dequeue[A] { self =>
+    new Dequeue.Internal[A] { self =>
       def awaitShutdown(implicit trace: Trace): UIO[Unit] =
         shutdownHook.await
       val capacity: Int =

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
  * A `Queue` is a lightweight, asynchronous queue into which values can be
  * enqueued and of which elements can be dequeued.
  */
-abstract class Queue[A] extends Dequeue[A] with Enqueue[A] {
+sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
    * Checks whether the queue is currently empty.
@@ -42,6 +42,7 @@ abstract class Queue[A] extends Dequeue[A] with Enqueue[A] {
 }
 
 object Queue extends QueuePlatformSpecific {
+  private[zio] abstract class Internal[A] extends Queue[A]
 
   /**
    * Makes a new bounded queue. When the capacity of the queue is reached, any

--- a/core/shared/src/main/scala/zio/Ref.scala
+++ b/core/shared/src/main/scala/zio/Ref.scala
@@ -203,7 +203,7 @@ object Ref extends Serializable {
    * semantically block other writers, while multiple readers can read
    * simultaneously.
    */
-  abstract class Synchronized[A] extends Ref[A] {
+  sealed abstract class Synchronized[A] extends Ref[A] {
 
     /**
      * Reads the value from the `Ref`.
@@ -295,6 +295,7 @@ object Ref extends Serializable {
   }
 
   object Synchronized {
+    private[zio] abstract class Internal[A] extends Synchronized[A]
 
     /**
      * Creates a new `Ref.Synchronized` with the specified value.

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -24,7 +24,8 @@ import scala.concurrent.Future
 /**
  * A `Runtime[R]` is capable of executing tasks within an environment `R`.
  */
-sealed trait Runtime[+R] { self =>
+@deprecatedInheritance("Use Runtime.apply", since = "2.1.18")
+trait Runtime[+R] { self =>
 
   /**
    * The environment of the runtime.
@@ -207,7 +208,6 @@ sealed trait Runtime[+R] { self =>
 }
 
 object Runtime extends RuntimePlatformSpecific {
-  private[zio] abstract class Internal[+R] extends Runtime[R]
 
   def addFatal(fatal: Class[_ <: Throwable])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentFatal.locallyScopedWith(_ | IsFatal(fatal)))

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -24,7 +24,7 @@ import scala.concurrent.Future
 /**
  * A `Runtime[R]` is capable of executing tasks within an environment `R`.
  */
-trait Runtime[+R] { self =>
+sealed trait Runtime[+R] { self =>
 
   /**
    * The environment of the runtime.
@@ -207,6 +207,7 @@ trait Runtime[+R] { self =>
 }
 
 object Runtime extends RuntimePlatformSpecific {
+  private[zio] abstract class Internal[+R] extends Runtime[R]
 
   def addFatal(fatal: Class[_ <: Throwable])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentFatal.locallyScopedWith(_ | IsFatal(fatal)))

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -27,7 +27,7 @@ import scala.collection.immutable.LongMap
  * to the scope, and `close`, which closes a scope and runs all finalizers that
  * have been added to the scope.
  */
-trait Scope extends Serializable { self =>
+sealed trait Scope extends Serializable { self =>
 
   /**
    * Adds a finalizer to this scope. The finalizer is guaranteed to be run when

--- a/core/shared/src/main/scala/zio/ScopedRef.scala
+++ b/core/shared/src/main/scala/zio/ScopedRef.scala
@@ -23,7 +23,7 @@ package zio
  * resources). The reference itself takes care of properly releasing resources
  * for the old value whenever a new value is obtained.
  */
-trait ScopedRef[A] {
+sealed trait ScopedRef[A] {
 
   /**
    * Sets the value of this reference to the specified resourcefully-created

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -5,7 +5,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicReference
 
-trait ThreadLocalBridge {
+sealed trait ThreadLocalBridge {
   def makeFiberRef[A](initialValue: A)(link: A => Unit): ZIO[Scope, Nothing, FiberRef[A]]
 }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6020,7 +6020,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       }
   }
 
-  trait ZIOConstructorLowPriority1 extends ZIOConstructorLowPriority2 {
+  sealed trait ZIOConstructorLowPriority1 extends ZIOConstructorLowPriority2 {
 
     /**
      * Constructs a `ZIO[Any, E, A]` from an `Either[E, A]`.
@@ -6059,7 +6059,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       }
   }
 
-  trait ZIOConstructorLowPriority2 extends ZIOConstructorLowPriority3 {
+  sealed trait ZIOConstructorLowPriority2 extends ZIOConstructorLowPriority3 {
 
     /**
      * Constructs a `ZIO[Any, Throwable, A]` from an `A`.

--- a/core/shared/src/main/scala/zio/ZInputStream.scala
+++ b/core/shared/src/main/scala/zio/ZInputStream.scala
@@ -20,7 +20,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 
-trait ZInputStream {
+sealed trait ZInputStream {
   def readN(n: Int)(implicit trace: Trace): IO[Option[IOException], Chunk[Byte]]
   def skip(n: Long)(implicit trace: Trace): IO[IOException, Long]
   def readAll(bufferSize: Int)(implicit trace: Trace): IO[Option[IOException], Chunk[Byte]]

--- a/core/shared/src/main/scala/zio/ZKeyedPool.scala
+++ b/core/shared/src/main/scala/zio/ZKeyedPool.scala
@@ -18,7 +18,7 @@ package zio
 
 import zio.internal.Platform
 
-trait ZKeyedPool[+Err, -Key, Item] {
+sealed trait ZKeyedPool[+Err, -Key, Item] {
 
   /**
    * Retrieves an item from the pool belonging to the given key in a scoped

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -574,7 +574,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
      *   correct type inference and dependency resolution during `ZLayer`
      *   derivation.
      */
-    sealed trait Default[+A] {
+    trait Default[+A] {
       type R
       type E
 
@@ -967,7 +967,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * a function of type `Input`. This allows the type of the `ZLayer` value
    * constructed to depend on `Input`.
    */
-  sealed trait FunctionConstructor[In] {
+  trait FunctionConstructor[In] {
 
     /**
      * The type of the `ZLayer` value.

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -574,7 +574,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
      *   correct type inference and dependency resolution during `ZLayer`
      *   derivation.
      */
-    trait Default[+A] {
+    sealed trait Default[+A] {
       type R
       type E
 
@@ -967,7 +967,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
    * a function of type `Input`. This allows the type of the `ZLayer` value
    * constructed to depend on `Input`.
    */
-  trait FunctionConstructor[In] {
+  sealed trait FunctionConstructor[In] {
 
     /**
      * The type of the `ZLayer` value.

--- a/core/shared/src/main/scala/zio/ZOutputStream.scala
+++ b/core/shared/src/main/scala/zio/ZOutputStream.scala
@@ -20,7 +20,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 
-trait ZOutputStream {
+sealed trait ZOutputStream {
   def write(chunk: Chunk[Byte])(implicit trace: Trace): IO[IOException, Unit]
 }
 

--- a/core/shared/src/main/scala/zio/package.scala
+++ b/core/shared/src/main/scala/zio/package.scala
@@ -46,7 +46,7 @@ package object zio
 
   type Trace = Tracer.instance.Type with Tracer.Traced
 
-  trait Tag[A] extends EnvironmentTag[A] {
+  sealed trait Tag[A] extends EnvironmentTag[A] {
     def tag: LightTypeTag
   }
 

--- a/core/shared/src/main/scala/zio/stm/TDequeue.scala
+++ b/core/shared/src/main/scala/zio/stm/TDequeue.scala
@@ -21,7 +21,7 @@ import zio._
 /**
  * A transactional queue that can only be dequeued.
  */
-trait TDequeue[+A] extends Serializable {
+sealed trait TDequeue[+A] extends Serializable {
 
   /**
    * The maximum capacity of the queue.
@@ -137,4 +137,7 @@ trait TDequeue[+A] extends Serializable {
    */
   final def takeN(n: Int): ZSTM[Any, Nothing, Chunk[A]] =
     takeBetween(n, n)
+}
+private[zio] object TDequeue {
+  private[zio] abstract class Internal[+A] extends TDequeue[A]
 }

--- a/core/shared/src/main/scala/zio/stm/TDequeue.scala
+++ b/core/shared/src/main/scala/zio/stm/TDequeue.scala
@@ -139,5 +139,5 @@ sealed trait TDequeue[+A] extends Serializable {
     takeBetween(n, n)
 }
 private[zio] object TDequeue {
-  private[zio] abstract class Internal[+A] extends TDequeue[A]
+  private[zio] trait Internal[+A] extends TDequeue[A]
 }

--- a/core/shared/src/main/scala/zio/stm/TEnqueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TEnqueue.scala
@@ -21,7 +21,7 @@ import zio._
 /**
  * A transactional queue that can only be enqueued.
  */
-trait TEnqueue[-A] extends Serializable {
+sealed trait TEnqueue[-A] extends Serializable {
 
   /**
    * The maximum capacity of the queue.
@@ -72,4 +72,7 @@ trait TEnqueue[-A] extends Serializable {
    */
   def isFull: USTM[Boolean] =
     size.map(_ == capacity)
+}
+private[zio] object TEnqueue {
+  private[zio] trait Internal[-A] extends TEnqueue[A]
 }

--- a/core/shared/src/main/scala/zio/stm/THub.scala
+++ b/core/shared/src/main/scala/zio/stm/THub.scala
@@ -23,7 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A `THub` is a transactional message hub. Publishers can publish messages to
  * the hub and subscribers can subscribe to take messages from the hub.
  */
-abstract class THub[A] extends TEnqueue[A] {
+sealed abstract class THub[A] extends TEnqueue.Internal[A] {
 
   /**
    * Publishes a message to the hub, returning whether the message was published
@@ -253,7 +253,7 @@ object THub {
     subscriberCount: TRef[Int],
     subscribers: TRef[Set[TRef[TRef[Node[A]]]]]
   ): TDequeue[A] =
-    new TDequeue[A] {
+    new TDequeue.Internal[A] {
       override def capacity: Int =
         requestedCapacity
       override def isShutdown: USTM[Boolean] =

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -25,7 +25,7 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  * A `TQueue` is a transactional queue. Offerors can offer values to the queue
  * and takers can take values from the queue.
  */
-trait TQueue[A] extends TDequeue[A] with TEnqueue[A] {
+sealed trait TQueue[A] extends TDequeue.Internal[A] with TEnqueue.Internal[A] {
 
   override final def awaitShutdown: USTM[Unit] =
     isShutdown.flatMap(b => if (b) ZSTM.unit else ZSTM.retry)

--- a/docs/reference/concurrency/hub.md
+++ b/docs/reference/concurrency/hub.md
@@ -131,6 +131,10 @@ As you can see, the operators on `Hub` are identical to the ones on `Queue` with
 
 In fact, a `Hub` can be viewed as a `Queue` that can only be written to.
 
+```scala mdoc:invisible
+trait Enqueue[-A]
+```
+
 ```scala mdoc:nest
 trait Hub[A] extends Enqueue[A]
 ```

--- a/docs/reference/stream/subscriptionref.md
+++ b/docs/reference/stream/subscriptionref.md
@@ -5,6 +5,12 @@ title: "SubscriptionRef"
 
 A `SubscriptionRef[A]` is a `Ref` that lets us subscribe to receive the current value along with all changes to that value.
 
+```scala mdoc:invisible
+object Ref {
+  abstract class Synchronized[A]
+}
+```
+
 ```scala mdoc
 import zio._
 import zio.stream._

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -2432,7 +2432,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * [[ZManaged]] to the `apply` method will create (inside an effect) a managed
    * resource which is already acquired and cannot fail.
    */
-  abstract class PreallocationScope {
+  sealed abstract class PreallocationScope {
     def apply[R, E, A](managed: => ZManaged[R, E, A]): ZIO[R, E, Managed[Nothing, A]]
   }
 
@@ -2507,7 +2507,7 @@ object ZManaged extends ZManagedPlatformSpecific {
    * managed resource to the `apply` method will return an effect that allocates
    * the resource and returns it with an early-release handle.
    */
-  abstract class Scope {
+  sealed abstract class Scope {
     def apply[R, E, A](managed: => ZManaged[R, E, A]): ZIO[R, E, (ZManaged.Finalizer, A)]
   }
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -829,7 +829,7 @@ object ZSinkSpec extends ZIOBaseSpec {
       suite("fromQueueWithShutdown")(
         test("should enqueue all elements and shutsdown queue") {
 
-          def createQueueSpy[A](q: Queue[A]) = new Queue[A] {
+          def createQueueSpy[A](q: Queue[A]) = new Queue.Internal[A] {
 
             @volatile
             private var isShutDown = false

--- a/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
+++ b/streams/shared/src/main/scala/zio/stream/SubscriptionRef.scala
@@ -23,7 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
  * A `SubscriptionRef[A]` is a `Ref` that can be subscribed to in order to
  * receive the current value as well as all changes to the value.
  */
-sealed trait SubscriptionRef[A] extends Ref.Synchronized[A] {
+sealed trait SubscriptionRef[A] extends Ref.Synchronized.Internal[A] {
 
   /**
    * A stream containing the current value of the `Ref` as well as all changes

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -6205,7 +6205,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   }
 
   private def mapDequeue[A, B](dequeue: Dequeue[A])(f: A => B): Dequeue[B] =
-    new Dequeue[B] {
+    new Dequeue.Internal[B] {
       def awaitShutdown(implicit trace: Trace): UIO[Unit] =
         dequeue.awaitShutdown
       def capacity: Int =

--- a/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -23,7 +23,7 @@ private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
 
   def scheduler(implicit trace: Trace): UIO[Scheduler] =
     ZIO.runtime[Any].map { runtime =>
-      new Scheduler {
+      new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
             runtime.unsafe.fork(sleep(duration) *> ZIO.succeed(runnable.run()))

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -29,7 +29,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
 
   def scheduler(implicit trace: Trace): UIO[Scheduler] =
     (ZIO.executor <*> ZIO.runtime[Any]).map { case (executor, runtime) =>
-      new Scheduler {
+      new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
             runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())))


### PR DESCRIPTION
It's important to prevent user extension where we can choose to make optimizations if our classes are the only implementations.