### PR TITLE
Fix FiberRuntime observer memory leak

### DIFF
--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -66,6 +66,24 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
         }
       }
     ),
+    suite("observers")(
+      test("removed on uncompleted fiber - bug #10181") {
+        val observerCalled = Ref.unsafe.make(false)
+        for {
+          p     <- Promise.make[Nothing, Unit]
+          fiber <- ZIO.never.interruptible.onInterrupt(_ => p.succeedUnit).fork.uninterruptible
+          // Add an observer, then remove it while fiber is still running
+          _ <- ZIO.succeed {
+                 val obs: Exit[Nothing, Unit] => Unit = _ => observerCalled.unsafe.set(true)
+                 fiber.unsafe.addObserver(obs)
+                 fiber.unsafe.removeObserver(obs)
+               }
+          _      <- fiber.interruptAsFork(FiberId.None)
+          _      <- p.await
+          called <- observerCalled.get
+        } yield assertTrue(!called)
+      } @@ nonFlaky(100) @@ timeout(10.seconds)
+    ),
     suite("async")(
       test("async callback after interruption is ignored") {
         ZIO.suspendSucceed {

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1606,7 +1606,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         self.getFiberRefs()
 
       def removeObserver(observer: Exit[E, A] => Unit)(implicit unsafe: Unsafe): Unit =
-        if (self._exitValue ne null)
+        if (self._exitValue eq null)
           self.tell(FiberMessage.Stateful(_.asInstanceOf[FiberRuntime[E, A]].removeObserver(observer)))
 
       def poll(implicit unsafe: Unsafe): Option[Exit[E, A]] =


### PR DESCRIPTION
/fixes #10181

This change fixes a memory leak introduced in #9848 due to flipped boolean. The change introduced an optimization attempting to avoid removing observers when a fiber is already complete. Unfortunately, the check was inverted and resulted in `fiber.await` leaking observers.

Thank you to @vladimirkl for reporting and identifying the commit.