### PR TITLE
Add Loom-friendly concurrent weak fiber set (FiberSet)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
@@ -1,0 +1,28 @@
+package zio.internal
+
+import zio._
+import zio.test._
+import zio.test.TestAspect._
+
+object FiberSetSpec extends ZIOSpecDefault {
+  def spec = suite("FiberSetSpec")(
+    test("add & foreach sees live fibers") {
+      val set = FiberSet.make()
+      for {
+        f1 <- ZIO.never.fork
+        f2 <- ZIO.unit.fork
+        _   = set.add(f1)
+        _   = set.add(f2)
+        seen <- ZIO.succeed {
+          val b = scala.collection.mutable.Set[Fiber.Runtime[_, _]]()
+          set.foreach(b.add)
+          b.size
+        }
+        _ <- f2.interrupt
+        _  = set.remove(f2)
+      } yield assertTrue(seen >= 2)
+    } @@ eventually
+  ) @@ timed
+
+  private val eventually = TestAspect.eventually
+}

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -15,7 +15,7 @@
  */
 
 package zio
-
+import zio.internal.FiberSet
 import zio.internal.{FiberRenderer, FiberScope}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -1028,7 +1028,11 @@ object Fiber extends FiberPlatformSpecific {
    * returned chunk is only weakly consistent.
    */
   def roots(implicit trace: Trace): UIO[Chunk[Fiber.Runtime[_, _]]] =
-    ZIO.succeed(Chunk.fromIterator(_roots.iterator))
+  ZIO.succeed {
+    val buf = scala.collection.mutable.ArrayBuffer[Fiber.Runtime[_, _]]()
+    _roots.foreach(f => buf += f)
+    Chunk.fromArray(buf.toArray)
+  }
 
   /**
    * Returns a fiber that has already succeeded with the specified value.
@@ -1062,7 +1066,7 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
+  private[zio] val _roots: FiberSet = FiberSet.make()
     WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
       .withAutoGc(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -15,7 +15,7 @@
  */
 
 package zio.internal
-
+import zio.internal.FiberSet
 import zio.Exit.{Failure, Success}
 import zio._
 import zio.internal.SpecializationHelpers.SpecializeInt
@@ -43,7 +43,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
   private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var _children       = null.asInstanceOf[FiberSet]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
   private var _stack          = null.asInstanceOf[Array[Continuation]]
@@ -84,16 +84,14 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       )
   }
 
