### PR TITLE
Change ZPipeline split implementations to use Trie Data Structure

### DIFF
--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -70,7 +70,7 @@ ZStream("This is the first line.\nSecond line.\nAnd the last line.")
 
 ```scala mdoc:silent:nest
 ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-  .via(ZPipeline.splitOnChunk(Chunk(4, 5, 6), true))
+  .via(ZPipeline.splitOnChunk(Chunk(4, 5, 6), allowEmpty = true))
 // Output: Chunk(1, 2, 3), Chunk(7, 8, 9, 10)
 ```
 

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -70,7 +70,7 @@ ZStream("This is the first line.\nSecond line.\nAnd the last line.")
 
 ```scala mdoc:silent:nest
 ZStream(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
-  .via(ZPipeline.splitOnChunk(Chunk(4, 5, 6)))
+  .via(ZPipeline.splitOnChunk(Chunk(4, 5, 6), true))
 // Output: Chunk(1, 2, 3), Chunk(7, 8, 9, 10)
 ```
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -143,6 +143,11 @@ object ZPipelineSpec extends ZIOBaseSpec {
           assertZIO(
             ZStream("abc<", ">abc").via(ZPipeline.splitOn("<>")).runCollect
           )(equalTo(Chunk("abc", "abc")))
+        },
+        test("repetitive delimiters that might be in progress and shouldn't be discarded on first non-match") {
+          assertZIO(
+            ZStream("a", "a", "a", "b", "a", "b").via(ZPipeline.splitOn("aab")).runCollect
+          )(equalTo(Chunk("a", "ab")))
         }
       ),
       suite("splitOnMany")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -145,6 +145,33 @@ object ZPipelineSpec extends ZIOBaseSpec {
           )(equalTo(Chunk("abc", "abc")))
         }
       ),
+      suite("splitOnMany")(
+        test("preserves data")(
+          check(Gen.chunkOf(Gen.string.filter(!_.contains("|")).filter(!_.contains("&")).filter(_.nonEmpty))) { lines =>
+            val data     = lines.grouped(2).map(_.mkString("|")).mkString("&")
+            val pipeline = ZPipeline.splitOnMany(Seq("|", "&"))
+            assertZIO(pipeline(ZStream.fromChunks(Chunk.single(data))).runCollect)(equalTo(lines))
+          }
+        ),
+        test("handles leftovers") {
+          val pipeline = ZPipeline.splitOnMany(Seq("\n"))
+          assertZIO(pipeline(ZStream.fromChunks(Chunk("ab", "c\nb"), Chunk("c"))).runCollect)(
+            equalTo(Chunk("abc", "bc"))
+          )
+        },
+        test("works") {
+          assertZIO(
+            ZStream("abc", "delimiter", "bc", "other", "bcd", "bcd")
+              .via(ZPipeline.splitOnMany(Seq("delimiter", "other")))
+              .runCollect
+          )(equalTo(Chunk("abc", "bc", "bcdbcd")))
+        },
+        test("no delimiter in data") {
+          assertZIO(
+            ZStream("abc", "abc", "abc").via(ZPipeline.splitOnMany(Seq("hello"))).runCollect
+          )(equalTo(Chunk("abcabcabc")))
+        }
+      ),
       suite("take")(
         test("it takes the correct number of elements") {
           assertZIO(

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2096,7 +2096,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       offset: Int
     ): ((Chunk[T], Seq[Trie[T1]]), Iterable[Chunk[T]]) = {
       val iterator          = chunk.chunkIterator
-      var partitionBuffer   = scala.collection.mutable.ArrayBuffer.empty[Chunk[T]]
+      var partitionBuffer   = scala.collection.mutable.ListBuffer.empty[Chunk[T]]
       var curTries          = carryTries
       var index             = offset
       var curPartitionStart = 0

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -25,6 +25,7 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
 import scala.annotation.tailrec
+import scala.collection.mutable.ListBuffer
 
 /**
  * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer.
@@ -2090,26 +2091,33 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
   private final case class Trie[T1](structure: Map[T1, Trie[T1]], depth: Int, isLeaf: Boolean = false) {
-    @tailrec
     def partitionAll[T <: T1](
       chunk: Chunk[T],
-      curTries: Seq[Trie[T1]],
-      offset: Int,
-      curPartitions: Seq[Chunk[T]]
-    ): ((Chunk[T], Int, Seq[Trie[T1]]), Seq[Chunk[T]]) =
-      if (offset < chunk.size) {
-        val matchingTries = curTries.flatMap(_.structure.get(chunk(offset)))
+      carryTries: Seq[Trie[T1]],
+      offset: Int
+    ): ((Chunk[T], Seq[Trie[T1]]), Seq[Chunk[T]]) = {
+      val iterator          = chunk.chunkIterator
+      var partitionBuffer   = new ListBuffer[Chunk[T]]()
+      var curTries          = carryTries
+      var index             = offset
+      var curPartitionStart = 0
+      while (iterator.hasNextAt(index)) {
+        val matchingTries = curTries.flatMap(_.structure.get(iterator.nextAt(index)))
         matchingTries.filter(_.isLeaf).reverse.headOption match {
-          case Some(trie) =>
-            partitionAll(
-              if (chunk.size - 1 > offset) chunk.takeRight(chunk.size - offset - 1) else Chunk.empty,
-              Seq(this),
-              0,
-              chunk.take(offset - trie.depth + 1) +: curPartitions
-            )
-          case None => partitionAll(chunk, this +: matchingTries, offset + 1, curPartitions)
+          case Some(trie) => {
+            partitionBuffer += chunk.slice(curPartitionStart, index - trie.depth + 1)
+            index += 1
+            curPartitionStart = index
+            curTries = Seq(this)
+          }
+          case None => {
+            index += 1
+            curTries = matchingTries.prepended(this)
+          }
         }
-      } else ((chunk, offset, curTries), curPartitions.reverse)
+      }
+      ((chunk.slice(curPartitionStart, chunk.length), curTries), partitionBuffer.toSeq)
+    }
   }
 
   private object Trie {
@@ -2162,14 +2170,13 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
     ZPipeline.suspend {
       def next(
         leftover: Chunk[In],
-        offset: Int,
         curTries: Seq[Trie[In1]]
       ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any] =
         ZChannel.readWithCause(
           inputChunk => {
-            delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, offset, Seq.empty) match {
-              case ((carryChunk, carryOffset, carryTries), partitions) =>
-                writeChunkOfChunks(Chunk.fromIterable(partitions)) *> next(carryChunk, carryOffset, carryTries)
+            delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, leftover.size) match {
+              case ((carryChunk, carryTries), partitions) =>
+                writeChunkOfChunks(Chunk.fromIterable(partitions)) *> next(carryChunk, carryTries)
             }
           },
           halt =>
@@ -2185,7 +2192,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
               ZChannel.succeed(done)
             }
         )
-      new ZPipeline(next(Chunk.empty, 0, Seq(delimiterTrie)))
+      new ZPipeline(next(Chunk.empty, Seq(delimiterTrie)))
     }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2211,6 +2211,11 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * Splits strings on a delimiter.
    */
+  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, In] =
+    splitOnChunk(delimiter, allowEmpty = true)
+
   def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1], allowEmpty: Boolean)(implicit
     trace: Trace
   ): ZPipeline[Any, Nothing, In, In] =

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2151,7 +2151,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       Trie(Seq(delimiter))
     )
 
