### PR TITLE
Enable build tools to relocate "target/test-reports-zio/output.json".

### DIFF
--- a/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
+++ b/test-sbt/jvm/src/main/scala/zio/test/sbt/ZTestRunnerJVM.scala
@@ -91,7 +91,8 @@ final class ZTestRunnerJVM(val args: Array[String], val remoteArgs: Array[String
     val testArgs = TestArgs.parse(args)
 
     renderer = testArgs.testRenderer // Ensures summary is pretty in same style as rest of the test output
-    val sharedTestOutputLayer = ExecutionEventPrinter.live(console, testArgs.testEventRenderer) >>> TestOutput.live
+    val sharedTestOutputLayer =
+      ExecutionEventPrinter.live(console, testArgs.testEventRenderer, testArgs.reportsParent) >>> TestOutput.live
 
     val specTasks: Array[ZIOSpecAbstract] = defs.map(disectTask(_, testClassLoader))
     val sharedLayerFromSpecs: ZLayer[Any, Any, Any] =

--- a/test/js/src/main/scala/zio/test/results/ResultFileOpsJson.scala
+++ b/test/js/src/main/scala/zio/test/results/ResultFileOpsJson.scala
@@ -9,7 +9,7 @@ private[test] trait ResultFileOps {
 }
 
 private[test] object ResultFileOps {
-  val live: ZLayer[Any, Nothing, ResultFileOps] =
+  def live(jsonResultPath: String): ZLayer[Any, Nothing, ResultFileOps] =
     ZLayer.succeed(
       Json()
     )

--- a/test/js/src/main/scala/zio/test/results/ResultPrinterJson.scala
+++ b/test/js/src/main/scala/zio/test/results/ResultPrinterJson.scala
@@ -4,10 +4,10 @@ import zio._
 import zio.test._
 
 private[test] object ResultPrinterJson {
-  val live: ZLayer[Any, Nothing, ResultPrinter] =
+  def live(jsonResultPath: String): ZLayer[Any, Nothing, ResultPrinter] =
     ZLayer.make[ResultPrinter](
       ResultSerializer.live,
-      ResultFileOps.live,
+      ResultFileOps.live(jsonResultPath),
       ZLayer.fromFunction(
         LiveImpl(_, _)
       )

--- a/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
+++ b/test/jvm-native/src/main/scala/zio/test/results/ResultFileOps.scala
@@ -9,8 +9,8 @@ private[test] trait ResultFileOps {
 }
 
 private[test] object ResultFileOps {
-  val live: ZLayer[Any, Nothing, ResultFileOps] =
-    ZLayer.scoped(Json.apply)
+  def live(jsonResultPath: String): ZLayer[Any, Nothing, ResultFileOps] =
+    ZLayer.scoped(Json.apply(jsonResultPath))
 
   private[test] final class Json private (resultPath: String) extends ResultFileOps {
     private val queue = new ConcurrentLinkedQueue[String]()
@@ -61,8 +61,5 @@ private[test] object ResultFileOps {
   object Json {
     def apply(filename: String): ZIO[Scope, Nothing, Json] =
       ZIO.acquireRelease(ZIO.succeed(new Json(filename)))(_.close)
-
-    def apply: ZIO[Scope, Nothing, Json] =
-      apply("target/test-reports-zio/output.json")
   }
 }

--- a/test/jvm-native/src/main/scala/zio/test/results/ResultPrinterJson.scala
+++ b/test/jvm-native/src/main/scala/zio/test/results/ResultPrinterJson.scala
@@ -4,10 +4,10 @@ import zio.test._
 import zio.{ZIO, ZLayer}
 
 private[test] object ResultPrinterJson {
-  val live: ZLayer[Any, Nothing, ResultPrinter] =
+  def live(jsonResultPath: String): ZLayer[Any, Nothing, ResultPrinter] =
     ZLayer.make[ResultPrinter](
       ResultSerializer.live,
-      ResultFileOps.live,
+      ResultFileOps.live(jsonResultPath),
       ZLayer.fromFunction(LiveImpl.apply _)
     )
 

--- a/test/shared/src/main/scala/zio/test/ExecutionEventPrinter.scala
+++ b/test/shared/src/main/scala/zio/test/ExecutionEventPrinter.scala
@@ -17,9 +17,13 @@ private[test] object ExecutionEventPrinter {
         })
   }
 
-  def live(console: Console, eventRenderer: ReporterEventRenderer): ZLayer[Any, Nothing, ExecutionEventPrinter] =
+  def live(
+    console: Console,
+    eventRenderer: ReporterEventRenderer,
+    reportsParent: String
+  ): ZLayer[Any, Nothing, ExecutionEventPrinter] =
     ZLayer.make[ExecutionEventPrinter](
-      ResultPrinter.json,
+      ResultPrinter.json(reportsParent),
       ExecutionEventConsolePrinter.live(eventRenderer),
       TestLogger.fromConsole(console),
       ZLayer.fromFunction(Live.apply _)

--- a/test/shared/src/main/scala/zio/test/ExecutionEventSink.scala
+++ b/test/shared/src/main/scala/zio/test/ExecutionEventSink.scala
@@ -39,8 +39,15 @@ object ExecutionEventSink {
     }
 
   def live(console: Console, eventRenderer: ReporterEventRenderer): ZLayer[Any, Nothing, ExecutionEventSink] =
+    live(console, eventRenderer, reportsParent = TestArgs.reportsParentDefault)
+
+  def live(
+    console: Console,
+    eventRenderer: ReporterEventRenderer,
+    reportsParent: String
+  ): ZLayer[Any, Nothing, ExecutionEventSink] =
     ZLayer.make[ExecutionEventSink](
-      ExecutionEventPrinter.live(console, eventRenderer),
+      ExecutionEventPrinter.live(console, eventRenderer, reportsParent),
       TestOutput.live,
       ZLayer.fromZIO(
         for {

--- a/test/shared/src/main/scala/zio/test/TestArgs.scala
+++ b/test/shared/src/main/scala/zio/test/TestArgs.scala
@@ -26,7 +26,8 @@ private[test] final case class TestArgs(
   tagIgnoreTerms: List[String],
   testTaskPolicy: Option[String],
   testRenderer: TestRenderer,
-  printSummary: Boolean
+  printSummary: Boolean,
+  reportsParent: String
 ) {
   val testEventRenderer: ReporterEventRenderer =
     testRenderer match {
@@ -44,20 +45,32 @@ private[test] final case class TestArgs(
 }
 
 object TestArgs {
+  val reportsParentDefault: String = "target"
+  val jsonResultPath: String       = "test-reports-zio/output.json"
+
   def empty: TestArgs =
-    TestArgs(List.empty[String], List.empty[String], List.empty[String], None, ConsoleRenderer, printSummary = true)
+    TestArgs(
+      List.empty[String],
+      List.empty[String],
+      List.empty[String],
+      None,
+      ConsoleRenderer,
+      printSummary = true,
+      reportsParentDefault
+    )
 
   def parse(args: Array[String]): TestArgs = {
     // TODO: Add a proper command-line parser
     val parsedArgs = args
       .sliding(2, 2)
       .collect {
-        case Array("-t", term)           => ("testSearchTerm", term)
-        case Array("-tags", term)        => ("tagSearchTerm", term)
-        case Array("-ignore-tags", term) => ("tagIgnoreTerm", term)
-        case Array("-policy", name)      => ("policy", name)
-        case Array("-renderer", name)    => ("renderer", name)
-        case Array("-summary", flag)     => ("summary", flag)
+        case Array("-t", term)            => ("testSearchTerm", term)
+        case Array("-tags", term)         => ("tagSearchTerm", term)
+        case Array("-ignore-tags", term)  => ("tagIgnoreTerm", term)
+        case Array("-policy", name)       => ("policy", name)
+        case Array("-renderer", name)     => ("renderer", name)
+        case Array("-summary", flag)      => ("summary", flag)
+        case Array("-reports", directory) => ("reportsParent", directory)
       }
       .toList
       .groupBy(_._1)
@@ -71,11 +84,12 @@ object TestArgs {
     val testTaskPolicy = parsedArgs.getOrElse("policy", Nil).headOption
     val testRenderer   = parsedArgs.getOrElse("renderer", Nil).headOption.map(_.toLowerCase)
     val printSummary   = parsedArgs.getOrElse("summary", Nil).headOption.forall(_.toBoolean)
+    val reportsParent  = parsedArgs.getOrElse("reportsParent", Nil).headOption.getOrElse(reportsParentDefault)
     val typedTestRenderer =
       testRenderer match {
         case Some(value) if value == "intellij" => IntelliJRenderer
         case _                                  => ConsoleRenderer
       }
-    TestArgs(terms, tags, ignoreTags, testTaskPolicy, typedTestRenderer, printSummary)
+    TestArgs(terms, tags, ignoreTags, testTaskPolicy, typedTestRenderer, printSummary, reportsParent)
   }
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -111,7 +111,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       perTestLayer = (ZLayer.succeedEnvironment(scopeEnv) ++ liveEnvironment) >>>
                        (TestEnvironment.live ++ ZLayer.environment[Scope])
 
-      executionEventSinkLayer = ExecutionEventSink.live(console, testArgs.testEventRenderer)
+      executionEventSinkLayer = ExecutionEventSink.live(console, testArgs.testEventRenderer, testArgs.reportsParent)
       environment            <- ZIO.environment[Environment]
       runner =
         TestRunner(

--- a/test/shared/src/main/scala/zio/test/results/TestResultPrinter.scala
+++ b/test/shared/src/main/scala/zio/test/results/TestResultPrinter.scala
@@ -1,12 +1,15 @@
 package zio.test.results
 
 import zio.{ZIO, ZLayer}
-import zio.test.ExecutionEvent
+import zio.test.{ExecutionEvent, TestArgs}
 
 trait ResultPrinter {
   def print[E](event: ExecutionEvent.Test[E]): ZIO[Any, Nothing, Unit]
 }
 
 object ResultPrinter {
-  val json: ZLayer[Any, Nothing, ResultPrinter] = ResultPrinterJson.live
+  val json: ZLayer[Any, Nothing, ResultPrinter] = json(TestArgs.reportsParentDefault)
+
+  def json(reportsParent: String): ZLayer[Any, Nothing, ResultPrinter] =
+    ResultPrinterJson.live(s"$reportsParent/${TestArgs.jsonResultPath}")
 }


### PR DESCRIPTION
Currently, ZIO Test writes test report into "target/test-reports-zio/output.json"; this location is appropriate when running with sbt - and completely out of place for other build tools (e.g. Gradle).

This pull request introduces a test argument `-reports` (`zio.test.TestArgs.reportsParent`) that specifies parent directory of `test-reports-zio/output.json`, enabling build tools running ZIO Test via its `sbt.testing.Framework` implementation to place test report in an appropriate location.

fixes #10037

Currently, `output.json` is written when running on JVM and Scala Native - but not on Scala.js; this pull request does _not_ change that.

Currently, "target/test-reports-zio" directory is also hard-coded as a directory where test debug files `**_debug.txt` are written to (in `zio.test.TestDebug`); this pull request does _not_ change that either.