### PR TITLE
Fix provideSome(Shared) in Scala 3

### DIFF
--- a/core/shared/src/main/scala-3/zio/ZIOVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOVersionSpecific.scala
@@ -48,5 +48,5 @@ private[zio] transparent trait ZIOVersionSpecific[-R, +E, +A] { self: ZIO[R, E, 
 
 final class ProvideSomePartiallyApplied[R0, -R, +E, +A](val self: ZIO[R, E, A]) extends AnyVal {
   inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): ZIO[R0, E1, A] =
-    ${ LayerMacros.provideStaticImpl[R0, R, E1, A]('self, 'layer) }
+    ${ LayerMacros.provideSomeStaticImpl[R0, R, E1, A]('self, 'layer) }
 }

--- a/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZLayerCompanionVersionSpecific.scala
@@ -5,12 +5,12 @@ import scala.deriving._
 
 final class WirePartiallyApplied[R](val dummy: Boolean = true) extends AnyVal {
   inline def apply[E](inline layer: ZLayer[_, E, _]*): ZLayer[Any, E, R] =
-    ${ LayerMacros.constructStaticLayer[Any, R, E]('layer) }
+    ${ LayerMacros.constructStaticProvideLayer[Any, R, E]('layer) }
 }
 
 final class WireSomePartiallyApplied[R0, R](val dummy: Boolean = true) extends AnyVal {
   inline def apply[E](inline layer: ZLayer[_, E, _]*): ZLayer[R0, E, R] =
-    ${ LayerMacros.constructStaticLayer[R0, R, E]('layer) }
+    ${ LayerMacros.constructStaticProvideSomeLayer[R0, R, E]('layer) }
 }
 
 private[zio] transparent trait ZLayerCompanionVersionSpecific {

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -25,6 +25,15 @@ private[zio] object LayerMacroUtils {
     constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, R]]
   }
 
+  def constructStaticSomeLayer[R0: Type, R: Type, E: Type](using Quotes)(
+    layers: Seq[LayerExpr[E]],
+    provideMethod: ProvideMethod
+  ): Expr[ZLayer[R0, E, _]] = {
+    import quotes.reflect._
+
+    constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, _]]
+  }
+
   def constructDynamicLayer[R: Type, E: Type](using Quotes)(
     layers: Seq[LayerExpr[E]],
     provideMethod: ProvideMethod
@@ -131,7 +140,7 @@ private[zio] object LayerMacroUtils {
           reportError = report.errorAndAbort
         )
 
-        builder.build.asTerm.asExprOf[ZLayer[R0, E, R]]
+        builder.build.asTerm.asExprOf[ZLayer[_, _, _]]
       }
     }
   }

--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -80,6 +80,9 @@ final case class LayerBuilder[Type, Expr](
     providedLayers.map(exprToNode).partition(_.outputs.exists(typeEquals(_, sideEffectType)))
 
   /**
+   * 
+   * Returns tree representing final `ZLayer[In, Err, Out]`
+   * 
    * ==If [[remainder]] is [[RemainderMethod.Inferred]]==
    *   - `In` will be some generated type
    *   - `Err` will be the union of all errors in the provided layers

--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -80,9 +80,8 @@ final case class LayerBuilder[Type, Expr](
     providedLayers.map(exprToNode).partition(_.outputs.exists(typeEquals(_, sideEffectType)))
 
   /**
-   * 
    * Returns tree representing final `ZLayer[In, Err, Out]`
-   * 
+   *
    * ==If [[remainder]] is [[RemainderMethod.Inferred]]==
    *   - `In` will be some generated type
    *   - `Err` will be the union of all errors in the provided layers

--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -79,6 +79,23 @@ final case class LayerBuilder[Type, Expr](
   private val (sideEffectNodes, providedLayerNodes): (List[Node[Type, Expr]], List[Node[Type, Expr]]) =
     providedLayers.map(exprToNode).partition(_.outputs.exists(typeEquals(_, sideEffectType)))
 
+  /**
+   * ==If [[remainder]] is [[RemainderMethod.Inferred]]==
+   *   - `In` will be some generated type
+   *   - `Err` will be the union of all errors in the provided layers
+   *   - `Out` will be AND'ed together types from [[target0]]
+   *
+   * ==If [[remainder]] is [[RemainderMethod.Provided]] and provide method is not [[ProvideMethod.ProvideSomeShared]]==
+   *   - `In` will be AND'ed together types from [[remainder]]
+   *   - `Err` will be the union of all errors in the provided layers
+   *   - `Out` will be AND'ed together types from [[target0]]
+   *
+   * ==If [[remainder]] is [[RemainderMethod.Provided]] and provide method is [[ProvideMethod.ProvideSomeShared]]==
+   *   - `In` will be AND'ed together types from [[remainder]]
+   *   - `Err` will be the union of all errors in the provided layers
+   *   - `Out` will be generated type (AND'ed together types from [[target0]]
+   *     minus types from [[remainder]])
+   */
   def build: Expr = {
     assertNoAmbiguity()
 

--- a/internal-macros/src/main/scala/zio/internal/TerminalRendering.scala
+++ b/internal-macros/src/main/scala/zio/internal/TerminalRendering.scala
@@ -77,7 +77,7 @@ object TerminalRendering {
       if (isUsingProvideSome) {
         s"""
  Alternatively, you may add them to the remainder type ascription:
- 
+
    ${methodName("provideSome")}[${allMissingTypes.map(_.magenta.bold).mkString(" & ")}]
 """
 
@@ -92,7 +92,7 @@ object TerminalRendering {
        | ${message.bold}
        |
        |$errors
-       |$provideSomeSuggestion      
+       |$provideSomeSuggestion
        |${line.red}
        |
        |""".stripMargin

--- a/managed/shared/src/main/scala-3/zio/managed/ZManagedVersionSpecific.scala
+++ b/managed/shared/src/main/scala-3/zio/managed/ZManagedVersionSpecific.scala
@@ -41,7 +41,7 @@ object ZManagedMacros {
     schedule: Expr[ZManaged[R, E, A]],
     layer: Expr[Seq[ZLayer[_, E, _]]]
   )(using Quotes): Expr[ZManaged[R0, E, A]] = {
-    val layerExpr = LayerMacros.constructStaticLayer[R0, R, E](layer)
+    val layerExpr = LayerMacros.constructStaticProvideLayer[R0, R, E](layer)
     '{
       $schedule.provideLayer($layerExpr.asInstanceOf[ZLayer[R0, E, R]])
     }

--- a/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
+++ b/streams/shared/src/main/scala-3/zio.stream/ZStreamVersionSpecific.scala
@@ -21,7 +21,7 @@ private[stream] object ZStreamProvideMacro {
     zstream: Expr[ZStream[R, E, A]],
     layer: Expr[Seq[ZLayer[_, E, _]]]
   )(using Quotes): Expr[ZStream[R0, E, A]] = {
-    val layerExpr = LayerMacros.constructStaticLayer[R0, R, E](layer)
+    val layerExpr = LayerMacros.constructStaticProvideLayer[R0, R, E](layer)
     '{ $zstream.provideLayer($layerExpr.asInstanceOf[ZLayer[R0, E, R]]) }
   }
 }

--- a/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/SpecVersionSpecific.scala
@@ -74,10 +74,10 @@ private[test] trait SpecVersionSpecific[-R, +E] { self: Spec[R, E] =>
 
 final class ProvideSomePartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
   inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1] =
-    ${ SpecLayerMacros.provideImpl[R0, R, E1]('self, 'layer) }
+    ${ SpecLayerMacros.provideSomeImpl[R0, R, E1]('self, 'layer) } // TODO:
 }
 
 final class ProvideSomeSharedPartiallyApplied[R0, -R, +E](val self: Spec[R, E]) extends AnyVal {
   inline def apply[E1 >: E](inline layer: ZLayer[_, E1, _]*): Spec[R0, E1] =
-    ${ SpecLayerMacros.provideSharedImpl[R0, R, E1]('self, 'layer) }
+    ${ SpecLayerMacros.provideSomeSharedImpl[R0, R, E1]('self, 'layer) }
 }


### PR DESCRIPTION
provideSomeShared tests were disabled for Scala 3, because they were failing. This MR reenabled these tests and fixes multiple other Scala 3 macro calls.