### PR TITLE
remove: custom `IsFatal` for jvm Runtime

### DIFF
--- a/core/jvm/src/main/scala/zio/RuntimePlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/RuntimePlatformSpecific.scala
@@ -28,8 +28,7 @@ private[zio] trait RuntimePlatformSpecific {
   final val defaultBlockingExecutor: Executor =
     Blocking.blockingExecutor
 
-  final val defaultFatal: IsFatal =
-    IsFatal(classOf[VirtualMachineError])
+  final val defaultFatal: IsFatal = IsFatal.empty
 
   final val defaultLoggers: Set[ZLogger[String, Any]] =
     Set(ZLogger.default.map(println(_)).filterLogLevel(_ >= LogLevel.Info))

--- a/core/shared/src/main/scala/zio/internal/IsFatal.scala
+++ b/core/shared/src/main/scala/zio/internal/IsFatal.scala
@@ -103,7 +103,7 @@ object IsFatal {
       }
 
   private[zio] def toSet(isFatal: IsFatal): Set[IsFatal] =
-    if (isFatal == IsFatal.empty) Set.empty
+    if (isFatal eq IsFatal.empty) Set.empty
     else
       isFatal match {
         case Both(left, right) => toSet(left) ++ toSet(right)


### PR DESCRIPTION
- PR: #9867 made all `VirtualMachineError` exceptions Fatal on all platforms