-  def splitWithTrie[In1 >: In, In, Out](
+  private def splitWithTrie[In1 >: In, In, Out](
     writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any],
     writeLeftover: Chunk[In] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any]
   )(

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2078,7 +2078,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOn(delimiter: => String)(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitOnChunk[Char, Char](delimiter.toList) >>>
+      ZPipeline.splitOnChunk[Char, Char](delimiter.toList, true) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
   /**
@@ -2086,14 +2086,15 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOnMany(delimiters: => Seq[String])(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitOnManyChunk[Char, Char](delimiters.map(_.toList)) >>>
+      ZPipeline.splitOnManyChunk[Char, Char](delimiters.map(_.toList), true) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
   private final case class Trie[T1](structure: Map[T1, Trie[T1]], depth: Int, isLeaf: Boolean = false) {
     def partitionAll[T <: T1](
       chunk: Chunk[T],
       carryTries: Seq[Trie[T1]],
-      offset: Int
+      offset: Int,
+      allowEmpty: Boolean = true
     ): ((Chunk[T], Seq[Trie[T1]]), Iterable[Chunk[T]]) = {
       val iterator          = chunk.chunkIterator
       var partitionBuffer   = scala.collection.mutable.ListBuffer.empty[Chunk[T]]
@@ -2105,7 +2106,9 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         index += 1
         curTries.filter(_.isLeaf).reverse.headOption match {
           case Some(leaf) => {
-            partitionBuffer += chunk.slice(curPartitionStart, index - leaf.depth)
+            if (index - leaf.depth > curPartitionStart || allowEmpty) {
+              partitionBuffer += chunk.slice(curPartitionStart, index - leaf.depth)
+            }
             curPartitionStart = index
             curTries = Seq.empty
           }
@@ -2138,29 +2141,97 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       }
   }
 
+  def splitWhereChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    splitWhere[In, In](where, allowEmpty)(ZChannel.writeChunk, ZChannel.write)
+
+  def splitWhereChunkToProduceChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
+    splitWhere[In, Chunk[In]](where, allowEmpty)(ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))
+
+  private def partitionAllWhere[T](
+    chunk: Chunk[T],
+    offset: Int,
+    where: T => Boolean,
+    allowEmpty: Boolean = false
+  ): (Chunk[T], Iterable[Chunk[T]]) = {
+    val iterator          = chunk.chunkIterator
+    var partitionBuffer   = scala.collection.mutable.ListBuffer.empty[Chunk[T]]
+    var index             = offset
+    var curPartitionStart = 0
+    while (iterator.hasNextAt(index)) {
+      if (where(iterator.nextAt(index))) {
+        if (index > curPartitionStart || allowEmpty) {
+          partitionBuffer += chunk.slice(curPartitionStart, index)
+        }
+        curPartitionStart = index + 1
+      }
+      index += 1
+    }
+    (chunk.takeRight(chunk.length - curPartitionStart), partitionBuffer)
+  }
+
+  private def splitWhere[In, Out](
+    where: In => Boolean,
+    allowEmpty: Boolean
+  )(
+    writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any],
+    writeLeftover: Chunk[In] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any]
+  )(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, Out] =
+    ZPipeline.suspend {
+      def next(leftover: Chunk[In]): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any] =
+        ZChannel.readWithCause(
+          inputChunk => {
+            partitionAllWhere(leftover ++ inputChunk, leftover.size, where, allowEmpty) match {
+              case (carryChunk, partitions) =>
+                writeChunkOfChunks(Chunk.fromIterable(partitions)) *> next(carryChunk)
+            }
+          },
+          halt =>
+            if (leftover.isDefinedAt(0)) {
+              writeLeftover(leftover) *> ZChannel.refailCause(halt)
+            } else {
+              ZChannel.refailCause(halt)
+            },
+          done =>
+            if (leftover.isDefinedAt(0)) {
+              writeLeftover(leftover) *> ZChannel.succeed(done)
+            } else {
+              ZChannel.succeed(done)
+            }
+        )
+      new ZPipeline(next(Chunk.empty))
+    }
+
   /**
    * Splits strings on a delimiter.
    */
-  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(Seq(delimiter)))
+  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1], allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    (delimiter match {
+      case Seq(head) => splitWhere[In, In]((x: In) => x == head, allowEmpty)(_, _)
+      case _         => splitWithTrie[In1, In, In](Trie(Seq(delimiter)), allowEmpty)(_, _)
+    })(ZChannel.writeChunk, ZChannel.write)
 
