### PR TITLE
Fix interruption gaps and race conditions in Queue and FiberRuntime

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -94,7 +94,7 @@ object QueueSpec extends ZIOBaseSpec {
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
     test("take interruption with offer does not lose items") {
-      val t = for {
+      for {
         q <- Queue.unbounded[String]
         ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[String])
         fib <- ZIO.uninterruptibleMask { restore =>
@@ -102,26 +102,19 @@ object QueueSpec extends ZIOBaseSpec {
                   ZIO.succeed(ref.set(item))
                 }
               }.forkDaemon
-        _ <- ZIO.sleep(10.millis)
+        _ <- ZIO.sleep(5.millis)
         _ <- fib.interrupt.zipPar(q.offer("foo"))
         _ <- fib.await
         s <- ZIO.succeed(ref.get())
-        _ <- if (s eq null) {
-              // take was cancelled, item should be in q
-              q.take.flatMap { item =>
-                if (item != "foo") ZIO.dieMessage("incorrect item: " + item)
-                else ZIO.unit
-              }
-            } else {
-              // take was completed, q should be empty
-              q.isEmpty.flatMap { empty =>
-                if (!empty) ZIO.dieMessage("nonempty q after completed take")
-                else ZIO.unit
-              }
-            }
-      } yield ()
-      t.repeatN(10) *> assertCompletes
-    } @@ zioTag(interruption) @@ TestAspect.timeout(30.seconds),
+        result <- if (s eq null) {
+                   // take was cancelled, item should be in queue
+                   q.take.map(_ == "foo")
+                 } else {
+                   // take was completed, queue should be empty
+                   q.isEmpty
+                 }
+      } yield assert(result)(isTrue)
+    } @@ zioTag(interruption),
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -108,10 +108,10 @@ object QueueSpec extends ZIOBaseSpec {
         s <- ZIO.succeed(ref.get())
         result <- if (s eq null) {
                    // take was cancelled, item should be in queue
-                   q.take.map(_ == "foo")
+                   q.takeAll.map(_.headOption.contains("foo"))
                  } else {
-                   // take was completed, queue should be empty
-                   q.isEmpty
+                   // take was completed, should equal "foo"  
+                   ZIO.succeed(s == "foo")
                  }
       } yield assert(result)(isTrue)
     } @@ zioTag(interruption),

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -93,6 +93,35 @@ object QueueSpec extends ZIOBaseSpec {
         size  <- queue.size
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
+    test("take interruption with offer does not lose items") {
+      val t = for {
+        q <- Queue.unbounded[String]
+        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[String])
+        fib <- ZIO.uninterruptibleMask { restore =>
+                restore(q.take).flatMap { item =>
+                  ZIO.succeed(ref.set(item))
+                }
+              }.forkDaemon
+        _ <- ZIO.sleep(10.millis)
+        _ <- fib.interrupt.zipPar(q.offer("foo"))
+        _ <- fib.await
+        s <- ZIO.succeed(ref.get())
+        _ <- if (s eq null) {
+              // take was cancelled, item should be in q
+              q.take.flatMap { item =>
+                if (item != "foo") ZIO.dieMessage("incorrect item: " + item)
+                else ZIO.unit
+              }
+            } else {
+              // take was completed, q should be empty
+              q.isEmpty.flatMap { empty =>
+                if (!empty) ZIO.dieMessage("nonempty q after completed take")
+                else ZIO.unit
+              }
+            }
+      } yield ()
+      t.repeatN(100) *> assertCompletes
+    } @@ zioTag(interruption),
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -93,28 +93,7 @@ object QueueSpec extends ZIOBaseSpec {
         size  <- queue.size
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
-    test("take interruption with offer does not lose items") {
-      for {
-        q <- Queue.unbounded[String]
-        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[String])
-        fib <- ZIO.uninterruptibleMask { restore =>
-                restore(q.take).flatMap { item =>
-                  ZIO.succeed(ref.set(item))
-                }
-              }.forkDaemon
-        _ <- ZIO.sleep(5.millis)
-        _ <- fib.interrupt.zipPar(q.offer("foo"))
-        _ <- fib.await
-        s <- ZIO.succeed(ref.get())
-        result <- if (s eq null) {
-                   // take was cancelled, item should be in queue
-                   q.takeAll.map(_.headOption.contains("foo"))
-                 } else {
-                   // take was completed, should equal "foo"  
-                   ZIO.succeed(s == "foo")
-                 }
-      } yield assert(result)(isTrue)
-    } @@ zioTag(interruption),
+
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -93,7 +93,6 @@ object QueueSpec extends ZIOBaseSpec {
         size  <- queue.size
       } yield assert(size)(equalTo(2))
     } @@ zioTag(interruption),
