### PR TITLE
[test-sbt]: emit `sbt.testing.Event`s on `Scala.js` and `Scala Native`.

### DIFF
--- a/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
+++ b/test-sbt/js/src/main/scala/zio/test/sbt/ZTestRunnerJS.scala
@@ -105,8 +105,10 @@ sealed class ZTestTask(
       val logic =
         ZIO.consoleWith { console =>
           (for {
-            summary <- spec
-                         .runSpecAsApp(FilteredSpec(spec.spec, args), args, console)
+            summary <- {
+              val zTestHandler = new ZTestEventHandlerSbt(eventHandler, taskDef, args.testRenderer)
+              spec.runSpecAsApp(FilteredSpec(spec.spec, args), args, console, zTestHandler)
+            }
             _ <- sendSummary.provide(ZLayer.succeed(summary))
             // TODO Confirm if/how these events needs to be handled in #6481
             //    Check XML behavior

--- a/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
+++ b/test-sbt/native/src/main/scala/zio/test/sbt/ZTestRunnerNative.scala
@@ -118,8 +118,11 @@ sealed class ZTestTask(
       resOutter = Runtime.default.unsafe.runToFuture {
         ZIO.consoleWith { console =>
           (for {
-            summary <- spec.runSpecAsApp(FilteredSpec(spec.spec, args), args, console)
-            _       <- sendSummary.provideSomeEnvironment[Any](_.add(summary))
+            summary <- {
+              val zTestHandler = new ZTestEventHandlerSbt(eventHandler, taskDef, args.testRenderer)
+              spec.runSpecAsApp(FilteredSpec(spec.spec, args), args, console, zTestHandler)
+            }
+            _ <- sendSummary.provideSomeEnvironment[Any](_.add(summary))
             // TODO Confirm if/how these events needs to be handled in #6481
             //    Check XML behavior
             _ <- ZIO.when(summary.status == Summary.Failure) {


### PR DESCRIPTION
fixes #9629

/claim #9629