### PR TITLE
Fix `ZPipeline.encodeCharsWith` flushing to prevent memory leaks

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1225,7 +1225,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         for {
           result         <- ZIO.succeed(encoder.encode(charBuffer, byteBuffer, true))
           encodedBytes   <- handleCoderResult(result)
-          remainderBytes <- if (result.isOverflow) endOfInput else Exit.emptyChunk
+          remainderBytes <- if (result.isOverflow) flushRemaining else Exit.emptyChunk
         } yield encodedBytes ++ remainderBytes
 
       def flushRemaining: IO[CharacterCodingException, Chunk[Byte]] =

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1241,9 +1241,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         case None =>
           for {
             _              <- ZIO.succeed(charBuffer.flip())
-            encodedBytes   <- endOfInput
-            remainingBytes <- flushRemaining
-            result          = encodedBytes ++ remainingBytes
+            result   <- endOfInput
             _ <- ZIO.succeed {
                    charBuffer.clear()
                    byteBuffer.clear()

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1240,8 +1240,8 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           encodeChunk(inChunk)
         case None =>
           for {
-            _              <- ZIO.succeed(charBuffer.flip())
-            result   <- endOfInput
+            _      <- ZIO.succeed(charBuffer.flip())
+            result <- endOfInput
             _ <- ZIO.succeed {
                    charBuffer.clear()
                    byteBuffer.clear()


### PR DESCRIPTION
Addresses #9935.

Ok, the more I think about this, one thing seems clear.
If `CharsetEncoder.encode` is called with the `endOfInput` argument as true, no further characters are expected to be provided. At this point looping within the local `endOfInput` method shouldn't happen at all.
This change seems to fix the memory leak.

What I don't understand is how exactly under the current implementation do subsequent recurse calls of `endOfInput` seem to end up with `overflow` as result. This doesn't seem too obvious but my assumption is that the encoder itself keeps some internal state that is interpreted as overflow. 