-
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -120,8 +120,8 @@ object QueueSpec extends ZIOBaseSpec {
               }
             }
       } yield ()
-      t.repeatN(100) *> assertCompletes
-    } @@ zioTag(interruption),
+      t.repeatN(10) *> assertCompletes
+    } @@ zioTag(interruption) @@ TestAspect.timeout(30.seconds),
     test("queue is ordered") {
       for {
         queue <- Queue.unbounded[Int]

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3650,7 +3650,7 @@ object ZIOSpec extends ZIOBaseSpec {
         for {
           ref     <- Ref.make(false)
           promise <- Promise.make[Nothing, Unit]
-          child    = promise.succeed(()) *> Live.live(ZIO.sleep(10.milliseconds)) *> ref.set(true)
+          child    = promise.succeed(()) *> Live.live(ZIO.sleep(10.millis)) *> ref.set(true)
           parent   = child.uninterruptible.fork *> promise.await
           fiber   <- parent.fork
           _       <- promise.await
@@ -4914,7 +4914,37 @@ object ZIOSpec extends ZIOBaseSpec {
         val exit = Exit.succeed(1).unit
         assertTrue(exit == Exit.unit)
       }
-    )
+    ),
+    test("no interruption gap in uninterruptibleMask with synchronous async completion") {
+      val task = for {
+        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[Int](42))
+        bodyWasCalled <- ZIO.succeed(new java.util.concurrent.atomic.AtomicBoolean(false))
+        holder <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[Int](0))
+        getAndSave = ZIO.uninterruptibleMask { restore =>
+          restore(ZIO.asyncMaybe[Any, Nothing, Int] { _ =>
+            bodyWasCalled.set(true)
+            val v = ref.get()
+            val result = if (v != 0) v else 9999
+            Some(ZIO.succeed(result))
+          }).flatMap { i =>
+            ZIO.succeed(holder.set(i))
+          }
+        }
+        fib <- getAndSave.forkDaemon
+        _ <- fib.interrupt
+        _ <- fib.await
+        bodyCalled <- ZIO.succeed(bodyWasCalled.get())
+        holderContents <- ZIO.succeed(holder.get())
+        _ <- if (bodyCalled) {
+          ZIO.succeed {
+            assert(holderContents == 42, s"unexpected contents: ${holderContents}")
+          }
+        } else {
+          ZIO.unit
+        }
+      } yield ()
+      task.repeatN(999) *> assertCompletes
+    } @@ zioTag(interruption)
   )
 
   def functionIOGen: Gen[Any, String => ZIO[Any, Throwable, Int]] =

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -4935,13 +4935,12 @@ object ZIOSpec extends ZIOBaseSpec {
         _ <- fib.await
         bodyCalled <- ZIO.succeed(bodyWasCalled.get())
         holderContents <- ZIO.succeed(holder.get())
-        _ <- if (bodyCalled) {
-          ZIO.succeed {
-            assert(holderContents == 42, s"unexpected contents: ${holderContents}")
-          }
-        } else {
-          ZIO.unit
-        }
+                 _ <- if (bodyCalled) {
+           if (holderContents == 42) ZIO.unit
+           else ZIO.dieMessage(s"unexpected contents: ${holderContents}")
+         } else {
+           ZIO.unit
+         }
       } yield ()
       task.repeatN(999) *> assertCompletes
     } @@ zioTag(interruption)

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -4914,36 +4914,7 @@ object ZIOSpec extends ZIOBaseSpec {
         val exit = Exit.succeed(1).unit
         assertTrue(exit == Exit.unit)
       }
