### PR TITLE
Fix double-counting of failures when joining Fibers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.internal.FiberScope
+import zio.metrics.Metric
 import zio.test._
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -61,6 +62,35 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
               )
             }
         }
+      }
+    ),
+    suite("runtime metrics")(
+      test("Failures are counted once for the fiber that caused them and exits are not") {
+        val nullErrors = ZIO.foreachParDiscard(1 to 2)(_ => ZIO.attempt(throw new NullPointerException))
+
+        val customErrors =
+          ZIO.foreachParDiscard(1 to 5)(_ => ZIO.fail("Custom application error"))
+
+        val exitErrors =
+          ZIO.foreachParDiscard(1 to 5)(_ => Exit.fail(new IllegalArgumentException("Foo")))
+
+        (nullErrors <&> exitErrors <&> customErrors)
+          .foldCauseZIO(
+            _ =>
+              Metric.runtime.fiberFailureCauses.value
+                .map(_.occurrences)
+                .map { oc =>
+                  assertTrue(
+                    oc.size == 2,
+                    oc.get("java.lang.String").contains(5),
+                    oc.get("java.lang.NullPointerException").contains(2)
+                  )
+                },
+            _ => ZIO.succeed(assertNever("Effect did not fail"))
+          )
+          .provide(Runtime.enableRuntimeMetrics) @@
+          // Need to tag them to extract metrics from this specific effect
+          ZIOAspect.tagged("FiberRuntimeSpec" -> "Failures")
       }
     )
   )

--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -1,7 +1,9 @@
 package zio
 
+import zio.Random.RandomLive
 import zio.internal.FiberScope
 import zio.metrics.Metric
+import zio.test.TestAspect.{nonFlaky, timeout}
 import zio.test._
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -74,11 +76,18 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
         val exitErrors =
           ZIO.foreachParDiscard(1 to 5)(_ => Exit.fail(new IllegalArgumentException("Foo")))
 
-        (nullErrors <&> exitErrors <&> customErrors)
+        (nullErrors <&> exitErrors <&> customErrors).uninterruptible
           .foldCauseZIO(
             _ =>
               Metric.runtime.fiberFailureCauses.value
                 .map(_.occurrences)
+                // NOTE: Fibers in foreachParDiscard register metrics at the very end of the fiber's life which might be after we check them
+                // so we might need to retry until they are registered
+                .repeatUntil { oc =>
+                  oc.size >= 2 &&
+                  oc.getOrElse("java.lang.String", 0L) >= 5L &&
+                  oc.getOrElse("java.lang.NullPointerException", 0L) >= 2L
+                }
                 .map { oc =>
                   assertTrue(
                     oc.size == 2,
@@ -90,8 +99,8 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
           )
           .provide(Runtime.enableRuntimeMetrics) @@
           // Need to tag them to extract metrics from this specific effect
-          ZIOAspect.tagged("FiberRuntimeSpec" -> "Failures")
-      }
+          ZIOAspect.tagged("FiberRuntimeSpec" -> RandomLive.unsafe.nextString(20))
+      } @@ nonFlaky(1000) @@ timeout(10.seconds)
     )
   )
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1312,9 +1312,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
           }
 
           if (runtimeMetricsEnabled) {
-            val tags = getFiberRef(FiberRef.currentTags)
-            Metric.runtime.fiberFailures.unsafe.update(1, tags)(Unsafe)
-            cause.foldContext(tags)(FiberRuntime.fiberFailureTracker)
+            val filteredCause = cause.filter(_.traces.exists(_.fiberId eq fiberId))
+            if (!filteredCause.isEmpty) {
+              val tags = getFiberRef(FiberRef.currentTags)
+              Metric.runtime.fiberFailures.unsafe.update(1, tags)(Unsafe)
+              filteredCause.foldContext(tags)(FiberRuntime.fiberFailureTracker)
+            }
           }
         } catch {
           case throwable: Throwable =>


### PR DESCRIPTION
/fixes #9742

Currently we could every fiber that results in a failure in runtime metrics as a failure. In cases were we join fibers (i.e., parallel ops) this results in double+ counting of failures as both fibers will show up as failures.

With this PR we filter the Cause and count failures only for the ones that originated from the current fiber (based on its id). However, this means that we won't be counting failures that are stackless (i.e., `Exit.fail`). After discussing this with @jdegoes, we agreed that this is OK as `Exit.fail` should not be tracked as it's stackless.