### PR TITLE
Remove printing / logging to console during tests and reduce testsuite execution time

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
@@ -34,7 +34,7 @@ object OneShotSpec extends ZIOBaseSpec {
         test("get must fail if no value is set") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.get(10000L))(throwsA[Error])
+          assert(oneShot.get(10L))(throwsA[Error])
         },
         test("cannot set value twice") {
           val oneShot = OneShot.make[Int]

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -337,12 +337,10 @@ object CauseSpec extends ZIOBaseSpec {
         val bldr = Seq.newBuilder[(Seq[String], Boolean)]
         val c = c123.filter { c =>
           val res = !c.isInstanceOf[Cause.Both[?]]
-          println(s"applying filter on: ${c.failures} -> $res")
           bldr += (c.failures -> res)
           res
         }
 
-        println(s"\nfiltered cause: $c")
         zio.test.assert(c)(Assertion.equalTo(c1)) &&
         zio.test.assert(bldr.result()) {
           equalTo {

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -969,7 +969,6 @@ object ConfigProviderSpec extends ZIOBaseSpec {
 
         for {
           result <- configProvider.load(config)
-          _       = println(result)
         } yield assertTrue(result == List(Nil, List(1), List(1, 2)))
       }
   }

--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -49,7 +49,7 @@ object LoggingSpec extends ZIOBaseSpec {
         for {
           _      <- ZIO.logSpan("test span")(ZIO.log("It's alive!"))
           output <- ZTestLogger.logOutput
-          _      <- ZIO.debug(output(0).call(ZLogger.default))
+          _       = output(0).call(ZLogger.default)
         } yield assertTrue(true)
       },
       test("an empty log size is, at least, 142 characters") {
@@ -79,5 +79,5 @@ object LoggingSpec extends ZIOBaseSpec {
             assertTrue(output(0).context.get(ref).contains(value))
         )
       }
-    )
+    ) @@ TestAspect.silentLogging
 }