-  def splitOnManyChunk[In1 >: In, In](delimiters: => Seq[Seq[In1]])(implicit
+  def splitOnManyChunk[In1 >: In, In](delimiters: => Seq[Seq[In1]], allowEmpty: Boolean)(implicit
     trace: Trace
   ): ZPipeline[Any, Nothing, In, In] =
-    splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(delimiters))
+    splitWithTrie[In1, In, In](Trie(delimiters), allowEmpty)(ZChannel.writeChunk, ZChannel.write)
 
   def splitOnChunkToProduceChunk[In1 >: In, In](
-    delimiter: => Seq[In1]
+    delimiter: => Seq[In1],
+    allowEmpty: Boolean
   )(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
-    splitWithTrie[In1, In, Chunk[In]](ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))(
-      Trie(Seq(delimiter))
-    )
+    (delimiter match {
+      case Seq(head) => splitWhere[In, Chunk[In]]((x: In) => x == head, allowEmpty)(_, _)
+      case _         => splitWithTrie[In1, In, Chunk[In]](Trie(Seq(delimiter)), allowEmpty)(_, _)
+    })(ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))
 
   private def splitWithTrie[In1 >: In, In, Out](
+    delimiterTrie: Trie[In1],
+    allowEmpty: Boolean
+  )(
     writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any],
     writeLeftover: Chunk[In] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any]
-  )(
-    delimiterTrie: Trie[In1]
   )(implicit
     trace: Trace
   ): ZPipeline[Any, Nothing, In, Out] =
@@ -2171,7 +2242,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any] =
         ZChannel.readWithCause(
           inputChunk => {
-            delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, leftover.size) match {
+            delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, leftover.size, allowEmpty) match {
               case ((carryChunk, carryTries), partitions) =>
                 writeChunkOfChunks(Chunk.fromIterable(partitions)) *> next(carryChunk, carryTries)
             }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2139,19 +2139,25 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
     splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(Seq(delimiter)))
 
-  def splitOnManyChunk[In1 >: In, In](delimiters: => Seq[Seq[In1]])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+  def splitOnManyChunk[In1 >: In, In](delimiters: => Seq[Seq[In1]])(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, In] =
     splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(delimiters))
 
