### PR TITLE
Optimise `ZIO.interrupt` and `Promise.interrupt`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -198,6 +198,7 @@ object StackTracesSpec extends ZIOBaseSpec {
               |	at zio.StackTracesSpec$.$anonfun$spec
               |	at zio.ZIO$.$anonfun$die
               |	at zio.ZIO$.$anonfun$failCause
+              |	at zio.ZIO$.$anonfun$failCauseWithFiberId
               |	at zio.internal.FiberRuntime.runLoop
               |	at zio.internal.FiberRuntime.evaluateEffect
               |	at zio.internal.FiberRuntime.start
@@ -234,6 +235,7 @@ object StackTracesSpec extends ZIOBaseSpec {
               |	at zio.StackTracesSpec$.subcall2$2$$anonfun
               |	at zio.ZIO$.die$$anonfun
               |	at zio.ZIO$.failCause$$anonfun
+              |	at zio.ZIO$.failCauseWithFiberId$$anonfun
               |	at zio.internal.FiberRuntime.runLoop
               |	at zio.internal.FiberRuntime.evaluateEffect
               |	at zio.internal.FiberRuntime.start

--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -99,10 +99,8 @@ private[zio] trait ZIOCompanionVersionSpecific {
       catch {
         case t: Throwable =>
           ZIO.isFatalWith { isFatal =>
-            if (!isFatal(t))
-              ZIO.failCause(Cause.fail(t))
-            else
-              throw t
+            if (!isFatal(t)) ZIO.fail(t)
+            else throw t
           }
       }
     }

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -101,10 +101,8 @@ private[zio] transparent trait ZIOCompanionVersionSpecific {
       } catch {
         case t: Throwable =>
           ZIO.isFatalWith { isFatal =>
-            if (!isFatal(t))
-              ZIO.failCause(Cause.fail(t))
-            else
-              throw t
+            if (!isFatal(t)) ZIO.fail(t)
+            else throw t
           }
       }
     }

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -128,7 +128,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
    * waiting on the value of the promise as by the fiber calling this method.
    */
   def interrupt(implicit trace: Trace): UIO[Boolean] =
-    ZIO.fiberIdWith(id => interruptAs(id))
+    ZIO.succeed(unsafe.interrupt(trace, Unsafe))
 
   /**
    * Completes the promise with interruption. This will interrupt all fibers
@@ -180,6 +180,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
     def fail(e: E)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def failCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean
+    def interrupt(implicit trace: Trace, unsafe: Unsafe): Boolean
     def interruptAs(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def isDone(implicit unsafe: Unsafe): Boolean
     def poll(implicit unsafe: Unsafe): Option[IO[E, A]]
@@ -218,6 +219,9 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
 
     def failCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean =
       completeWith(ZIO.failCause(e))
+
+    def interrupt(implicit trace: Trace, unsafe: Unsafe): Boolean =
+      completeWith(ZIO.interrupt)
 
     def interruptAs(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Boolean =
       completeWith(ZIO.interruptAs(fiberId))

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3245,18 +3245,22 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * equivalent of `throw` for pure code.
    */
   def fail[E](error: => E)(implicit trace: Trace): IO[E, Nothing] =
-    failCause(Cause.fail(error))
+    failCauseWithFiberId(_ => Cause.fail(error))
 
   /**
    * Returns an effect that models failure with the specified `Cause`.
    */
   def failCause[E](cause: => Cause[E])(implicit trace0: Trace): IO[E, Nothing] =
+    failCauseWithFiberId(_ => cause)
+
+  def failCauseWithFiberId[E](cause: FiberId.Runtime => Cause[E])(implicit trace0: Trace): IO[E, Nothing] =
     ZIO.withFiberRuntime[Any, E, Nothing] { (state, _) =>
+      val id    = state.id
       val trace = state.generateStackTrace()
       val refs  = state.getFiberRefs(false)
       val spans = refs.getOrDefault(FiberRef.currentLogSpan)
       val anns  = refs.getOrDefault(FiberRef.currentLogAnnotations)
-      Exit.failCause(cause.applyAll(trace, spans, anns))
+      Exit.failCause(cause(id).applyAll(trace, spans, anns))
     }
 
   /**
@@ -3954,13 +3958,13 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * method.
    */
   def interrupt(implicit trace: Trace): UIO[Nothing] =
-    fiberIdWith(interruptAs(_))
+    failCauseWithFiberId(Cause.interrupt(_))
 
   /**
    * Returns an effect that is interrupted as if by the specified fiber.
    */
   def interruptAs(fiberId: => FiberId)(implicit trace: Trace): UIO[Nothing] =
-    failCause(Cause.interrupt(fiberId))
+    failCauseWithFiberId(_ => Cause.interrupt(fiberId))
 
   /**
    * Prefix form of `ZIO#interruptible`.


### PR DESCRIPTION
The original thing I detected was that `ZIO.interrupt` was implemented like this:

<img width="660" height="286" alt="image" src="https://github.com/user-attachments/assets/84d2ab90-5dc6-4444-895c-597f1c462a03" />

But `fiberIdWith` is implemented as follows:

<img width="842" height="140" alt="image" src="https://github.com/user-attachments/assets/df59bd5b-bfca-4f90-8c52-af8851da7ebb" />

And `failCause` is implemented as follows:

<img width="646" height="234" alt="image" src="https://github.com/user-attachments/assets/4634a84a-c87e-4b64-ada5-c4d74d065145" />

Knowing that `withFiberRuntime` is implemented as:

<img width="621" height="111" alt="Screenshot 2025-08-08 at 1 09 13 pm" src="https://github.com/user-attachments/assets/5c10ea07-1db0-49a1-b12c-b187ad2d3a79" />

That means that `ZIO.interrupt` was resulting in something like: `StateFul(..., Stateful(..., ...))`
We don't need two `StateFul` here. It can be implemented in only one.
That's the change in the `ZIO.interrupt` implementation proposed in this PR.

FYI, I tried to deprecated `ZIO.interruptAs` and `Promise.interruptAs` in this PR: https://github.com/zio/zio/pull/10090 but  it makes some `Queue` specs fail:
```scala
  - QueueSpec / shutdown with offer fiber - 26 ms
    ✗ .fiberId.id : expected '15352' got '15353'
.fiberId.startTimeMillis : expected '1754625267140' got '1754625267141'
.fiberId.location : expected 'zio.QueueSpec.spec(QueueSpec.scala:476)' got 'zio.QueueSpec.spec(QueueSpec.scala:471)'
.trace.stackTrace[0] : expected 'null' got 'zio.QueueSpec.spec(QueueSpec.scala:473)'
.trace.stackTrace[1] : expected 'null' got 'zio.QueueSpec.spec(QueueSpec.scala:471)'

  - QueueSpec / shutdown with take fiber - 31 ms
    ✗ .fiberId.id : expected '15284' got '15285'
.fiberId.location : expected 'zio.QueueSpec.spec(QueueSpec.scala:464)' got 'zio.QueueSpec.spec(QueueSpec.scala:459)'
```

I'm not sure what is the correct behaviour so I decided to not deprecated `ZIO.interruptAs` nor `Promise.interruptAs` to keep the current `Queue` behaviour.
But, as explained in https://github.com/zio/zio/pull/10090, `interruptAs` is always used in such a pattern:
```scala
ZIO.fiberIdWith { fiberId =>
   ...
   [ZIO|Promise].interruptAs(fiberId)
   ...
}
```
which leads to the `Stateful(..., Stateful(..., ...))` issue