### PR TITLE
zio-test: Ignored annotated suites should not trigger shared layer creation

### DIFF
--- a/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -147,9 +147,9 @@ object FrameworkSpecInstances {
     // succeeding test with `provide`
     private val suiteWithValidProvideEnv =
       (
-      suite("suite with tag and valid `provide` env")(
-        test("should be executed - 1")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
-      ).provide(ZLayer.succeed(1))
+        suite("suite with tag and valid `provide` env")(
+          test("should be executed - 1")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+        ).provide(ZLayer.succeed(1))
       ) @@ TestAspect.tag("Executed")
 
     // failing test with `provideShared`
@@ -163,9 +163,9 @@ object FrameworkSpecInstances {
     // succeeding test with `provideShared`
     private val suiteWithValidProvideSharedEnv =
       (
-      suite("suite with tag and valid `provideShared` env")(
-        test("should be executed - 3")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
-      ).provideShared(ZLayer.succeed(1))
+        suite("suite with tag and valid `provideShared` env")(
+          test("should be executed - 3")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+        ).provideShared(ZLayer.succeed(1))
       ) @@ TestAspect.tag("Executed")
 
     // failing test with `provideLayerShared`
@@ -179,9 +179,9 @@ object FrameworkSpecInstances {
     // succeeding test with `provideLayerShared`
     private val suiteWithValidProvideLayerSharedEnv =
       (
-      suite("suite with tag and valid `provideShared` env")(
-        test("should be executed - 5")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
-      ).provideLayerShared(ZLayer.succeed(1))
+        suite("suite with tag and valid `provideShared` env")(
+          test("should be executed - 5")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+        ).provideLayerShared(ZLayer.succeed(1))
       ) @@ TestAspect.tag("Executed")
 
     // failing test with `provideSomeLayerShared`

--- a/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import zio.test._
-import zio.{ZIO, ZLayer, durationInt}
+import zio.{Scope, ZIO, ZLayer, durationInt}
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -133,6 +133,100 @@ object FrameworkSpecInstances {
         assert(1)(Assertion.equalTo(1))
       }.annotate(TestAnnotation.tagged, Set("UnitTest"))
     )
+  }
+
+  object TagsSpecWithFailingEnv extends ZIOSpecDefault {
+    // failing test with `provide`
+    private val suiteWithFailingProvideEnv =
+      (
+        suite("suite with tag and failing `provide` env")(
+          test("should not be executed - 0")(assertTrue(false))
+        ).provide(ZLayer(ZIO.fail(new RuntimeException("should not be called - 0"))))
+      ) @@ TestAspect.tag("NotExecuted")
+
+    // succeeding test with `provide`
+    private val suiteWithValidProvideEnv =
+      (
+      suite("suite with tag and valid `provide` env")(
+        test("should be executed - 1")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+      ).provide(ZLayer.succeed(1))
+      ) @@ TestAspect.tag("Executed")
+
+    // failing test with `provideShared`
+    private val suiteWithFailingProvideSharedEnv =
+      (
+        suite("suite with tag and failing `provideShared` env")(
+          test("should not be executed - 2")(assertTrue(false))
+        ).provideShared(ZLayer(ZIO.fail(new RuntimeException("should not be called - 2"))))
+      ) @@ TestAspect.tag("NotExecuted")
+
+    // succeeding test with `provideShared`
+    private val suiteWithValidProvideSharedEnv =
+      (
+      suite("suite with tag and valid `provideShared` env")(
+        test("should be executed - 3")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+      ).provideShared(ZLayer.succeed(1))
+      ) @@ TestAspect.tag("Executed")
+
+    // failing test with `provideLayerShared`
+    private val suiteWithFailingProvideLayerSharedEnv =
+      (
+        suite("suite with tag and failing `provideShared` env")(
+          test("should not be executed - 4")(assertTrue(false))
+        ).provideLayerShared(ZLayer(ZIO.fail(new RuntimeException("should not be called - 4"))))
+      ) @@ TestAspect.tag("NotExecuted")
+
+    // succeeding test with `provideLayerShared`
+    private val suiteWithValidProvideLayerSharedEnv =
+      (
+      suite("suite with tag and valid `provideShared` env")(
+        test("should be executed - 5")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+      ).provideLayerShared(ZLayer.succeed(1))
+      ) @@ TestAspect.tag("Executed")
+
+    // failing test with `provideSomeLayerShared`
+    private val suiteWithFailingProvideSomeLayerSharedEnv =
+      (
+        suite("suite with tag and failing `provideShared` env")(
+          test("should not be executed - 6")(assertTrue(false))
+        ).provideSomeLayerShared[Int](
+          ZLayer.fail(new RuntimeException("should not be called - 6")): ZLayer[Int, Throwable, Any]
+        )
+      ).provide(ZLayer.succeed(1)) @@ TestAspect.tag("NotExecuted")
+
+    // succeeding test with `provideSomeLayerShared`
+    private val suiteWithValidProvideSomeLayerSharedEnv =
+      (
+        suite("suite with tag and valid `provideShared` env")(
+          test("should be executed - 7")(ZIO.serviceWith[Int](i => assertTrue(i == 1)))
+        ).provideSomeLayerShared[Int](ZLayer.service[Int])
+      ).provide(ZLayer.succeed(1)) @@ TestAspect.tag("Executed")
+
+    private val suiteWithTestWithFailingProvideEnv =
+      suite("suite with tags and with tests having invalid env")(
+        (
+          test("should not be executed - 8") {
+            assertTrue(false)
+          }.provide(ZLayer(ZIO.fail(new RuntimeException("should not be called - 8"))))
+        ) @@ TestAspect.tag("NotExecuted"),
+        test("should be executed - 9") {
+          assertTrue(true)
+        } @@ TestAspect.tag("Executed")
+      )
+
+    override def spec: Spec[TestEnvironment with Scope, Any] =
+      suite("tag suite with failing env")(
+        suiteWithFailingProvideEnv,
+        suiteWithValidProvideEnv,
+        suiteWithFailingProvideSharedEnv,
+        suiteWithValidProvideSharedEnv,
+        suiteWithFailingProvideLayerSharedEnv,
+        suiteWithValidProvideLayerSharedEnv,
+        suiteWithValidProvideSomeLayerSharedEnv,
+        suiteWithValidProvideSomeLayerSharedEnv,
+        suiteWithFailingProvideSomeLayerSharedEnv,
+        suiteWithTestWithFailingProvideEnv
+      )
   }
 
   object NestedSpec extends ZIOSpecDefault {

--- a/test-sbt/shared/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -1,10 +1,10 @@
 package zio.test.sbt
 
 import sbt.testing.{Status, TestSelector}
-import zio.{Scope, ZIO}
-import zio.test.{Spec, TestAspect, TestEnvironment, TestResult, ZIOSpecDefault, assertTrue}
 import zio.test.sbt.Colors.{green, red, yellow}
 import zio.test.sbt.ExecuteSpecs.{getEvents, getOutput, getOutputs}
+import zio.test.{Spec, TestAspect, TestEnvironment, TestResult, ZIOSpecDefault, assertTrue, assert}
+import zio.{Scope, ZIO}
 
 object ZTestFrameworkSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("test framework")(
@@ -135,6 +135,37 @@ object ZTestFrameworkSpec extends ZIOSpecDefault {
             s"""  ${green("+")} unit test - tagged: "UnitTest"\n"""
           )
       } yield assertTrue(output.equals(expected))
+    },
+    test("do not create layers for test with ignored tag") {
+      for {
+        output <- getOutput(FrameworkSpecInstances.TagsSpecWithFailingEnv, args = Array("-ignore-tags", "NotExecuted"))
+      } yield {
+        // Verify all tests with "Executed" tag ran successfully
+        assertTrue(
+          output.exists(_.contains("""should be executed - 1 - tagged: "Executed"""")),
+          output.exists(_.contains("""should be executed - 3 - tagged: "Executed"""")),
+          output.exists(_.contains("""should be executed - 5 - tagged: "Executed"""")),
+          output.exists(_.contains("""should be executed - 7 - tagged: "Executed"""")),
+          output.exists(_.contains("""should be executed - 9 - tagged: "Executed""""))
+        ) &&
+        // Verify that tests with "NotExecuted" tag did NOT run
+        assertTrue(
+          !output.exists(_.contains("""should not be executed - 0""")),
+          !output.exists(_.contains("""should not be executed - 2""")),
+          !output.exists(_.contains("""should not be executed - 4""")),
+          !output.exists(_.contains("""should not be executed - 6""")),
+          !output.exists(_.contains("""should not be executed - 8"""))
+        ) &&
+        // Verify that layers for filtered tests were NOT constructed
+        // This is the critical assertion: if layers were built, we'd see these error messages
+        assertTrue(
+          !output.exists(_.contains("should not be called - 0")),
+          !output.exists(_.contains("should not be called - 2")),
+          !output.exists(_.contains("should not be called - 4")),
+          !output.exists(_.contains("should not be called - 6")),
+          !output.exists(_.contains("should not be called - 8"))
+        )
+      }
     },
     test("honor `TestSelector`s") {
       for {

--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -83,28 +83,25 @@ object SpecSpec extends ZIOBaseSpec {
         trait Service {
           def open: UIO[Boolean]
         }
-        object Service {
-          val open: ZIO[Service, Nothing, Boolean] =
-            ZIO.serviceWithZIO(_.open)
-        }
         val layer =
           ZLayer {
             for {
               ref <- Ref.make(true)
               _   <- ZIO.addFinalizer(ref.set(false))
             } yield new Service {
-              def open: UIO[Boolean] =
-                ref.get
+              def open: UIO[Boolean] = ref.get
             }
           }
-        val spec = suite("suite")(
-          test("test1") {
-            assertZIO(Service.open)(isTrue)
-          },
-          test("test2") {
-            assertZIO(Service.open)(isTrue)
-          }
-        ).provideLayerShared(layer).provideLayer(Scope.default) @@ sequential
+        val spec =
+          suite("suite")(
+            test("test1") {
+              assertZIO(ZIO.serviceWithZIO[Service](_.open))(isTrue)
+            },
+            test("test2") {
+              assertZIO(ZIO.serviceWithZIO[Service](_.open))(isTrue)
+            }
+          ).provideLayerShared(layer).provideLayer(Scope.default) @@ sequential
+
         assertZIO(succeeded(spec))(isTrue)
       },
       test("propagates the scope to multiple tests") {

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -349,17 +349,15 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
       case MultipleCase(specs) =>
         Spec.scoped[R0] {
           ZIO.scopeWith { scope =>
-            import Spec.RichLayer
-
-            val scopedLayer: ZLayer[R0, E1, R] =
-              ZLayer.makeSome[R0, R](
+            ZLayer
+              .makeSome[R0, R](
                 ZLayer.succeed(scope),
                 layer.extendScope
               )
-
-            scopedLayer.memoizeWithinScope(scope).map { memoizedLayer =>
-              Spec.multiple(specs.map(_.provideLayer(memoizedLayer)))
-            }
+              .memoize
+              .map { memoizedLayer =>
+                Spec.multiple(specs.map(_.provideLayer(memoizedLayer)))
+              }
           }
         }
       case TestCase(test, annotations) => Spec.test(test.provideLayer(layer.mapError(TestFailure.fail)), annotations)
@@ -550,15 +548,15 @@ object Spec {
         case MultipleCase(specs) =>
           Spec.scoped[R0] {
             ZIO.scopeWith { scope =>
-              val scopedLayer: ZLayer[R0, E1, R1] =
-                ZLayer.makeSome[R0, R1](
+              ZLayer
+                .makeSome[R0, R1](
                   ZLayer.succeed(scope),
                   layer.extendScope
                 )
-
-              scopedLayer.memoizeWithinScope(scope).map { memoizedLayer =>
-                Spec.multiple(specs.map(_.provideSomeLayer[R0](memoizedLayer)))
-              }
+                .memoize
+                .map { memoizedLayer =>
+                  Spec.multiple(specs.map(_.provideSomeLayer[R0](memoizedLayer)))
+                }
             }
           }
         case TestCase(test, annotations) =>
@@ -585,12 +583,4 @@ object Spec {
       self.provideSomeEnvironment(_.updateAt(key)(f))
   }
 
-  private implicit final class RichLayer[RIn, E0, ROut](private val layer: ZLayer[RIn, E0, ROut]) extends AnyVal {
-
-    /**
-     * Version of `ZLayer::memoize` that uses the provided scope.
-     */
-    def memoizeWithinScope(scope: Scope)(implicit trace: Trace): ZIO[Any, Nothing, ZLayer[RIn, E0, ROut]] =
-      layer.build(scope).memoize.map(ZLayer.fromZIOEnvironment(_))
-  }
 }

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -347,11 +347,21 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
             .flatMap(r => scoped.map(_.provideEnvironment(r)).provideSomeEnvironment[Scope](r.union[Scope]))
         )
       case MultipleCase(specs) =>
-        Spec.scoped[R0](
-          layer.memoize.flatMap(layer =>
-            layer.mapError(TestFailure.fail).build.map(_ => Spec.multiple(specs.map(_.provideLayer(layer))))
-          )
-        )
+        Spec.scoped[R0] {
+          ZIO.scopeWith { scope =>
+            import Spec.RichLayer
+
+            val scopedLayer: ZLayer[R0, E1, R] =
+              ZLayer.makeSome[R0, R](
+                ZLayer.succeed(scope),
+                layer.extendScope
+              )
+
+            scopedLayer.memoizeWithinScope(scope).map { memoizedLayer =>
+              Spec.multiple(specs.map(_.provideLayer(memoizedLayer)))
+            }
+          }
+        }
       case TestCase(test, annotations) => Spec.test(test.provideLayer(layer.mapError(TestFailure.fail)), annotations)
     }
 
@@ -538,12 +548,19 @@ object Spec {
             }
           )
         case MultipleCase(specs) =>
-          Spec.scoped[R0](
-            layer.memoize
-              .flatMap(layer =>
-                layer.mapError(TestFailure.fail).build.map(_ => Spec.multiple(specs.map(_.provideSomeLayer[R0](layer))))
-              )
-          )
+          Spec.scoped[R0] {
+            ZIO.scopeWith { scope =>
+              val scopedLayer: ZLayer[R0, E1, R1] =
+                ZLayer.makeSome[R0, R1](
+                  ZLayer.succeed(scope),
+                  layer.extendScope
+                )
+
+              scopedLayer.memoizeWithinScope(scope).map { memoizedLayer =>
+                Spec.multiple(specs.map(_.provideSomeLayer[R0](memoizedLayer)))
+              }
+            }
+          }
         case TestCase(test, annotations) =>
           Spec.test(test.provideSomeLayer(layer.mapError(TestFailure.fail)), annotations)
       }
@@ -566,5 +583,14 @@ object Spec {
       f: Service => Service
     )(implicit tag: Tag[Map[Key, Service]], trace: Trace): Spec[R1, E] =
       self.provideSomeEnvironment(_.updateAt(key)(f))
+  }
+
+  private implicit final class RichLayer[RIn, E0, ROut](private val layer: ZLayer[RIn, E0, ROut]) extends AnyVal {
+
+    /**
+     * Version of `ZLayer::memoize` that uses the provided scope.
+     */
+    def memoizeWithinScope(scope: Scope)(implicit trace: Trace): ZIO[Any, Nothing, ZLayer[RIn, E0, ROut]] =
+      layer.build(scope).memoize.map(ZLayer.fromZIOEnvironment(_))
   }
 }

--- a/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
+++ b/test/shared/src/main/scala/zio/test/ZIOSpecAbstract.scala
@@ -97,14 +97,11 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
   ): URIO[
     Environment with TestEnvironment with Scope,
     Summary
-  ] = {
-    val filteredSpec: Spec[Environment with TestEnvironment with Scope, Any] = FilteredSpec(spec, testArgs)
-
+  ] =
     for {
-      runtime <-
-        ZIO.runtime[
-          TestEnvironment with Scope
-        ]
+      runtime <- ZIO.runtime[TestEnvironment with Scope]
+
+      filteredSpec = FilteredSpec(spec, testArgs)
 
       scopeEnv: ZEnvironment[Scope] = runtime.environment
       perTestLayer = (ZLayer.succeedEnvironment(scopeEnv) <*> liveEnvironment) >>>
@@ -128,7 +125,6 @@ abstract class ZIOSpecAbstract extends ZIOApp with ZIOSpecAbstractVersionSpecifi
                    aspects.foldLeft(filteredSpec)(_ @@ _) @@ TestAspect.fibers: @nowarn("cat=deprecation")
                  )
     } yield summary
-  }
 
   @deprecated("use the overload that does not take Console parameter")
   private[zio] def runSpecWithSharedRuntimeLayer(


### PR DESCRIPTION
I need to be able to ignore some tests by tagging them and use `-ignore-tags <tag>`

But I noticed that if my tests use `.provideShared` then the layers inside are launched even if my entire suite (including the `.provideShared`) is flagged to not be run.

Example:
```scala
suite("should be filtered out by the -ignore-tags option")(
   ...
).provideShared(
   TestContainersPG.layer, // should not be started. Will fail if the Docker socket is not available
) @@ TestAspect.tag("dontRun")
```

Before the changes in this PR, the `TestContainersPG.layer` was always started, even if I launched my tests with the `-ignore-tags dontRun` option
With these changes, the `TestContainersPG.layer` is not started when I launch my tests with with the `-ignore-tags dontRun` option 🎉 

My test launched in an env without Docker before these changes:
```scala
+ migration
16:22:21.180 [zio-default-blocking-1] [] ERROR org.testcontainers.dockerclient.DockerClientProviderStrategy - Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
	UnixSocketClientProviderStrategy: failed with exception InvalidConfigurationException (Could not find unix domain socket). Root cause NoSuchFileException (/var/run/docker.sock)
	DockerDesktopClientProviderStrategy: failed with exception NullPointerException (Cannot invoke "java.nio.file.Path.toString()" because the return value of "org.testcontainers.dockerclient.DockerDesktopClientProviderStrategy.getSocketPath()" is null)As no valid configuration was found, execution cannot continue.
See https://java.testcontainers.org/on_failure.html for more details.
    - does migrate
      java.lang.IllegalStateException: Could not find a valid Docker environment. Please see logs and check configuration
      	at org.testcontainers.dockerclient.DockerClientProviderStrategy.lambda$getFirstValidStrategy$7(DockerClientProviderStrategy.java:274)
      	at java.base/java.util.Optional.orElseThrow(Optional.java:403)
```

Same test with these changes:
```
+ migration
No tests were executed
[info] Completed tests
```