-  def splitOnChunkToProduceChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
-    splitWithTrie[In1, In, Chunk[In]](ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))(Trie(Seq(delimiter)))
+  def splitOnChunkToProduceChunk[In1 >: In, In](
+    delimiter: => Seq[In1]
+  )(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
+    splitWithTrie[In1, In, Chunk[In]](ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))(
+      Trie(Seq(delimiter))
+    )
 
   def splitWithTrie[In1 >: In, In, Out](
-    writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any], 
+    writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any],
     writeLeftover: Chunk[In] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any]
   )(
     delimiterTrie: Trie[In1]
-  )(
-    implicit trace: Trace
+  )(implicit
+    trace: Trace
   ): ZPipeline[Any, Nothing, In, Out] =
     ZPipeline.suspend {
       def next(

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -25,8 +25,6 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
 import scala.annotation.tailrec
-import scala.collection.concurrent.TrieMap
-import scala.util.{Either, Left, Right}
 
 /**
  * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer.

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -24,6 +24,7 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.annotation.tailrec
 
 /**
@@ -2121,25 +2122,59 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   }
 
   private object Trie {
-    private val _empty               = Trie(structure = Map.empty[Any, Trie[Any]], depth = 0, isLeaf = false)
-    def empty[T]: Trie[T]            = _empty.asInstanceOf[Trie[T]]
-    def next[T](depth: Int): Trie[T] = empty[T].copy(depth = depth + 1)
+    private final case class MutableTrie[T](
+      structure: scala.collection.mutable.Map[T, MutableTrie[T]],
+      depth: Int,
+      isLeaf: AtomicBoolean
+    ) {
+      def toTrie: Trie[T] =
+        Trie(
+          structure = this.structure.map { case (key, mutableTrie) => (key, mutableTrie.toTrie) }.toMap,
+          depth = this.depth,
+          isLeaf = this.isLeaf.get()
+        )
+    }
 
-    def insert[T](trie: Trie[T], seq: => Seq[T]): Trie[T] =
-      seq match {
-        case head +: tail => {
-          val next = trie.structure.getOrElse(head, Trie.next[T](trie.depth))
-          trie.copy(structure = trie.structure.updated(head, insert(next, tail)))
-        }
-        case Nil => trie.copy(isLeaf = true)
-      }
+    private object MutableTrie {
+      def empty[T]: MutableTrie[T] = MutableTrie(
+        structure = scala.collection.mutable.Map.empty[T, MutableTrie[T]],
+        depth = 0,
+        isLeaf = new AtomicBoolean(false)
+      )
+      def next[T](depth: Int): MutableTrie[T] = MutableTrie(
+        structure = scala.collection.mutable.Map.empty[T, MutableTrie[T]],
+        depth = depth,
+        isLeaf = new AtomicBoolean(false)
+      )
+    }
 
-    def apply[T](delimiters: Seq[Seq[T]]): Trie[T] =
-      delimiters.foldLeft(Trie.empty[T]) {
-        case (trie, delimiter) => {
-          insert(trie, delimiter)
+    def apply[T](delimiters: Seq[Seq[T]]): Trie[T] = {
+      var index         = 0
+      val outerIterator = delimiters.iterator
+      var root          = MutableTrie.empty[T]
+
+      while (outerIterator.hasNext) {
+        val innerIterator = outerIterator.next().iterator
+        var curNode       = root
+        index = 0
+        if (innerIterator.hasNext) {
+          while (innerIterator.hasNext) {
+            val elem = innerIterator.next()
+            curNode = curNode.structure.get(elem) match {
+              case Some(nextNode) => nextNode
+              case None => {
+                var nextNode = MutableTrie.next[T](depth = index + 1)
+                curNode.structure += (elem -> nextNode)
+                nextNode
+              }
+            }
+            index += 1
+          }
+          curNode.isLeaf.set(true)
         }
       }
+      return root.toTrie
+    }
   }
 
   def splitWhereChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -25,6 +25,8 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
 import scala.annotation.tailrec
+import scala.collection.concurrent.TrieMap
+import scala.util.{Either, Left, Right}
 
 /**
  * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer.
@@ -2078,52 +2080,95 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOn(delimiter: => String)(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitOnChunk[Char](Chunk.fromArray(delimiter.toArray)) >>>
+      ZPipeline.splitWithTrie[Char](Trie(Seq(delimiter.toList))) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
+
+  /**
+   * Splits strings on several possible delimiters.
+   */
+  def splitOnMany(delimiters: => Seq[String])(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
+    ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
+      ZPipeline.splitWithTrie[Char](Trie(delimiters.map(_.toList))) >>>
+      ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
+
+  private final case class Trie[T](structure: Map[T, Trie[T]], depth: Int, isLeaf: Boolean = false) {
+    @tailrec
+    def partitionAll(
+      chunk: Chunk[T],
+      curTries: Seq[Trie[T]],
+      offset: Int,
+      curPartitions: Seq[Chunk[T]]
+    ): ((Chunk[T], Int, Seq[Trie[T]]), Seq[Chunk[T]]) =
+      if (offset < chunk.size) {
+        val matchingTries = curTries.flatMap(_.structure.get(chunk(offset)))
+        matchingTries.filter(_.isLeaf).headOption match {
+          case Some(trie) =>
+            partitionAll(
+              if (chunk.size - 1 > offset) chunk.takeRight(chunk.size - offset - 1) else Chunk.empty,
+              Seq(this),
+              0,
+              curPartitions :+ chunk.take(offset - trie.depth + 1)
+            )
+          case None => partitionAll(chunk, matchingTries :+ this, offset + 1, curPartitions)
+        }
+      } else ((chunk, offset, curTries), curPartitions)
+  }
+
+  private object Trie {
+    def empty[T]            = Trie(Map.empty[T, Trie[T]], 0, false)
+    def next[T](depth: Int) = Trie(Map.empty[T, Trie[T]], depth + 1, false)
+
+    def insert[T](trie: Trie[T], seq: => Seq[T]): Trie[T] =
+      seq match {
+        case head +: tail => {
+          val next = trie.structure.getOrElse(head, Trie.next[T](trie.depth))
+          trie.copy(structure = trie.structure.updated(head, insert(next, tail)))
+        }
+        case Nil => trie.copy(isLeaf = true)
+      }
+
+    def apply[T](delimiters: Seq[Seq[T]]): Trie[T] =
+      delimiters.foldLeft(Trie.empty[T]) {
+        case (trie, delimiter) => {
+          insert(trie, delimiter)
+        }
+      }
+  }
 
   /**
    * Splits strings on a delimiter.
    */
-  def splitOnChunk[In](delimiter: => Chunk[In])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    ZPipeline.suspend {
+  def splitOnChunk[In](delimiter: => Seq[In])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    splitWithTrie(Trie(Seq(delimiter)))
 
+  private def splitWithTrie[In](delimiterTrie: Trie[In])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    ZPipeline.suspend {
       def next(
-        leftover: Option[Chunk[In]],
-        delimiterIndex: Int
+        leftover: Chunk[In],
+        offset: Int,
+        curTries: Seq[Trie[In]]
       ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[In], Any] =
         ZChannel.readWithCause(
           inputChunk => {
-            var buffer = null.asInstanceOf[collection.mutable.ArrayBuffer[Chunk[In]]]
-            inputChunk.foldLeft((leftover getOrElse Chunk.empty, delimiterIndex)) {
-              case ((carry, delimiterCursor), a) =>
-                val concatenated = carry :+ a
-                if (delimiterCursor < delimiter.length && a == delimiter(delimiterCursor)) {
-                  if (delimiterCursor + 1 == delimiter.length) {
-                    if (buffer eq null) buffer = collection.mutable.ArrayBuffer[Chunk[In]]()
-                    buffer += concatenated.take(concatenated.length - delimiter.length)
-                    (Chunk.empty, 0)
-                  } else (concatenated, delimiterCursor + 1)
-                } else (concatenated, if (a == delimiter(0)) 1 else 0)
-            } match {
-              case (carry, delimiterCursor) =>
-                ZChannel.writeChunk(if (buffer eq null) Chunk.empty else Chunk.fromArray(buffer.toArray)) *> next(
-                  if (carry.nonEmpty) Some(carry) else None,
-                  delimiterCursor
-                )
+            delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, offset, Seq.empty) match {
+              case ((carryChunk, carryOffset, carryTries), partitions) =>
+                ZChannel.writeChunk(Chunk.fromIterable(partitions)) *> next(carryChunk, carryOffset, carryTries)
             }
           },
           halt =>
-            leftover match {
-              case Some(chunk) => ZChannel.write(chunk) *> ZChannel.refailCause(halt)
-              case None        => ZChannel.refailCause(halt)
+            if (leftover.isDefinedAt(0)) {
+              ZChannel.write(leftover) *> ZChannel.refailCause(halt)
+            } else {
+              ZChannel.refailCause(halt)
             },
           done =>
-            leftover match {
-              case Some(chunk) => ZChannel.write(chunk) *> ZChannel.succeed(done)
-              case None        => ZChannel.succeed(done)
+            if (leftover.isDefinedAt(0)) {
+              ZChannel.write(leftover) *> ZChannel.succeed(done)
+            } else {
+              ZChannel.succeed(done)
             }
         )
-      new ZPipeline(next(None, 0))
+      new ZPipeline(next(Chunk.empty, 0, Seq(delimiterTrie)))
     }
 
   /**
@@ -2131,85 +2176,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    * newlines (`\n`).
    */
   def splitLines(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
-    ZPipeline.suspend {
-      val stringBuilder = new StringBuilder
-      var midCRLF       = false
-
-      def splitLinesChunk(chunk: Chunk[String]): Chunk[String] = {
-        val chunkBuilder = ChunkBuilder.make[String]()
-        chunk.foreach { string =>
-          if (string.nonEmpty) {
-            var from      = 0
-            var indexOfCR = string.indexOf('\r')
-            var indexOfLF = string.indexOf('\n')
-            if (midCRLF) {
-              if (indexOfLF == 0) {
-                chunkBuilder += stringBuilder.result()
-                stringBuilder.clear()
-                from = 1
-                indexOfLF = string.indexOf('\n', from)
-              } else {
-                stringBuilder += '\r'
-              }
-              midCRLF = false
-            }
-            while (indexOfCR != -1 || indexOfLF != -1) {
-              if (indexOfCR == -1 || (indexOfLF != -1 && indexOfLF < indexOfCR)) {
-                if (stringBuilder.isEmpty) {
-                  chunkBuilder += string.substring(from, indexOfLF)
-                } else {
-                  stringBuilder.append(string.substring(from, indexOfLF))
-                  chunkBuilder += stringBuilder.result()
-                  stringBuilder.clear()
-                }
-                from = indexOfLF + 1
-                indexOfLF = string.indexOf('\n', from)
-              } else {
-                if (string.length == indexOfCR + 1) {
-                  midCRLF = true
-                  indexOfCR = -1
-                } else {
-                  if (indexOfLF == indexOfCR + 1) {
-                    if (stringBuilder.isEmpty) {
-                      chunkBuilder += string.substring(from, indexOfCR)
-                    } else {
-                      stringBuilder.append(string.substring(from, indexOfCR))
-                      chunkBuilder += stringBuilder.result()
-                      stringBuilder.clear()
-                    }
-                    from = indexOfCR + 2
-                    indexOfCR = string.indexOf('\r', from)
-                    indexOfLF = string.indexOf('\n', from)
-                  } else {
-                    indexOfCR = string.indexOf('\r', indexOfCR + 1)
-                  }
-                }
-              }
-            }
-
-            if (midCRLF) stringBuilder.append(string.substring(from, string.length - 1))
-            else stringBuilder.append(string.substring(from, string.length))
-          }
-        }
-        chunkBuilder.result()
-      }
-
-      lazy val loop: ZChannel[Any, ZNothing, Chunk[String], Any, Nothing, Chunk[String], Any] =
-        ZChannel.readWithCause(
-          in => {
-            val out = splitLinesChunk(in)
-            if (out.isEmpty) loop else ZChannel.write(out) *> loop
-          },
-          err =>
-            if (stringBuilder.isEmpty) ZChannel.refailCause(err)
-            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.refailCause(err),
-          done =>
-            if (stringBuilder.isEmpty) ZChannel.succeed(done)
-            else ZChannel.write(Chunk.single(stringBuilder.result)) *> ZChannel.succeed(done)
-        )
-
-      new ZPipeline(loop)
-    }
+    splitOnMany(Seq("\r\n", "\n"))
 
   /**
    * Lazily constructs a pipeline.

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2078,7 +2078,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOn(delimiter: => String)(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitWithTrie[Char](Trie(Seq(delimiter.toList))) >>>
+      ZPipeline.splitOnChunk[Char, Char](delimiter.toList) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
   /**
@@ -2086,30 +2086,30 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOnMany(delimiters: => Seq[String])(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitWithTrie[Char](Trie(delimiters.map(_.toList))) >>>
+      ZPipeline.splitOnManyChunk[Char, Char](delimiters.map(_.toList)) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
-  private final case class Trie[T](structure: Map[T, Trie[T]], depth: Int, isLeaf: Boolean = false) {
+  private final case class Trie[T1](structure: Map[T1, Trie[T1]], depth: Int, isLeaf: Boolean = false) {
     @tailrec
-    def partitionAll(
+    def partitionAll[T <: T1](
       chunk: Chunk[T],
-      curTries: Seq[Trie[T]],
+      curTries: Seq[Trie[T1]],
       offset: Int,
       curPartitions: Seq[Chunk[T]]
-    ): ((Chunk[T], Int, Seq[Trie[T]]), Seq[Chunk[T]]) =
+    ): ((Chunk[T], Int, Seq[Trie[T1]]), Seq[Chunk[T]]) =
       if (offset < chunk.size) {
         val matchingTries = curTries.flatMap(_.structure.get(chunk(offset)))
-        matchingTries.filter(_.isLeaf).headOption match {
+        matchingTries.filter(_.isLeaf).reverse.headOption match {
           case Some(trie) =>
             partitionAll(
               if (chunk.size - 1 > offset) chunk.takeRight(chunk.size - offset - 1) else Chunk.empty,
               Seq(this),
               0,
-              curPartitions :+ chunk.take(offset - trie.depth + 1)
+              chunk.take(offset - trie.depth + 1) +: curPartitions
             )
-          case None => partitionAll(chunk, matchingTries :+ this, offset + 1, curPartitions)
+          case None => partitionAll(chunk, this +: matchingTries, offset + 1, curPartitions)
         }
-      } else ((chunk, offset, curTries), curPartitions)
+      } else ((chunk, offset, curTries), curPartitions.reverse)
   }
 
   private object Trie {
@@ -2136,32 +2136,45 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * Splits strings on a delimiter.
    */
-  def splitOnChunk[In](delimiter: => Seq[In])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
-    splitWithTrie(Trie(Seq(delimiter)))
+  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(Seq(delimiter)))
 
-  private def splitWithTrie[In](delimiterTrie: Trie[In])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+  def splitOnManyChunk[In1 >: In, In](delimiters: => Seq[Seq[In1]])(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+    splitWithTrie[In1, In, In](ZChannel.writeChunk, ZChannel.write)(Trie(delimiters))
+
+  def splitOnChunkToProduceChunk[In1 >: In, In](delimiter: => Seq[In1])(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
+    splitWithTrie[In1, In, Chunk[In]](ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))(Trie(Seq(delimiter)))
+
+  def splitWithTrie[In1 >: In, In, Out](
+    writeChunkOfChunks: Chunk[Chunk[In]] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any], 
+    writeLeftover: Chunk[In] => ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any]
+  )(
+    delimiterTrie: Trie[In1]
+  )(
+    implicit trace: Trace
+  ): ZPipeline[Any, Nothing, In, Out] =
     ZPipeline.suspend {
       def next(
         leftover: Chunk[In],
         offset: Int,
-        curTries: Seq[Trie[In]]
-      ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[In], Any] =
+        curTries: Seq[Trie[In1]]
+      ): ZChannel[Any, ZNothing, Chunk[In], Any, Nothing, Chunk[Out], Any] =
         ZChannel.readWithCause(
           inputChunk => {
             delimiterTrie.partitionAll(leftover ++ inputChunk, curTries, offset, Seq.empty) match {
               case ((carryChunk, carryOffset, carryTries), partitions) =>
-                ZChannel.writeChunk(Chunk.fromIterable(partitions)) *> next(carryChunk, carryOffset, carryTries)
+                writeChunkOfChunks(Chunk.fromIterable(partitions)) *> next(carryChunk, carryOffset, carryTries)
             }
           },
           halt =>
             if (leftover.isDefinedAt(0)) {
-              ZChannel.write(leftover) *> ZChannel.refailCause(halt)
+              writeLeftover(leftover) *> ZChannel.refailCause(halt)
             } else {
               ZChannel.refailCause(halt)
             },
           done =>
             if (leftover.isDefinedAt(0)) {
-              ZChannel.write(leftover) *> ZChannel.succeed(done)
+              writeLeftover(leftover) *> ZChannel.succeed(done)
             } else {
               ZChannel.succeed(done)
             }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -25,7 +25,6 @@ import zio.stream.internal.CharacterSet.{BOM, CharsetUtf32BE, CharsetUtf32LE}
 import java.nio.charset._
 import java.nio.{ByteBuffer, CharBuffer}
 import scala.annotation.tailrec
-import scala.collection.mutable.ListBuffer
 
 /**
  * A `ZPipeline[Env, Err, In, Out]` is a polymorphic stream transformer.
@@ -2095,29 +2094,26 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       chunk: Chunk[T],
       carryTries: Seq[Trie[T1]],
       offset: Int
-    ): ((Chunk[T], Seq[Trie[T1]]), Seq[Chunk[T]]) = {
-      val iterator                     = chunk.chunkIterator
-      var partitionBuffer              = new ListBuffer[Chunk[T]]()
-      var curTries                     = carryTries
-      var matchingTries: Seq[Trie[T1]] = null
-      var index                        = offset
-      var curPartitionStart            = 0
+    ): ((Chunk[T], Seq[Trie[T1]]), Iterable[Chunk[T]]) = {
+      val iterator          = chunk.chunkIterator
+      var partitionBuffer   = scala.collection.mutable.ArrayBuffer.empty[Chunk[T]]
+      var curTries          = carryTries
+      var index             = offset
+      var curPartitionStart = 0
       while (iterator.hasNextAt(index)) {
-        matchingTries = curTries.flatMap(_.structure.get(iterator.nextAt(index)))
-        matchingTries.filter(_.isLeaf).reverse.headOption match {
+        curTries = curTries.flatMap(_.structure.get(iterator.nextAt(index)))
+        index += 1
+        curTries.filter(_.isLeaf).reverse.headOption match {
           case Some(leaf) => {
-            partitionBuffer += chunk.slice(curPartitionStart, index - leaf.depth + 1)
-            index += 1
+            partitionBuffer += chunk.slice(curPartitionStart, index - leaf.depth)
             curPartitionStart = index
-            curTries = Seq(this)
+            curTries = Seq.empty
           }
-          case None => {
-            index += 1
-            curTries = matchingTries.prepended(this)
-          }
+          case None => {}
         }
+        curTries = this +: curTries
       }
-      ((chunk.slice(curPartitionStart, chunk.length), curTries), partitionBuffer.toSeq)
+      ((chunk.slice(curPartitionStart, chunk.length), curTries), partitionBuffer)
     }
   }
 

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2096,16 +2096,17 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       carryTries: Seq[Trie[T1]],
       offset: Int
     ): ((Chunk[T], Seq[Trie[T1]]), Seq[Chunk[T]]) = {
-      val iterator          = chunk.chunkIterator
-      var partitionBuffer   = new ListBuffer[Chunk[T]]()
-      var curTries          = carryTries
-      var index             = offset
-      var curPartitionStart = 0
+      val iterator                     = chunk.chunkIterator
+      var partitionBuffer              = new ListBuffer[Chunk[T]]()
+      var curTries                     = carryTries
+      var matchingTries: Seq[Trie[T1]] = null
+      var index                        = offset
+      var curPartitionStart            = 0
       while (iterator.hasNextAt(index)) {
-        val matchingTries = curTries.flatMap(_.structure.get(iterator.nextAt(index)))
+        matchingTries = curTries.flatMap(_.structure.get(iterator.nextAt(index)))
         matchingTries.filter(_.isLeaf).reverse.headOption match {
-          case Some(trie) => {
-            partitionBuffer += chunk.slice(curPartitionStart, index - trie.depth + 1)
+          case Some(leaf) => {
+            partitionBuffer += chunk.slice(curPartitionStart, index - leaf.depth + 1)
             index += 1
             curPartitionStart = index
             curTries = Seq(this)

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2141,10 +2141,14 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
       }
   }
 
-  def splitWhereChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+  def splitWhereChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, In] =
     splitWhere[In, In](where, allowEmpty)(ZChannel.writeChunk, ZChannel.write)
 
-  def splitWhereChunkToProduceChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, Chunk[In]] =
+  def splitWhereChunkToProduceChunk[In](where: In => Boolean, allowEmpty: Boolean)(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, Chunk[In]] =
     splitWhere[In, Chunk[In]](where, allowEmpty)(ZChannel.write, chunk => ZChannel.write(Chunk.single(chunk)))
 
   private def partitionAllWhere[T](
@@ -2206,7 +2210,9 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   /**
    * Splits strings on a delimiter.
    */
-  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1], allowEmpty: Boolean)(implicit trace: Trace): ZPipeline[Any, Nothing, In, In] =
+  def splitOnChunk[In1 >: In, In](delimiter: => Seq[In1], allowEmpty: Boolean)(implicit
+    trace: Trace
+  ): ZPipeline[Any, Nothing, In, In] =
     (delimiter match {
       case Seq(head) => splitWhere[In, In]((x: In) => x == head, allowEmpty)(_, _)
       case _         => splitWithTrie[In1, In, In](Trie(Seq(delimiter)), allowEmpty)(_, _)

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2113,7 +2113,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         }
         curTries = this +: curTries
       }
-      ((chunk.slice(curPartitionStart, chunk.length), curTries), partitionBuffer)
+      ((chunk.takeRight(chunk.length - curPartitionStart), curTries), partitionBuffer)
     }
   }
 

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2078,7 +2078,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def splitOn(delimiter: => String)(implicit trace: Trace): ZPipeline[Any, Nothing, String, String] =
     ZPipeline.mapChunks[String, Char](_.flatMap(string => Chunk.fromArray(string.toArray))) >>>
-      ZPipeline.splitOnChunk[Char, Char](delimiter.toList, true) >>>
+      ZPipeline.splitOnChunk[Char, Char](delimiter.toList, allowEmpty = true) >>>
       ZPipeline.mapChunks[Char, String](chunk => Chunk.single(chunk.mkString("")))
 
   /**
@@ -2121,8 +2121,9 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
   }
 
   private object Trie {
-    def empty[T]            = Trie(Map.empty[T, Trie[T]], 0, false)
-    def next[T](depth: Int) = Trie(Map.empty[T, Trie[T]], depth + 1, false)
+    private val _empty               = Trie(structure = Map.empty[Any, Trie[Any]], depth = 0, isLeaf = false)
+    def empty[T]: Trie[T]            = _empty.asInstanceOf[Trie[T]]
+    def next[T](depth: Int): Trie[T] = empty[T].copy(depth = depth + 1)
 
     def insert[T](trie: Trie[T], seq: => Seq[T]): Trie[T] =
       seq match {

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3190,45 +3190,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * output.
    */
   def splitOnChunk[A1 >: A](delimiter: => Chunk[A1])(implicit trace: Trace): ZStream[R, E, Chunk[A]] =
-    ZStream.succeed(delimiter).flatMap { delimiter =>
-      def next(
-        leftover: Option[Chunk[A]],
-        delimiterIndex: Int
-      ): ZChannel[R, E, Chunk[A], Any, E, Chunk[Chunk[A]], Any] =
-        ZChannel.readWithCause(
-          inputChunk => {
-            var buffer = null.asInstanceOf[collection.mutable.ArrayBuffer[Chunk[A]]]
-            inputChunk.foldLeft((leftover getOrElse Chunk.empty, delimiterIndex)) {
-              case ((carry, delimiterCursor), a) =>
-                val concatenated = carry :+ a
-                if (delimiterCursor < delimiter.length && a == delimiter(delimiterCursor)) {
-                  if (delimiterCursor + 1 == delimiter.length) {
-                    if (buffer eq null) buffer = collection.mutable.ArrayBuffer[Chunk[A]]()
-                    buffer += concatenated.take(concatenated.length - delimiter.length)
-                    (Chunk.empty, 0)
-                  } else (concatenated, delimiterCursor + 1)
-                } else (concatenated, if (a == delimiter(0)) 1 else 0)
-            } match {
-              case (carry, delimiterCursor) =>
-                ZChannel.write(
-                  if (buffer eq null) Chunk.empty
-                  else Chunk.fromArray(buffer.toArray)
-                ) *> next(if (carry.nonEmpty) Some(carry) else None, delimiterCursor)
-            }
-          },
-          halt =>
-            leftover match {
-              case Some(chunk) => ZChannel.write(Chunk.single(chunk)) *> ZChannel.refailCause(halt)
-              case None        => ZChannel.refailCause(halt)
-            },
-          done =>
-            leftover match {
-              case Some(chunk) => ZChannel.write(Chunk.single(chunk)) *> ZChannel.succeed(done)
-              case None        => ZChannel.succeed(done)
-            }
-        )
-      new ZStream(self.channel >>> next(None, 0))
-    }
+    this >>> ZPipeline.splitOnChunkToProduceChunk[A1, A](delimiter)
 
   /**
    * Takes the specified number of elements from this stream.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3164,7 +3164,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   ZStream.range(1, 10).split(_ % 4 == 0).runCollect // Chunk(Chunk(1, 2, 3), Chunk(5, 6, 7), Chunk(9))
    * }}}
    */
-  def split(f: A => Boolean)(implicit trace: Trace): ZStream[R, E, Chunk[A]] = 
+  def split(f: A => Boolean)(implicit trace: Trace): ZStream[R, E, Chunk[A]] =
     this >>> ZPipeline.splitWhereChunkToProduceChunk(f, false)
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3164,33 +3164,15 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   ZStream.range(1, 10).split(_ % 4 == 0).runCollect // Chunk(Chunk(1, 2, 3), Chunk(5, 6, 7), Chunk(9))
    * }}}
    */
