### PR TITLE
Fix awaiting application finalizers to run on external interruption

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
@@ -34,7 +34,7 @@ object OneShotSpec extends ZIOBaseSpec {
         test("get must fail if no value is set") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.get(10L))(throwsA[Error])
+          assert(oneShot.get(10L))(throwsA[OneShot.TimeoutException])
         },
         test("cannot set value twice") {
           val oneShot = OneShot.make[Int]

--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -48,7 +48,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
               case _: OneShot.TimeoutException =>
                 println(
                   "**** WARNING ****\n" +
-                    s"Timed out waiting for ZIO application to shut down after $gracefulShutdownTimeout. " +
+                    s"Timed out waiting for ZIO application to shut down after ${gracefulShutdownTimeout.render}. " +
                     "You can adjust your application's shutdown timeout by overriding the `shutdownTimeout` method"
                 )
               case _: Throwable =>

--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -39,7 +39,11 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
           } else {
             try {
               fiber.tellInterrupt(Cause.interrupt(fiberId))
-              shutdownLatch.get(gracefulShutdownTimeout.toMillis)
+              gracefulShutdownTimeout match {
+                case Duration.Infinity       => shutdownLatch.get()
+                case d if d <= Duration.Zero => ()
+                case d                       => shutdownLatch.get(d.toMillis)
+              }
             } catch {
               case _: OneShot.TimeoutException =>
                 println(

--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -10,7 +10,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
    */
   final def main(args0: Array[String]): Unit = {
     implicit val trace: Trace   = Trace.empty
-    implicit val unsafe: Unsafe = Unsafe.unsafe
+    implicit val unsafe: Unsafe = Unsafe
 
     val newLayer =
       ZLayer.succeed(ZIOAppArgs(Chunk.fromIterable(args0))) >>>
@@ -23,42 +23,58 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
         result  <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
       } yield result).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_)))
 
-    runtime.unsafe.run {
-      ZIO.uninterruptible {
-        for {
-          fiberId <- ZIO.fiberId
-          fiber <- workflow.interruptible.exitWith { exit0 =>
-                     val exitCode = if (exit0.isSuccess) ExitCode.success else ExitCode.failure
-                     interruptRootFibers(fiberId).as(exitCode)
-                   }.fork
-          _ <-
-            ZIO.succeed(Platform.addShutdownHook { () =>
-              if (shuttingDown.compareAndSet(false, true)) {
+    val shutdownLatch = internal.OneShot.make[Unit]
 
-                if (FiberRuntime.catastrophicFailure.get) {
-                  println(
-                    "**** WARNING ****\n" +
-                      "Catastrophic error encountered. " +
-                      "Application not safely interrupted. " +
-                      "Resources may be leaked. " +
-                      "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
-                  )
-                } else {
-                  // NOTE: try-catch likely not needed,
-                  // but guarding against cases where the submission of the task fails spuriously
-                  try {
-                    fiber.tellInterrupt(Cause.interrupt(fiberId))
-                  } catch {
-                    case _: Throwable =>
-                  }
-                }
-              }
-            })
-          result <- fiber.join
-          _      <- exit(result)
-        } yield ()
+    def shutdownHook(fiberId: FiberId, fiber: Fiber.Runtime[Nothing, ExitCode]): Unit =
+      Platform.addShutdownHook { () =>
+        if (shuttingDown.compareAndSet(false, true)) {
+          if (FiberRuntime.catastrophicFailure.get) {
+            println(
+              "**** WARNING ****\n" +
+                "Catastrophic error encountered. " +
+                "Application not safely interrupted. " +
+                "Resources may be leaked. " +
+                "Check the logs for more details and consider overriding `Runtime.reportFatal` to capture context."
+            )
+          } else {
+            try {
+              fiber.tellInterrupt(Cause.interrupt(fiberId))
+              shutdownLatch.get(gracefulShutdownTimeout.toMillis)
+            } catch {
+              case _: OneShot.TimeoutException =>
+                println(
+                  "**** WARNING ****\n" +
+                    s"Timed out waiting for ZIO application to shut down after $gracefulShutdownTimeout. " +
+                    "You can adjust your application's shutdown timeout by overriding the `shutdownTimeout` method"
+                )
+              case _: Throwable =>
+            }
+          }
+        }
       }
-    }.getOrThrowFiberFailure()
+
+    val exit0 =
+      runtime.unsafe.run {
+        ZIO.uninterruptible {
+          for {
+            fiberId <- ZIO.fiberId
+            fiber <- workflow.interruptible.exitWith { exit0 =>
+                       val exitCode = if (exit0.isSuccess) ExitCode.success else ExitCode.failure
+                       interruptRootFibers(fiberId).as(exitCode)
+                     }.fork
+            result <- {
+              shutdownHook(fiberId, fiber)
+              fiber.join
+            }
+          } yield result
+        }
+      }
+
+    shutdownLatch.set(())
+    exit0 match {
+      case Exit.Success(code) => exitUnsafe(code)
+      case f                  => exitUnsafe(ExitCode.failure)
+    }
   }
 
   private def interruptRootFibers(mainFiberId: FiberId)(implicit trace: Trace): UIO[Unit] =