--- a/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/TagCorrectnessSpec.scala
@@ -151,13 +151,11 @@ object HigherKindedTagCorrectness extends ZIOBaseSpec {
         (for {
           _     <- Cache.put[Option, Int, String](1, "one")
           value <- Cache.get[Option, Int, String](1)
-          _     <- ZIO.debug(value)
           a      = Tag[Cache[Option, Int, String]]
           b      = Tag[Cache[({ type Out[In] = Option[In] })#Out, Int, String]]
           c      = Tag[Cache[({ type Bar = Double; type Out[In] = Option[Bar] })#Out, Int, String]]
           d      = Tag[Cache[({ type Out[In] = Option[Double] })#Out, Int, String]]
           e      = Tag[Cache[({ type Id[A] = A; type Out[In] = Option[Id[In]] })#Out, Int, String]]
-          _     <- ZIO.debug(s"WHAT" + b)
         } yield assertTrue(
           a.tag <:< b.tag,
           b.tag <:< a.tag,

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1466,11 +1466,9 @@ object ZStreamSpec extends ZIOBaseSpec {
                          _ <- ZStream.acquireReleaseWith(push("open1"))(_ => push("close1"))
                          _ <- ZStream
                                 .fromChunks(Chunk(()), Chunk(()))
-                                .tap(_ => ZIO.debug("use2") *> push("use2"))
+                                .tap(_ => push("use2"))
                                 .ensuring(push("close2"))
-                         _ <- ZStream.acquireReleaseWith(ZIO.debug("open3") *> push("open3"))(_ =>
-                                ZIO.debug("close3") *> push("close3")
-                              )
+                         _ <- ZStream.acquireReleaseWith(push("open3"))(_ => push("close3"))
                          _ <- ZStream
                                 .fromChunks(Chunk(()), Chunk(()))
                                 .tap(_ => push("use4"))
@@ -1507,10 +1505,8 @@ object ZStreamSpec extends ZIOBaseSpec {
               stream = for {
                          _ <- ZStream
                                 .fromChunks(Chunk(1), Chunk(2))
-                                .tap(n => ZIO.debug(s">>> use2 $n") *> push("use2"))
-                         _ <- ZStream.acquireReleaseWith(ZIO.debug("open3") *> push("open3"))(_ =>
-                                ZIO.debug("close3") *> push("close3")
-                              )
+                                .tap(_ => push("use2"))
+                         _ <- ZStream.acquireReleaseWith(push("open3"))(_ => push("close3"))
                        } yield ()
               _      <- stream.runDrain
               result <- effects.get
@@ -4636,7 +4632,7 @@ object ZStreamSpec extends ZIOBaseSpec {
             val pipeline = ZPipeline.fromFunction[Scope, Throwable, Byte, Unit] { s =>
               ZStream.fromZIO {
                 for {
-                  is <- s.toInputStream.debug("toInputStream")
+                  is <- s.toInputStream
                   _  <- ZIO.attemptBlocking(is.read())
                 } yield ()
               }

--- a/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestEventSpec.scala
+++ b/test-sbt/jvm/src/test/scala/zio/test/sbt/ZTestEventSpec.scala
@@ -75,28 +75,24 @@ object ZTestEventSpec extends ZIOSpecDefault {
   // Required because
   //  - `Selector` equality isn't working
   //  - Ansi colors make comparisons horrible to work with
-  def assertEqualEvents(result: Event, expected: Event): TestResult = {
-    println(stripAnsi(result.throwable()))
-    println("\n==================\n")
-    println(stripAnsi(result.throwable()))
+  def assertEqualEvents(result: Event, expected: Event): TestResult =
     assertTrue(
       result.fullyQualifiedName() == expected.fullyQualifiedName()
     ) &&
-    assertTrue(
-      result.selector().toString == expected.selector().toString
-    ) &&
-    assertTrue(
-      result.status() == expected.status()
-    ) &&
-    assertTrue(
-      stripAnsi(result.throwable())
-        == stripAnsi(expected.throwable())
-    ) &&
-    assertTrue(
-      result.duration() == expected.duration()
-    ) &&
-    assertCompletes
-  }
+      assertTrue(
+        result.selector().toString == expected.selector().toString
+      ) &&
+      assertTrue(
+        result.status() == expected.status()
+      ) &&
+      assertTrue(
+        stripAnsi(result.throwable())
+          == stripAnsi(expected.throwable())
+      ) &&
+      assertTrue(
+        result.duration() == expected.duration()
+      ) &&
+      assertCompletes
 
   private def stripAnsi(input: Any) =
     input.toString

--- a/test-tests/jvm-native/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm-native/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -123,7 +123,6 @@ object TestClockSpecJVM extends ZIOBaseSpec {
             _      <- ZIO.succeed(future.cancel(false))
             _      <- TestClock.adjust(11.seconds)
             values <- ref.get
-            _      <- ZIO.logInfo(s"Values after interruption: $values")
           } yield assert(values.reverse)(equalTo(List(5L)))
         }
       ),
@@ -132,5 +131,5 @@ object TestClockSpecJVM extends ZIOBaseSpec {
           (TestClock.adjust(1.second) &> TestClock.adjust(1.second)).as(assertCompletes)
         } @@ timeout(10.seconds)
       )
-    ) @@ nonFlaky(20)
+    ) @@ nonFlaky(10)
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestOutputSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestOutputSpec.scala
@@ -75,7 +75,7 @@ object TestOutputSpec extends ZIOBaseSpec {
       for {
         _            <- ZIO.foreach(events)(event => TestOutput.print(event))
         outputEvents <- ZIO.serviceWithZIO[ExecutionEventHolder](_.getEvents)
-        _            <- ZIO.service[ExecutionEventPrinter].debug("Printer in test")
+        _            <- ZIO.service[ExecutionEventPrinter]
       } yield assertTrue(
         outputEvents ==
           List(

--- a/test-tests/shared/src/test/scala/zio/test/TestProvideSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestProvideSpec.scala
@@ -163,7 +163,7 @@ object TestProvideSpec extends ZIOBaseSpec {
 
           val intService: ULayer[IntService] = ZLayer(Ref.make(0).map(IntService(_)))
           val stringService: ULayer[StringService] =
-            ZLayer(Ref.make("Hello").map(StringService(_)).debug("MAKING"))
+            ZLayer(Ref.make("Hello").map(StringService(_)))
 
           def customTest(int: Int) =
             test(s"test $int") {
@@ -201,7 +201,7 @@ object TestProvideSpec extends ZIOBaseSpec {
           } yield IntService(ref))
 
           val stringService: ULayer[StringService] =
-            ZLayer(Ref.make("Hello").map(StringService(_)).debug("MAKING"))
+            ZLayer(Ref.make("Hello").map(StringService(_)))
 
           def customTest(int: Int) =
             test(s"test $int") {


### PR DESCRIPTION
This PR is to make things a bit more DX friendly by:
1. removing a lot of unnecessary logging / printing to console that happens during test execution
2. reduces execution time for some tests that are taking too long (> 5-10 seconds in some cases)