-  def split(f: A => Boolean)(implicit trace: Trace): ZStream[R, E, Chunk[A]] = {
-    def split(leftovers: Chunk[A])(in: Chunk[A]): ZChannel[R, E, Chunk[A], Any, E, Chunk[Chunk[A]], Any] = {
-      val (chunk, remaining) = (leftovers ++ in).splitWhere(f)
-      if (chunk.isEmpty || remaining.isEmpty) loop(chunk ++ remaining.drop(1))
-      else ZChannel.write(Chunk.single(chunk)) *> split(Chunk.empty)(remaining.drop(1))
-    }
-
-    def loop(leftovers: Chunk[A]): ZChannel[R, E, Chunk[A], Any, E, Chunk[Chunk[A]], Any] =
-      ZChannel.readWithCause(
-        (in: Chunk[A]) => split(leftovers)(in),
-        (e: Cause[E]) => ZChannel.refailCause(e),
-        (_: Any) => {
-          if (leftovers.isEmpty) ZChannel.unit
-          else if (leftovers.find(f).isEmpty) ZChannel.write(Chunk.single(leftovers)) *> ZChannel.unit
-          else split(Chunk.empty)(leftovers) *> ZChannel.unit
-        }
-      )
-
-    new ZStream(self.channel >>> loop(Chunk.empty))
-  }
+  def split(f: A => Boolean)(implicit trace: Trace): ZStream[R, E, Chunk[A]] = 
+    this >>> ZPipeline.splitWhereChunkToProduceChunk(f, false)
 
   /**
    * Splits elements on a delimiter and transforms the splits into desired
    * output.
    */
   def splitOnChunk[A1 >: A](delimiter: => Chunk[A1])(implicit trace: Trace): ZStream[R, E, Chunk[A]] =
-    this >>> ZPipeline.splitOnChunkToProduceChunk[A1, A](delimiter)
+    this >>> ZPipeline.splitOnChunkToProduceChunk[A1, A](delimiter, true)
 
   /**
    * Takes the specified number of elements from this stream.


### PR DESCRIPTION
Tries are a good tool for this type of problem, using them allows for the two similar implementations to be consolidated. I added a somewhat contrived test case to show that a Trie ensures correctness, whereas simple resets could produce incorrect results. Please let me know if there are more efficient ways to do the processing (ex. maybe calling writeChunk per chunk rather than at end).