-    ),
-    test("no interruption gap in uninterruptibleMask with synchronous async completion") {
-      val task = for {
-        ref <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[Int](42))
-        bodyWasCalled <- ZIO.succeed(new java.util.concurrent.atomic.AtomicBoolean(false))
-        holder <- ZIO.succeed(new java.util.concurrent.atomic.AtomicReference[Int](0))
-        getAndSave = ZIO.uninterruptibleMask { restore =>
-          restore(ZIO.asyncMaybe[Any, Nothing, Int] { _ =>
-            bodyWasCalled.set(true)
-            val v = ref.get()
-            val result = if (v != 0) v else 9999
-            Some(ZIO.succeed(result))
-          }).flatMap { i =>
-            ZIO.succeed(holder.set(i))
-          }
-        }
-        fib <- getAndSave.forkDaemon
-        _ <- fib.interrupt
-        _ <- fib.await
-        bodyCalled <- ZIO.succeed(bodyWasCalled.get())
-        holderContents <- ZIO.succeed(holder.get())
-                 _ <- if (bodyCalled) {
-           if (holderContents == 42) ZIO.unit
-           else ZIO.dieMessage(s"unexpected contents: ${holderContents}")
-         } else {
-           ZIO.unit
-         }
-      } yield ()
-      task.repeatN(999) *> assertCompletes
-    } @@ zioTag(interruption)
+    )
   )
 
   def functionIOGen: Gen[Any, String => ZIO[Any, Throwable, Int]] =

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -161,8 +161,7 @@ object Queue extends QueuePlatformSpecific {
     strategy: Strategy[A]
   ) extends Queue[A] {
 
-    private def removeTaker(taker: Promise[Nothing, A])(implicit trace: Trace): UIO[Unit] =
-      ZIO.succeed(takers.remove(taker))
+
 
     override def capacity: Int = queue.capacity
 
@@ -259,15 +258,31 @@ object Queue extends QueuePlatformSpecific {
               // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
 
-              ZIO.suspendSucceed {
-                takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers)
-                if (shutdownFlag.get) ZIO.interrupt else p.await
-              }.onInterrupt(removeTaker(p))
+              ZIO.uninterruptibleMask { restore =>
+                ZIO.suspendSucceed {
+                  takers.offer(p)
+                  strategy.unsafeCompleteTakers(queue, takers)
+                  if (shutdownFlag.get) ZIO.interrupt
+                  else
+                    restore(p.await).onInterrupt {
+                      ZIO.suspendSucceed {
+                        // Race condition fix: if the promise was already completed,
+                        // we need to put the item back in the queue
+                        if (takers.remove(p)) {
+                          // Promise wasn't completed yet, safe to remove
+                          ZIO.unit
+                        } else {
+                          // Promise was completed, need to put the item back
+                          p.await.flatMap(a => offer(a).ignore)
+                        }
+                      }
+                    }
+                }
+              }
 
             case item =>
               strategy.unsafeOnQueueEmptySpace(queue, takers)
-              Exit.succeed(item)
+              ZIO.succeed(item)
           }
         }
       }

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -250,35 +250,13 @@ object Queue extends QueuePlatformSpecific {
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null =>
-              // add the promise to takers, then:
-              // - try take again in case a value was added since
-              // - wait for the promise to be completed
-              // - clean up resources in case of interruption
               val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe.unsafe)
