### PR TITLE
Fix `ZStream#mapZIOPar` freezes when output is only partially consumed (#10195)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2765,6 +2765,13 @@ object ZStreamSpec extends ZIOBaseSpec {
           }
         ),
         suite("mapZIOPar")(
+          test("i10195 - partially consumed output") {
+            val inputStream = ZStream.fromChunks(Seq.fill(1)(Chunk.fill(100)("abc")): _*)
+
+            for {
+              _ <- inputStream.mapZIOPar(8)(_ => ZIO.unit).take(1).runDrain
+            } yield assertCompletes
+          } @@ TestAspect.timeout(30.seconds),
           test("foreachParN equivalence") {
             checkN(10)(Gen.small(Gen.listOfN(_)(Gen.byte)), Gen.function(Gen.successes(Gen.byte))) { (data, f) =>
               val s = ZStream.fromIterable(data)

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -713,7 +713,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                              case Right(cause) =>
                                val continue = outgoing.offer(Fiber.done(ZChannel.failLeftUnit))
 
-                               if (cause.isInterruptedOnly) outgoing.takeAll *> continue
+                               if (cause.isInterruptedOnly) ZIO.uninterruptible(outgoing.takeAll *> continue)
                                else failureRef.update(_ && cause) *> continue
                            })
                            .ignore
@@ -802,7 +802,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               case Right(cause) =>
                 val continue = outgoing.offer(ZChannel.failLeftUnit)
 
-                if (cause.isInterruptedOnly) outgoing.takeAll *> continue
+                if (cause.isInterruptedOnly) ZIO.uninterruptible(outgoing.takeAll *> continue)
                 else failure.update(_ && cause) *> continue
             })
             .ignore

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -713,7 +713,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                              case Right(cause) =>
                                val continue = outgoing.offer(Fiber.done(ZChannel.failLeftUnit))
 
-                               if (cause.isInterruptedOnly) continue
+                               if (cause.isInterruptedOnly) outgoing.takeAll *> continue
                                else failureRef.update(_ && cause) *> continue
                            })
                            .ignore
@@ -802,7 +802,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               case Right(cause) =>
                 val continue = outgoing.offer(ZChannel.failLeftUnit)
 
-                if (cause.isInterruptedOnly) continue
+                if (cause.isInterruptedOnly) outgoing.takeAll *> continue
                 else failure.update(_ && cause) *> continue
             })
             .ignore


### PR DESCRIPTION
This PR fixes Issue #10195 by emptying the outgoing queue before trying to enqueuing something more.

When we interrupt a stream, the underlying back pressure queue is most likely full. And we are trying to offer one more message.