### PR TITLE
Speedup CI

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,7 +10,8 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: '0'
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Approve PR
         run: gh pr review --approve ${{ github.event.number }}
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.7.1
         with:
@@ -83,7 +84,8 @@ jobs:
       - name: Checkout Current Branch
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.7.1
         with:
@@ -291,7 +293,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - uses: actions/download-artifact@v4
         with:
           name: website-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,8 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1000
+          fetch-tags: true
       - name: Setup Java
         uses: actions/setup-java@v4.7.1
         with:


### PR DESCRIPTION
Some time in the repo's past, _very_ large files were being committed, and fetching the full history takes a long time (~2 and a half minutes in CI). Unfortunately, for some steps we have to get the history because we need to resolve the latest tag. Luckily, we can do that by using a relatively large `fetch-depth`, but not large enough that'll go all the way back to the start of the repo's history.

Hopefully this will work; every time I tried to "solve" this it resulted in me breaking the release job. I think this time it'll work though (famous last words)