### PR TITLE
Add Schedule.deadline method as an alias for Schedule.upTo (#4351)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -137,6 +137,22 @@ object ScheduleSpec extends ZIOBaseSpec {
         val expected  = Chunk(0L, 1L, 2L, 3L, 4L, 5L)
         assertZIO(scheduled)(equalTo(expected))
       },
+      test("respect Schedule.deadline even if more input is provided than needed") {
+        val schedule  = Schedule.spaced(1.second).deadline(5.seconds)
+        val scheduled = Clock.currentDateTime.flatMap(schedule.run(_, 1 to 10))
+        val expected  = Chunk(0L, 1L, 2L, 3L, 4L, 5L)
+        assertZIO(scheduled)(equalTo(expected))
+      },
+      test("Schedule.deadline is an alias for Schedule.upTo") {
+        val schedule1 = Schedule.deadline(5.seconds)
+        val schedule2 = Schedule.upTo(5.seconds)
+        val scheduled1 = Clock.currentDateTime.flatMap(schedule1.run(_, 1 to 10))
+        val scheduled2 = Clock.currentDateTime.flatMap(schedule2.run(_, 1 to 10))
+        for {
+          result1 <- scheduled1
+          result2 <- scheduled2
+        } yield assert(result1)(equalTo(result2))
+      },
       test("free from stack overflow") {
         assertZIO(ZStream.fromSchedule(Schedule.forever *> Schedule.recurs(100000)).runCount)(
           equalTo(100000L)

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -422,6 +422,15 @@ trait Schedule[-Env, -In, +Out] extends Serializable { self =>
     trace: Trace
   ): Schedule.WithState[(self.State, Option[OffsetDateTime]), Env, In, Out] =
     self <* Schedule.upTo(duration)
+    
+  /**
+   * A schedule that recurs until the specified duration has elapsed.
+   * Alias for `upTo` with a more intuitive name.
+   */
+  final def deadline(duration: Duration)(implicit
+    trace: Trace
+  ): Schedule.WithState[(self.State, Option[OffsetDateTime]), Env, In, Out] =
+    upTo(duration)
 
   /**
    * Returns a new schedule with the specified effectfully computed delay added
@@ -1319,6 +1328,15 @@ object Schedule {
     trace: Trace
   ): Schedule.WithState[Option[OffsetDateTime], Any, Any, Duration] =
     elapsed.whileOutput(_ < duration)
+
+  /**
+   * A schedule that recurs until the specified duration has elapsed.
+   * Alias for `upTo` with a more intuitive name.
+   */
+  def deadline(duration: Duration)(implicit
+    trace: Trace
+  ): Schedule.WithState[Option[OffsetDateTime], Any, Any, Duration] =
+    upTo(duration)
 
   /**
    * A schedule that always recurs, producing a count of repeats: 0, 1, 2.


### PR DESCRIPTION
This PR adds a `deadline` method to ZIO's Schedule to improve API discoverability. The method is an alias for the existing `upTo` method, providing a more intuitive name for the functionality where a schedule runs until a specified duration has elapsed.

Fixes #4351