### PR TITLE
Deprecate adding Fatal to the Runtime

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -209,6 +209,7 @@ trait Runtime[+R] { self =>
 
 object Runtime extends RuntimePlatformSpecific {
 
+  @deprecated("Custom Fatal handling is deprecated, kept only for binary compatability.", "2.1.22")
   def addFatal(fatal: Class[_ <: Throwable])(implicit trace: Trace): ZLayer[Any, Nothing, Unit] =
     ZLayer.scoped(FiberRef.currentFatal.locallyScopedWith(_ | IsFatal(fatal)))
 


### PR DESCRIPTION
This is a followup, as I missed it in #10140