### PR TITLE
Do not log an interruption error on app shutdown

### DIFF
--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -20,7 +20,11 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
       (for {
         runtime <- ZIO.runtime[Environment with ZIOAppArgs]
         _       <- installSignalHandlers(runtime)
-        result  <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause(ZIO.logErrorCause(_))
+        result <- runtime.run(ZIO.scoped[Environment with ZIOAppArgs](run)).tapErrorCause { c =>
+                    // Don't log an interruption error if we're shutting down
+                    if (shuttingDown.get() && c.isInterruptedOnly) Exit.unit
+                    else ZIO.logErrorCause(c)
+                  }
       } yield result).provideLayer(newLayer.tapErrorCause(ZIO.logErrorCause(_)))
 
     val shutdownLatch = internal.OneShot.make[Unit]


### PR DESCRIPTION
/fixes #10122

With this change we won't log an interruption error on app shutdown. Note that this will still log an interruption error in case that the app is interrupted internally, e.g.,:

```scala
object Foo extends zio.ZIOAppDefault {
  override def run =
    for {
      f <- ZIO.never.forkDaemon
      _ <- f.interrupt.delay(2.seconds).forkDaemon
      _ <- f.join
    } yield ()
}
```