--- a/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
@@ -49,23 +49,6 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
     }
   }
 
-  def trySet(v: A): Boolean = {
-    if (v == null) throw new Error("Defect: OneShot variable cannot be set to null value")
-
-    this.lock()
-
-    try {
-      if (value ne null) return false
-
-      value = v.asInstanceOf[A with AnyRef]
-
-      this.isSetCondition.signalAll()
-      true
-    } finally {
-      this.unlock()
-    }
-  }
-
   /**
    * Determines if the variable has been set.
    */

--- a/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
@@ -18,7 +18,6 @@ package zio.internal
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
 /**

--- a/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
@@ -18,6 +18,7 @@ package zio.internal
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.locks.{Condition, ReentrantLock}
 
 /**
@@ -48,6 +49,23 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
     }
   }
 
+  def trySet(v: A): Boolean = {
+    if (v == null) throw new Error("Defect: OneShot variable cannot be set to null value")
+
+    this.lock()
+
+    try {
+      if (value ne null) return false
+
+      value = v.asInstanceOf[A with AnyRef]
+
+      this.isSetCondition.signalAll()
+      true
+    } finally {
+      this.unlock()
+    }
+  }
+
   /**
    * Determines if the variable has been set.
    */
@@ -72,7 +90,7 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
         this.unlock()
       }
 
-      if (value eq null) throw new Error("Timed out waiting for variable to be set")
+      if (value eq null) throw new OneShot.TimeoutException
 
       value
     }
@@ -106,4 +124,6 @@ private[zio] object OneShot {
    * Makes a new (unset) variable.
    */
   def make[A]: OneShot[A] = new OneShot()
+
+  final class TimeoutException extends Error("Timed out waiting for variable to be set")
 }

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -49,6 +49,12 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific {
   def run: ZIO[Environment with ZIOAppArgs with Scope, Any, Any]
 
   /**
+   * The time that the application will wait for finalizers to run before
+   * exiting.
+   */
+  def gracefulShutdownTimeout: Duration = Duration.Infinity
+
+  /**
    * Composes this [[ZIOApp]] with another [[ZIOApp]], to yield an application
    * that executes the logic of both applications.
    */
@@ -71,12 +77,13 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific {
    * A helper function to exit the application with the specified exit code.
    */
   final def exit(code: ExitCode)(implicit trace: Trace): UIO[Unit] =
-    ZIO.succeed {
-      if (shuttingDown.compareAndSet(false, true)) {
-        try Platform.exit(code.code)(Unsafe.unsafe)
-        catch {
-          case _: SecurityException =>
-        }
+    ZIO.succeed(exitUnsafe(code)(Unsafe))
+
+  protected[zio] def exitUnsafe(code: ExitCode)(implicit unsafe: Unsafe): Unit =
+    if (shuttingDown.compareAndSet(false, true)) {
+      try Platform.exit(code.code)
+      catch {
+        case _: SecurityException =>
       }
     }
 

--- a/core/shared/src/main/scala/zio/ZIOApp.scala
+++ b/core/shared/src/main/scala/zio/ZIOApp.scala
@@ -51,6 +51,8 @@ trait ZIOApp extends ZIOAppPlatformSpecific with ZIOAppVersionSpecific {
   /**
    * The time that the application will wait for finalizers to run before
    * exiting.
+   *
+   * '''NOTE''': This is currently used only for JVM & ScalaNative applications
    */
   def gracefulShutdownTimeout: Duration = Duration.Infinity
 


### PR DESCRIPTION
/fixes #9901

It seems that https://github.com/zio/zio/pull/9827 introduced a bug where finalizers might not run in applications that are exited externally. I'll create a release straight after this PR is merged because this can be a relatively severe bug. This should revert the behaviour to what was in 2.1.17 but without the bug that was fixed (https://github.com/zio/zio/issues/9807)

One other thing is that this PR adds the `gracefulShutdownTimeout` method on `ZIOApp`. This way users can configure how much time the runtime will wait before exiting after an external interruption signal is received. This is partially to mitigate issues where the app might hang on termination (e.g., https://github.com/zio/zio/issues/5185) or because of uninterruptible finalizers that never complete. I set the default value to `Duration.Infinity` in order to avoid breaking applications and to match the behaviour pre-2.1.17.

I'll followup with:
1. Creating an issue to add tests for ensuring correct behaviour of `ZIOApp`
2. Documenting `gracefulShutdownTimeout`