### PR TITLE
Make `TestArrow.run` stack safe

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkSpec.scala
@@ -174,7 +174,6 @@ object ChunkSpec extends ZIOBaseSpec {
       test("fails if the chunk does not contain the specified index") {
         val chunk     = Chunk(1, 2, 3)
         val prepended = 0 +: chunk
-        val _         = -1 +: chunk
         assert(prepended(-1))(throwsA[IndexOutOfBoundsException])
       }
     ),

--- a/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
@@ -159,7 +159,16 @@ object TestArrowSpec extends ZIOBaseSpec {
           val span = Span(4, 2)
           assertTrue(span.substring("foo bar baz") == "")
         }
-      )
+      ),
+      test("stack safety - bug #10051") {
+        val depth = 4096 // TODO: this should really be much larger, like 20K, but `run` is not fully stack safe
+        val step  = TestArrow.fromFunction[Int, Int](_ + 1)
+        val arrow = (0 until depth).foldLeft(TestArrow.succeed(0): TestArrow[Any, Int]) { (acc, _) =>
+          acc >>> step
+        }
+        val testTrace = TestArrow.run(arrow, Right(()))
+        assertTrue(testTrace.result == Result.Succeed(depth))
+      }
     )
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
@@ -168,7 +168,31 @@ object TestArrowSpec extends ZIOBaseSpec {
         }
         val testTrace = TestArrow.run(arrow, Right(()))
         assertTrue(testTrace.result == Result.Succeed(depth))
-      }
+      },
+      suite("run resumes with die")(
+        test("suspend") {
+          val ex      = new Exception("test")
+          val failing = TestArrow.suspend[Any, Int](_ => throw ex)
+          val arrow = failing >>> TestArrow.makeEither(
+            onFail = TestTrace.die,
+            onSucceed = _ => TestTrace.fail("expected failure")
+          )
+
+          val testTrace = TestArrow.run(arrow, Right(()))
+          assertTrue(testTrace.result == Result.Die(ex))
+        },
+        test("succeed") {
+          val ex      = new Exception("test")
+          val failing = TestArrow.succeed[Int](throw ex)
+          val arrow = failing >>> TestArrow.makeEither(
+            onFail = TestTrace.die,
+            onSucceed = _ => TestTrace.fail("expected failure")
+          )
+
+          val testTrace = TestArrow.run(arrow, Right(()))
+          assertTrue(testTrace.result == Result.Die(ex))
+        }
+      )
     )
 
 }

--- a/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
@@ -168,7 +168,7 @@ object TestArrowSpec extends ZIOBaseSpec {
         }
         val testTrace = TestArrow.run(arrow, Right(()))
         assertTrue(testTrace.result == Result.Succeed(depth))
