### PR TITLE
Fix race condition when interrupting applications

### DIFF
--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -24,20 +24,18 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       } yield result).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_)))
 
     runtime.unsafe.run {
-      ZIO.uninterruptibleMask { restore =>
+      ZIO.uninterruptible {
         for {
           fiberId <- ZIO.fiberId
-          p       <- Promise.make[Nothing, Set[FiberId.Runtime]]
-          fiber <- restore(workflow).onExit { exit0 =>
-                     val exitCode  = if (exit0.isSuccess) ExitCode.success else ExitCode.failure
-                     val interrupt = interruptRootFibers(p)
+          fiber <- workflow.interruptible.exitWith { exit0 =>
+                     val exitCode = if (exit0.isSuccess) ExitCode.success else ExitCode.failure
                      // If we're shutting down due to an external signal, the shutdown hook will fulfill the promise
                      // Otherwise it means we're shutting down due to normal completion and we need to fulfill the promise
-                     ZIO.unless(shuttingDown.get())(p.succeed(Set(fiberId))) *> interrupt *> exit(exitCode)
+                     interruptRootFibers(fiberId).as(exitCode)
                    }.fork
           _ <-
             ZIO.succeed(Platform.addShutdownHook { () =>
-              if (!shuttingDown.getAndSet(true)) {
+              if (shuttingDown.compareAndSet(false, true)) {
 
                 if (FiberRuntime.catastrophicFailure.get) {
                   println(
@@ -49,27 +47,23 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
                   )
                 } else {
                   try {
-                    val completePromise = ZIO.fiberIdWith(fid2 => p.succeed(Set(fiberId, fid2)))
-                    runtime.unsafe.run(completePromise *> fiber.interrupt)
+                    fiber.tellInterrupt(Cause.interrupt(fiberId))
                   } catch {
                     case _: Throwable =>
                   }
                 }
-
-                ()
               }
             })
           result <- fiber.join
-        } yield result
+          _      <- exit(result)
+        } yield ()
       }
     }.getOrThrowFiberFailure()
   }
 
-  private def interruptRootFibers(p: Promise[Nothing, Set[FiberId.Runtime]])(implicit trace: Trace): UIO[Unit] =
+  private def interruptRootFibers(mainFiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
     for {
-      ignoredIds <- p.await
-      roots      <- Fiber.roots
-      _          <- Fiber.interruptAll(roots.view.filter(fiber => fiber.isAlive() && !ignoredIds(fiber.id)))
+      roots <- Fiber.roots
+      _     <- Fiber.interruptAll(roots.view.filter(fiber => fiber.isAlive() && (fiber.id != mainFiberId)))
     } yield ()
-
 }

--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -29,8 +29,6 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
           fiberId <- ZIO.fiberId
           fiber <- workflow.interruptible.exitWith { exit0 =>
                      val exitCode = if (exit0.isSuccess) ExitCode.success else ExitCode.failure
-                     // If we're shutting down due to an external signal, the shutdown hook will fulfill the promise
-                     // Otherwise it means we're shutting down due to normal completion and we need to fulfill the promise
                      interruptRootFibers(fiberId).as(exitCode)
                    }.fork
           _ <-
@@ -46,6 +44,8 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
                       "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
                   )
                 } else {
+                  // NOTE: try-catch likely not needed,
+                  // but guarding against cases where the submission of the task fails spuriously
                   try {
                     fiber.tellInterrupt(Cause.interrupt(fiberId))
                   } catch {


### PR DESCRIPTION
/fixes #9807

The main issue here is that in cases where the shutdown hooks were taking some time to process, the `fiber.join` would win the race and the thrown Exception (in this case the interruption exception) would be thrown in the main thread. The fix is to make sure that all errors in `workflow` are caught (by using `exitWith` instead of `onExit`, and gracefully close the application with `exit(exitCode)` after we join the forked fiber.

I also made some cleanups in the logic so that it's easier to follow, since the code previously relied on unsafely running effects unnecessarily and was harder to follow terms of what was executed in what sequence