### PR TITLE
Optimise `ZStream.repeatZIOChunkOption`

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6866,6 +6866,7 @@ object Exit extends Serializable {
   private[zio] val `true`: Exit[Nothing, Boolean]            = Success(true)
   private[zio] val `false`: Exit[Nothing, Boolean]           = Success(false)
   private[zio] val none: Exit[Nothing, Option[Nothing]]      = Success(None)
+  private[zio] val `null`: Exit[Nothing, AnyRef]             = Success(null)
   private[zio] val emptyChunk: Exit[Nothing, Chunk[Nothing]] = Success(Chunk.empty)
   private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.none)
   private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.unit)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5009,16 +5009,30 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    */
   def repeatZIOChunkOption[R, E, A](
     fa: => ZIO[R, Option[E], Chunk[A]]
-  )(implicit trace: Trace): ZStream[R, E, A] =
-    unfoldChunkZIO(fa)(fa =>
-      fa.foldZIO(
-        failure = {
-          case None    => Exit.none
-          case Some(e) => Exit.fail(e)
-        },
-        success = chunk => Exit.succeed(Some((chunk, fa)))
-      )
+  )(implicit trace: Trace): ZStream[R, E, A] = {
+    def loop(s: ZIO[R, E, Chunk[A]]): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+      ZChannel.unwrap {
+        s.map {
+          case null => ZChannel.unit
+          case as   => ZChannel.write(as) *> loop(s)
+        }
+      }
+
+    new ZStream(
+      ZChannel.suspend {
+        val fa0: ZIO[R, E, Chunk[A]] =
+          fa.foldZIO(
+            failure = {
+              case None    => Exit.`null`.asInstanceOf[ZIO[R, E, Chunk[A]]]
+              case Some(e) => Exit.fail(e)
+            },
+            success = chunk => Exit.succeed(chunk)
+          )
+
+        loop(fa0)
+      }
     )
+  }
 
   /**
    * Creates a stream from an effect producing values of type `A` until it fails
@@ -5129,7 +5143,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream by peeling off the "layers" of a value of type `S`
    */
   def unfold[S, A](s: => S)(f: S => Option[(A, S)])(implicit trace: Trace): ZStream[Any, Nothing, A] =
-    unfoldChunk(s)(f(_).map { case (a, s) => Chunk.single(a) -> s })
+    unfoldChunk(s)(f(_).map { case (a, s0) => Chunk.single(a) -> s0 })
 
   /**
    * Creates a stream by peeling off the "layers" of a value of type `S`.
@@ -5137,10 +5151,10 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldChunk[S, A](
     s: => S
   )(f: S => Option[(Chunk[A], S)])(implicit trace: Trace): ZStream[Any, Nothing, A] = {
-    def loop(s: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
-      f(s) match {
-        case Some((as, s)) => ZChannel.write(as) *> loop(s)
-        case None          => ZChannel.unit
+    def loop(s0: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
+      f(s0) match {
+        case Some((as, s1)) => ZChannel.write(as) *> loop(s1)
+        case None           => ZChannel.unit
       }
 
     new ZStream(ZChannel.suspend(loop(s)))
@@ -5153,11 +5167,11 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldChunkZIO[R, E, A, S](
     s: => S
   )(f: S => ZIO[R, E, Option[(Chunk[A], S)]])(implicit trace: Trace): ZStream[R, E, A] = {
-    def loop(s: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+    def loop(s0: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
       ZChannel.unwrap {
-        f(s).map {
-          case Some((as, s)) => ZChannel.write(as) *> loop(s)
-          case None          => ZChannel.unit
+        f(s0).map {
+          case Some((as, s1)) => ZChannel.write(as) *> loop(s1)
+          case None           => ZChannel.unit
         }
       }
 
@@ -5171,7 +5185,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldZIO[R, E, A, S](s: => S)(f: S => ZIO[R, E, Option[(A, S)]])(implicit
     trace: Trace
   ): ZStream[R, E, A] =
-    unfoldChunkZIO(s)(f(_).map(_.map { case (a, s) => Chunk.single(a) -> s }))
+    unfoldChunkZIO(s)(f(_).map(_.map { case (a, s0) => Chunk.single(a) -> s0 }))
 
   /**
    * Creates a stream produced from an effect


### PR DESCRIPTION
With these changes, the benchmark introduced in #10085 has the following result:
```scala
[info] Result "zio.StreamBenchmarks.zioRepeatZIOChunkOption":
[info]   597.608 ±(99.9%) 4.112 ops/s [Average]
[info]   (min, avg, max) = (592.259, 597.608, 601.780), stdev = 2.720
[info]   CI (99.9%): [593.496, 601.721] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:20
[info] Benchmark                                 (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioRepeatZIOChunkOption         10000         5000  thrpt   10  597.608 ± 4.112  ops/s
[success] Total time: 21 s, completed 5 Aug 2025, 5:44:24 pm
```