### PR TITLE
Return interop-cats ecosystem page

### DIFF
--- a/website/upgrade-zio-docs.sh
+++ b/website/upgrade-zio-docs.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 packages=(
+  "@zio.dev/interop-cats"
   "@zio.dev/izumi-reflect"
   "@zio.dev/zio-aws"
   "@zio.dev/zio-cache"
@@ -28,8 +29,6 @@ packages=(
   "@zio.dev/zio-sqs"
   "@zio.dev/zio-telemetry"
   "@zio.dev/zio2-interop-cats2"
-  # this seems to be deleted and no longer exists
-  # "@zio.dev/zio2-interop-cats3"
 )
 
 # Construct the package add command by joining the packages with a space


### PR DESCRIPTION
interop-cats website is now pushed to https://www.npmjs.com/package/@zio.dev/interop-cats ([ci log](https://github.com/zio/interop-cats/actions/runs/19553145358/job/55990656799#step:8:28))

Fix zio/interop-cats#547
Fix zio/interop-cats#548