### PR TITLE
Add benchmark for `ZStream.repeatZIOChunkOption`

### DIFF
--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -289,7 +289,7 @@ class StreamBenchmarks {
               index += 1
               Chunk.single(1) // Use a single-element chunk for consistent overhead
             }
-          else ZIO.fail(None)
+          else Exit.failNone
         }
       }.runCount
 

--- a/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/StreamBenchmarks.scala
@@ -277,6 +277,25 @@ class StreamBenchmarks {
     unsafeRun(result)
   }
 
+  @Benchmark
+  def zioRepeatZIOChunkOption: Long = {
+    var index = 0
+
+    val result =
+      ZStream.repeatZIOChunkOption {
+        ZIO.suspendSucceed {
+          if (index < chunkCount)
+            ZIO.succeed {
+              index += 1
+              Chunk.single(1) // Use a single-element chunk for consistent overhead
+            }
+          else ZIO.fail(None)
+        }
+      }.runCount
+
+    unsafeRun(result)
+  }
+
 }
 
 @State(JScope.Thread)


### PR DESCRIPTION
Command used:
```bash
benchmarks/Jmh/run -i 10 -wi 10 -f1 -t1 .*StreamBenchmarks.zioRepeatZIOChunkOption
```

Before any change:
```scala
[info] Result "zio.StreamBenchmarks.zioRepeatZIOChunkOption":
[info]   552.372 ±(99.9%) 3.531 ops/s [Average]
[info]   (min, avg, max) = (548.131, 552.372, 556.583), stdev = 2.336
[info]   CI (99.9%): [548.841, 555.903] (assumes normal distribution)
[info] # Run complete. Total time: 00:00:20
[info] Benchmark                                 (chunkCount)  (chunkSize)   Mode  Cnt    Score   Error  Units
[info] StreamBenchmarks.zioRepeatZIOChunkOption         10000         5000  thrpt   10  552.372 ± 3.531  ops/s
[success] Total time: 22 s, completed 5 Aug 2025, 5:34:17 pm
```