### PR TITLE
 Fix scala Native NPE: Use Collections.newSetFromMap instead of ConcurrentHashMap.newKeySet

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
/claim #9681 
Fix- #9681 
Replace `ConcurrentHashMap.newKeySet[A]()` with `Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())`.

This approach:
-  Avoids the buggy `newKeySet` method
-  Maintains true concurrency (no synchronized fallback)
-  Uses the standard Java pattern for concurrent sets
-  Preserves JVM-equivalent performance