### PR TITLE
Deprecate `ZIO.infinity`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CancelableFutureSpec.scala
@@ -66,7 +66,7 @@ object CancelableFutureSpec extends ZIOBaseSpec {
         for {
           start <- Promise.make[Nothing, Unit]
           end   <- Promise.make[Nothing, Int]
-          fiber <- roundtrip((start.succeed(()) *> ZIO.infinity).onInterrupt(end.succeed(42))).fork
+          fiber <- roundtrip((start.succeed(()) *> ZIO.never).onInterrupt(end.succeed(42))).fork
           _     <- start.await
           _     <- fiber.interrupt
           value <- end.await

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -124,7 +124,7 @@ object FiberSpec extends ZIOBaseSpec {
         },
         test("in race") {
           for {
-            f <- ZIO.infinity.race(ZIO.infinity).fork
+            f <- ZIO.never.race(ZIO.never).fork
             blockingOn <- f.status
                             .collect(()) { case Fiber.Status.Suspended(_, _, blockingOn) =>
                               blockingOn

--- a/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeBootstrapTests.scala
@@ -108,7 +108,7 @@ object RuntimeBootstrapTests {
       for {
         ref    <- Ref.make(0)
         latch  <- Promise.make[Nothing, Unit]
-        child   = (latch.succeed(()) *> ZIO.infinity).ensuring(ref.update(_ + 1))
+        child   = (latch.succeed(()) *> ZIO.never).ensuring(ref.update(_ + 1))
         parent <- (child.fork *> latch.await).fork
         _      <- parent.await
         count  <- ref.get
@@ -298,7 +298,7 @@ object RuntimeBootstrapTests {
   def uninterruptibleRace() =
     test("race in uninterruptible region") {
       for {
-        _ <- ZIO.unit.race(ZIO.infinity).uninterruptible
+        _ <- ZIO.unit.race(ZIO.never).uninterruptible
       } yield assert(true)
     }
 
@@ -308,7 +308,7 @@ object RuntimeBootstrapTests {
         startLatch <- Promise.make[Nothing, Unit]
         endLatch   <- Promise.make[Nothing, Unit]
         finalized  <- Ref.make(false)
-        fiber      <- (startLatch.succeed(()) *> ZIO.infinity).onInterrupt(finalized.set(true) *> endLatch.succeed(())).fork
+        fiber      <- (startLatch.succeed(()) *> ZIO.never).onInterrupt(finalized.set(true) *> endLatch.succeed(())).fork
         _          <- startLatch.await
         _          <- fiber.interrupt
         _          <- endLatch.await
@@ -324,7 +324,7 @@ object RuntimeBootstrapTests {
         exitRef             <- Ref.make[Exit[Any, Any]](Exit.succeed(()))
         pastInterruptionRef <- Ref.make(false)
         fiber <- (ZIO.uninterruptibleMask { restore =>
-                   restore(startLatch.succeed(()) *> ZIO.infinity).exit.flatMap(exitRef.set(_))
+                   restore(startLatch.succeed(()) *> ZIO.never).exit.flatMap(exitRef.set(_))
                  } *> pastInterruptionRef.set(true)).ensuring(endLatch.succeed(())).fork
         _    <- startLatch.await
         _    <- fiber.interrupt
@@ -360,7 +360,7 @@ object RuntimeBootstrapTests {
   def interruptionOfForkedRace() =
     testN(100)("interruption of forked raced") {
       def make(ref: Ref[Int], start: Promise[Nothing, Unit], done: Promise[Nothing, Unit]) =
-        (start.succeed(()) *> ZIO.infinity).onInterrupt(ref.update(_ + 1) *> done.succeed(()))
+        (start.succeed(()) *> ZIO.never).onInterrupt(ref.update(_ + 1) *> done.succeed(()))
 
       for {
         ref   <- Ref.make(0)
@@ -456,7 +456,7 @@ object RuntimeBootstrapTests {
     test("child becoming interruptible is interrupted due to auto-supervision of uninterruptible parent") {
       for {
         latch <- Promise.make[Nothing, Unit]
-        child  = ZIO.infinity.interruptible.onInterrupt(latch.succeed(())).fork
+        child  = ZIO.never.interruptible.onInterrupt(latch.succeed(())).fork
         _     <- child.fork.uninterruptible
         _     <- latch.await
       } yield assert(true)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3053,8 +3053,8 @@ object ZIOSpec extends ZIOBaseSpec {
           latch2 <- Promise.make[Nothing, Unit]
           p1     <- Promise.make[Nothing, Unit]
           p2     <- Promise.make[Nothing, Unit]
-          loser1  = ZIO.acquireReleaseWith(latch1.succeed(()))(_ => p1.succeed(()))(_ => ZIO.infinity)
-          loser2  = ZIO.acquireReleaseWith(latch2.succeed(()))(_ => p2.succeed(()))(_ => ZIO.infinity)
+          loser1  = ZIO.acquireReleaseWith(latch1.succeed(()))(_ => p1.succeed(()))(_ => ZIO.never)
+          loser2  = ZIO.acquireReleaseWith(latch2.succeed(()))(_ => p2.succeed(()))(_ => ZIO.never)
           fiber  <- (loser1 race loser2).forkDaemon
           _      <- latch1.await
           _      <- latch2.await
@@ -3065,7 +3065,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       test("supervise fibers") {
         def makeChild(n: Int): UIO[Fiber[Nothing, Unit]] =
-          (Clock.sleep(20.millis * n.toDouble) *> ZIO.infinity).fork
+          (Clock.sleep(20.millis * n.toDouble) *> ZIO.never).fork
 
         val io =
           for {
@@ -3121,7 +3121,7 @@ object ZIOSpec extends ZIOBaseSpec {
           s      <- Promise.make[Nothing, Unit]
           effect <- Promise.make[Nothing, Int]
           winner  = s.await *> ZIO.fromEither(Right(()))
-          loser   = ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.infinity)
+          loser   = ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.never)
           race    = winner raceFirst loser
           _      <- race
           b      <- effect.await
@@ -3132,7 +3132,7 @@ object ZIOSpec extends ZIOBaseSpec {
           s      <- Promise.make[Nothing, Unit]
           effect <- Promise.make[Nothing, Int]
           winner  = s.await *> ZIO.fromEither(Left(new Exception))
-          loser   = ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.infinity)
+          loser   = ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.never)
           race    = winner raceFirst loser
           _      <- race.either
           b      <- effect.await
@@ -3143,7 +3143,7 @@ object ZIOSpec extends ZIOBaseSpec {
           s      <- Promise.make[Nothing, Unit]
           effect <- Promise.make[Nothing, Int]
           winner  = s.await *> ZIO.fromEither(Right(()))
-          losers  = List(ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.infinity))
+          losers  = List(ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.never))
           race    = ZIO.raceFirst(winner, losers)
           _      <- race
           b      <- effect.await
@@ -3154,7 +3154,7 @@ object ZIOSpec extends ZIOBaseSpec {
           s      <- Promise.make[Nothing, Unit]
           effect <- Promise.make[Nothing, Int]
           winner  = s.await *> ZIO.fromEither(Left(new Exception))
-          losers  = List(ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.infinity))
+          losers  = List(ZIO.acquireReleaseWith(s.succeed(()))(_ => effect.succeed(42))(_ => ZIO.never))
           race    = ZIO.raceFirst(winner, losers)
           _      <- race.either
           b      <- effect.await
@@ -3439,7 +3439,7 @@ object ZIOSpec extends ZIOBaseSpec {
       },
       test("interruption of raced") {
         def make(ref: Ref[Int], start: Promise[Nothing, Unit], done: Promise[Nothing, Unit]) =
-          (start.succeed(()) *> ZIO.infinity).onInterrupt(ref.update(_ + 1) *> done.succeed(()))
+          (start.succeed(()) *> ZIO.never).onInterrupt(ref.update(_ + 1) *> done.succeed(()))
 
         for {
           ref   <- Ref.make(0)
@@ -4089,8 +4089,8 @@ object ZIOSpec extends ZIOBaseSpec {
           fiber <- ZIO.transplant { grafter =>
                      grafter {
                        val zio = for {
-                         _ <- (latch1.succeed(()) *> ZIO.infinity).onInterrupt(latch2.succeed(())).fork
-                         _ <- ZIO.infinity
+                         _ <- (latch1.succeed(()) *> ZIO.never).onInterrupt(latch2.succeed(())).fork
+                         _ <- ZIO.never
                        } yield ()
                        zio.fork
                      }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3934,6 +3934,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Like [[never]], but fibers that running this effect won't be garbage
    * collected unless interrupted.
    */
+  @deprecated("Use `ZIO.never` instead", "2.1.20")
   def infinity(implicit trace: Trace): UIO[Nothing] =
     ZIO.sleep(Duration.fromNanos(Long.MaxValue)) *> ZIO.never
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -84,7 +84,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               sink = ZSink.foldZIO(List[Int]())(_ => true) { (acc, el: Int) =>
                        if (el == 1) ZIO.succeed(el :: acc)
                        else
-                         (latch.succeed(()) *> ZIO.infinity)
+                         (latch.succeed(()) *> ZIO.never)
                            .onInterrupt(cancelled.set(true))
                      }
               fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.fork
@@ -98,7 +98,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch     <- Promise.make[Nothing, Unit]
               cancelled <- Ref.make(false)
               sink = ZSink.fromZIO {
-                       (latch.succeed(()) *> ZIO.infinity)
+                       (latch.succeed(()) *> ZIO.never)
                          .onInterrupt(cancelled.set(true))
                      }
               fiber  <- ZStream(1, 1, 2).aggregateAsync(sink).runCollect.fork
@@ -246,7 +246,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               sink = ZSink.foldZIO(List[Int]())(_ => true) { (acc, el: Int) =>
                        if (el == 1) ZIO.succeed(el :: acc)
                        else
-                         (latch.succeed(()) *> ZIO.infinity)
+                         (latch.succeed(()) *> ZIO.never)
                            .onInterrupt(cancelled.set(true))
                      }
               fiber <- ZStream(1, 1, 2)
@@ -263,7 +263,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch     <- Promise.make[Nothing, Unit]
               cancelled <- Ref.make(false)
               sink = ZSink.fromZIO {
-                       (latch.succeed(()) *> ZIO.infinity)
+                       (latch.succeed(()) *> ZIO.never)
                          .onInterrupt(cancelled.set(true))
                      }
               fiber <- ZStream(1, 1, 2)
@@ -1601,7 +1601,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               fiber <- ZStream(())
                          .flatMapPar(1)(_ =>
                            ZStream.fromZIO(
-                             (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                             (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                            )
                          )
                          .runDrain
@@ -1617,7 +1617,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch              <- Promise.make[Nothing, Unit]
               result <- ZStream(
                           ZStream.fromZIO(
-                            (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                            (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                           ),
                           ZStream.fromZIO(latch.await *> ZIO.fail("Ouch"))
                         ).flatMapPar(2)(identity).runDrain.either
@@ -1631,7 +1631,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- (ZStream(()) ++ ZStream.fromZIO(latch.await *> ZIO.fail("Ouch")))
                           .flatMapPar(2) { _ =>
                             ZStream.fromZIO(
-                              (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                              (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                             )
                           }
                           .runDrain
@@ -1647,7 +1647,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch              <- Promise.make[Nothing, Unit]
               result <- ZStream(
                           ZStream.fromZIO(
-                            (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                            (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                           ),
                           ZStream.fromZIO(latch.await *> ZIO.die(ex))
                         ).flatMapPar(2)(identity).runDrain.exit
@@ -1663,7 +1663,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- (ZStream(()) ++ ZStream.fromZIO(latch.await *> ZIO.die(ex)))
                           .flatMapPar(2) { _ =>
                             ZStream.fromZIO(
-                              (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                              (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                             )
                           }
                           .runDrain
@@ -1772,7 +1772,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               fiber <- ZStream(())
                          .flatMapParSwitch(1)(_ =>
                            ZStream.fromZIO(
-                             (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                             (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                            )
                          )
                          .runCollect
@@ -1788,7 +1788,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch              <- Promise.make[Nothing, Unit]
               result <- ZStream(
                           ZStream.fromZIO(
-                            (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                            (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                           ),
                           ZStream.fromZIO(latch.await *> ZIO.fail("Ouch"))
                         ).flatMapParSwitch(2)(identity).runDrain.either
@@ -1802,7 +1802,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- (ZStream(()) ++ ZStream.fromZIO(latch.await *> ZIO.fail("Ouch")))
                           .flatMapParSwitch(2) { _ =>
                             ZStream.fromZIO(
-                              (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                              (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                             )
                           }
                           .runDrain
@@ -1818,7 +1818,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch              <- Promise.make[Nothing, Unit]
               result <- ZStream(
                           ZStream.fromZIO(
-                            (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                            (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                           ),
                           ZStream.fromZIO(latch.await *> ZIO.die(ex))
                         ).flatMapParSwitch(2)(identity).runDrain.exit
@@ -1834,7 +1834,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- (ZStream(()) ++ ZStream.fromZIO(latch.await *> ZIO.die(ex)))
                           .flatMapParSwitch(2) { _ =>
                             ZStream.fromZIO(
-                              (latch.succeed(()) *> ZIO.infinity).onInterrupt(substreamCancelled.set(true))
+                              (latch.succeed(()) *> ZIO.never).onInterrupt(substreamCancelled.set(true))
                             )
                           }
                           .runDrain
@@ -2787,7 +2787,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               interrupted <- Ref.make(false)
               latch       <- Promise.make[Nothing, Unit]
               fib <- ZStream(())
-                       .mapZIOPar(1)(_ => (latch.succeed(()) *> ZIO.infinity).onInterrupt(interrupted.set(true)))
+                       .mapZIOPar(1)(_ => (latch.succeed(()) *> ZIO.never).onInterrupt(interrupted.set(true)))
                        .runDrain
                        .fork
               _      <- latch.await
@@ -2913,7 +2913,7 @@ object ZStreamSpec extends ZIOBaseSpec {
               latch       <- Promise.make[Nothing, Unit]
               fib <-
                 ZStream(())
-                  .mapZIOParUnordered(1)(_ => (latch.succeed(()) *> ZIO.infinity).onInterrupt(interrupted.set(true)))
+                  .mapZIOParUnordered(1)(_ => (latch.succeed(()) *> ZIO.never).onInterrupt(interrupted.set(true)))
                   .runDrain
                   .fork
               _      <- latch.await


### PR DESCRIPTION
In #9986, Kyri noticed that `Clock.sleep(Duration.Infinity)` won't be scheduled. This is also true if the Duration is instantiated with `fromNanos` - meaning that `ZIO.infinity` has been (and still is) semantically equivalent to `ZIO.never`.
```
import zio.Duration
Duration.fromNanos(Long.MaxValue) match {
  case Duration.Infinity => "INF"
  case _                 => "NOT"
}
```