### PR TITLE
Optimise ZStream.repeatZIOChunkOption

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6866,7 +6866,6 @@ object Exit extends Serializable {
   private[zio] val `true`: Exit[Nothing, Boolean]            = Success(true)
   private[zio] val `false`: Exit[Nothing, Boolean]           = Success(false)
   private[zio] val none: Exit[Nothing, Option[Nothing]]      = Success(None)
-  private[zio] val `null`: Exit[Nothing, AnyRef]             = Success(null)
   private[zio] val emptyChunk: Exit[Nothing, Chunk[Nothing]] = Success(Chunk.empty)
   private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.none)
   private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.unit)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6866,6 +6866,7 @@ object Exit extends Serializable {
   private[zio] val `true`: Exit[Nothing, Boolean]            = Success(true)
   private[zio] val `false`: Exit[Nothing, Boolean]           = Success(false)
   private[zio] val none: Exit[Nothing, Option[Nothing]]      = Success(None)
+  private[zio] val `null`: Exit[Nothing, AnyRef]             = Success(null)
   private[zio] val emptyChunk: Exit[Nothing, Chunk[Nothing]] = Success(Chunk.empty)
   private[zio] val failNone: Exit[Option[Nothing], Nothing]  = Failure(Cause.none)
   private[zio] val failUnit: Exit[Unit, Nothing]             = Failure(Cause.unit)

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5838,6 +5838,20 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assert(result)(equalTo(1))
           }
         ),