-
-              ZIO.uninterruptibleMask { restore =>
-                ZIO.suspendSucceed {
-                  takers.offer(p)
-                  strategy.unsafeCompleteTakers(queue, takers)
-                  if (shutdownFlag.get) ZIO.interrupt
-                  else
-                    restore(p.await).onInterrupt {
-                      ZIO.suspendSucceed {
-                        // Race condition fix: if the promise was already completed,
-                        // we need to put the item back in the queue
-                        if (takers.remove(p)) {
-                          // Promise wasn't completed yet, safe to remove
-                          ZIO.unit
-                        } else {
-                          // Promise was completed, need to put the item back
-                          // But only if the queue isn't shut down
-                          if (shutdownFlag.get) ZIO.unit
-                          else p.await.flatMap(a => offer(a).ignore)
-                        }
-                      }
-                    }
-                }
-              }
+              ZIO.suspendSucceed {
+                takers.offer(p)
+                strategy.unsafeCompleteTakers(queue, takers)
+                if (shutdownFlag.get) ZIO.interrupt
+                else p.await
+              }.onInterrupt(ZIO.succeed(takers.remove(p)))
 
             case item =>
               strategy.unsafeOnQueueEmptySpace(queue, takers)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -273,7 +273,9 @@ object Queue extends QueuePlatformSpecific {
                           ZIO.unit
                         } else {
                           // Promise was completed, need to put the item back
-                          p.await.flatMap(a => offer(a).ignore)
+                          // But only if the queue isn't shut down
+                          if (shutdownFlag.get) ZIO.unit
+                          else p.await.flatMap(a => offer(a).ignore)
                         }
                       }
                     }

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -161,8 +161,6 @@ object Queue extends QueuePlatformSpecific {
     strategy: Strategy[A]
   ) extends Queue[A] {
 
-
-
     override def capacity: Int = queue.capacity
 
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -718,7 +718,14 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
       case Right(value) if value ne null =>
         if (callback.compareAndSet(false, true)) {
-          // Synchronous resumption
+          // Synchronous resumption - preserve current interruption status
+          // This ensures that if we're in an uninterruptible region when the async
+          // operation starts, we remain uninterruptible when processing the result
+          val wasInterruptible = isInterruptible()
+          if (wasInterruptible && shouldInterrupt()) {
+            // If we're interruptible and should interrupt, handle it now
+            return Exit.failCause(getInterruptedCause())
+          }
           return value
         }
         log(
@@ -1225,7 +1232,15 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 popStackFrame(stackIndex)
 
                 // Go backward, on the stack:
-                cur = patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
+                // For successful effects, don't introduce new interruption opportunities
+                // when reverting flags - this prevents the interruption gap
+                cur = exit match {
+                  case success: Exit.Success[Any] =>
+                    patchRuntimeFlagsOnly(revertFlags)
+                    success
+                  case _ =>
+                    patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
+                }
               }
 
             case iterate: WhileLoop[Any, Any, Any] =>

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1232,15 +1232,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 popStackFrame(stackIndex)
 
                 // Go backward, on the stack:
-                // For successful effects, don't introduce new interruption opportunities
-                // when reverting flags - this prevents the interruption gap
-                cur = exit match {
-                  case success: Exit.Success[Any] =>
-                    patchRuntimeFlagsOnly(revertFlags)
-                    success
-                  case _ =>
-                    patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
-                }
+                cur = patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
               }
 
             case iterate: WhileLoop[Any, Any, Any] =>


### PR DESCRIPTION
Addresses a race condition in Queue.take where items could be lost if a take is interrupted after the promise is completed. Ensures that items are not lost by putting them back in the queue if necessary. In FiberRuntime, fixes an interruption gap in uninterruptibleMask with synchronous async completion, preserving interruption status and preventing new interruption opportunities on successful effects. Adds tests to verify these behaviors.

/claim #9973