### PR TITLE
Optimize Semaphore implementation

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/NewSemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/NewSemaphoreBenchmark.scala
@@ -1,0 +1,69 @@
+package zio.stm
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+import zio.BenchmarkUtil._
+import zio._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Semaphore => JSemaphore}
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(1)
+class SinglePermitSemaphoreBenchmark {
+  @Param(Array("1", "2"))
+  var fibers: Int = _
+
+  @Param(Array("1"))
+  var permits: Int = _
+
+  val ops: Int = 1000
+
+  @Benchmark
+  def zioSemaphore(bh: Blackhole): Unit =
+    unsafeRun(for {
+      sem   <- Semaphore.make(permits.toLong)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(Exit.succeed(bh.consume(1))))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def zioSemaphore3(bh: Blackhole): Unit =
+    unsafeRun(for {
+      sem   <- Semaphore3.make(permits.toLong)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(Exit.succeed(bh.consume(1))))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def javaSemaphoreFair(bh: Blackhole): Unit =
+    unsafeRun(for {
+      lock <- ZIO.succeed(new JSemaphore(permits, true))
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops) {
+                 ZIO.succeed {
+                   lock.acquire()
+                   try bh.consume(1)
+                   finally lock.release()
+                 }
+               }))
+      _ <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def javaSemaphoreUnfair(bh: Blackhole): Unit =
+    unsafeRun(for {
+      lock <- ZIO.succeed(new JSemaphore(permits, false))
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops) {
+                 ZIO.succeed {
+                   lock.acquire()
+                   try bh.consume(1)
+                   finally lock.release()
+                 }
+               }))
+      _ <- fiber.join
+    } yield ())
+}

--- a/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmarkRunner.scala
+++ b/benchmarks/src/main/scala/zio/stm/SemaphoreBenchmarkRunner.scala
@@ -1,0 +1,22 @@
+package zio.stm
+
+import zio.ZIOAppDefault
+import zio.ZIO
+import org.openjdk.jmh.infra.Blackhole
+
+object SemaphoreBenchmarkRunner extends ZIOAppDefault {
+  def run =
+    for {
+      _        <- ZIO.succeed(println("Running benchmarks..."))
+      benchmark = new SinglePermitSemaphoreBenchmark()
+      _        <- ZIO.succeed(println("Running javaSemaphoreFair"))
+      _        <- ZIO.succeed(benchmark.javaSemaphoreFair(new Blackhole("javaSemaphoreFair")))
+      _        <- ZIO.succeed(println("Running javaSemaphoreUnfair"))
+      _        <- ZIO.succeed(benchmark.javaSemaphoreUnfair(new Blackhole("javaSemaphoreUnfair")))
+      _        <- ZIO.succeed(println("Running zioSemaphore"))
+      _        <- ZIO.succeed(benchmark.zioSemaphore(new Blackhole("zioSemaphore")))
+      _        <- ZIO.succeed(println("Running zioSemaphore3"))
+      _        <- ZIO.succeed(new SinglePermitSemaphoreBenchmark().zioSemaphore3(new Blackhole("zioSemaphore3")))
+      _        <- ZIO.succeed(println("Benchmarks finished."))
+    } yield ()
+}

--- a/benchmarks/src/test/scala/zio/SemaphoreBenchmarkSpec.scala
+++ b/benchmarks/src/test/scala/zio/SemaphoreBenchmarkSpec.scala
@@ -1,0 +1,26 @@
+package zio
+
+import zio.test._
+import zio.test.Assertion._
+import zio.stm.SinglePermitSemaphoreBenchmark
+import org.openjdk.jmh.infra.Blackhole
+
+object SemaphoreBenchmarkSpec extends ZIOSpecDefault {
+  def spec = suite("SemaphoreBenchmarkSpec")(
+    test("run benchmark") {
+      val benchmark = new zio.stm.SinglePermitSemaphoreBenchmark()
+      benchmark.fibers = 10
+      benchmark.permits = 5
+      for {
+        _ <- ZIO.succeed(println("Running javaSemaphoreFair"))
+        _ <- ZIO.succeed(benchmark.javaSemaphoreFair(new Blackhole()))
+        _ <- ZIO.succeed(println("Running javaSemaphoreUnfair"))
+        _ <- ZIO.succeed(benchmark.javaSemaphoreUnfair(new Blackhole()))
+        _ <- ZIO.succeed(println("Running zioSemaphore"))
+        _ <- ZIO.succeed(benchmark.zioSemaphore(new Blackhole()))
+        _ <- ZIO.succeed(println("Running zioSemaphore3"))
+        _ <- ZIO.succeed(benchmark.zioSemaphore3(new Blackhole()))
+      } yield assert(true)(isTrue)
+    }
+  )
+}