+        suite("repeatZIOChunkOption")(
+          test("is stacksafe") {
+            for {
+              ref <- Ref.make(0)
+              fa = for {
+                     newCount <- ref.updateAndGet(_ + 1)
+                     res      <- if (newCount > 10000000) ZIO.fail(None) else ZIO.succeed(Chunk.single(newCount))
+                   } yield res
+              res <- ZStream
+                       .repeatZIOChunkOption(fa)
+                       .runCount
+            } yield assert(res)(equalTo(10000000L))
+          }
+        ),
         suite("repeatZIOWithSchedule")(
           test("succeed")(
             for {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5009,30 +5009,25 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    */
   def repeatZIOChunkOption[R, E, A](
     fa: => ZIO[R, Option[E], Chunk[A]]
-  )(implicit trace: Trace): ZStream[R, E, A] = {
-    def loop(s: ZIO[R, E, Chunk[A]]): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
-      ZChannel.unwrap {
-        s.map {
-          case null => ZChannel.unit
-          case as   => ZChannel.write(as) *> loop(s)
-        }
-      }
-
+  )(implicit trace: Trace): ZStream[R, E, A] =
     new ZStream(
       ZChannel.suspend {
-        val fa0: ZIO[R, E, Chunk[A]] =
-          fa.foldZIO(
-            failure = {
-              case None    => Exit.`null`.asInstanceOf[ZIO[R, E, Chunk[A]]]
-              case Some(e) => Exit.fail(e)
-            },
-            success = chunk => Exit.succeed(chunk)
-          )
+        val fa0 = fa
 
-        loop(fa0)
+        def channel: ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+          ZChannel.unwrap {
+            fa0.fold(
+              failure = {
+                case None    => ZChannel.unit
+                case Some(e) => ZChannel.fail(e)
+              },
+              success = chunk => ZChannel.write(chunk) *> channel
+            )
+          }
+
+        channel
       }
     )
-  }
 
   /**
    * Creates a stream from an effect producing values of type `A` until it fails
@@ -5154,7 +5149,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def loop(s0: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
       f(s0) match {
         case Some((as, s1)) => ZChannel.write(as) *> loop(s1)
-        case None          => ZChannel.unit
+        case None           => ZChannel.unit
       }
 
     new ZStream(ZChannel.suspend(loop(s)))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -5009,16 +5009,30 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    */
   def repeatZIOChunkOption[R, E, A](
     fa: => ZIO[R, Option[E], Chunk[A]]
-  )(implicit trace: Trace): ZStream[R, E, A] =
-    unfoldChunkZIO(fa)(fa =>
-      fa.foldZIO(
-        failure = {
-          case None    => Exit.none
-          case Some(e) => Exit.fail(e)
-        },
-        success = chunk => Exit.succeed(Some((chunk, fa)))
-      )
+  )(implicit trace: Trace): ZStream[R, E, A] = {
+    def loop(s: ZIO[R, E, Chunk[A]]): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+      ZChannel.unwrap {
+        s.map {
+          case null => ZChannel.unit
+          case as   => ZChannel.write(as) *> loop(s)
+        }
+      }
+
+    new ZStream(
+      ZChannel.suspend {
+        val fa0: ZIO[R, E, Chunk[A]] =
+          fa.foldZIO(
+            failure = {
+              case None    => Exit.`null`.asInstanceOf[ZIO[R, E, Chunk[A]]]
+              case Some(e) => Exit.fail(e)
+            },
+            success = chunk => Exit.succeed(chunk)
+          )
+
+        loop(fa0)
+      }
     )
+  }
 
   /**
    * Creates a stream from an effect producing values of type `A` until it fails
@@ -5129,7 +5143,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream by peeling off the "layers" of a value of type `S`
    */
   def unfold[S, A](s: => S)(f: S => Option[(A, S)])(implicit trace: Trace): ZStream[Any, Nothing, A] =
-    unfoldChunk(s)(f(_).map { case (a, s) => Chunk.single(a) -> s })
+    unfoldChunk(s)(f(_).map { case (a, s0) => Chunk.single(a) -> s0 })
 
   /**
    * Creates a stream by peeling off the "layers" of a value of type `S`.
@@ -5137,9 +5151,9 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldChunk[S, A](
     s: => S
   )(f: S => Option[(Chunk[A], S)])(implicit trace: Trace): ZStream[Any, Nothing, A] = {
-    def loop(s: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
-      f(s) match {
-        case Some((as, s)) => ZChannel.write(as) *> loop(s)
+    def loop(s0: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
+      f(s0) match {
+        case Some((as, s1)) => ZChannel.write(as) *> loop(s1)
         case None          => ZChannel.unit
       }
 
@@ -5153,11 +5167,11 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldChunkZIO[R, E, A, S](
     s: => S
   )(f: S => ZIO[R, E, Option[(Chunk[A], S)]])(implicit trace: Trace): ZStream[R, E, A] = {
-    def loop(s: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
+    def loop(s0: S): ZChannel[R, Any, Any, Any, E, Chunk[A], Any] =
       ZChannel.unwrap {
-        f(s).map {
-          case Some((as, s)) => ZChannel.write(as) *> loop(s)
-          case None          => ZChannel.unit
+        f(s0).map {
+          case Some((as, s1)) => ZChannel.write(as) *> loop(s1)
+          case None           => ZChannel.unit
         }
       }
 
@@ -5171,7 +5185,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def unfoldZIO[R, E, A, S](s: => S)(f: S => ZIO[R, E, Option[(A, S)]])(implicit
     trace: Trace
   ): ZStream[R, E, A] =
-    unfoldChunkZIO(s)(f(_).map(_.map { case (a, s) => Chunk.single(a) -> s }))
+    unfoldChunkZIO(s)(f(_).map(_.map { case (a, s0) => Chunk.single(a) -> s0 }))
 
   /**
    * Creates a stream produced from an effect


### PR DESCRIPTION
Needs:
- #10085 

With these changes, the benchmark introduced in #10085 has the following result:
```scala
[info] Result "zio.StreamBenchmarks.zioRepeatZIOChunkOption":
[info]   638.780 ±(99.9%) 2.943 ops/s [Average]
[info]   (min, avg, max) = (636.058, 638.780, 641.936), stdev = 1.947
[info]   CI (99.9%): [635.837, 641.723] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:20
[info] Benchmark                                 (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioRepeatZIOChunkOption         10000         5000  thrpt   10  638.780 ± 2.943  ops/s
[success] Total time: 22 s, completed 5 Aug 2025, 5:39:14 pm
```