### PR TITLE
Optimise `ZIO.interrupt` && deprecate `ZIO.interruptAs` and `Promise.interruptAs`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOLazinessSpec.scala
@@ -20,7 +20,6 @@ object ZIOLazinessSpec extends ZIOBaseSpec {
     test("fromOption")(assertLazy(ZIO.fromOption)),
     test("fromTry")(assertLazy(ZIO.fromTry)),
     test("getOrFailUnit")(assertLazy(ZIO.getOrFailUnit)),
-    test("interruptAs")(assertLazy(ZIO.interruptAs)),
     test("left")(assertLazy(ZIO.left)),
     test("onExecutor")(assertLazy(ZIO.onExecutor)),
     test("provideEnvironment")(assertLazy(ZIO.provideEnvironment)),

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -128,12 +128,13 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
    * waiting on the value of the promise as by the fiber calling this method.
    */
   def interrupt(implicit trace: Trace): UIO[Boolean] =
-    ZIO.fiberIdWith(id => interruptAs(id))
+    ZIO.succeed(unsafe.interrupt(trace, Unsafe))
 
   /**
    * Completes the promise with interruption. This will interrupt all fibers
    * waiting on the value of the promise as by the specified fiber.
    */
+  @deprecated("Use interrupt instead", "2.1.21")
   def interruptAs(fiberId: FiberId)(implicit trace: Trace): UIO[Boolean] =
     ZIO.succeed(unsafe.interruptAs(fiberId)(trace, Unsafe))
 
@@ -180,6 +181,8 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
     def fail(e: E)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def failCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean
+    def interrupt(implicit trace: Trace, unsafe: Unsafe): Boolean
+    @deprecated("Use interrupt instead", "2.1.21")
     def interruptAs(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def isDone(implicit unsafe: Unsafe): Boolean
     def poll(implicit unsafe: Unsafe): Option[IO[E, A]]
@@ -219,6 +222,10 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     def failCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean =
       completeWith(ZIO.failCause(e))
 
+    def interrupt(implicit trace: Trace, unsafe: Unsafe): Boolean =
+      completeWith(ZIO.interrupt)
+
+    @deprecated("Use interrupt instead", "2.1.21")
     def interruptAs(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Boolean =
       completeWith(ZIO.interruptAs(fiberId))
 

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -232,18 +232,18 @@ object Queue extends QueuePlatformSpecific {
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
-      ZIO.fiberIdWith { fiberId =>
+      ZIO.uninterruptible {
         if (shutdownFlag.compareAndSet(false, true)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
           val it = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.interrupt
           }
-          strategy.shutdown(fiberId)
+          strategy.shutdown
         }
         Exit.unit
-      }.uninterruptible
+      }
 
     override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
 
@@ -334,7 +334,7 @@ object Queue extends QueuePlatformSpecific {
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(implicit trace: Trace, unsafe: Unsafe): Unit
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -452,11 +452,11 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(implicit trace: Trace, unsafe: Unsafe): Unit = {
         var next = putters.poll()
         while (next ne null) {
           val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          if (isLast) promise.unsafe.interrupt
           next = putters.poll()
         }
       }
@@ -478,7 +478,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -519,7 +519,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3259,6 +3259,16 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       Exit.failCause(cause.applyAll(trace, spans, anns))
     }
 
+  def failCauseWithFiberId[E](cause: FiberId.Runtime => Cause[E])(implicit trace0: Trace): IO[E, Nothing] =
+    ZIO.withFiberRuntime[Any, E, Nothing] { (state, _) =>
+      val id    = state.id
+      val trace = state.generateStackTrace()
+      val refs  = state.getFiberRefs(false)
+      val spans = refs.getOrDefault(FiberRef.currentLogSpan)
+      val anns  = refs.getOrDefault(FiberRef.currentLogAnnotations)
+      Exit.failCause(cause(id).applyAll(trace, spans, anns))
+    }
+
   /**
    * Returns the `FiberId` of the fiber executing the effect that calls this
    * method.
@@ -3954,11 +3964,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * method.
    */
   def interrupt(implicit trace: Trace): UIO[Nothing] =
-    fiberIdWith(interruptAs(_))
+    failCauseWithFiberId(Cause.interrupt(_))
 
   /**
    * Returns an effect that is interrupted as if by the specified fiber.
    */
+  @deprecated("Use `ZIO.interrupt` instead", "2.1.20")
   def interruptAs(fiberId: => FiberId)(implicit trace: Trace): UIO[Nothing] =
     failCause(Cause.interrupt(fiberId))
 


### PR DESCRIPTION
The original thing I detected was that `ZIO.interrupt` was implemented like this:

<img width="660" height="286" alt="image" src="https://github.com/user-attachments/assets/84d2ab90-5dc6-4444-895c-597f1c462a03" />

But `fiberIdWith` is implemented as follows:

<img width="842" height="140" alt="image" src="https://github.com/user-attachments/assets/df59bd5b-bfca-4f90-8c52-af8851da7ebb" />

And `failCause` is implemented as follows:

<img width="646" height="234" alt="image" src="https://github.com/user-attachments/assets/4634a84a-c87e-4b64-ada5-c4d74d065145" />

Knowing that `withFiberRuntime` is implemented as:

<img width="621" height="111" alt="Screenshot 2025-08-08 at 1 09 13 pm" src="https://github.com/user-attachments/assets/5c10ea07-1db0-49a1-b12c-b187ad2d3a79" />

That means that `ZIO.interrupt` was resulting in something like: `StateFul(..., Stateful(..., ...))`
We don't need two `StateFul` here. It can be implemented in only one.
That's the change in the `ZIO.interrupt` implementation proposed in this PR.

Then I had a look at the usages of `ZIO.interruptAs(fiber: FiberId)` and saw that it was always used in such following pattern:
```scala
ZIO.fiberIdWith { fiberId =>
   ...
   [ZIO|Promise].interruptAs(fiberId)
   ...
}
```

Which again, will result in a `StateFul(..., Stateful(..., ...))` pattern, meaning that `ZIO.interruptAs` is actually probably useless and probably allows incorrect code: allowing someone to potentially pass the wrong `FiberId`