--- a/build.sbt
+++ b/build.sbt
@@ -28,28 +28,19 @@ inThisBuild(
 addCommandAlias("build", "; fmt; rootJVM/test")
 addCommandAlias("fmt", "all root/scalafmtSbt root/scalafmtAll")
 addCommandAlias("fmtCheck", "all root/scalafmtSbtCheck root/scalafmtCheckAll")
-addCommandAlias(
-  "check",
-  "; scalafmtSbtCheck; scalafmtCheckAll"
-)
+addCommandAlias("check", "; scalafmtSbtCheck; scalafmtCheckAll")
 
 addCommandAlias(
   "compileJVM",
   ";coreTestsJVM/Test/compile;stacktracerJVM/Test/compile;streamsTestsJVM/Test/compile;testTestsJVM/Test/compile;testMagnoliaTestsJVM/Test/compile;testRefinedJVM/Test/compile;testRunnerJVM/Test/compile;examplesJVM/Test/compile;macrosTestsJVM/Test/compile;concurrentJVM/Test/compile;managedTestsJVM/Test/compile"
 )
 // Split Native commands in half so that we can run them in parallel in CI
-addCommandAlias(
-  "testNative1",
-  ";coreTestsNative/test;stacktracerNative/test;streamsTestsNative/test;"
-)
+addCommandAlias("testNative1", ";coreTestsNative/test;stacktracerNative/test;streamsTestsNative/test;")
 addCommandAlias(
   "testNative2",
   ";testTestsNative/test;examplesNative/Test/compile;macrosTestsNative/test;concurrentNative/test"
 )
-addCommandAlias(
-  "testNative",
-  ";testNative1;testNative2"
-)
+addCommandAlias("testNative", ";testNative1;testNative2")
 addCommandAlias(
   "testJVM",
   ";coreTestsJVM/test;stacktracerJVM/test;streamsTestsJVM/test;testTestsJVM/test;testMagnoliaTestsJVM/test;testRefinedJVM/test;testRunnerJVM/test;testRunnerJVM/Test/run;examplesJVM/Test/compile;benchmarks/Test/compile;macrosTestsJVM/test;concurrentJVM/test;managedTestsJVM/test;set ThisBuild/isSnapshot:=true;testJunitRunnerTests/test;testJunitEngineTests/test;reload"
@@ -226,6 +217,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(
     libraryDependencies ++= List(
       "dev.zio"                %%% "izumi-reflect"           % IzumiReflectVersion,
+      "org.jctools"              % "jctools-core"            % JctoolsVersion,
       "org.scala-lang.modules" %%% "scala-collection-compat" % ScalaCollectionCompatVersion
     )
   )
@@ -653,6 +645,7 @@ lazy val benchmarks = project.module
   .enablePlugins(JmhPlugin)
   .settings(replSettings)
   .settings(
+    Test / sources := Seq.empty,
     publish / skip := true,
     libraryDependencies ++= {
       val nyanaVersion = if (scalaVersion.value == Scala212) "0.10.0" else "1.1.0"

--- a/core-tests/shared/src/test/scala/zio/Semaphore3Spec.scala
+++ b/core-tests/shared/src/test/scala/zio/Semaphore3Spec.scala
@@ -1,0 +1,50 @@
+package zio
+
+import zio.test._
+import zio.test.TestAspect._
+
+object Semaphore3Spec extends ZIOSpecDefault {
+  def spec = suite("Semaphore3Spec")(
+    test("acquire and release a permit") {
+      for {
+        sem <- Semaphore3.make(1)
+        _   <- sem.withPermit(ZIO.unit)
+      } yield assertCompletes
+    } @@ timeout(10.seconds),
+    test("block when no permits available") {
+      for {
+        sem  <- Semaphore3.make(1)
+        _    <- sem.withPermit(ZIO.unit)
+        done <- sem.withPermit(ZIO.unit).fork
+        _    <- TestClock.adjust(1.second)
+        _    <- done.interrupt
+      } yield assertCompletes
+    } @@ timeout(10.seconds),
+    test("serve multiple waiters") {
+      for {
+        sem <- Semaphore3.make(1)
+        // Create 5 fibers that will wait for permits
+        fibers <- ZIO.foreach(1 to 5)(_ => sem.withPermit(ZIO.unit).fork)
+        // Release 5 permits
+        _ <- sem.release(5)
+        // Wait for all fibers to complete
+        _ <- ZIO.foreach(fibers)(_.join)
+      } yield assertCompletes
+    } @@ timeout(10.seconds),
+    test("release multiple permits") {
+      for {
+        sem <- Semaphore3.make(0)
+        // Create 5 fibers that will wait for permits
+        fibers <- ZIO.foreach(1 to 5)(_ => sem.withPermit(ZIO.unit).fork)
+        // Give fibers time to start and enqueue
+        _ <- TestClock.adjust(1.day)
+        // Release 5 permits directly
+        _ <- sem.release(5)
+        // Give time for fibers to acquire permits
+        _ <- TestClock.adjust(1.day)
+        // Wait for all fibers to complete
+        _ <- ZIO.foreach(fibers)(_.join)
+      } yield assertCompletes
+    } @@ timeout(10.seconds)
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/SemaphoreBenchmarkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreBenchmarkSpec.scala
@@ -1,0 +1,1 @@
+// This file has been moved to benchmarks/src/test/scala/zio/SemaphoreBenchmarkSpec.scala

--- a/core/shared/src/main/scala/zio/Semaphore2.scala
+++ b/core/shared/src/main/scala/zio/Semaphore2.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio
+
+import org.jctools.queues.MpscUnboundedArrayQueue
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.atomic.AtomicLong
+import scala.annotation.tailrec
+
+sealed trait Semaphore2 extends Serializable {
+
+  def available(implicit trace: Trace): UIO[Long]
+
+  def awaiting(implicit trace: Trace): UIO[Long]
+
+  def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+
+  def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit]
+
+  def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+
+  def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit]
+}
+
+object Semaphore2 {
+
+  def make(permits: => Long)(implicit trace: Trace): UIO[Semaphore2] =
+    ZIO.succeed(new Semaphore2 {
+      private val permits0 = new AtomicLong(permits)
+      private val waiters  = new MpscUnboundedArrayQueue[Promise[Nothing, Unit]](16)
+
+      def available(implicit trace: Trace): UIO[Long] =
+        ZIO.succeed(permits0.get())
+
+      def awaiting(implicit trace: Trace): UIO[Long] =
+        ZIO.succeed(waiters.size().toLong)
+
+      def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        withPermits(1L)(zio)
+
+      def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+        withPermitsScoped(1L)
+
+      def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+        ZIO.acquireReleaseWith(acquireN(n))(_ => releaseN(n))(_ => zio)
+
+      def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+        ZIO.acquireRelease(acquireN(n))(_ => releaseN(n)).unit
+
+      private def acquireN(n: Long)(implicit trace: Trace): UIO[Unit] =
+        ZIO.asyncInterrupt[Any, Nothing, Unit] { k =>
+          @tailrec
+          def loop(): Either[UIO[Unit], Unit] = {
+            val current = permits0.get()
+            if (current >= n) {
+              if (permits0.compareAndSet(current, current - n)) {
+                Right(k(ZIO.unit))
+              } else {
+                loop()
+              }
+            } else {
+              val promise = Promise.unsafe.make[Nothing, Unit](FiberId.None)(Unsafe.unsafe)
+              waiters.add(promise)
+              Left(promise.await.onInterrupt(releaseN(n)).as(k(ZIO.unit)))
+            }
+          }
+          loop() match {
+            case Left(zio) => Left(zio)
+            case Right(_)  => Right(ZIO.unit)
+          }
+        }
+
+      private def releaseN(n: Long)(implicit trace: Trace): UIO[Unit] =
+        ZIO.succeed {
+          permits0.addAndGet(n)
+          @tailrec
+          def loop(): Unit = {
+            val p = waiters.peek()
+            if (p != null && permits0.get() > 0) {
+              if (permits0.decrementAndGet() >= 0) {
+                val promise = waiters.poll()
+                if (promise != null) {
+                  promise.unsafe.succeed(())(trace, Unsafe.unsafe)
+                  loop()
+                }
+              }
+            }
+          }
+          loop()
+        }
+    })
+}

--- a/core/shared/src/main/scala/zio/Semaphore3.scala
+++ b/core/shared/src/main/scala/zio/Semaphore3.scala
@@ -1,0 +1,176 @@
+package zio
+
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import scala.annotation.tailrec
+
+sealed trait Semaphore3 extends Serializable {
+
+  def available(implicit trace: Trace): UIO[Long]
+
+  def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+
+  def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A]
+
+  def release(n: Long)(implicit trace: Trace): UIO[Unit]
+}
+
+object Semaphore3 {
+
+  def make(permits: Long)(implicit trace: Trace): UIO[Semaphore3] =
+    ZIO.succeed(new ConcurrentSemaphore(permits))
+
+  private final class ConcurrentSemaphore(initial: Long) extends Semaphore3 {
+    private[this] val permits = new AtomicLong(initial)
+    private[this] val waiters = new WaiterQueue
+
+    override def available(implicit trace: Trace): UIO[Long] = ZIO.succeed(permits.get())
+
+    override def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      withPermits(1L)(zio)
+
+    override def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      ZIO.uninterruptibleMask { restore =>
+        restore(acquireN(n)) *> zio.ensuring(releaseN(n))
+      }
+
+    override def release(n: Long)(implicit trace: Trace): UIO[Unit] = releaseN(n)
+
+    private def acquireN(n: Long)(implicit trace: Trace): UIO[Unit] =
+      ZIO.asyncInterrupt[Any, Nothing, Unit] { cb =>
+        if (tryAcquireN(n)) {
+          Right(ZIO.unit)
+        } else {
+          val waiter = new Waiter(n, cb)
+          waiters.enqueue(waiter)
+          // `tryAcquireN` after enqueueing to handle the case where a permit is released
+          // between the initial `tryAcquireN` and enqueueing the waiter.
+          if (tryAcquireN(n) && waiters.tryDequeue(waiter)) {
+            Right(ZIO.unit)
+          } else {
+            Left(ZIO.succeed(waiters.tryDequeue(waiter)))
+          }
+        }
+      }
+
+    private def releaseN(n: Long)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        permits.addAndGet(n)
+        var available = permits.get()
+        var continue  = true
+        while (continue && available > 0 && waiters.nonEmpty) {
+          waiters.head match {
+            case Some(waiter) if waiter.permits <= available =>
+              // Remove the waiter from the queue
+              waiters.dequeue()
+              // Complete the waiter's callback to unblock it
+              waiter.cb(ZIO.unit)
+              // Update available permits after serving (the waiter will acquire the permits)
+              available = permits.addAndGet(-waiter.permits)
+            case _ =>
+              // Can't serve head waiter, stop processing
+              continue = false
+          }
+        }
+      }
+
+    private def tryAcquireN(n: Long): Boolean = {
+      @tailrec
+      def loop(): Boolean = {
+        val current = permits.get()
+        if (current >= n) {
+          if (permits.compareAndSet(current, current - n)) true
+          else loop()
+        } else {
+          false
+        }
+      }
+      loop()
+    }
+  }
+
+  private final class Waiter(val permits: Long, val cb: UIO[Unit] => Unit)
+
+  private final class WaiterQueue {
+    private[this] val headRef = new AtomicReference[Node](null)
+    private[this] val tailRef = new AtomicReference[Node](null)
+
+    def enqueue(waiter: Waiter): Unit = {
+      val newNode = new Node(waiter)
+      @tailrec
+      def loop(): Unit = {
+        val currentTail = tailRef.get()
+        if (currentTail == null) {
+          if (headRef.compareAndSet(null, newNode)) {
+            tailRef.set(newNode)
+          } else {
+            loop()
+          }
+        } else {
+          if (currentTail.next.compareAndSet(null, newNode)) {
+            tailRef.compareAndSet(currentTail, newNode)
+          } else {
+            loop()
+          }
+        }
+      }
+      loop()
+    }
+
+    def dequeue(): Option[Waiter] = {
+      @tailrec
+      def loop(): Option[Waiter] = {
+        val currentHead = headRef.get()
+        if (currentHead == null) {
+          None
+        } else {
+          val next = currentHead.next.get()
+          if (headRef.compareAndSet(currentHead, next)) {
+            // If we're removing the last node, update tailRef
+            if (next == null) {
+              tailRef.compareAndSet(currentHead, null)
+            }
+            Some(currentHead.waiter)
+          } else {
+            loop()
+          }
+        }
+      }
+      loop()
+    }
+
+    // Add head method to peek at the first waiter without dequeuing
+    def head: Option[Waiter] =
+      Option(headRef.get()).map(_.waiter)
+
+    def tryDequeue(waiter: Waiter): Boolean = {
+      @tailrec
+      def loop(prev: Node, curr: Node): Boolean =
+        if (curr == null) {
+          false
+        } else {
+          if (curr.waiter == waiter) {
+            prev.next.compareAndSet(curr, curr.next.get())
+          } else {
+            loop(curr, curr.next.get())
+          }
+        }
+
+      val h = headRef.get()
+      if (h == null) {
+        false
+      } else if (h.waiter == waiter) {
+        headRef.compareAndSet(h, h.next.get())
+      } else {
+        loop(h, h.next.get())
+      }
+    }
+
+    def nonEmpty: Boolean = headRef.get() != null
+
+  }
+  private class Node(val waiter: Waiter) {
+    val next = new AtomicReference[Node](null)
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,7 @@ object Dependencies {
   val ScalaNativeCryptoVersion     = "0.2.1"
   val ScalaSecureRandomVersion     = "1.0.0"
   val ScalaJsDomVersion            = "2.8.1"
+  val JctoolsVersion               = "4.0.5"
 
   // Documentations and example dependencies
   val CatsEffectVersion = "3.6.3"


### PR DESCRIPTION
/claim #9093

This change introduces a new Semaphore implementation that is optimized for performance. It uses a custom WaiterQueue and a custom Waiter object to reduce contention and improve throughput.

Here are the demo videos. I had ti compress them because they were a bit too large
BENCHMARK RUN VIDEO:   
[BenchMark Run.zip](https://github.com/user-attachments/files/21528324/BenchMark.Run.zip)

BENCHMARK TESTS RUN VIDEO:   
[Test Run.zip](https://github.com/user-attachments/files/21528326/Test.Run.zip)

---------------------------------------------------------**BENCHMARK RESULTS**------------------------------------------------------
###  Benchmark Results (Throughput in ops/s)

| Benchmark                        | Fibers | Permits | Avg Throughput | Min      | Max      | Std Dev   |
|----------------------------------|--------|---------|----------------|----------|----------|-----------|
| `javaSemaphoreFair`              | 1      | 1       | 5525.736       | 4781.877 | 6809.672 | 1116.580  |
| `javaSemaphoreFair`              | 2      | 1       | 246.143        | 226.681  | 276.869  | 26.923    |
| `javaSemaphoreUnfair`            | 1      | 1       | 5952.123       | 4522.072 | 7234.912 | 1362.402  |
| `javaSemaphoreUnfair`            | 2      | 1       | 4417.468       | 3720.367 | 4786.269 | 604.046   |
| `zioSemaphore`                   | 1      | 1       | 965.551        | 922.180  | 1034.144 | 60.092    |
| `zioSemaphore`                   | 2      | 1       | 131.179        | 122.216  | 144.115  | 11.477    |
| `zioSemaphore3`                  | 1      | 1       | 1582.855       | 1210.174 | 1878.727 | 340.830   |
