### PR TITLE
Add methods for sequential composition of ZLayers

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZLayerSpec.scala
@@ -74,11 +74,19 @@ object ZLayerSpec extends ZIOBaseSpec {
           r6 <- testSize(TestSystem.default, 1, "TestSystem.default")
         } yield r1 && r2 && r3 && r4 && r5 && r6
       },
-      test("Size of >>> (9)") {
+      test("Size of >>> (9) with ++") {
         val layer = liveEnvironment >>>
           (Annotations.live ++ ((Live.default ++ Annotations.live) >>> TestConsole.debug) ++
             Live.default ++ TestRandom.deterministic ++ Sized.live(100)
             ++ TestSystem.default)
+
+        testSize(layer, 6)
+      },
+      test("Size of >>> (9) with <*>") {
+        val layer = liveEnvironment >>>
+          (Annotations.live <*> ((Live.default <*> Annotations.live) >>> TestConsole.debug) <*>
+            Live.default <*> TestRandom.deterministic <*> Sized.live(100)
+            <*> TestSystem.default)
 
         testSize(layer, 6)
       },
@@ -96,6 +104,22 @@ object ZLayerSpec extends ZIOBaseSpec {
         val m1     = new Service1 {}
         val layer1 = ZLayer.succeed(m1)
         val env    = layer1 ++ (layer1 ++ layer1)
+        env.build.flatMap(m => ZIO.attempt(assert(m.get)(equalTo(m1))))
+      } @@ exceptJS(nonFlaky),
+      test("sharing with <*>") {
+        val expected = Vector(acquire1, release1)
+        for {
+          ref    <- makeRef
+          layer1  = makeLayer1(ref)
+          env     = (layer1 <*> layer1).build
+          _      <- ZIO.scoped(env)
+          actual <- ref.get
+        } yield assert(actual)(equalTo(expected))
+      } @@ exceptJS(nonFlaky),
+      test("sharing itself with <*>") {
+        val m1     = new Service1 {}
+        val layer1 = ZLayer.succeed(m1)
+        val env    = layer1 <*> (layer1 ++ layer1)
         env.build.flatMap(m => ZIO.attempt(assert(m.get)(equalTo(m1))))
       } @@ exceptJS(nonFlaky),
       test("sharing with >>>") {
@@ -128,6 +152,17 @@ object ZLayerSpec extends ZIOBaseSpec {
           layer1  = makeLayer1(ref)
           layer2  = makeLayer2(ref)
           env     = (layer1 ++ layer2).build
+          _      <- ZIO.scoped(env)
+          actual <- ref.get
+        } yield assert(actual.slice(0, 2))(hasSameElements(Vector(acquire1, acquire2))) &&
+          assert(actual.slice(2, 4))(hasSameElements(Vector(release1, release2)))
+      } @@ exceptJS(nonFlaky),
+      test("finalizers with ++") {
+        for {
+          ref    <- makeRef
+          layer1  = makeLayer1(ref)
+          layer2  = makeLayer2(ref)
+          env     = (layer1 <*> layer2).build
           _      <- ZIO.scoped(env)
           actual <- ref.get
         } yield assert(actual.slice(0, 2))(hasSameElements(Vector(acquire1, acquire2))) &&
@@ -304,6 +339,16 @@ object ZLayerSpec extends ZIOBaseSpec {
           ref    <- makeRef
           layer1  = makeLayer1(ref)
           env     = (layer1 ++ layer1.fresh).build
+          _      <- ZIO.scoped(env)
+          result <- ref.get
+        } yield assert(result)(equalTo(expected))
+      } @@ exceptJS(nonFlaky),
+      test("fresh with <*>") {
+        val expected = Vector(acquire1, acquire1, release1, release1)
+        for {
+          ref    <- makeRef
+          layer1  = makeLayer1(ref)
+          env     = (layer1 <*> layer1.fresh).build
           _      <- ZIO.scoped(env)
           result <- ref.get
         } yield assert(result)(equalTo(expected))

--- a/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
+++ b/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala
@@ -48,13 +48,13 @@ trait DefaultJvmMetrics {
       with VersionInfo
   ] =
     jvmMetricsSchedule >>>
-      (BufferPools.live ++
-        ClassLoading.live ++
-        GarbageCollector.live ++
-        MemoryAllocation.live ++
-        memoryPools ++
-        Standard.live ++
-        Thread.live ++
+      (BufferPools.live <*>
+        ClassLoading.live <*>
+        GarbageCollector.live <*>
+        MemoryAllocation.live <*>
+        memoryPools <*>
+        Standard.live <*>
+        Thread.live <*>
         VersionInfo.live)
 }
 

--- a/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
+++ b/core/shared/src/main/scala/zio/ThreadLocalBridge.scala
@@ -36,7 +36,7 @@ object ThreadLocalBridge {
           }
       }
     }
