### PR TITLE
Fix ZIO HTTP wildcard redirect

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,2 +1,2 @@
-/zio-http      https://ziohttp.com  308
-/zio-http/*    https://ziohttp.com  308
+/zio-http      https://ziohttp.com         308
+/zio-http/*    https://ziohttp.com/:splat  308


### PR DESCRIPTION
Add `:splat` to wildcard path to make sure requested path is copied for redirect as documented here:

https://docs.netlify.com/manage/routing/redirects/redirect-options/#splats

Currently when trying search for ZIO HTTP documentation on Google results will show correct preview text but link to e.g: https://zio.dev/zio-http/reference/body/binary_codecs when clicking the link you are redirected to main page https://ziohttp.com instead of directly to https://ziohttp.com/reference/body/binary_codecs