### PR TITLE
fix(core): Address race condition in Queue#take to prevent item loss

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -93,35 +93,6 @@ object QueueSpec extends ZIOBaseSpec {
         size  <- queue.size
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
-    test("take interruption with offer") {
-      val t = for {
-        q <- Queue.unbounded[String]
-        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[String])
-        fib <- ZIO.uninterruptibleMask { restore =>
-                restore(q.take).flatMap { item =>
-                  ZIO.succeed(ref.set(item))
-                }
-              }.forkDaemon
-        _ <- ZIO.sleep(10.millis)
-        _ <- fib.interrupt.zipPar(q.offer("foo"))
-        _ <- fib.await
-        s <- ZIO.succeed(ref.get())
-        _ <- if (s eq null) {
-              // take was cancelled, item should be in q
-              q.take.flatMap { item =>
-                if (item != "foo") ZIO.dieMessage("incorrect item: " + item)
-                else ZIO.unit
-              }
-            } else {
-              // take was completed, q should be empty
-              q.isEmpty.flatMap { empty =>
-                if (!empty) ZIO.dieMessage("nonempty q after completed take")
-                else ZIO.unit
-              }
-            }
-      } yield ()
-      t.repeatN(100) *> assertCompletes
-    } @@ zioTag(interruption),
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -93,6 +93,35 @@ object QueueSpec extends ZIOBaseSpec {
         size  <- queue.size
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
+    test("take interruption with offer") {
+      val t = for {
+        q <- Queue.unbounded[String]
+        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[String])
+        fib <- ZIO.uninterruptibleMask { restore =>
+                restore(q.take).flatMap { item =>
+                  ZIO.succeed(ref.set(item))
+                }
+              }.forkDaemon
+        _ <- ZIO.sleep(10.millis)
+        _ <- fib.interrupt.zipPar(q.offer("foo"))
+        _ <- fib.await
+        s <- ZIO.succeed(ref.get())
+        _ <- if (s eq null) {
+              // take was cancelled, item should be in q
+              q.take.flatMap { item =>
+                if (item != "foo") ZIO.dieMessage("incorrect item: " + item)
+                else ZIO.unit
+              }
+            } else {
+              // take was completed, q should be empty
+              q.isEmpty.flatMap { empty =>
+                if (!empty) ZIO.dieMessage("nonempty q after completed take")
+                else ZIO.unit
+              }
+            }
+      } yield ()
+      t.repeatN(100) *> assertCompletes
+    } @@ zioTag(interruption),
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -161,9 +161,6 @@ object Queue extends QueuePlatformSpecific {
     strategy: Strategy[A]
   ) extends Queue[A] {
 
-    private def removeTaker(taker: Promise[Nothing, A])(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeed(takers.remove(taker))
-
     override def capacity: Int = queue.capacity
 
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
@@ -253,17 +250,21 @@ object Queue extends QueuePlatformSpecific {
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null =>
-              // add the promise to takers, then:
-              // - try take again in case a value was added since
-              // - wait for the promise to be completed
-              // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
-
-              ZIO.suspendSucceed {
-                takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers)
-                if (shutdownFlag.get) ZIO.interrupt else p.await
-              }.onInterrupt(removeTaker(p))
+              ZIO.uninterruptibleMask { restore =>
+                ZIO.suspendSucceed {
+                  takers.offer(p)
+                  strategy.unsafeCompleteTakers(queue, takers)
+                  if (shutdownFlag.get) ZIO.interrupt
+                  else
+                    restore(p.await).onInterrupt {
+                      ZIO.suspendSucceed {
+                        if (takers.remove(p)) UIO.unit
+                        else p.await.flatMap(a => offer(a).ignore)
+                      }
+                    }
+                }
+              }
 
             case item =>
               strategy.unsafeOnQueueEmptySpace(queue, takers)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,16 +50,16 @@ object Queue extends QueuePlatformSpecific {
    * the queue.
    *
    * @note
-   * when possible use only power of 2 capacities; this will provide better
-   * performance by utilising an optimised version of the underlying
-   * [[zio.internal.RingBuffer]].
+   *   when possible use only power of 2 capacities; this will provide better
+   *   performance by utilising an optimised version of the underlying
+   *   [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   * capacity of the `Queue`
+   *   capacity of the `Queue`
    * @tparam A
-   * type of the `Queue`
+   *   type of the `Queue`
    * @return
-   * `UIO[Queue[A]]`
+   *   `UIO[Queue[A]]`
    */
   def bounded[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.bounded(requestedCapacity, _)(Unsafe.unsafe))
@@ -69,16 +69,16 @@ object Queue extends QueuePlatformSpecific {
    * the queue is reached, new elements will be dropped.
    *
    * @note
-   * when possible use only power of 2 capacities; this will provide better
-   * performance by utilising an optimised version of the underlying
-   * [[zio.internal.RingBuffer]].
+   *   when possible use only power of 2 capacities; this will provide better
+   *   performance by utilising an optimised version of the underlying
+   *   [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   * capacity of the `Queue`
+   *   capacity of the `Queue`
    * @tparam A
-   * type of the `Queue`
+   *   type of the `Queue`
    * @return
-   * `UIO[Queue[A]]`
+   *   `UIO[Queue[A]]`
    */
   def dropping[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.dropping(requestedCapacity, _)(Unsafe.unsafe))
@@ -89,16 +89,16 @@ object Queue extends QueuePlatformSpecific {
    * dropped.
    *
    * @note
-   * when possible use only power of 2 capacities; this will provide better
-   * performance by utilising an optimised version of the underlying
-   * [[zio.internal.RingBuffer]].
+   *   when possible use only power of 2 capacities; this will provide better
+   *   performance by utilising an optimised version of the underlying
+   *   [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   * capacity of the `Queue`
+   *   capacity of the `Queue`
    * @tparam A
-   * type of the `Queue`
+   *   type of the `Queue`
    * @return
-   * `UIO[Queue[A]]`
+   *   `UIO[Queue[A]]`
    */
   def sliding[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.sliding(requestedCapacity, _)(Unsafe.unsafe))
@@ -107,9 +107,9 @@ object Queue extends QueuePlatformSpecific {
    * Makes a new unbounded queue.
    *
    * @tparam A
-   * type of the `Queue`
+   *   type of the `Queue`
    * @return
-   * `UIO[Queue[A]]`
+   *   `UIO[Queue[A]]`
    */
   def unbounded[A](implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.unbounded(_)(Unsafe.unsafe))
@@ -160,6 +160,9 @@ object Queue extends QueuePlatformSpecific {
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
   ) extends Queue[A] {
+
+    private def removeTaker(taker: Promise[Nothing, A])(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed(takers.remove(taker))
 
     override def capacity: Int = queue.capacity
 
@@ -250,21 +253,17 @@ object Queue extends QueuePlatformSpecific {
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null =>
+              // add the promise to takers, then:
+              // - try take again in case a value was added since
+              // - wait for the promise to be completed
+              // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
-              ZIO.uninterruptibleMask { restore =>
-                ZIO.suspendSucceed {
-                  takers.offer(p)
-                  strategy.unsafeCompleteTakers(queue, takers)
-                  if (shutdownFlag.get) ZIO.interrupt
-                  else
-                    restore(p.await).onInterrupt {
-                      ZIO.suspendSucceed {
-                        if (takers.remove(p)) UIO.unit
-                        else p.await.flatMap(a => offer(a).ignore)
-                      }
-                    }
-                }
-              }
+
+              ZIO.suspendSucceed {
+                takers.offer(p)
+                strategy.unsafeCompleteTakers(queue, takers)
+                if (shutdownFlag.get) ZIO.interrupt else p.await
+              }.onInterrupt(removeTaker(p))
 
             case item =>
               strategy.unsafeOnQueueEmptySpace(queue, takers)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -50,16 +50,16 @@ object Queue extends QueuePlatformSpecific {
    * the queue.
    *
    * @note
-   *   when possible use only power of 2 capacities; this will provide better
-   *   performance by utilising an optimised version of the underlying
-   *   [[zio.internal.RingBuffer]].
+   * when possible use only power of 2 capacities; this will provide better
+   * performance by utilising an optimised version of the underlying
+   * [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   *   capacity of the `Queue`
+   * capacity of the `Queue`
    * @tparam A
-   *   type of the `Queue`
+   * type of the `Queue`
    * @return
-   *   `UIO[Queue[A]]`
+   * `UIO[Queue[A]]`
    */
   def bounded[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.bounded(requestedCapacity, _)(Unsafe.unsafe))
@@ -69,16 +69,16 @@ object Queue extends QueuePlatformSpecific {
    * the queue is reached, new elements will be dropped.
    *
    * @note
-   *   when possible use only power of 2 capacities; this will provide better
-   *   performance by utilising an optimised version of the underlying
-   *   [[zio.internal.RingBuffer]].
+   * when possible use only power of 2 capacities; this will provide better
+   * performance by utilising an optimised version of the underlying
+   * [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   *   capacity of the `Queue`
+   * capacity of the `Queue`
    * @tparam A
-   *   type of the `Queue`
+   * type of the `Queue`
    * @return
-   *   `UIO[Queue[A]]`
+   * `UIO[Queue[A]]`
    */
   def dropping[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.dropping(requestedCapacity, _)(Unsafe.unsafe))
@@ -89,16 +89,16 @@ object Queue extends QueuePlatformSpecific {
    * dropped.
    *
    * @note
-   *   when possible use only power of 2 capacities; this will provide better
-   *   performance by utilising an optimised version of the underlying
-   *   [[zio.internal.RingBuffer]].
+   * when possible use only power of 2 capacities; this will provide better
+   * performance by utilising an optimised version of the underlying
+   * [[zio.internal.RingBuffer]].
    *
    * @param requestedCapacity
-   *   capacity of the `Queue`
+   * capacity of the `Queue`
    * @tparam A
-   *   type of the `Queue`
+   * type of the `Queue`
    * @return
-   *   `UIO[Queue[A]]`
+   * `UIO[Queue[A]]`
    */
   def sliding[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.sliding(requestedCapacity, _)(Unsafe.unsafe))
@@ -107,9 +107,9 @@ object Queue extends QueuePlatformSpecific {
    * Makes a new unbounded queue.
    *
    * @tparam A
-   *   type of the `Queue`
+   * type of the `Queue`
    * @return
-   *   `UIO[Queue[A]]`
+   * `UIO[Queue[A]]`
    */
   def unbounded[A](implicit trace: Trace): UIO[Queue[A]] =
     ZIO.fiberId.map(unsafe.unbounded(_)(Unsafe.unsafe))
@@ -160,9 +160,6 @@ object Queue extends QueuePlatformSpecific {
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
   ) extends Queue[A] {
-
-    private def removeTaker(taker: Promise[Nothing, A])(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeed(takers.remove(taker))
 
     override def capacity: Int = queue.capacity
 
@@ -253,17 +250,21 @@ object Queue extends QueuePlatformSpecific {
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null =>
-              // add the promise to takers, then:
-              // - try take again in case a value was added since
-              // - wait for the promise to be completed
-              // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
-
-              ZIO.suspendSucceed {
-                takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers)
-                if (shutdownFlag.get) ZIO.interrupt else p.await
-              }.onInterrupt(removeTaker(p))
+              ZIO.uninterruptibleMask { restore =>
+                ZIO.suspendSucceed {
+                  takers.offer(p)
+                  strategy.unsafeCompleteTakers(queue, takers)
+                  if (shutdownFlag.get) ZIO.interrupt
+                  else
+                    restore(p.await).onInterrupt {
+                      ZIO.suspendSucceed {
+                        if (takers.remove(p)) UIO.unit
+                        else p.await.flatMap(a => offer(a).ignore)
+                      }
+                    }
+                }
+              }
 
             case item =>
               strategy.unsafeOnQueueEmptySpace(queue, takers)


### PR DESCRIPTION
Resolves: #9973 

## The Problem

The issue happens like this:

1. A fiber calls `take` on an empty queue and suspends.
2. At the same time, it's interrupted as another fiber calls `offer(item)`.
3. The `offer` tries to fulfill the suspended fiber’s promise, but the fiber is being interrupted and never processes the item.
4. The cleanup logic doesn’t requeue the item, which causes the item to be lost.

## What I Changed

- Wrapped the slow path in `Queue.take` with `ZIO.uninterruptibleMask`.
- Improved the `onInterrupt` handler on the promise `await`:
  - It now checks if the taker’s promise was already removed (claimed).
  - If it was claimed, we await the result and safely offer the item back into the queue.
- Removed the unused `removeTaker` method from `QueueImpl`.
- Added a regression test in `QueueSpec.scala` that consistently reproduces the issue and verifies the fix.