### PR TITLE
Fix OOM issue in `ZPipeline#encodeStringWith`

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -5,6 +5,7 @@ import zio.stream.encoding.EncodingException
 import zio.test.Assertion.{equalTo, fails, isEmpty}
 import zio.test._
 
+import java.nio.charset.Charset
 import scala.io.Source
 
 object ZPipelineSpec extends ZIOBaseSpec {
@@ -43,6 +44,20 @@ object ZPipelineSpec extends ZIOBaseSpec {
             .map(res => assert(res)(equalTo(Chunk[Byte](49, 50))))
         }
       ),
+      suite("encodeStringWith")(
+        test("doesn't cause OOM errors on large inputs") {
+          for {
+            bytes <- Random.RandomLive.nextString(12 * 1024 * 1024).map(_.getBytes)
+            stream = ZStream.fromIterable(bytes)
+            pipeline = ZPipeline.decodeStringWith(Charset.forName("UTF-8")) >>>
+                         ZPipeline.splitOn("\n") >>>
+                         ZPipeline.map[String, String](_.concat("\n")) >>>
+                         ZPipeline.encodeStringWith(Charset.forName("UTF-8"))
+            pipelined = stream.rechunk(1024).via(pipeline)
+            out      <- pipelined.runCollect
+          } yield assertTrue(out.dropRight(1).sameElements(bytes))
+        }
+      ) @@ TestAspect.jvmOnly,
       suite("splitLines")(
         test("preserves data")(
           check(weirdStringGenForSplitLines) { lines =>

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -24,6 +24,7 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
+import scala.annotation.tailrec
 
 /**
  * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer.
@@ -1184,77 +1185,100 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       val charBuffer = CharBuffer.allocate((bufferSize.toFloat / encoder.averageBytesPerChar).round)
       val byteBuffer = ByteBuffer.allocate(bufferSize)
 
-      def handleCoderResult(coderResult: CoderResult): ZIO[Any, CharacterCodingException, Chunk[Byte]] =
+      def handleCoderResult(coderResult: CoderResult): Chunk[Byte] =
         if (coderResult.isUnderflow || coderResult.isOverflow) {
-          ZIO.succeed {
-            charBuffer.compact()
-            byteBuffer.flip()
-            val array = new Array[Byte](byteBuffer.remaining())
-            byteBuffer.get(array)
-            byteBuffer.clear()
-            Chunk.fromArray(array)
-          }
+          charBuffer.compact()
+          byteBuffer.flip()
+          val array = new Array[Byte](byteBuffer.remaining())
+          byteBuffer.get(array)
+          byteBuffer.clear()
+          Chunk.fromArray(array)
         } else if (coderResult.isMalformed) {
-          ZIO.fail(new MalformedInputException(coderResult.length()))
+          throw new MalformedInputException(coderResult.length())
         } else if (coderResult.isUnmappable) {
-          ZIO.fail(new UnmappableCharacterException(coderResult.length()))
+          throw new UnmappableCharacterException(coderResult.length())
         } else {
-          ZIO.dieMessage(s"Invalid CoderResult state")
+          throw new RuntimeException("Invalid CoderResult state")
         }
 
-      def encodeChunk(inChars: Chunk[Char]): IO[CharacterCodingException, Chunk[Byte]] =
-        for {
-          remainingChars <- ZIO.succeed {
-                              val bufRemaining = charBuffer.remaining()
-                              val (decodeChars, remainingChars) =
-                                if (inChars.length > bufRemaining) {
-                                  inChars.splitAt(bufRemaining)
-                                } else
-                                  (inChars, Chunk.empty)
-                              charBuffer.put(decodeChars.toArray)
-                              charBuffer.flip()
-                              remainingChars
-                            }
-          result         <- ZIO.succeed(encoder.encode(charBuffer, byteBuffer, false))
-          encodedBytes   <- handleCoderResult(result)
-          remainderBytes <- if (remainingChars.isEmpty) Exit.emptyChunk else encodeChunk(remainingChars)
+      def encodeChunk(inChars: Chunk[Char]): Chunk[Byte] = {
+        @tailrec
+        def loop(inChars: Chunk[Char], acc: Chunk[Byte] = Chunk.empty): Chunk[Byte] = {
+          val remainingChars = {
+            val bufRemaining = charBuffer.remaining()
+            val (decodeChars, remainingChars) =
+              if (inChars.length > bufRemaining) {
+                inChars.splitAt(bufRemaining)
+              } else
+                (inChars, Chunk.empty)
+            charBuffer.put(decodeChars.toArray)
+            charBuffer.flip()
+            remainingChars
+          }
+          val result = encoder.encode(charBuffer, byteBuffer, false)
+          val bytes  = handleCoderResult(result)
+          val out    = acc ++ bytes
 
-        } yield encodedBytes ++ remainderBytes
+          if (remainingChars.isEmpty) out
+          else loop(remainingChars, out)
+        }
 
-      def endOfInput: IO[CharacterCodingException, Chunk[Byte]] =
-        for {
-          result         <- ZIO.succeed(encoder.encode(charBuffer, byteBuffer, true))
-          encodedBytes   <- handleCoderResult(result)
-          remainderBytes <- if (result.isOverflow) endOfInput else Exit.emptyChunk
-        } yield encodedBytes ++ remainderBytes
+        loop(inChars)
+      }
 
-      def flushRemaining: IO[CharacterCodingException, Chunk[Byte]] =
-        for {
-          result         <- ZIO.succeed(encoder.flush(byteBuffer))
-          encodedBytes   <- handleCoderResult(result)
-          remainderBytes <- if (result.isOverflow) flushRemaining else Exit.emptyChunk
-        } yield encodedBytes ++ remainderBytes
+      def endOfInput(): Chunk[Byte] = {
+        @tailrec
+        def loop(acc: Chunk[Byte] = Chunk.empty): Chunk[Byte] = {
+          charBuffer.flip()
+          val result       = encoder.encode(charBuffer, byteBuffer, true)
+          val encodedBytes = handleCoderResult(result)
+          val out          = acc ++ encodedBytes
+
+          if (result.isOverflow) loop(out) else out
+        }
+        loop()
+      }
+
+      def flushRemaining(): Chunk[Byte] = {
+        @tailrec
+        def loop(acc: Chunk[Byte] = Chunk.empty): Chunk[Byte] = {
+          val result       = encoder.flush(byteBuffer)
+          val encodedBytes = handleCoderResult(result)
+          val out          = acc ++ encodedBytes
+
+          if (result.isOverflow) loop(out) else out
+        }
+        loop()
+      }
+
+      def safely(bytes: => Chunk[Byte]): IO[CharacterCodingException, Chunk[Byte]] =
+        ZIO.suspendSucceed {
+          try {
+            Exit.succeed(bytes)
+          } catch {
+            case t: CharacterCodingException => ZIO.fail(t)
+            case t: RuntimeException         => ZIO.die(t)
+          }
+        }
 
       val push: Option[Chunk[Char]] => IO[CharacterCodingException, Chunk[Byte]] = {
         case Some(inChunk: Chunk[Char]) =>
-          encodeChunk(inChunk)
+          safely(encodeChunk(inChunk))
         case None =>
-          for {
-            _              <- ZIO.succeed(charBuffer.flip())
-            encodedBytes   <- endOfInput
-            remainingBytes <- flushRemaining
-            result          = encodedBytes ++ remainingBytes
-            _ <- ZIO.succeed {
-                   charBuffer.clear()
-                   byteBuffer.clear()
-                 }
-          } yield result
+          safely {
+            val encodedBytes   = endOfInput()
+            val remainingBytes = flushRemaining()
+            charBuffer.clear()
+            byteBuffer.clear()
+            encodedBytes ++ remainingBytes
+          }
       }
 
       val createPush: ZIO[Any, Nothing, Option[Chunk[Char]] => IO[CharacterCodingException, Chunk[Byte]]] =
-        for {
-          _ <- ZIO.succeed(encoder.reset)
-        } yield push
+        ZIO.succeed {
+          encoder.reset
+          push
+        }
 
       ZPipeline.fromPush(createPush)
     }


### PR DESCRIPTION
/fixes #9935
/claim #9935

Main issue is that `charBuffer.flip()` was being called just once (see comment below), so in case that we couldn't drain the `charBuffer` in a single iteration, we were not flipping it in the next iteration causing an infinite loop (and eventually an OOM error).

I also took the opportunity to re-write this method using tail recursion instead of ZIO recursion which should be far more performant