-    supervisorLayer ++ bridgeLayer
+    supervisorLayer <*> bridgeLayer
   }
 
   private class FiberRefTrackingSupervisor extends Supervisor[Unit] {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4551,7 +4551,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def provideLayer[RIn, E, ROut, RIn2, ROut2](layer: ZLayer[RIn, E, ROut])(
     zio: ZIO[ROut with RIn2, E, ROut2]
   )(implicit ev: EnvironmentTag[RIn2], tag: EnvironmentTag[ROut], trace: Trace): ZIO[RIn with RIn2, E, ROut2] =
-    zio.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer)
+    zio.provideSomeLayer[RIn with RIn2](layer)
 
   /**
    * Races an `IO[E, A]` against zero or more other effects. Yields either the
@@ -5505,7 +5505,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       tagged: EnvironmentTag[R1],
       trace: Trace
     ): ZIO[R0, E1, A] =
-      self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZIO[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] <*> layer)
   }
 
   final class UpdateService[-R, +E, +A, M](private val self: ZIO[R, E, A]) extends AnyVal {

--- a/core/shared/src/main/scala/zio/ZLayer.scala
+++ b/core/shared/src/main/scala/zio/ZLayer.scala
@@ -52,14 +52,23 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] extends ZLayerVersionSpecific[RIn,
   ): ZLayer[RIn, Nothing, ROut] =
     self.orDie
 
+  /**
+   * Combines this layer with the specified layer sequentially, producing a new
+   * layer that has the inputs and outputs of both.
+   */
+  final def <*>[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
+    that: => ZLayer[RIn2, E1, ROut2]
+  )(implicit tag: EnvironmentTag[ROut2]): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
+    self.zipWith(that)(_.union[ROut2](_))
+
   final def +!+[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
     that: => ZLayer[RIn2, E1, ROut2]
   ): ZLayer[RIn with RIn2, E1, ROut1 with ROut2] =
     self.zipWithPar(that)(_.unionAll[ROut2](_))
 
   /**
-   * Combines this layer with the specified layer, producing a new layer that
-   * has the inputs and outputs of both.
+   * Combines this layer with the specified layer in parallel, producing a new
+   * layer that has the inputs and outputs of both.
    */
   final def ++[E1 >: E, RIn2, ROut1 >: ROut, ROut2](
     that: => ZLayer[RIn2, E1, ROut2]
@@ -380,9 +389,19 @@ sealed abstract class ZLayer[-RIn, +E, +ROut] extends ZLayerVersionSpecific[RIn,
     map(_.update[A](f))
 
   /**
-   * Combines this layer the specified layer, producing a new layer that has the
-   * inputs of both, and the outputs of both combined using the specified
-   * function.
+   * Combines this layer the specified layer sequentially, producing a new layer
+   * that has the inputs of both, and the outputs of both combined using the
+   * specified function.
+   */
+  final def zipWith[E1 >: E, RIn2, ROut1 >: ROut, ROut2, ROut3](
+    that: => ZLayer[RIn2, E1, ROut2]
+  )(f: (ZEnvironment[ROut], ZEnvironment[ROut2]) => ZEnvironment[ROut3]): ZLayer[RIn with RIn2, E1, ROut3] =
+    ZLayer.suspend(ZLayer.ZipWith(self, that, f))
+
+  /**
+   * Combines this layer the specified layer in parallel, producing a new layer
+   * that has the inputs of both, and the outputs of both combined using the
+   * specified function.
    */
   final def zipWithPar[E1 >: E, RIn2, ROut1 >: ROut, ROut2, ROut3](
     that: => ZLayer[RIn2, E1, ROut2]
@@ -908,7 +927,7 @@ object ZLayer extends ZLayerCompanionVersionSpecific {
       out: EnvironmentTag[ROut],
       trace: Trace
     ): ZLayer[RIn, E, RIn with ROut] =
-      ZLayer.environment[RIn] ++ self
+      ZLayer.environment[RIn] <*> self
 
     /**
      * Projects out part of one of the services output by this layer using the

--- a/managed/shared/src/main/scala/zio/managed/ZManaged.scala
+++ b/managed/shared/src/main/scala/zio/managed/ZManaged.scala
@@ -1329,7 +1329,7 @@ object ZManaged extends ZManagedPlatformSpecific {
       tagged: EnvironmentTag[R1],
       trace: Trace
     ): ZManaged[R0, E1, A] =
-      self.asInstanceOf[ZManaged[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZManaged[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] <*> layer)
   }
 
   final class UnlessManaged[R, E](private val b: () => ZManaged[R, E, Boolean]) extends AnyVal {
@@ -2456,7 +2456,7 @@ object ZManaged extends ZManagedPlatformSpecific {
     tag: EnvironmentTag[ROut],
     trace: Trace
   ): ZManaged[RIn with RIn2, E, ROut2] =
-    managed.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer)
+    managed.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] <*> layer)
 
   /**
    * Reduces an `Iterable[IO]` to a single `IO`, working sequentially.

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -2145,7 +2145,7 @@ object ZChannel {
     tag: EnvironmentTag[Env1],
     trace: Trace
   ): ZChannel[Env0 with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
-    ZChannel.suspend(channel.provideSomeLayer[Env0 with Env1](ZLayer.environment[Env1] ++ layer))
+    ZChannel.suspend(channel.provideSomeLayer[Env0 with Env1](ZLayer.environment[Env1] <*> layer))
 
   def readWithCause[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone](
     in: InElem => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, OutDone],
@@ -2339,7 +2339,7 @@ object ZChannel {
     ): ZChannel[Env0, InErr, InElem, InDone, OutErr1, OutElem, OutDone] =
       self
         .asInstanceOf[ZChannel[Env0 with Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone]]
-        .provideLayer(ZLayer.environment[Env0] ++ layer)
+        .provideLayer(ZLayer.environment[Env0] <*> layer)
   }
 
   final class ScopedPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -1894,7 +1894,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
       new ZSink(
         channel
           .asInstanceOf[ZChannel[R0 with R1, ZNothing, Chunk[In], Any, E, Chunk[L], Z]]
-          .provideLayer(ZLayer.environment[R0] ++ layer)
+          .provideLayer(ZLayer.environment[R0] <*> layer)
       )
   }
 }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4939,7 +4939,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     tag: EnvironmentTag[ROut],
     trace: Trace
   ): ZStream[RIn with RIn2, E, ROut2] =
-    ZStream.suspend(stream.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] ++ layer))
+    ZStream.suspend(stream.provideSomeLayer[RIn with RIn2](ZLayer.environment[RIn2] <*> layer))
 
   /**
    * Like [[unfoldZIO]], but allows the emission of values to end one step
@@ -5342,7 +5342,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       tagged: EnvironmentTag[R1],
       trace: Trace
     ): ZStream[R0, E1, A] =
-      self.asInstanceOf[ZStream[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[ZStream[R0 with R1, E, A]].provideLayer(ZLayer.environment[R0] <*> layer)
   }
 
   final class UpdateService[-R, +E, +A, M](private val self: ZStream[R, E, A]) extends AnyVal {

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassDescriptor.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassDescriptor.scala
@@ -88,7 +88,7 @@ class ZIOTestClassDescriptor(parent: TestDescriptor, uniqueId: UniqueId, val tes
       .run(
         scoped
           .provide(
-            Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+            Scope.default >>> (liveEnvironment >>> TestEnvironment.live <*> ZLayer.environment[Scope]),
             spec.bootstrap
           )
       )

--- a/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassRunner.scala
+++ b/test-junit-engine/src/main/scala/zio/test/junit/ZIOTestClassRunner.scala
@@ -127,7 +127,7 @@ class ZIOTestClassRunner(descriptor: ZIOTestClassDescriptor) {
     spec
       .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive, eventHandler)
       .provide(
-        Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+        Scope.default >>> (liveEnvironment >>> TestEnvironment.live <*> ZLayer.environment[Scope]),
         spec.bootstrap
       )
   }

--- a/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -97,7 +97,8 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
       spec
         .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive)
         .provide(
-          Scope.default >>> (liveEnvironment >>> (TestEnvironment.live <*> ZLayer.environment[Scope]) +!+ spec.bootstrap)
+          Scope.default >>> (liveEnvironment >>> (TestEnvironment.live <*> ZLayer
+            .environment[Scope]) +!+ spec.bootstrap)
         )
     }(Trace.empty, Unsafe.unsafe).getOrThrowFiberFailure()(Unsafe.unsafe)
   }

--- a/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -81,7 +81,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
       .run(
         scoped
           .provide(
-            Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope]),
+            Scope.default >>> (liveEnvironment >>> TestEnvironment.live <*> ZLayer.environment[Scope]),
             spec.bootstrap
           )
       )(Trace.empty, Unsafe.unsafe)
@@ -97,7 +97,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
       spec
         .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive)
         .provide(
-          Scope.default >>> (liveEnvironment >>> TestEnvironment.live ++ ZLayer.environment[Scope] +!+ spec.bootstrap)
+          Scope.default >>> (liveEnvironment >>> TestEnvironment.live <*> ZLayer.environment[Scope] +!+ spec.bootstrap)
         )
     }(Trace.empty, Unsafe.unsafe).getOrThrowFiberFailure()(Unsafe.unsafe)
   }

--- a/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
+++ b/test-junit/src/main/scala/zio/test/junit/ZTestJUnitRunner.scala
@@ -97,7 +97,7 @@ class ZTestJUnitRunner(klass: Class[_]) extends Runner with Filterable {
       spec
         .runSpecAsApp(instrumented, TestArgs.empty, Console.ConsoleLive)
         .provide(
-          Scope.default >>> (liveEnvironment >>> TestEnvironment.live <*> ZLayer.environment[Scope] +!+ spec.bootstrap)
+          Scope.default >>> (liveEnvironment >>> (TestEnvironment.live <*> ZLayer.environment[Scope]) +!+ spec.bootstrap)
         )
     }(Trace.empty, Unsafe.unsafe).getOrThrowFiberFailure()(Unsafe.unsafe)
   }

--- a/test-sbt/shared/src/main/scala/zio/test/sbt/TestRunner.scala
+++ b/test-sbt/shared/src/main/scala/zio/test/sbt/TestRunner.scala
@@ -70,7 +70,7 @@ abstract class TestRunner(
       ExecutionEventPrinter.live(console, testArgs.testEventRenderer, testArgs.reportsParent) >>> TestOutput.live
 
     val sharedLayerFromSpecs: ZLayer[Any, Any, Any] =
-      (Scope.default ++ ZIOAppArgs.empty) >>> specs
+      (Scope.default <*> ZIOAppArgs.empty) >>> specs
         .map(_.bootstrap)
         .foldLeft(ZLayer.empty: ZLayer[ZIOAppArgs, Any, Any])(_ +!+ _)
 

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -515,7 +515,7 @@ object Spec {
       tagged: EnvironmentTag[R1],
       trace: Trace
     ): Spec[R0, E1] =
-      self.asInstanceOf[Spec[R0 with R1, E]].provideLayer(ZLayer.environment[R0] ++ layer)
+      self.asInstanceOf[Spec[R0 with R1, E]].provideLayer(ZLayer.environment[R0] <*> layer)
   }
 
   final class ProvideSomeLayerShared[R0, -R, +E](private val self: Spec[R, E]) extends AnyVal {

--- a/test/shared/src/main/scala/zio/test/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/TestRandom.scala
@@ -806,7 +806,7 @@ object TestRandom extends Serializable {
 
   val random: ZLayer[Clock, Nothing, TestRandom] = {
     implicit val trace = Tracer.newTrace
-    (ZLayer.service[Clock] ++ deterministic) >>> ZLayer {
+    (ZLayer.service[Clock] <*> deterministic) >>> ZLayer {
       for {
         random     <- ZIO.service[Random]
         testRandom <- ZIO.service[TestRandom]

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -107,8 +107,8 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
         ]
 
       scopeEnv: ZEnvironment[Scope] = runtime.environment
-      perTestLayer = (ZLayer.succeedEnvironment(scopeEnv) ++ liveEnvironment) >>>
-                       (TestEnvironment.live ++ ZLayer.environment[Scope])
+      perTestLayer = (ZLayer.succeedEnvironment(scopeEnv) <*> liveEnvironment) >>>
+                       (TestEnvironment.live <*> ZLayer.environment[Scope])
 
       executionEventSinkLayer = ExecutionEventSink.live(console, testArgs.testEventRenderer, testArgs.reportsParent)
       environment            <- ZIO.environment[Environment]
@@ -166,7 +166,7 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
       TestExecutor
         .default[Environment, Any](
           ZLayer.succeedEnvironment(castedRuntime.environment),
-          testEnvironment ++ Scope.default,
+          testEnvironment <*> Scope.default,
           ZLayer.succeedEnvironment(castedRuntime.environment) >>> ExecutionEventSink.live,
           testEventHandler
         )

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -56,13 +56,13 @@ package object test extends CompileVariants {
       ZLayer.environment[TestEnvironment](Tracer.newTrace)
     val live: ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] = {
       implicit val trace = Tracer.newTrace
-      Annotations.live ++
-        Live.default ++
-        Sized.live(100) ++
-        ((Live.default ++ Annotations.live) >>> TestClock.default) ++
-        TestConfig.live(100, 100, 200, 1000) ++
-        ((Live.default ++ Annotations.live) >>> TestConsole.debug) ++
-        TestRandom.deterministic ++
+      Annotations.live <*>
+        Live.default <*>
+        Sized.live(100) <*>
+        ((Live.default <*> Annotations.live) >>> TestClock.default) <*>
+        TestConfig.live(100, 100, 200, 1000) <*>
+        ((Live.default <*> Annotations.live) >>> TestConsole.debug) <*>
+        TestRandom.deterministic <*>
         TestSystem.default
 
     }
@@ -85,7 +85,7 @@ package object test extends CompileVariants {
 
   val testEnvironment: ZLayer[Any, Nothing, TestEnvironment] = {
     implicit val trace = Tracer.newTrace
-    liveEnvironment >>> (TestEnvironment.live ++ testFiberRefGen)
+    liveEnvironment >>> (TestEnvironment.live <*> testFiberRefGen)
   }
 
   /**
@@ -934,7 +934,7 @@ package object test extends CompileVariants {
     TestRunner(
       TestExecutor.default(
         testEnvironment,
-        Scope.default ++ testEnvironment,
+        Scope.default <*> testEnvironment,
         ExecutionEventSink.live(Console.ConsoleLive, ConsoleEventRenderer),
         ZTestEventHandler.silent // The default test runner handles its own events, writing their output to the provided sink.
       )


### PR DESCRIPTION
Currently the only way to compose `ZLayers` is with `++` or `+!+`, which both execute the effects in parallel. While this is beneficial for cases that the ZLayer initializes resources such as DB / HTTP clients (because it can acquire them in parallel), it can be quite heavyweight for ZLayers that do not initialize resources (e.g., `ZLayer.environment`).

With this PR we offer a way to sequentially compose ZLayers without the overhead of processing them all in parallel