### PR TITLE
Add test for `ZStream.fromIterator` about exceptional case

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -20,7 +20,7 @@ object ZStreamSpec extends ZIOBaseSpec {
   def inParallel(action: => Unit)(implicit ec: ExecutionContext): Unit =
     ec.execute(() => action)
 
-  def spec =
+  override def spec: Spec[TestEnvironment with Scope, Any] =
     suite("ZStreamSpec")(
       suite("Combinators")(
         suite("absolve")(
@@ -5621,11 +5621,36 @@ object ZStreamSpec extends ZIOBaseSpec {
             _ <- ZStream.fromIterableZIO(ZIO.succeed(1 to 5000000)).runDrain
           } yield assertCompletes
         },
-        test("fromIterator") {
-          check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
-            assertZIO(ZStream.fromIterator(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))
+        suite("fromIterator")(
+          test("with values") {
+            check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), min = 1)) { (chunk, maxChunkSize) =>
+              assertZIO(ZStream.fromIterator(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))
+            }
+          },
+          test("handles exceptions from making the iterator") {
+            check(Gen.small(Gen.const(_), min = 1)) { maxChunkSize =>
+              val exception = new RuntimeException("Iterator error")
+              def failingIterator = {
+                throw exception
+
+                List(1, 2).iterator
+              }
+
+              assertZIO(ZStream.fromIterator(failingIterator, maxChunkSize).runCollect.exit)(fails(equalTo(exception)))
+            }
+          },
+          test("handles exceptions from iterator") {
+            check(Gen.small(Gen.const(_), min = 1)) { maxChunkSize =>
+              val exception = new RuntimeException("Iterator error")
+              val failingIterator =
+                new Iterator[Int] {
+                  def hasNext: Boolean = true
+                  def next(): Int      = throw exception
+                }
+              assertZIO(ZStream.fromIterator(failingIterator, maxChunkSize).runCollect.exit)(fails(equalTo(exception)))
+            }
           }
-        },
+        ),
         test("fromIteratorSucceed") {
           check(Gen.small(Gen.chunkOfN(_)(Gen.int)), Gen.small(Gen.const(_), 1)) { (chunk, maxChunkSize) =>
             assertZIO(ZStream.fromIteratorSucceed(chunk.iterator, maxChunkSize).runCollect)(equalTo(chunk))

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5630,11 +5630,7 @@ object ZStreamSpec extends ZIOBaseSpec {
           test("handles exceptions from making the iterator") {
             check(Gen.small(Gen.const(_), min = 1)) { maxChunkSize =>
               val exception = new RuntimeException("Iterator error")
-              def failingIterator = {
-                throw exception
-
-                List(1, 2).iterator
-              }
+              def failingIterator: Iterator[Int] = throw exception
 
               assertZIO(ZStream.fromIterator(failingIterator, maxChunkSize).runCollect.exit)(fails(equalTo(exception)))
             }


### PR DESCRIPTION
I didn't manage to add a case for a fatal error as I didn't manage to cactch the fatal error. No idea why

Needed for: https://github.com/zio/zio/pull/10060