### PR TITLE
fix #9844 Improved Queue shutdown functionality 

### DIFF
--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -159,15 +159,16 @@ object Queue extends QueuePlatformSpecific {
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
+  ): Queue[Nothing,A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
 
-  private final class QueueImpl[A](
+  private final class QueueImpl[E,A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ) extends Queue[A] {
+    shutdownCauseRef: Ref.Synchronized[Option[Cause[E]]]
+  ) extends Queue[E,A] {
 
     private def removeTaker(taker: Promise[Nothing, A])(implicit trace: Trace): UIO[Unit] =
       ZIO.succeed(takers.remove(taker))

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -176,7 +176,10 @@ object Queue extends QueuePlatformSpecific {
 
     override def capacity: Int = queue.capacity
 
-    override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
+    override def offer(a: A)(implicit trace: Trace): ZIO[Any,E,Boolean] =
+      shutdownCauseRef.get.flatMap {
+       case Some(cause) => ZIO.failCause(cause)
+       case None        =>
       ZIO.suspendSucceed {
         if (shutdownFlag.get) ZIO.interrupt
         else {
@@ -204,8 +207,12 @@ object Queue extends QueuePlatformSpecific {
           }
         }
       }
+   }
 
-    override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
+    override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): ZIO[Any,E,Chunk[A1]] =
+      shutdownCauseRef.get.flatMap {
+        case Some(cause) => ZIO.failCause(cause)
+        case None        =>
       ZIO.suspendSucceed {
         if (shutdownFlag.get) ZIO.interrupt
         else {
@@ -230,16 +237,21 @@ object Queue extends QueuePlatformSpecific {
           }
         }
       }
+    }
 
     override def awaitShutdown(implicit trace: Trace): UIO[Unit] = shutdownHook.await
 
-    override def size(implicit trace: Trace): UIO[Int] =
+    override def size(implicit trace: Trace): ZIO[Any,E,Int] =
+      shutdownCauseRef.get.flatMap {
+       case Some(cause) => ZIO.failCause(cause)
+       case None        =>
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
           ZIO.interrupt
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
+    }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
@@ -269,9 +281,9 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
                ZIO.failCause(cause)
   } yield items
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def isShutdown(implicit trace: Trace): UIO[E,Boolean] = ZIO.succeed(shutdownFlag.get)
 
-    override def take(implicit trace: Trace): UIO[A] =
+    override def take(implicit trace: Trace): ZIO[Any,E,A] =
       ZIO.fiberIdWith { fiberId =>
         if (shutdownFlag.get) ZIO.interrupt
         else {
@@ -283,6 +295,9 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
               // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
 
+             shutdownCauseRef.get.flatMap {
+               case Some(cause) => ZIO.failCause(cause)
+               case None        =>
               ZIO.suspendSucceed {
                 takers.offer(p)
                 strategy.unsafeCompleteTakers(queue, takers)
@@ -295,8 +310,13 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
           }
         }
       }
+    }
 
-    override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
+    override def takeAll(implicit trace: Trace): ZIO[Any,E,Chunk[A]] =
+      shutdownCauseRef.get.flatMap {
+       case Some(cause) => ZIO.failCause(cause)
+       case None        =>
+      
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
           ZIO.interrupt
@@ -310,8 +330,12 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
           }
         }
       }
+    }
 
-    override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
+    override def takeUpTo(max: Int)(implicit trace: Trace): ZIO[Any,E,Chunk[A]] =
+     shutdownCauseRef.get.flatMap {
+      case Some(cause) => ZIO.failCause(cause)
+      case None        =>
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
           ZIO.interrupt
@@ -325,8 +349,12 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
           }
         }
       }
+    }
 
-    override def poll(implicit trace: Trace): UIO[Option[A]] =
+    override def poll(implicit trace: Trace): ZIO[Any,E,Option[A]] =
+     shutdownCauseRef.get.flatMap {
+      case Some(cause) => ZIO.failCause(cause)
+      case None        =>
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
           ZIO.interrupt
@@ -340,6 +368,7 @@ override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]
         }
       }
   }
