### PR TITLE
Optimize `race` and synchronous interruption

### DIFF
--- a/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/EmptyRaceBenchmark.scala
@@ -11,7 +11,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 10, time = 3, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
-@Threads(1)
+@Threads(4)
 class EmptyRaceBenchmark {
   @Param(Array("1000"))
   var size: Int = _
@@ -28,15 +28,11 @@ class EmptyRaceBenchmark {
   }
 
   @Benchmark
-  def zioEmptyRace(): Int = zioEmptyRace(BenchmarkUtil)
-
-  private[this] def zioEmptyRace(runtime: Runtime[Any]): Int = {
+  def zioEmptyRace(): Int = {
     def loop(i: Int): UIO[Int] =
       if (i < size) ZIO.never.raceFirst(ZIO.succeed(i + 1)).flatMap(loop)
       else ZIO.succeed(i)
 
-    Unsafe.unsafe { implicit unsafe =>
-      runtime.unsafe.run(loop(0)).getOrThrowFiberFailure()
-    }
+    BenchmarkUtil.unsafeRun(loop(0))
   }
 }

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -58,6 +58,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor {
     supervisor.start()
   }
 
+  override private[zio] def isCurrentThreadInExecutor: Boolean =
+    Thread.currentThread().isInstanceOf[ZScheduler.Worker]
+
   def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = {
     val metrics = new ExecutionMetrics {
       def capacity: Int =

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -89,6 +89,14 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
 
   private[zio] def stealWork(depth: Int): Boolean =
     false
+
+  /**
+   * Used to identify whether the current thread is part of this executor.
+   * @note
+   *   This method is only ovewritten in the ZScheduler
+   */
+  private[zio] def isCurrentThreadInExecutor: Boolean =
+    false
 }
 
 object Executor extends DefaultExecutors with Serializable {

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -166,7 +166,7 @@ sealed abstract class Fiber[+E, +A] { self =>
    *   `UIO[Exit, E, A]]`
    */
   final def interrupt(implicit trace: Trace): UIO[Exit[E, A]] =
-    ZIO.fiberIdWith(fiberId => self.interruptAs(fiberId))
+    ZIO.fiberIdWith(self.interruptAs)
 
   /**
    * Interrupts the fiber as if interrupted from the specified fiber. If the
@@ -176,7 +176,7 @@ sealed abstract class Fiber[+E, +A] { self =>
    * @return
    *   `UIO[Exit, E, A]]`
    */
-  final def interruptAs(fiberId: FiberId)(implicit trace: Trace): UIO[Exit[E, A]] =
+  def interruptAs(fiberId: FiberId)(implicit trace: Trace): UIO[Exit[E, A]] =
     self.interruptAsFork(fiberId) *> self.await
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1465,11 +1465,8 @@ sealed trait ZIO[-R, +E, +A]
             complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
           }(Unsafe)
 
+          leftFiber.startConcurrently(leftEff)
           rightFiber.startConcurrently(rightEff)
-          // Start effect on current thread until the first async boundary.
-          // In cases that the left effect does not contain any async effects, that will be
-          // substantially faster as sync resumption will kick in instantly
-          leftFiber.start(leftEff)
           ()
         },
         leftFiber.id <> rightFiber.id

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1391,8 +1391,10 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def raceFirst[R1 <: R, E1 >: E, A1 >: A](that: => ZIO[R1, E1, A1])(implicit
     trace: Trace
-  ): ZIO[R1, E1, A1] =
-    (self.exit race that.exit).unexit
+  ): ZIO[R1, E1, A1] = {
+    val f = (exit: Exit[E1, A1], loser: Fiber[E1, A1]) => loser.interrupt *> exit
+    self.raceWith(that)(f, f)
+  }
 
   @deprecated("use raceFirst", "2.0.7")
   final def raceFirstAwait[R1 <: R, E1 >: E, A1 >: A](that: => ZIO[R1, E1, A1])(implicit
@@ -1423,19 +1425,14 @@ sealed trait ZIO[-R, +E, +A]
    * with the fibers. It can be considered a low-level building block for
    * higher-level operators like `race`.
    */
-  private final def raceFibersWith[R1 <: R, ER, E2, B, C](right: ZIO[R1, ER, B])(
+  private final def raceFibersWith[R1 <: R, ER, E2, B, C](right: => ZIO[R1, ER, B])(
     leftWins: (Fiber.Runtime[E, A], Fiber.Runtime[ER, B]) => ZIO[R1, E2, C],
     rightWins: (Fiber.Runtime[ER, B], Fiber.Runtime[E, A]) => ZIO[R1, E2, C],
     leftScope: FiberScope = null,
     rightScope: FiberScope = null
   )(implicit trace: Trace): ZIO[R1, E2, C] =
     ZIO.withFiberRuntime[R1, E2, C] { (parentFiber, parentStatus) =>
-      val graft = ZIO.Grafter(parentFiber)
       import java.util.concurrent.atomic.AtomicBoolean
-
-      implicit val unsafe: Unsafe = Unsafe
-
-      val parentRuntimeFlags = parentStatus.runtimeFlags
 
       @inline def complete[E0, E1, A, B](
         winner: Fiber.Runtime[E0, A],
@@ -1443,35 +1440,40 @@ sealed trait ZIO[-R, +E, +A]
         cont: (Fiber.Runtime[E0, A], Fiber.Runtime[E1, B]) => ZIO[R1, E2, C],
         ab: AtomicBoolean,
         cb: ZIO[R1, E2, C] => Any
-      ): Any =
-        if (ab.compareAndSet(true, false)) {
+      ): Unit =
+        if (ab.compareAndSet(false, true)) {
           cb(cont(winner, loser))
         }
 
-      val raceIndicator = new AtomicBoolean(true)
+      val graft    = ZIO.Grafter(parentFiber)
+      val leftEff  = graft.applyOnExit(self)
+      val rightEff = graft.applyOnExit(right)
 
-      val leftFiber  = ZIO.unsafe.makeChildFiber(trace, self, parentFiber, parentRuntimeFlags, leftScope)
-      val rightFiber = ZIO.unsafe.makeChildFiber(trace, right, parentFiber, parentRuntimeFlags, rightScope)
+      val flags      = parentStatus.runtimeFlags
+      val leftFiber  = ZIO.unsafe.makeChildFiber(trace, leftEff, parentFiber, flags, leftScope)(Unsafe)
+      val rightFiber = ZIO.unsafe.makeChildFiber(trace, rightEff, parentFiber, flags, rightScope)(Unsafe)
 
-      val startLeftFiber  = leftFiber.startSuspended()
-      val startRightFiber = rightFiber.startSuspended()
+      ZIO.async[R1, E2, C](
+        { cb =>
+          val raceIndicator = new AtomicBoolean()
 
-      ZIO
-        .async[R1, E2, C](
-          { cb =>
-            leftFiber.addObserver { _ =>
-              complete(leftFiber, rightFiber, leftWins, raceIndicator, cb)
-            }
+          leftFiber.addObserver { _ =>
+            complete(leftFiber, rightFiber, leftWins, raceIndicator, cb)
+          }(Unsafe)
 
-            rightFiber.addObserver { _ =>
-              complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
-            }
+          rightFiber.addObserver { _ =>
+            complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
+          }(Unsafe)
 
-            startLeftFiber(graft.applyOnExit(self))
-            startRightFiber(graft.applyOnExit(right))
-          },
-          leftFiber.id <> rightFiber.id
-        )
+          rightFiber.startConcurrently(rightEff)
+          // Start effect on current thread until the first async boundary.
+          // In cases that the left effect does not contain any async effects, that will be
+          // substantially faster as sync resumption will kick in instantly
+          leftFiber.start(leftEff)
+          ()
+        },
+        leftFiber.id <> rightFiber.id
+      )
     }
 
   /**
@@ -1488,14 +1490,14 @@ sealed trait ZIO[-R, +E, +A]
         winner.await.flatMap {
           case exit: Exit.Success[?] =>
             winner.inheritAll *> leftDone(exit, loser)
-          case exit: Exit.Failure[_] =>
+          case exit =>
             leftDone(exit, loser)
         },
       (winner, loser) =>
         winner.await.flatMap {
           case exit: Exit.Success[B] =>
             winner.inheritAll *> rightDone(exit, loser)
-          case exit: Exit.Failure[E1] =>
+          case exit =>
             rightDone(exit, loser)
         }
     )

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -121,6 +121,26 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       }
     }
 
+  override def interruptAs(fiberId: FiberId)(implicit trace: Trace): UIO[Exit[E, A]] =
+    ZIO.suspendSucceed {
+      val exit = _exitValue
+      if (exit ne null) Exit.succeed(exit)
+      else {
+        val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
+        inbox.add(FiberMessage.InterruptSignal(cause))
+
+        // If the fiber is not running (which means it's suspended), and the current thread is in the same executor as the fiber,
+        // then execute the runloop on the current thread, avoiding context switching and suspension
+        if (running.compareAndSet(false, true)) {
+          val executor = getCurrentExecutor()
+          if (executor.isCurrentThreadInExecutor) run()
+          else drainQueueLaterOnExecutor(false)
+        }
+
+        await
+      }
+    }
+
   def interruptAsFork(fiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
     ZIO.succeed {
       val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
@@ -553,9 +573,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private[zio] def getCurrentExecutor(): Executor =
-    getFiberRef(FiberRef.overrideExecutor) match {
-      case None        => Runtime.defaultExecutor
+    getFiberRefOrNull(FiberRef.overrideExecutor) match {
       case Some(value) => value
+      case _           => Runtime.defaultExecutor
     }
 
   private[zio] def getFiberRef[A](fiberRef: FiberRef[A]): A =
@@ -1491,7 +1511,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         self.getFiberRefs()
 
       def removeObserver(observer: Exit[E, A] => Unit)(implicit unsafe: Unsafe): Unit =
-        self.tell(FiberMessage.Stateful(_.asInstanceOf[FiberRuntime[E, A]].removeObserver(observer)))
+        if (self._exitValue ne null)
+          self.tell(FiberMessage.Stateful(_.asInstanceOf[FiberRuntime[E, A]].removeObserver(observer)))
 
       def poll(implicit unsafe: Unsafe): Option[Exit[E, A]] =
         Option(self.exitValue())

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -67,19 +67,22 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   @volatile private var _exitValue = null.asInstanceOf[Exit[E, A]]
 
   def await(implicit trace: Trace): UIO[Exit[E, A]] =
-    ZIO.suspendSucceed {
-      val exitValue = self._exitValue
-      if (exitValue ne null) Exit.succeed(exitValue)
-      else
-        ZIO.asyncInterrupt[Any, Nothing, Exit[E, A]](
-          { k =>
-            val cb = (exit: Exit[_, _]) => k(Exit.Success(exit.asInstanceOf[Exit[E, A]]))
-            unsafe.addObserver(cb)(Unsafe)
-            Left(ZIO.succeed(unsafe.removeObserver(cb)(Unsafe)))
-          },
-          id
-        )
-    }
+    ZIO.suspendSucceed(awaitUnsafe)
+
+  @inline
+  private[this] def awaitUnsafe(implicit trace: Trace): UIO[Exit[E, A]] = {
+    val exitValue = self._exitValue
+    if (exitValue ne null) Exit.succeed(exitValue)
+    else
+      ZIO.asyncInterrupt[Any, Nothing, Exit[E, A]](
+        { k =>
+          val cb = (exit: Exit[_, _]) => k(Exit.Success(exit.asInstanceOf[Exit[E, A]]))
+          unsafe.addObserver(cb)(Unsafe)
+          Left(ZIO.succeed(unsafe.removeObserver(cb)(Unsafe)))
+        },
+        id
+      )
+  }
 
   private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
     // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
@@ -133,11 +136,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         // then execute the runloop on the current thread, avoiding context switching and suspension
         if (running.compareAndSet(false, true)) {
           val executor = getCurrentExecutor()
-          if (executor.isCurrentThreadInExecutor) run()
+          if (executor.isCurrentThreadInExecutor) drainQueueOnCurrentThread(0)
           else drainQueueLaterOnExecutor(false)
         }
 
-        await
+        awaitUnsafe(trace)
       }
     }
 


### PR DESCRIPTION
/fixes #7628
/claim #7628

## Context
This is a rather unorthodox (for lack of better word) approach to improve the performance of ZIO's `race` / `raceFirst`. This PR does that via 2 types of optimizations:
1. CPU-bound (i.e., reduce number of flatmaps and CPU cycles involved)
2. Reduce context-switching & thread parking/unparking

I'm not going to talk much about (1) because those changes are fairly straightforward and don't require much explanation when looking at the PR, so I'm going to focus on (2).

What occurred to me is that `race` is almost never used on 2 effects that are synchronously executed (because why would you want to do that right?). In almost all cases what is being raced with 2 asynchronous effects, and for simplicity I'll use the following example:

```scala
ZIO.sleep(1.second) race ZIO.sleep(2.seconds)
```

Using this example, the following happens under the current implementation:
1. The current fiber (Main Fiber) creates 2 fibers (Child1, Child2) and starts them concurrently.
2. Main Fiber is suspended and awaits for its callback to be invoked
3. Both Child fibers reach an async boundary (i.e., `sleep`), are suspended and await for some external threadpool to invoke their callback.
4. (1 second later) Child A starts again, completes and then invokes the Main Fiber's callback.
5. Main Fiber becomes active, and:
  i. inherits Child A
  ii. sends an `interrupt` signal to Child B (which is suspended)
  iii. suspends until Child B notifies the Main Fiber that it's been interrupted

The main "problem" lies somewhere around 5(ii) and 5(iii). During this time, the current Thread (ZScheduler Worker) will:
1. put a new runnable in its own queue
2. unpark another worker (since it's a work-stealing executor)
3. depending who wins the race, either the current worker or the newly awaken worker pick up the runnable from the queue to simply interrupt that fiber
4. invoke the main fiber's callback which will do the same unparking / parking thing.

This is kind of a simplified explanation of the sequence of events, but it's quite clear that the bottleneck is introduced due to the context switching / parking-unparking that it's happening during the interruption of the loser fiber.

This PR changes this sequence in a bit of an unorthodox way. When we invoke `interrupt` on a Fiber, in cases that the Fiber is not currently running, instead of going through the Executor we re-start the fiber in the current thread without suspending the fiber that calls `interrupt` and without scheduling the interruption. In fact, the main thing that we're optimizing here is _not_ `race`, but `interrupt`.

## Benchmark results

Enough explanations, results when running `EmptyRaceBenchmark` using 4 threads:

```
[info] Benchmark                         (size)   Mode  Cnt     Score     Error  Units
[info] EmptyRaceBenchmark.catsEmptyRace    1000  thrpt   10  2394.288 ± 252.022  ops/s
# Old approach
[info] EmptyRaceBenchmark.zioEmptyRace     1000  thrpt   10  1526.311 ±  41.670  ops/s
# New approach
[info] EmptyRaceBenchmark.zioEmptyRace     1000  thrpt   10  2476.248 ± 121.550  ops/s
```

This approach is ~60% faster than the old one, and en-par with CE's `race`.

## Final Remarks
There is a good chance I might have missed something crucial, and this approach might not work in practise. I'm even happy to feature-flag the new `interrupt` via runtime flags for the time being. I'd like to summon whoever has enough knowledge of ZIO's scheduling system and review this approach and let me know what they think.