### PR TITLE
Fix Scala Native WeakConcurrentBag NPE when forking 10K fibers

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,7 +19,7 @@ package zio.internal
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{Collections, WeakHashMap, Map => JMap, Set => JSet}
+import java.util.{Collections, HashSet, WeakHashMap, Map => JMap, Set => JSet}
 
 private[zio] trait PlatformSpecific {
 
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.synchronizedSet(new HashSet[A]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.synchronizedSet(new HashSet[A](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
/claim #9681 
Fix- #9681 

## Problem
The `PromiseSpec` test "waiter stack safety" fails with a `NullPointerException` on Scala Native when forking 10,000 fibers. The issue occurs in `WeakConcurrentBag` due to a bug in Scala Native's `ConcurrentHashMap.newKeySet` implementation under high concurrency.

## Root Cause
Scala Native's `ConcurrentHashMap.newKeySet()` has concurrency issues that cause NPEs when multiple threads access it simultaneously during high-stress scenarios like forking 10K fibers.

## Solution
Replace `ConcurrentHashMap.newKeySet` with `Collections.synchronizedSet(new HashSet[A]())` in the Scala Native-specific `PlatformSpecific.scala`. This provides thread-safe set operations without the concurrency bugs present in Scala Native's ConcurrentHashMap implementation.

## Changes
- `core/native/src/main/scala/zio/internal/PlatformSpecific.scala`: 
  - Replace `ConcurrentHashMap.newKeySet[A]()` with `Collections.synchronizedSet(new HashSet[A]())`
  - Replace `ConcurrentHashMap.newKeySet[A](initialCapacity)` with `Collections.synchronizedSet(new HashSet[A](initialCapacity))`
  - Add `HashSet` import

## Demo Video
https://drive.google.com/file/d/1SqJPecRrI51hFZcm9Qz_3LQpY9wmimUd/view?usp=sharing

## Testing
The previously failing test now passes consistently:
```bash
sbt "project coreTestsNative" "testOnly *PromiseSpec* -- -z \"waiter stack safety\""