### PR TITLE
Deprecated `ZIO#exitCode`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -1,6 +1,7 @@
 package zio
 
 import zio.test._
+import scala.annotation.nowarn
 
 object ZIOAppSpec extends ZIOBaseSpec {
   def spec = suite("ZIOAppSpec")(
@@ -13,12 +14,12 @@ object ZIOAppSpec extends ZIOBaseSpec {
     },
     test("failure translates into ExitCode.failure") {
       for {
-        code <- ZIOApp.fromZIO(ZIO.fail("Uh oh!")).invoke(Chunk.empty).exitCode
+        code <- ZIOApp.fromZIO(ZIO.fail("Uh oh!")).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
       } yield assertTrue(code == ExitCode.failure)
     },
     test("success translates into ExitCode.success") {
       for {
-        code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty).exitCode
+        code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
       } yield assertTrue(code == ExitCode.success)
     },
     test("composed app logic runs component logic") {
@@ -52,7 +53,7 @@ object ZIOAppSpec extends ZIOBaseSpec {
       val app1 = ZIOApp(ZIO.fail("Uh oh!"), Runtime.addLogger(logger1))
 
       for {
-        c <- app1.invoke(Chunk.empty).exitCode
+        c <- app1.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
         v <- ZIO.succeed(counter.get())
       } yield assertTrue(c == ExitCode.failure) && assertTrue(v == 1)
     },

--- a/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import scala.annotation.nowarn
 
 private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
 
@@ -21,7 +22,9 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
         runtime <- ZIO.runtime[Environment with ZIOAppArgs]
         _       <- installSignalHandlers(runtime)
         _       <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
-      } yield ()).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_))).exitCode.tap(exit)
+      } yield ()).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_))).exitCode.tap(exit): @nowarn(
+        "cat=deprecation"
+      )
     }
   }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -576,6 +576,7 @@ sealed trait ZIO[-R, +E, +A]
   /**
    * Maps this effect to the default exit codes.
    */
+  @deprecated("This operator swallows errors and is no longer necessary to create a ZIO App.", "2.1.20")
   final def exitCode(implicit trace: Trace): URIO[R, ExitCode] =
     self.foldCause(
       _ => ExitCode.failure,

--- a/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
@@ -1,6 +1,7 @@
 package zio.test
 import zio.{Scope, ZIO, ZIOAppArgs, ZLayer}
 import zio.internal.ansi.AnsiStringOps
+import scala.annotation.nowarn
 
 object ZIOSpecAbstractSpec extends ZIOBaseSpec {
   private val basicSpec: ZIOSpecAbstract = new ZIOSpecDefault {
@@ -32,7 +33,7 @@ object ZIOSpecAbstractSpec extends ZIOBaseSpec {
                  .runSpecAsApp(composedSpec.spec, TestArgs.empty, console)
                  .provideSome[zio.Scope with TestEnvironment](composedSpec.bootstrap)
                  .catchAllCause(t => console.printLine(t.toString))
-                 .exitCode
+                 .exitCode: @nowarn("cat=deprecation")
              }
         output <- TestConsole.output.map(_.mkString("\n"))
       } yield assertTrue(output.contains("scala.NotImplementedError: an implementation is missing")) &&
@@ -66,7 +67,7 @@ object ZIOSpecAbstractSpec extends ZIOBaseSpec {
                  .runSpecAsApp(composedSpec.spec, TestArgs.empty, console)
                  .provideSome[zio.Scope with TestEnvironment](composedSpec.bootstrap)
                  .catchAllCause(t => console.printLine(t.toString))
-                 .exitCode
+                 .exitCode: @nowarn("cat=deprecation")
              }
         output <- TestConsole.output.map(_.mkString("\n"))
       } yield assertTrue(output.contains("scala.NotImplementedError: an implementation is missing")) &&
@@ -106,12 +107,17 @@ object ZIOSpecAbstractSpec extends ZIOBaseSpec {
     },
     test("run method reports exitcode=1 sanely")(
       for {
-        exitCode <- basicFailSpec.run.provideSome[zio.ZIOAppArgs with zio.Scope](basicFailSpec.bootstrap).exitCode
+        exitCode <-
+          basicFailSpec.run.provideSome[zio.ZIOAppArgs with zio.Scope](basicFailSpec.bootstrap).exitCode: @nowarn(
+            "cat=deprecation"
+          )
       } yield assertTrue(exitCode.code == 1)
     ),
     test("run method reports exitcode=0 sanely")(
       for {
-        exitCode <- basicSpec.run.provideSome[zio.ZIOAppArgs with zio.Scope](basicSpec.bootstrap).exitCode
+        exitCode <- basicSpec.run.provideSome[zio.ZIOAppArgs with zio.Scope](basicSpec.bootstrap).exitCode: @nowarn(
+                      "cat=deprecation"
+                    )
       } yield assertTrue(exitCode.code == 0)
     )
   )

--- a/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ZIOSpecAbstractSpec.scala
@@ -40,15 +40,15 @@ object ZIOSpecAbstractSpec extends ZIOBaseSpec {
         assertTrue(
           // Brittle with the line numbers
           // number of line with "override val bootstrap = ZLayer.fromZIO(ZIO.attempt(???))"
-          output.contains("ZIOSpecAbstractSpec.scala:22")
+          output.contains("ZIOSpecAbstractSpec.scala:23")
         ) &&
         assertTrue(
           // number of line with "_ <- ZIO.consoleWith { console =>"
-          output.contains("ZIOSpecAbstractSpec.scala:30")
+          output.contains("ZIOSpecAbstractSpec.scala:31")
         ) &&
         assertTrue(
           // number of line with ".provideSome[zio.Scope with TestEnvironment](composedSpec.bootstrap)"
-          output.contains("ZIOSpecAbstractSpec.scala:33")
+          output.contains("ZIOSpecAbstractSpec.scala:34")
         )
     } @@ TestAspect.flaky @@ TestAspect.silent @@ TestAspect.scala2Only,
     test("highlighting composed layer failures - scala 3") {
@@ -74,15 +74,15 @@ object ZIOSpecAbstractSpec extends ZIOBaseSpec {
         assertTrue(
           // Brittle with the line numbers
           // number of line with "override val bootstrap = ZLayer.fromZIO(ZIO.attempt(???))"
-          output.contains("ZIOSpecAbstractSpec.scala:56")
+          output.contains("ZIOSpecAbstractSpec.scala:57")
         ) &&
         assertTrue(
           // number of line next to "_ <- ZIO.consoleWith { console =>"
-          output.contains("ZIOSpecAbstractSpec.scala:65")
+          output.contains("ZIOSpecAbstractSpec.scala:66")
         ) &&
         assertTrue(
           // number of line next to ".provideSome[zio.Scope with TestEnvironment](composedSpec.bootstrap)"
-          output.contains("ZIOSpecAbstractSpec.scala:68")
+          output.contains("ZIOSpecAbstractSpec.scala:69")
         )
     } @@ TestAspect.flaky @@ TestAspect.silent @@ TestAspect.scala3Only,
     test("run method reports successes sanely")(


### PR DESCRIPTION
/closes #9756

`exitCode` operator is dangerous as it swallows all errors. Since this is no longer necessary for creating a ZIOApp, it should no longer be used.