+}
 
   private sealed abstract class Strategy[A] {
     private[this] val draining = new AtomicBoolean(false)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
  * A `Queue` is a lightweight, asynchronous queue into which values can be
  * enqueued and of which elements can be dequeued.
  */
-sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
+sealed abstract class Queue[E,A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
    * Checks whether the queue is currently empty.

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -144,6 +144,7 @@ object Queue extends QueuePlatformSpecific {
     fiberId: FiberId
   )(implicit unsafe: Unsafe): Queue[A] = {
     val p = Promise.unsafe.make[Nothing, Unit](fiberId)
+    val causeRef = Ref.Synchronized.unsafe.make[Option[Cause[E]]](None)
     unsafeCreate(
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
@@ -159,7 +160,7 @@ object Queue extends QueuePlatformSpecific {
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ): Queue[Nothing,A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
+  ): Queue[Nothing,A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy, causeRef)
 
   private final class QueueImpl[E,A](
     queue: MutableConcurrentQueue[A],

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -29,6 +29,14 @@ import scala.annotation.tailrec
 sealed abstract class Queue[E,A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
+   * Shuts down the queue with a specific error cause. 
+   * Any future interaction with the queue
+   * (such as take, offer, poll) will fail with this cause. 
+   */
+  def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]]
+
+
+  /**
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -88,7 +88,7 @@ object Queue extends QueuePlatformSpecific {
    * @return
    *   `UIO[Queue[A]]`
    */
-  def dropping[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
+  def dropping[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[Nothing,A]] =
     ZIO.fiberId.map(unsafe.dropping(requestedCapacity, _)(Unsafe.unsafe))
 
   /**
@@ -108,7 +108,7 @@ object Queue extends QueuePlatformSpecific {
    * @return
    *   `UIO[Queue[A]]`
    */
-  def sliding[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[A]] =
+  def sliding[A](requestedCapacity: => Int)(implicit trace: Trace): UIO[Queue[Nothing,A]] =
     ZIO.fiberId.map(unsafe.sliding(requestedCapacity, _)(Unsafe.unsafe))
 
   /**
@@ -119,21 +119,21 @@ object Queue extends QueuePlatformSpecific {
    * @return
    *   `UIO[Queue[A]]`
    */
-  def unbounded[A](implicit trace: Trace): UIO[Queue[A]] =
+  def unbounded[A](implicit trace: Trace): UIO[Queue[Nothing,A]] =
     ZIO.fiberId.map(unsafe.unbounded(_)(Unsafe.unsafe))
 
   object unsafe {
 
-    def bounded[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[A] =
+    def bounded[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[Nothing,A] =
       createQueue(MutableConcurrentQueue.bounded[A](requestedCapacity), Strategy.BackPressure(), fiberId)
 
-    def dropping[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[A] =
+    def dropping[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[Nothing,A] =
       createQueue(MutableConcurrentQueue.bounded[A](requestedCapacity), Strategy.Dropping(), fiberId)
 
-    def sliding[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[A] =
+    def sliding[A](requestedCapacity: Int, fiberId: FiberId)(implicit unsafe: Unsafe): Queue[Nothing,A] =
       createQueue(MutableConcurrentQueue.bounded[A](requestedCapacity), Strategy.Sliding(), fiberId)
 
-    def unbounded[A](fiberId: FiberId)(implicit unsafe: Unsafe): Queue[A] =
+    def unbounded[A](fiberId: FiberId)(implicit unsafe: Unsafe): Queue[Nothing,A] =
       createQueue(MutableConcurrentQueue.unbounded[A], Strategy.Dropping(), fiberId)
 
   }

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -255,6 +255,20 @@ object Queue extends QueuePlatformSpecific {
         Exit.unit
       }.uninterruptible
 
+override def shutdownCause(cause: Cause[E])(implicit trace: Trace): UIO[Chunk[A]] =
+  for {
+    set <- shutdownCauseRef.modify {
+             case None    => (true, Some(cause))
+             case some    => (false, some)
+           }
+    items <- if (set) {
+               for {
+                 _ <- shutdown(Trace.empty)
+               } yield unsafePollAll(queue)
+             } else
+               ZIO.failCause(cause)
+  } yield items
+
     override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
 
     override def take(implicit trace: Trace): UIO[A] =


### PR DESCRIPTION
/claim #9844 
- add an E type parameter to Queue

- add a shutdownCause method that takes a type parameter of type Cause[E]

- shutdownCause would also return the items currently buffered in the queue in order to dispose of them

- after shutdownCause has been called, any attempt to interact with the queue will fail with the cause

- methods like take, offer etc. should indicate errors of type E

- streams created with ZStream.fromQueue would also fail with this cause

- shutdownCause should be atomic: when multiple fibers call it at the same time, one of them wins and the others fail with the cause supplied by the winner.