-      },
+      } @@ TestAspect.jvmOnly,
       suite("run resumes with die")(
         test("suspend") {
           val ex      = new Exception("test")

--- a/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestArrowSpec.scala
@@ -161,7 +161,7 @@ object TestArrowSpec extends ZIOBaseSpec {
         }
       ),
       test("stack safety - bug #10051") {
-        val depth = 4096 // TODO: this should really be much larger, like 20K, but `run` is not fully stack safe
+        val depth = 20000
         val step  = TestArrow.fromFunction[Int, Int](_ + 1)
         val arrow = (0 until depth).foldLeft(TestArrow.succeed(0): TestArrow[Any, Int]) { (acc, _) =>
           acc >>> step

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -227,10 +227,19 @@ object TestArrow {
       case Right(value) => onSucceed(value)
     }
 
+  private val onError: PartialFunction[Throwable, TestTrace[Nothing]] = {
+    case ex if NonFatal(ex) =>
+      ex.setStackTrace(ex.getStackTrace.filterNot { (ste: StackTraceElement) =>
+        ste.getClassName.startsWith("zio.test.TestArrow")
+      })
+      TestTrace.die(ex)
+  }
+
   private def runLoop[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
     arrow match {
       case TestArrowF(f) =>
-        f(in)
+        try f(in)
+        catch onError
 
       case AndThen(f, g) =>
         val t1 = runLoop(f, in)
@@ -254,7 +263,8 @@ object TestArrow {
           case Left(exception) =>
             TestTrace.die(exception)
           case Right(value) =>
-            runLoop(f(value), in)
+            try runLoop(f(value), in)
+            catch onError
         }
 
       case Meta(arrow, span, parentSpan, code, location, completeCode, customLabel, genFailureDetails) =>
@@ -270,13 +280,7 @@ object TestArrow {
 
   def run[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
     try runLoop(arrow, in)
-    catch {
-      case ex if NonFatal(ex) =>
-        ex.setStackTrace(ex.getStackTrace.filterNot { (ste: StackTraceElement) =>
-          ste.getClassName.startsWith("zio.test.TestArrow")
-        })
-        TestTrace.die(ex)
-    }
+    catch onError
 
   case class Span(start: Int, end: Int) {
     def substring(str: String): String = {

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -227,48 +227,38 @@ object TestArrow {
       case Right(value) => onSucceed(value)
     }
 
-  private def attempt[A](expr: => TestTrace[A]): TestTrace[A] =
-    try expr
-    catch {
-      case ex if NonFatal(ex) =>
-        ex.setStackTrace(ex.getStackTrace.filterNot { (ste: StackTraceElement) =>
-          ste.getClassName.startsWith("zio.test.TestArrow")
-        })
-        TestTrace.die(ex)
-    }
-
-  def run[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] = attempt {
+  private def runLoop[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
     arrow match {
       case TestArrowF(f) =>
         f(in)
 
       case AndThen(f, g) =>
-        val t1 = run(f, in)
+        val t1 = runLoop(f, in)
         t1.result match {
-          case Result.Fail           => t1.asInstanceOf[TestTrace[B]]
-          case Result.Die(err)       => t1 >>> run(g, Left(err))
-          case Result.Succeed(value) => t1 >>> run(g, Right(value))
+          case _: Result.Fail.type   => t1.asInstanceOf[TestTrace[B]]
+          case Result.Die(err)       => t1 >>> runLoop(g, Left(err))
+          case Result.Succeed(value) => t1 >>> runLoop(g, Right(value))
         }
 
       case And(lhs, rhs) =>
-        run(lhs, in) && run(rhs, in)
+        runLoop(lhs, in) && runLoop(rhs, in)
 
       case Or(lhs, rhs) =>
-        run(lhs, in) || run(rhs, in)
+        runLoop(lhs, in) || runLoop(rhs, in)
 
       case Not(arrow) =>
-        !run(arrow, in)
+        !runLoop(arrow, in)
 
       case Suspend(f) =>
         in match {
           case Left(exception) =>
             TestTrace.die(exception)
           case Right(value) =>
-            run(f(value), in)
+            runLoop(f(value), in)
         }
 
       case Meta(arrow, span, parentSpan, code, location, completeCode, customLabel, genFailureDetails) =>
-        run(arrow, in)
+        runLoop(arrow, in)
           .withSpan(span)
           .withCode(code)
           .withParentSpan(parentSpan)
@@ -278,7 +268,15 @@ object TestArrow {
           .withGenFailureDetails(genFailureDetails)
     }
 
-  }
+  def run[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
+    try runLoop(arrow, in)
+    catch {
+      case ex if NonFatal(ex) =>
+        ex.setStackTrace(ex.getStackTrace.filterNot { (ste: StackTraceElement) =>
+          ste.getClassName.startsWith("zio.test.TestArrow")
+        })
+        TestTrace.die(ex)
+    }
 
   case class Span(start: Int, end: Int) {
     def substring(str: String): String = {

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -8,7 +8,7 @@ import zio.internal.stacktracer.SourceLocation
 import zio.test.Assertion.Arguments
 
 import scala.annotation.tailrec
-import scala.util.control.NonFatal
+import scala.util.control.{NonFatal, TailCalls}
 
 case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
@@ -227,60 +227,68 @@ object TestArrow {
       case Right(value) => onSucceed(value)
     }
 
-  private val onError: PartialFunction[Throwable, TestTrace[Nothing]] = {
+  private val onError: PartialFunction[Throwable, TailCalls.TailRec[TestTrace[Nothing]]] = {
     case ex if NonFatal(ex) =>
       ex.setStackTrace(ex.getStackTrace.filterNot { (ste: StackTraceElement) =>
         ste.getClassName.startsWith("zio.test.TestArrow")
       })
-      TestTrace.die(ex)
+      TailCalls.done(TestTrace.die(ex))
   }
 
-  private def runLoop[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
-    arrow match {
+  private def runLoop[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TailCalls.TailRec[TestTrace[B]] =
+    TailCalls.tailcall(arrow match {
       case TestArrowF(f) =>
-        try f(in)
+        try TailCalls.done(f(in))
         catch onError
 
       case AndThen(f, g) =>
-        val t1 = runLoop(f, in)
-        t1.result match {
-          case _: Result.Fail.type   => t1.asInstanceOf[TestTrace[B]]
-          case Result.Die(err)       => t1 >>> runLoop(g, Left(err))
-          case Result.Succeed(value) => t1 >>> runLoop(g, Right(value))
+        runLoop(f, in).flatMap { t1 =>
+          t1.result match {
+            case _: Result.Fail.type   => TailCalls.done(t1.asInstanceOf[TestTrace[B]])
+            case Result.Die(err)       => runLoop(g, Left(err)).map(t1 >>> _)
+            case Result.Succeed(value) => runLoop(g, Right(value)).map(t1 >>> _)
+          }
         }
 
       case And(lhs, rhs) =>
-        runLoop(lhs, in) && runLoop(rhs, in)
+        for {
+          l <- runLoop(lhs, in)
+          r <- runLoop(rhs, in)
+        } yield l && r
 
       case Or(lhs, rhs) =>
-        runLoop(lhs, in) || runLoop(rhs, in)
+        for {
+          l <- runLoop(lhs, in)
+          r <- runLoop(rhs, in)
+        } yield l || r
 
       case Not(arrow) =>
-        !runLoop(arrow, in)
+        runLoop(arrow, in).map(!_)
 
       case Suspend(f) =>
         in match {
           case Left(exception) =>
-            TestTrace.die(exception)
+            TailCalls.done(TestTrace.die(exception))
           case Right(value) =>
             try runLoop(f(value), in)
             catch onError
         }
 
       case Meta(arrow, span, parentSpan, code, location, completeCode, customLabel, genFailureDetails) =>
-        runLoop(arrow, in)
-          .withSpan(span)
-          .withCode(code)
-          .withParentSpan(parentSpan)
-          .withLocation(location)
-          .withCompleteCode(completeCode)
-          .withCustomLabel(customLabel)
-          .withGenFailureDetails(genFailureDetails)
-    }
+        runLoop(arrow, in).map {
+          _.withSpan(span)
+            .withCode(code)
+            .withParentSpan(parentSpan)
+            .withLocation(location)
+            .withCompleteCode(completeCode)
+            .withCustomLabel(customLabel)
+            .withGenFailureDetails(genFailureDetails)
+        }
+    })
 
   def run[A, B](arrow: TestArrow[A, B], in: Either[Throwable, A]): TestTrace[B] =
-    try runLoop(arrow, in)
-    catch onError
+    (try runLoop(arrow, in)
+    catch onError).result
 
   case class Span(start: Int, end: Int) {
     def substring(str: String): String = {

--- a/test/shared/src/main/scala/zio/test/TestTrace.scala
+++ b/test/shared/src/main/scala/zio/test/TestTrace.scala
@@ -317,7 +317,7 @@ object TestTrace {
     }
   }
 
-  def fail: TestTrace[Nothing]                        = Node(Result.Fail)
+  val fail: TestTrace[Nothing]                        = Node(Result.Fail)
   def fail(message: String): TestTrace[Nothing]       = Node(Result.Fail, message = ErrorMessage.text(message))
   def fail(message: ErrorMessage): TestTrace[Nothing] = Node(Result.Fail, message = message)
   def succeed[A](value: A): TestTrace[A]              = Node(Result.succeed(value))


### PR DESCRIPTION
/fixes #10051 

This change makes `TestArrow.run` stack safe by removing indirection with the attempt method on each iteration of `run` loop, as well as introducing `TailCalls` to trampoline where necessary.

The `run` method has been split to a secondary `runLoop` method.

