### PR TITLE
Avoid usage of `given` within quoted code

### DIFF
--- a/core/shared/src/main/scala-3/zio/ZIOAppVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOAppVersionSpecific.scala
@@ -23,7 +23,7 @@ private[zio] object ZIOAppVersionSpecificMacros {
 }
 
 private[zio] class ZIOAppVersionSpecificMacros(val ctx: Quotes) {
-  given Quotes = ctx
+  inline given Quotes = ctx
   import ctx.reflect._
 
   def validate[Provided: Type, Required: Type, E: Type, A: Type](zio: Expr[ZIO[Required, E, A]]) = {

--- a/test-magnolia/src/main/scala-3/zio/test/magnolia/TypeUnionDerivation.scala
+++ b/test-magnolia/src/main/scala-3/zio/test/magnolia/TypeUnionDerivation.scala
@@ -48,7 +48,7 @@ object TypeUnionDerivation {
 
     val deriveGenByTypeNameList: Expr[List[DeriveGen[Any]]] = Expr.ofList(
       typeAndDeriveGens.map { case (t: TypeAndDeriveGen[a]) =>
-        given Type[a] = t.tpe
+        inline given Type[a] = t.tpe
         '{ ${ t.deriveGen }.asInstanceOf[DeriveGen[Any]] }
       }
     )

--- a/test/shared/src/main/scala-3/zio/test/SpecLayerMacros.scala
+++ b/test/shared/src/main/scala-3/zio/test/SpecLayerMacros.scala
@@ -47,7 +47,7 @@ object SpecLayerMacros {
     '{
       // Contract of constructStaticProvideSomeSharedLayer ensures this
       // I cannot obtain `?` from ZLayer, so I'm using `Any`
-      given <:<[R0 & Any, R] = null
+      implicit val ev: <:<[R0 & Any, R] = null
       $spec.provideSomeLayerShared[R0]($expr)
     }
   }

--- a/test/shared/src/main/scala-3/zio/test/ZIOSpecAbstractVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/ZIOSpecAbstractVersionSpecific.scala
@@ -23,7 +23,7 @@ private[test] object ZIOSpecAbstractSpecificMacros {
 }
 
 private[test] class ZIOSpecAbstractSpecificMacros(val ctx: Quotes) {
-  given Quotes = ctx
+  inline given Quotes = ctx
   import ctx.reflect._
 
   def validate[Provided: Type, Required: Type, E: Type](spec: Expr[Spec[Required, E]]) = {


### PR DESCRIPTION
Followup of https://github.com/zio/zio/pull/9826#discussion_r2069893592

`given` generates a fair bit of byte code, so it's better to avoid it by using `inline given` or `implicit val`. I think it only really matters within quotes (where we can't use `inline given`) but I thought to change it in a few other places as well just in case.