### PR TITLE
Add tests for `PrettyPrint` with `List.empty` and `Nil` values

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/PrettyPrintSpec.scala
@@ -9,7 +9,11 @@ object PrettyPrintSpec extends ZIOBaseSpec {
       assertTrue(PrettyPrint("A String").unstyled == "\"A String\"")
     },
     test("List") {
-      assertTrue(PrettyPrint(List(1, 2, 3)).unstyled == "List(1, 2, 3)")
+      assertTrue(
+        PrettyPrint(List(1, 2, 3)).unstyled == "List(1, 2, 3)",
+        PrettyPrint(List.empty).unstyled == "Nil",
+        PrettyPrint(Nil).unstyled == "Nil"
+      )
     },
     test("List of String") {
       assertTrue(PrettyPrint(List("1", "2", "3")).unstyled == "List(\"1\", \"2\", \"3\")")


### PR DESCRIPTION
Proof that https://github.com/zio/zio/pull/9900 isn't changing the pretty printing of `Nil`

See also https://github.com/zio/zio/pull/9900#discussion_r2121398409