### PR TITLE
Optimize and deprecate `TestAspect.fibers`

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -25,6 +25,8 @@ import zio.test.TestAspectPoly
 import zio.System.env
 import zio.test.TestAspectAtLeastR
 
+import scala.collection.mutable
+
 /**
  * A `TestAspect` is an aspect that can be weaved into specs. You can think of
  * an aspect as a polymorphic function, capable of transforming one test into
@@ -505,34 +507,46 @@ object TestAspect extends TimeoutVariants {
         )
     }
 
-  /**
-   * An aspect that records the state of fibers spawned by the current test in
-   * [[TestAnnotation.fibers]]. Applied by default in [[ZIOSpecAbstract]]. This
-   * aspect is required for the proper functioning of `TestClock.adjust`.
-   */
-  lazy val fibers: TestAspectPoly =
+  private[test] val _fibers: TestAspectPoly =
     new PerTest.Poly {
       def perTest[R, E](
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] = {
         val acquire = ZIO.succeed(new AtomicReference(SortedSet.empty[Fiber.Runtime[Any, Any]])).tap { ref =>
-          Annotations.annotate(TestAnnotation.fibers, Right(Chunk(ref)))
+          Annotations.annotate(TestAnnotation.fibers, Right(Chunk.single(ref)))
         }
         val release = Annotations.get(TestAnnotation.fibers).flatMap {
           case Right(refs) =>
-            ZIO
-              .foreach(refs)(ref => ZIO.succeed(ref.get))
-              .map(_.foldLeft(SortedSet.empty[Fiber.Runtime[Any, Any]])(_ ++ _).size)
-              .tap { n =>
-                Annotations.annotate(TestAnnotation.fibers, Left(n))
+            val n =
+              if (refs.size == 1) {
+                refs.head.get().size
+              } else {
+                val it      = refs.iterator
+                val builder = new mutable.HashSet[Fiber.Runtime[?, ?]]()
+                while (it.hasNext) {
+                  builder ++= it.next().get()
+                }
+                builder.result().size
               }
-          case Left(_) => ZIO.unit
+            Annotations.annotate(TestAnnotation.fibers, Left(n))
+          case _ => Exit.unit
         }
-        ZIO.acquireReleaseWith(acquire)(_ => release) { ref =>
-          Supervisor.fibersIn(ref).flatMap(supervisor => test.supervised(supervisor))
+        ZIO.acquireReleaseWith(acquire)(_ => release) {
+          Supervisor.fibersIn(_).flatMap(test.supervised(_))
         }
       }
     }
+
+  /**
+   * An aspect that records the state of fibers spawned by the current test in
+   * [[TestAnnotation.fibers]]. Applied automatically to all tests. This aspect
+   * is required for the proper functioning of `TestClock.adjust`.
+   */
+  @deprecated(
+    "This aspect is applied automatically to all tests and no longer needs to be provided explicitly",
+    "2.1.20"
+  )
+  def fibers = _fibers
 
   /**
    * An aspect that retries a test until success, with a default limit, for use

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -507,14 +507,28 @@ object TestAspect extends TimeoutVariants {
         )
     }
 
-  private[test] val _fibers: TestAspectPoly =
+  /**
+   * An aspect that records the state of fibers spawned by the current test in
+   * [[TestAnnotation.fibers]].
+   *
+   * '''NOTE''': Since this aspect is required for the proper functioning of
+   * `TestClock.adjust`, it is applied to all tests automatically. There is no
+   * need to apply this aspect manually to tests.
+   */
+  @deprecated(
+    "This aspect is applied automatically to all tests and no longer needs to be provided explicitly",
+    "2.1.20"
+  )
+  val fibers: TestAspectPoly =
     new PerTest.Poly {
       def perTest[R, E](
         test: ZIO[R, TestFailure[E], TestSuccess]
       )(implicit trace: Trace): ZIO[R, TestFailure[E], TestSuccess] = {
-        val acquire = ZIO.succeed(new AtomicReference(SortedSet.empty[Fiber.Runtime[Any, Any]])).tap { ref =>
-          Annotations.annotate(TestAnnotation.fibers, Right(Chunk.single(ref)))
+        val acquire = ZIO.suspendSucceed {
+          val ref = new AtomicReference(SortedSet.empty[Fiber.Runtime[Any, Any]])
+          Annotations.annotate(TestAnnotation.fibers, Right(Chunk.single(ref))).as(ref)
         }
+
         val release = Annotations.get(TestAnnotation.fibers).flatMap {
           case Right(refs) =>
             val n =
@@ -536,17 +550,6 @@ object TestAspect extends TimeoutVariants {
         }
       }
     }
-
-  /**
-   * An aspect that records the state of fibers spawned by the current test in
-   * [[TestAnnotation.fibers]]. Applied automatically to all tests. This aspect
-   * is required for the proper functioning of `TestClock.adjust`.
-   */
-  @deprecated(
-    "This aspect is applied automatically to all tests and no longer needs to be provided explicitly",
-    "2.1.20"
-  )
-  def fibers = _fibers
 
   /**
    * An aspect that retries a test until success, with a default limit, for use

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -122,8 +122,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
             )
         )
       randomId <- Random.RandomLive.nextInt.map("test_case_" + _)
-      summary <-
-        runner.run(randomId, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect.fibers)
+      summary  <- runner.run(randomId, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect._fibers)
     } yield summary
   }
 
@@ -150,6 +149,6 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
           ZLayer.succeedEnvironment(castedRuntime.environment) >>> ExecutionEventSink.live,
           testEventHandler
         )
-    ).run(fullyQualifiedName, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect.fibers)
+    ).run(fullyQualifiedName, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect._fibers)
   }
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -21,6 +21,8 @@ import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.render.ConsoleRenderer
 
+import scala.annotation.nowarn
+
 @EnableReflectiveInstantiation
 abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecific {
   self =>
@@ -122,7 +124,10 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
             )
         )
       randomId <- Random.RandomLive.nextInt.map("test_case_" + _)
-      summary  <- runner.run(randomId, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect._fibers)
+      summary <- runner.run(
+                   randomId,
+                   aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect.fibers: @nowarn("cat=deprecation")
+                 )
     } yield summary
   }
 
@@ -149,6 +154,9 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
           ZLayer.succeedEnvironment(castedRuntime.environment) >>> ExecutionEventSink.live,
           testEventHandler
         )
-    ).run(fullyQualifiedName, aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect._fibers)
+    ).run(
+      fullyQualifiedName,
+      aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect.fibers: @nowarn("cat=deprecation")
+    )
   }
 }


### PR DESCRIPTION
The `TestAspect.fibers` aspect is needed for `TestClock` to work properly. At some point it was added automatically to all tests, which means adding it to tests only adds overhead to the test execution.

In this PR we deprecate it and while I was at it I also optimized it