### PR TITLE
Deprecate `IsFatal` in preparation for removal

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
@@ -4,6 +4,7 @@ import zio.test.TestAspect.jvmOnly
 import zio.test._
 
 object RuntimeSpecJVM extends ZIOBaseSpec {
+  @annotation.nowarn("msg=IsFatal")
   def isFatal(t: Throwable): Boolean = FiberRef.currentFatal.initial.apply(t)
 
   def spec = suite("RuntimeSpecJVM")(

--- a/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRefSpec.scala
@@ -472,7 +472,7 @@ object FiberRefSpec extends ZIOBaseSpec {
           FiberRef.overrideExecutor,
           FiberRef.currentEnvironment,
           FiberRef.currentBlockingExecutor,
-          FiberRef.currentFatal,
+          FiberRef.currentFatal: @annotation.nowarn("msg=deprecated"),
           FiberRef.currentFiberIdGenerator,
           FiberRef.currentLoggers,
           FiberRef.currentReportFatal,

--- a/core-tests/shared/src/test/scala/zio/internal/IsFatalSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/IsFatalSpec.scala
@@ -4,6 +4,7 @@ import zio.test.Assertion._
 import zio.test._
 import zio.ZIOBaseSpec
 
+@annotation.nowarn("msg=deprecated")
 object IsFatalSpec extends ZIOBaseSpec {
   def spec =
     suite("IsFatal")(

--- a/core/jvm/src/main/scala/zio/RuntimePlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/RuntimePlatformSpecific.scala
@@ -28,6 +28,7 @@ private[zio] trait RuntimePlatformSpecific {
   final val defaultBlockingExecutor: Executor =
     Blocking.blockingExecutor
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   final val defaultFatal: IsFatal = IsFatal.empty
 
   final val defaultLoggers: Set[ZLogger[String, Any]] =

--- a/core/native/src/main/scala/zio/RuntimePlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/RuntimePlatformSpecific.scala
@@ -27,6 +27,7 @@ private[zio] trait RuntimePlatformSpecific {
   final val defaultBlockingExecutor: Executor =
     Blocking.blockingExecutor
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   final val defaultFatal: IsFatal =
     IsFatal.empty
 

--- a/core/shared/src/main/scala/zio/Differ.scala
+++ b/core/shared/src/main/scala/zio/Differ.scala
@@ -157,6 +157,7 @@ object Differ {
   /**
    * Constructs a differ that knows how to diff `IsFatal` values.
    */
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   def isFatal: Differ[IsFatal, IsFatal.Patch] =
     new Differ[IsFatal, IsFatal.Patch] {
       def combine(first: IsFatal.Patch, second: IsFatal.Patch): IsFatal.Patch =

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -616,6 +616,7 @@ object Fiber extends FiberPlatformSpecific {
      * invoked on this fiber, then values derived from the fiber's state
      * (including the log annotations and log level) may not be up-to-date.
      */
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
     private[zio] final def isFatal(t: Throwable): Boolean =
       getFiberRef(FiberRef.currentFatal).apply(t)
 

--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -438,7 +438,8 @@ object FiberRef {
         ZEnvironment.Patch.empty
       )
 
-    def makeIsFatal[A](
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
+    private[zio] def makeIsFatal[A](
       initial: IsFatal
     )(implicit unsafe: Unsafe): FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
       makePatch[IsFatal, IsFatal.Patch](
@@ -597,6 +598,7 @@ object FiberRef {
   private[zio] val currentBlockingExecutor: FiberRef[Executor] =
     FiberRef.unsafe.make(Runtime.defaultBlockingExecutor)(Unsafe.unsafe)
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   private[zio] val currentFatal: FiberRef.WithPatch[IsFatal, IsFatal.Patch] =
     FiberRef.unsafe.makeIsFatal(Runtime.defaultFatal)(Unsafe.unsafe)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -3992,12 +3992,14 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   /**
    * Retrieves the definition of a fatal error.
    */
+  @deprecated("isFatal is deprecated, kept only for binary compatability. Do not use.", "2.1.21")
   def isFatal(implicit trace: Trace): UIO[Throwable => Boolean] =
     isFatalWith(ZIO.successFn)
 
   /**
    * Constructs an effect based on the definition of a fatal error.
    */
+  @deprecated("isFatalWith is deprecated, kept only for binary compatability. Do not use.", "2.1.21")
   def isFatalWith[R, E, A](f: (Throwable => Boolean) => ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
     FiberRef.currentFatal.getWith(f)
 

--- a/core/shared/src/main/scala/zio/internal/IsFatal.scala
+++ b/core/shared/src/main/scala/zio/internal/IsFatal.scala
@@ -16,9 +16,11 @@
 
 package zio.internal
 
-sealed trait IsFatal extends (Throwable => Boolean) { self =>
+@deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
+private[zio] sealed trait IsFatal extends (Throwable => Boolean) { self =>
   import IsFatal._
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   def apply(t: Throwable): Boolean =
     if (t.isInstanceOf[VirtualMachineError]) true
     else
@@ -28,6 +30,7 @@ sealed trait IsFatal extends (Throwable => Boolean) { self =>
         case Single(tag)       => tag.isAssignableFrom(t.getClass)
       }
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   def |(that: IsFatal): IsFatal =
     if (self eq Empty) that
     else
@@ -37,11 +40,13 @@ sealed trait IsFatal extends (Throwable => Boolean) { self =>
       }
 }
 
-object IsFatal {
+private[zio] object IsFatal {
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   def apply(tag: Class[_ <: Throwable]): IsFatal =
     Single(tag)
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   val empty: IsFatal =
     Empty
 
@@ -49,8 +54,10 @@ object IsFatal {
   private case object Empty                                    extends IsFatal
   private final case class Both(left: IsFatal, right: IsFatal) extends IsFatal
 
+  @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
   sealed trait Patch { self =>
 
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
     def apply(isFatal: IsFatal): IsFatal = {
 
       def loop(isFatal: IsFatal, patches: List[Patch]): IsFatal =
@@ -65,12 +72,13 @@ object IsFatal {
       loop(isFatal, List(self))
     }
 
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
     def combine(that: Patch): Patch =
       Patch.AndThen(self, that)
   }
 
   object Patch {
-
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
     def diff(oldValue: IsFatal, newValue: IsFatal): Patch =
       if (oldValue == newValue) Empty
       else {
@@ -85,6 +93,7 @@ object IsFatal {
         added.combine(removed)
       }
 
+    @deprecated("IsFatal is deprecated, kept only for binary compatability.", "2.1.21")
     val empty: Patch =
       Empty
 


### PR DESCRIPTION
IsFatal is unused in any public codebase (see: https://github.com/zio/zio/issues/9880), has unclear semantics across functions, and has a significant performance cost. By removing configurability of `IsFatal`, we can optimize `attempt`, `suspend`, Java CS/CF interop, and more importantly the FiberRuntime itself!

In this PR, I made `IsFatal` itself package private, as well as the ability to add new fatals to the runtime. I also deprecated all relevant methods.

After the next release, we remove checks to the FiberRef, and use a static definition for IsFatal. Maintaining binary compatibility, but removing the feature from the codebase.