-  private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
-    // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
+  private[this] def childrenChunk(children: FiberSet): Chunk[Fiber.Runtime[_, _]] =
     if (children eq null) Chunk.empty
     else {
-      val bldr = Chunk.newBuilder[Fiber.Runtime[_, _]]
-      children.forEach { child =>
-        if ((child ne null) && child.isAlive())
-          bldr.addOne(child)
+      val buf = scala.collection.mutable.ArrayBuffer[Fiber.Runtime[_, _]]()
+      children.foreach { child =>
+        if (child ne null) buf += child
       }
-      bldr.result()
+      Chunk.fromArray(buf.toArray)
     }
 
   def children(implicit trace: Trace): UIO[Chunk[Fiber.Runtime[_, _]]] =
@@ -573,11 +571,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def getChildren(): JavaSet[Fiber.Runtime[_, _]] = {
+  private def getChildren(): FiberSet = {
     // executed by the fiber itself, no risk of racing with transferChildren
     var children = _children
     if (children eq null) {
-      children = Platform.newConcurrentWeakSet[Fiber.Runtime[_, _]]()(Unsafe)
+      children = FiberSet.make()
       _children = children
     }
     children
@@ -743,32 +741,30 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
   private def interruptAllChildren(): UIO[Any] =
-    if (sendInterruptSignalToAllChildren(_children)) {
-      val iterator = _children.iterator()
-      _children = null
+  if (sendInterruptSignalToAllChildren(_children)) {
+    val snapshot = childrenChunk(_children) // make a stable view
+    _children = null
 
-      var curr: Fiber.Runtime[_, _] = null
+    var i    = 0
+    var curr: Fiber.Runtime[_, _] = null
 
-      // this finds the next operable child fiber and stores it in the `curr` variable
-      def skip() = {
-        var next: Fiber.Runtime[_, _] = null
-        while (iterator.hasNext && (next eq null)) {
-          next = iterator.next()
-          if ((next ne null) && !next.isAlive())
-            next = null
-        }
-        curr = next
+    // advance to next alive child in the snapshot
+    def skip(): Unit = {
+      curr = null
+      while (i < snapshot.length && (curr eq null)) {
+        val n = snapshot(i)
+        i += 1
+        if ((n ne null) && n.isAlive()) curr = n
       }
+    }
 
-      // find the first operable child fiber
-      // if there isn't any we can simply return null and save ourselves an effect evaluation
-      skip()
+    // find the first operable child
+    skip()
 
-      if (null ne curr) {
-        ZIO
-          .whileLoop(null ne curr)(curr.await(id.location))(_ => skip())(id.location)
-      } else null
-    } else null
+    if (null ne curr)
+      ZIO.whileLoop(null ne curr)(curr.await(id.location))(_ => skip())(id.location)
+    else null
+  } else null
 
   private[zio] def isAlive(): Boolean =
     _exitValue eq null
@@ -1324,25 +1320,18 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private def sendInterruptSignalToAllChildren(
-    children: JavaSet[Fiber.Runtime[_, _]]
+    children: FiberSet
   ): Boolean =
-    if ((children eq null) || children.isEmpty) false
+    if (children eq null) false
     else {
-      // Initiate asynchronous interruption of all children:
-      val iterator = children.iterator()
-      var told     = false
-      val cause    = Cause.interrupt(fiberId)
-
-      while (iterator.hasNext) {
-        val next = iterator.next()
-
+      var told  = false
+      val cause = Cause.interrupt(fiberId)
+      children.foreach { next =>
         if ((next ne null) && next.isAlive()) {
           next.tellInterrupt(cause)
-
           told = true
         }
       }
-
       told
     }
 

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,80 @@
+package zio.internal
+
+import zio.Fiber
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.ConcurrentHashMap
+import scala.jdk.CollectionConverters._
+
+private[zio] trait FiberSet {
+  def add(f: Fiber.Runtime[_, _]): Unit
+  def remove(f: Fiber.Runtime[_, _]): Unit
+  def foreach(g: Fiber.Runtime[_, _] => Unit): Unit
+  def sizeApprox: Int
+}
+
+private[zio] object FiberSet {
+  def make(capacityHint: Int = 64): FiberSet = new Impl(capacityHint)
+
+  private val Dummy: AnyRef = new AnyRef
+
+  /** A weak ref whose hashCode never changes (cached identity hash).
+    * equals is reference-equality on the box (so we can remove polled keys directly).
+    */
+  private final class WeakBox[A <: AnyRef](a: A, q: ReferenceQueue[A])
+      extends WeakReference[A](a, q) {
+    private[this] val hc = System.identityHashCode(a)
+    override def hashCode(): Int = hc
+    override def equals(other: Any): Boolean = this.asInstanceOf[AnyRef] eq other.asInstanceOf[AnyRef]
+  }
+
+  private final class Impl(capacityHint: Int) extends FiberSet {
+    private[this] val queue = new ReferenceQueue[Fiber.Runtime[_, _]]()
+    private[this] val map   = new ConcurrentHashMap[WeakBox[Fiber.Runtime[_, _]], AnyRef](capacityHint)
+
+    // micro-throttle draining the reference queue
+    @volatile private[this] var opsSinceDrain = 0
+    private[this] val DrainEvery              = 64
+
+    private def drainQueue(): Unit = {
+      var polled = queue.poll()
+      while (polled ne null) {
+        map.remove(polled.asInstanceOf[WeakBox[Fiber.Runtime[_, _]]])
+        polled = queue.poll()
+      }
+    }
+
+    override def add(f: Fiber.Runtime[_, _]): Unit = {
+      map.put(new WeakBox(f, queue), Dummy)
+      val n = opsSinceDrain + 1
+      opsSinceDrain = if (n >= DrainEvery) { drainQueue(); 0 } else n
+    }
+
+    override def remove(f: Fiber.Runtime[_, _]): Unit = {
+      // best-effort scan (ticket does not require strict set semantics)
+      val it = map.keySet().iterator()
+      while (it.hasNext) {
+        val k = it.next()
+        val r = k.get()
+        if ((r eq null) || (r eq f)) {
+          it.remove()
+          if (r eq f) return
+        }
+      }
+      val n = opsSinceDrain + 1
+      opsSinceDrain = if (n >= DrainEvery) { drainQueue(); 0 } else n
+    }
+
+    override def foreach(g: Fiber.Runtime[_, _] => Unit): Unit = {
+      drainQueue()
+      val it = map.keySet().iterator()
+      while (it.hasNext) {
+        val ref = it.next()
+        val r   = ref.get()
+        if (r eq null) it.remove()
+        else g(r)
+      }
+    }
+
+    override def sizeApprox: Int = { drainQueue(); map.size() }
+  }
+}


### PR DESCRIPTION
This PR closes #8861

-  Adds zio.internal.FiberSet
- Includes a basic test
- Wiring into root/children fiber tracking


/claim #8861