### PR TITLE
fix: add scoped hook to shutdown hub on broadcastedQueues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ test-output/
 .bsp
 project/.sbt
 test-output/
+.cursor
 .bloop
 .metals
 metals.sbt

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -358,7 +358,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     maximumLag: => Int
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Chunk[Dequeue[Take[E, A]]]] =
     for {
-      hub    <- Hub.bounded[Take[E, A]](maximumLag)
+      hub    <- ZIO.acquireRelease(Hub.bounded[Take[E, A]](maximumLag))(_.shutdown)
       queues <- ZIO.collectAll(Chunk.fill(n)(hub.subscribe))
       _      <- self.runIntoHubScoped(hub).forkScoped
     } yield queues


### PR DESCRIPTION
Add scoped hook to shutdown hub on `broadcastedQueues`, similar to `broadcastedQueuesDynamic`