### PR TITLE
fix assertTrue on new instance creation

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -177,7 +177,7 @@ object BuildHelper {
       case Some((2, 13)) =>
         List("2.13+", "2.12-2.13")
       case Some((3, _)) =>
-        List("2.13+")
+        List("2.13+", "3")
       case _ =>
         List()
     }

--- a/test-tests/shared/src/test/scala-3/zio/test/SmartAssertionScala3Spec.scala
+++ b/test-tests/shared/src/test/scala-3/zio/test/SmartAssertionScala3Spec.scala
@@ -1,0 +1,95 @@
+package zio.test
+
+object SmartAssertionScala3Spec extends ZIOBaseSpec {
+
+  override def spec =
+    suite("SmartAssertionScala3Spec")(
+      suite("new instance creation")(
+        test("anonymous class (trait) with overload and type args - new instance") {
+          trait ClassWithOverload[X] {
+            def overloaded: Int         = 1
+            def overloaded(x: Int): Int = 1
+          }
+          assertTrue(new ClassWithOverload[Int]() {}.overloaded == 1)
+        },
+        test("anonymous class with overload - new instance") {
+          class ClassWithOverload {
+            def overloaded: Int         = 1
+            def overloaded(x: Int): Int = 1
+          }
+          assertTrue(new ClassWithOverload() {}.overloaded == 1)
+        },
+        test("anonymous class (trait) with overload - new instance") {
+          trait ClassWithOverload {
+            def overloaded: Int         = 1
+            def overloaded(x: Int): Int = 1
+          }
+          assertTrue(new ClassWithOverload() {}.overloaded == 1)
+        },
+        test("trait with parameter and overloaded methods") {
+          trait TraitOverloadedWithParameter(x: Int) {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+
+          assertTrue(new TraitOverloadedWithParameter(1) {}.overloaded == 1)
+        },
+        test("trait with overloaded methods with type args") {
+          trait TraitOverloadedAndTypeArgs[A] {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+
+          assertTrue(new TraitOverloadedAndTypeArgs[Int] {}.overloaded == 1)
+        },
+        test("trait with parameter and overloaded methods with type args") {
+          trait TraitOverloadedWithParameterAndTypeArgs[A](x: A) {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+
+          assertTrue(new TraitOverloadedWithParameterAndTypeArgs[Int](1) {}.overloaded == 1)
+        },
+        test("inlined trait with overloaded methods and parameter and type arg") {
+          trait TraitOverloadedWithParameterAndTypeArgs[A](x: A) {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+          @scala.annotation.nowarn
+          inline def create = new TraitOverloadedWithParameterAndTypeArgs[Int](1) {}
+
+          assertTrue(create.overloaded == 1)
+        },
+        test("inlined trait with overloaded methods and parameter") {
+          trait TraitOverloadedWithParameter(x: Int) {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+          @scala.annotation.nowarn
+          inline def create =
+            new TraitOverloadedWithParameter(1) {}
+
+          assertTrue(create.overloaded == 1)
+        },
+        test("inlined class with overloaded methods and parameter") {
+          class ClassOverloadedWithParameter(x: Int) {
+            def overloaded: Int = 1
+
+            def overloaded(x: Int) = 1
+          }
+
+          @scala.annotation.nowarn
+          inline def create =
+            new ClassOverloadedWithParameter(1)
+
+          assertTrue(create.overloaded == 1)
+        }
+      )
+    )
+
+}

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -628,6 +628,34 @@ object SmartAssertionSpec extends ZIOBaseSpec {
         val exit: Exit[String, Int] = Exit.succeed(1)
         assertTrue(exit.isSuccess)
       },
+      test("class with overload - new instance") {
+        class ClassWithOverload {
+          def overloaded: Int         = 1
+          def overloaded(x: Int): Int = x
+        }
+        assertTrue(new ClassWithOverload().overloaded == 1)
+      },
+      test("class with overload with type args - new instance") {
+        class ClassWithOverload[A] {
+          def overloaded: Int         = 1
+          def overloaded(x: Int): Int = x
+        }
+        assertTrue(new ClassWithOverload[Int]().overloaded == 1)
+      },
+      test("class with overload with args - new instance") {
+        class ClassWithOverload(x: Int) {
+          def overloaded: Int         = x
+          def overloaded(x: Int): Int = x
+        }
+        assertTrue(new ClassWithOverload(1).overloaded == 1)
+      },
+      test("class with overload with args and type args - new instance") {
+        class ClassWithOverload[A](x: Int) {
+          def overloaded: Int         = x
+          def overloaded(x: Int): Int = x
+        }
+        assertTrue(new ClassWithOverload[Int](1).overloaded == 1)
+      },
       test("equalTo on java.lang.Boolean works") {
         val jBool = java.lang.Boolean.FALSE
         assertTrue(jBool == false)

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -357,7 +357,7 @@ object SmartAssertMacros {
                       .find(f => f.name == name)
                       .orElse(s.methodMember(name).filter(_.declarations.nonEmpty).headOption)
                       .getOrElse(
-                        throw new Error(s"Could not resolve $name on ${owner.show(using Printer.TreeStructure)}")
+                        report.errorAndAbort(s"Could not resolve $name on ${owner.show(using Printer.TreeStructure)}")
                       )
                     Select(param, member)
                   }

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -345,29 +345,42 @@ object SmartAssertMacros {
         }
 
       case Unseal(method @ MethodCall(lhs, name, tpeArgs, args)) =>
-        def body(param: Term) =
+        def body(param: Term): Term =
           (tpeArgs, args) match {
             case (Nil, None) =>
               try Select.unique(param, name)
               catch {
                 case _: AssertionError =>
-                  def getFieldOrMethod(s: Symbol) =
-                    s.fieldMembers
+                  def getFieldOrMethod(tpe: TypeRepr, owner: Tree): Select = {
+                    val s = tpe.typeSymbol
+                    val member = s.fieldMembers
                       .find(f => f.name == name)
                       .orElse(s.methodMember(name).filter(_.declarations.nonEmpty).headOption)
+                      .getOrElse(
+                        throw new Error(s"Could not resolve $name on ${owner.show(using Printer.TreeStructure)}")
+                      )
+                    Select(param, member)
+                  }
 
-                  // Tries to find directly the referenced method on lhs's type (or if lhs is method, on lhs's returned type)
-                  lhs.symbol.tree match {
-                    case DefDef(_, _, tpt, _) =>
-                      getFieldOrMethod(tpt.symbol) match {
-                        case Some(fieldOrMethod) => Select(param, fieldOrMethod)
-                        case None                => throw new Error(s"Could not resolve $name on $tpt")
-                      }
-                    case _ =>
-                      getFieldOrMethod(lhs.symbol) match {
-                        case Some(fieldOrMethod) => Select(param, fieldOrMethod)
-                        case None                => throw new Error(s"Could not resolve $name on $lhs")
-                      }
+                  lhs.underlyingArgument match {
+                    case Block(List(cls: ClassDef), term) =>
+                      // if this is new instance of anonymous class - take symbol from it instead of block
+                      getFieldOrMethod(term.tpe, term)
+
+                    case Typed(Block(List(cls: ClassDef), term), _) =>
+                      getFieldOrMethod(term.tpe, term)
+
+                    // Tries to find directly the referenced method on lhs's type (or if lhs is method, on lhs's returned type)
+                    case lhs =>
+                      if lhs.symbol == Symbol.noSymbol then
+                        report.errorAndAbort(s"Can't get symbol of ${lhs.show(using Printer.TreeStructure)}")
+                      else
+                        lhs.symbol.tree match {
+                          case DefDef(_, _, tpt, _) =>
+                            getFieldOrMethod(tpt.tpe, tpt)
+                          case _ =>
+                            getFieldOrMethod(lhs.tpe, lhs)
+                        }
                   }
               }
             case (tpeArgs, Some(args)) => Select.overloaded(param, name, tpeArgs, args)


### PR DESCRIPTION
This PR improves support for creation of new objects in `assertTrue` macro in case of overloaded methods

There were several problems:
1. For anonymous classes the tree is  `Block(List(cls: ClassDef), term)` and it has no symbol. So we catch it and take correct symbol.
2. For inlined anonymous classes the tree is `Typed(Block(List(cls: ClassDef), term), _)` and it has no symbol too. Solution is same, but also I used `underlyingArgument` to remove `Inlined` nodes. 


Also:
1. Added error message in case something other has no symbol, so it will be easier to understand what tree is not working.
2. Changed signature of `getFieldOrMethod` to remove some boilerplate. Now it accepts `TypeRepr` and takes its `typeSymbol`. Note that it affects one of cases where `lhs.symbol` was used and now it is `lhs.tpe.typeSymbol`. IMO using `lhs.symbol` is not correct and I'm sure about it - if you think I'm wrong, we can discuss it.
3. added scala-3 directory as sources for scala 3 to make some specific test cases, e.g. with `inline`.

#9683 


