### PR TITLE
[Bug] `BitChunk[Byte|Int|Long].apply(n)` treats `n` as a raw bit index into the underlying array, ignoring `minBitIndex`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkApplyBugSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkApplyBugSpec.scala
@@ -1,0 +1,183 @@
+package zio
+
+import zio.test._
+
+/**
+ * Deterministic tests that expose the bug in BitChunk.apply() where minBitIndex
+ * was not accounted for. These tests use specific, hand-crafted inputs that
+ * directly trigger the bug without relying on property-based testing
+ * randomness.
+ *
+ * The bug: BitChunkByte/Int/Long.apply(n) treated 'n' as a raw bit index into
+ * the underlying array, ignoring minBitIndex. This caused incorrect results
+ * when accessing elements in sliced/dropped BitChunks.
+ *
+ * These tests should:
+ *   - FAIL with the buggy code (before fix) on ANY Scala version
+ *   - PASS with the fixed code on ANY Scala version
+ */
+object BitChunkApplyBugSpec extends ZIOBaseSpec {
+
+  def spec = suite("BitChunkApplyBugSpec")(
+    suite("BitChunkByte.apply with minBitIndex > 0")(
+      test("apply(0) on dropped BitChunkByte returns correct first bit") {
+        // Byte 0x81 = 10000001 in binary
+        // After drop(2), the first bit should be bit index 2 (which is '0'), not bit index 0 (which is '1')
+        val bytes    = Chunk(0x81.toByte) // "10000001"
+        val bitChunk = bytes.asBitsByte   // BitChunkByte(bytes, min=0, max=8)
+        val dropped  = bitChunk.drop(2)   // BitChunkByte(bytes, min=2, max=8), length=6
+
+        // With the bug: apply(0) returns bit 0 = true (the '1' at position 0)
+        // Correct:      apply(0) returns bit 2 = false (the '0' at position 2)
+        val firstBit = dropped(0)
+
+        assertTrue(!firstBit) // Should be false (bit at position 2 is '0')
+      },
+      test("apply on dropped BitChunkByte returns all correct bits") {
+        // Byte 0xA5 = 10100101 in binary
+        val bytes    = Chunk(0xa5.toByte) // "10100101"
+        val bitChunk = bytes.asBitsByte   // All 8 bits: 1,0,1,0,0,1,0,1
+        val dropped  = bitChunk.drop(3)   // Should be bits 3-7: 0,0,1,0,1
+
+        val bits = (0 until dropped.length).map(dropped(_)).toList
+
+        // Expected: bits at positions 3,4,5,6,7 = 0,0,1,0,1 = false,false,true,false,true
+        assertTrue(bits == List(false, false, true, false, true))
+      },
+      test("toBinaryString on dropped BitChunkByte is correct") {
+        // This is the exact failing case from CI: drop(2).take(11) on a specific byte sequence
+        val bytes   = Chunk(0x81.toByte, 0xa3.toByte) // "10000001 10100011"
+        val dropped = bytes.asBitsByte.drop(2).take(11)
+
+        // Original: "1000000110100011"
+        // After drop(2): "00000110100011" (14 bits)
+        // After take(11): "00000110100" (11 bits)
+        val actual   = dropped.toBinaryString
+        val expected = "00000110100"
+
+        assertTrue(actual == expected)
+      },
+      test("foreach on dropped BitChunkByte iterates correct bits") {
+        val bytes    = Chunk(0xf0.toByte) // "11110000"
+        val bitChunk = bytes.asBitsByte
+        val dropped  = bitChunk.drop(2)   // Should be bits 2-7: 1,1,0,0,0,0
+
+        val collected = scala.collection.mutable.ListBuffer[Boolean]()
+        dropped.foreach(b => collected += b)
+
+        // Expected: bits at positions 2,3,4,5,6,7 = 1,1,0,0,0,0
+        assertTrue(collected.toList == List(true, true, false, false, false, false))
+      },
+      test("toPackedByte on dropped BitChunkByte produces correct result") {
+        // This tests the interaction between BitChunk and ChunkPackedBoolean
+        val bytes   = Chunk(0x81.toByte, 0xa3.toByte) // "10000001 10100011"
+        val dropped = bytes.asBitsByte.drop(2).take(11)
+
+        // After drop(2).take(11): "00000110100" (11 bits)
+        // Packed as bytes: "00000110" (8 bits) + "100" padded to "10000000" (but only 3 bits matter)
+        val packed = dropped.toPackedByte
+
+        // First byte should be 0b00000110 = 6
+        assertTrue(packed.length == 2) &&
+        assertTrue(packed(0) == 6.toByte)
+      }
+    ),
+    suite("BitChunkInt.apply with minBitIndex > 0")(
+      test("apply(0) on dropped BitChunkInt returns correct first bit") {
+        val ints     = Chunk(0x80000001) // MSB=1, LSB=1, rest=0
+        val bitChunk = ints.asBitsInt(Chunk.BitChunk.Endianness.BigEndian)
+        val dropped  = bitChunk.drop(1)  // Drop the MSB
+
+        // After drop(1), first bit should be '0' (the second bit of original), not '1' (the MSB)
+        val firstBit = dropped(0)
+
+        assertTrue(!firstBit) // Should be false
+      },
+      test("toBinaryString on dropped BitChunkInt is correct") {
+        val ints    = Chunk(0xf0f0f0f0)
+        val dropped = ints.asBitsInt(Chunk.BitChunk.Endianness.BigEndian).drop(4).take(8)
+
+        // Original: "11110000111100001111000011110000"
+        // After drop(4).take(8): "00001111"
+        val actual   = dropped.toBinaryString
+        val expected = "00001111"
+
+        assertTrue(actual == expected)
+      }
+    ),
+    suite("BitChunkLong.apply with minBitIndex > 0")(
+      test("apply(0) on dropped BitChunkLong returns correct first bit") {
+        val longs    = Chunk(0x8000000000000001L) // MSB=1, LSB=1, rest=0
+        val bitChunk = longs.asBitsLong(Chunk.BitChunk.Endianness.BigEndian)
+        val dropped  = bitChunk.drop(1)           // Drop the MSB
+
+        // After drop(1), first bit should be '0', not '1'
+        val firstBit = dropped(0)
+
+        assertTrue(!firstBit) // Should be false
+      },
+      test("toBinaryString on dropped BitChunkLong is correct") {
+        val longs   = Chunk(0xff00ff00ff00ff00L)
+        val dropped = longs.asBitsLong(Chunk.BitChunk.Endianness.BigEndian).drop(8).take(8)
+
+        // Original starts with "11111111 00000000 ..."
+        // After drop(8).take(8): "00000000"
+        val actual   = dropped.toBinaryString
+        val expected = "00000000"
+
+        assertTrue(actual == expected)
+      }
+    ),
+    suite("Regression test: exact CI failure case")(
+      test("pack byte with drop(2).take(11) - the exact failing case") {
+        // This is the exact shrunk input that failed in CI:
+        // Chunk(true, false, false, false, false, false, false, true, true, false, true, false, ...)
+        // which corresponds to bytes 0x81, 0xA3, ...
+        // with drop=2, take=11
+
+        val bytes =
+          Chunk(0x81.toByte, 0xa3.toByte, 0x26.toByte, 0xdb.toByte, 0xe9.toByte, 0x47.toByte, 0x1f.toByte, 0x62.toByte)
+        val bools = bytes.asBitsByte.drop(2).take(11)
+
+        // Convert to binary string for comparison
+        def toBinaryStringByte(byte: Byte): String =
+          String.format("%8s", (byte.toInt & 0xff).toBinaryString).replace(' ', '0')
+
+        val actual = bools.toPackedByte.map(toBinaryStringByte).mkString
+        val expected = bytes
+          .map(toBinaryStringByte)
+          .mkString
+          .drop(2)
+          .take(11)
+          .grouped(8)
+          .map(s => s"%8s".format(s).replace(' ', '0'))
+          .mkString
+
+        assertTrue(actual == expected)
+      }
+    ),
+    suite("Multiple operations chain")(
+      test("drop.drop on BitChunkByte") {
+        val bytes    = Chunk(0xff.toByte, 0x00.toByte) // "11111111 00000000"
+        val bitChunk = bytes.asBitsByte
+        val result   = bitChunk.drop(4).drop(4)        // Should be bits 8-15: "00000000"
+
+        assertTrue(result.toBinaryString == "00000000")
+      },
+      test("take.drop on BitChunkByte") {
+        val bytes    = Chunk(0xff.toByte, 0x00.toByte) // "11111111 00000000"
+        val bitChunk = bytes.asBitsByte
+        val result   = bitChunk.take(12).drop(4)       // bits 0-11 then drop 4 = bits 4-11: "11110000"
+
+        assertTrue(result.toBinaryString == "11110000")
+      },
+      test("slice on BitChunkByte") {
+        val bytes    = Chunk(0xaa.toByte)   // "10101010"
+        val bitChunk = bytes.asBitsByte
+        val result   = bitChunk.slice(2, 6) // bits 2-5: "1010"
+
+        assertTrue(result.toBinaryString == "1010")
+      }
+    )
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
@@ -49,6 +49,108 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    test("pack byte - BitChunkByte with drop and take") {
+      // Deterministic version of "pack byte" that directly exposes the bug where
+      // BitChunk.apply() didn't account for minBitIndex when accessing sliced chunks.
+      // This test uses the EXACT same logic as "pack byte" but with fixed inputs.
+      //
+      // The bug: BitChunkByte.apply(n) treated 'n' as a raw bit index into the
+      // underlying byte array, ignoring minBitIndex. When drop() is called, a new
+      // BitChunk is created with minBitIndex > 0, but apply() would still read
+      // from the wrong position.
+      //
+      // Example with these inputs:
+      //   bytes = 0x81, 0xA3 = "10000001 10100011" (16 bits)
+      //   bls.drop(2).take(11) creates BitChunkByte with minBitIndex=2, maxBitIndex=13
+      //   Expected bits: positions 2-12 = "00000110100" (11 bits)
+      //
+      // With the bug:
+      //   apply(0) would return bit 0 ('1') instead of bit 2 ('0')
+      //   toPackedByte would pack the wrong bits, producing incorrect output
+      //
+      // Without the bug:
+      //   apply(0) correctly returns bit at (0 + minBitIndex) = bit 2 ('0')
+      //   toPackedByte correctly packs bits 2-12
+
+      val bytes = Chunk(0x81.toByte, 0xa3.toByte) // "10000001 10100011"
+      val bls   = bytes.asBitsByte
+
+      val drop = 2
+      val take = 11
+
+      val bools    = bls.drop(drop).take(take)
+      val actual   = bools.toPackedByte.map(toBinaryString).mkString
+      val expected = toBinaryString(bools, bits = 8, Chunk.BitChunk.Endianness.BigEndian)
+
+      assert(actual)(equalTo(expected))
+    },
+    test("pack byte - BitChunkByte with various drop/take combinations") {
+      // Tests multiple drop/take combinations on BitChunkByte to ensure the
+      // minBitIndex fix works correctly across different slicing scenarios.
+      //
+      // Each test case creates a sliced BitChunkByte and verifies that
+      // toPackedByte produces the correct output by comparing against
+      // the expected binary string representation.
+
+      val bytes = Chunk(0xff.toByte, 0x00.toByte, 0xaa.toByte, 0x55.toByte) // "11111111 00000000 10101010 01010101"
+      val bls   = bytes.asBitsByte
+
+      val testCases = List(
+        (1, 10), // drop 1, take 10 - starts mid-byte
+        (3, 15), // drop 3, take 15 - crosses multiple bytes
+        (7, 9),  // drop 7, take 9  - crosses byte boundary at awkward position
+        (8, 8),  // drop 8, take 8  - exactly the second byte (minBitIndex = 8)
+        (4, 20), // drop 4, take 20 - large slice crossing multiple bytes
+        (0, 16)  // drop 0 (baseline - minBitIndex = 0, should always work)
+      )
+
+      testCases.foldLeft(assertCompletes) { case (acc, (drop, take)) =>
+        val bools    = bls.drop(drop).take(take)
+        val actual   = bools.toPackedByte.map(toBinaryString).mkString
+        val expected = toBinaryString(bools, bits = 8, Chunk.BitChunk.Endianness.BigEndian)
+        acc && assert(actual)(equalTo(expected))
+      }
+    },
+    test("pack byte - BitChunkInt with drop and take") {
+      // Same bug pattern as BitChunkByte, but for BitChunkInt.
+      // BitChunkInt.apply(n) also needs to account for minBitIndex.
+      //
+      // Input: 0xF0F0F0F0, 0x0F0F0F0F as 64 bits in big-endian order
+      // Original: "11110000111100001111000011110000 00001111000011110000111100001111"
+      // After drop(4).take(24): bits 4-27 = "000011110000111100001111" (24 bits)
+
+      val ints = Chunk(0xf0f0f0f0, 0x0f0f0f0f)
+      val bls  = ints.asBitsInt(Chunk.BitChunk.Endianness.BigEndian)
+
+      val drop = 4
+      val take = 24
+
+      val bools    = bls.drop(drop).take(take)
+      val actual   = bools.toPackedByte.map(toBinaryString).mkString
+      val expected = toBinaryString(bools, bits = 8, Chunk.BitChunk.Endianness.BigEndian)
+
+      assert(actual)(equalTo(expected))
+    },
+    test("pack byte - BitChunkLong with drop and take") {
+      // Same bug pattern as BitChunkByte, but for BitChunkLong.
+      // BitChunkLong.apply(n) also needs to account for minBitIndex.
+      //
+      // Input: 0xFF00FF00FF00FF00L as 64 bits in big-endian order
+      // Original: "1111111100000000111111110000000011111111000000001111111100000000"
+      // After drop(8).take(32): bits 8-39 = "00000000111111110000000011111111" (32 bits)
+
+      val longs = Chunk(0xff00ff00ff00ff00L)
+      val bls   = longs.asBitsLong(Chunk.BitChunk.Endianness.BigEndian)
+
+      val drop = 8
+      val take = 32
+
+      val bools    = bls.drop(drop).take(take)
+      val actual   = bools.toPackedByte.map(toBinaryString).mkString
+      val expected = toBinaryString(bools, bits = 8, Chunk.BitChunk.Endianness.BigEndian)
+
+      assert(actual)(equalTo(expected))
+    },
     test("pack int") {
       check(genBoolChunk, genEndianness, genInt, genInt) { (bls, endianness, drop, take) =>
         val bools    = bls.drop(drop).take(take)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1996,7 +1996,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       val maxFullBitIndex = (maxLongIndex << bitsLog2) max minFullBitIndex
       var i               = minBitIndex
       while (i < minFullBitIndex) {
-        f(self.apply(i))
+        f(self.apply(i - minBitIndex))
         i += 1
       }
       i = minLongIndex
@@ -2006,7 +2006,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       }
       i = maxFullBitIndex
       while (i < maxBitIndex) {
-        f(self.apply(i))
+        f(self.apply(i - minBitIndex))
         i += 1
       }
     }
@@ -2067,8 +2067,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override val length: Int =
       maxBitIndex - minBitIndex
 
-    override def apply(n: Int): Boolean =
-      (bytes(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
+    override def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (bytes(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def elementAt(n: Int): Byte = bytes(n)
 
@@ -2134,7 +2136,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
         var mask       = 128
         var i          = 0
         while (i < leftovers) {
-          if (g(self.apply(offset + self.minBitIndex + i), that.apply(offset + that.minBitIndex + i)))
+          if (g(self.apply(offset + i), that.apply(offset + i)))
             last = (last | mask).asInstanceOf[Byte]
           i += 1
           mask >>= 1
@@ -2177,7 +2179,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       }
 
       if (leftovers != 0) {
-        val offset     = bytes * 8 + self.minBitIndex
+        val offset     = bytes * 8
         var last: Byte = null.asInstanceOf[Byte]
         var mask       = 128
         var i          = 0
@@ -2208,8 +2210,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override protected def elementAt(n: Int): Int =
       respectEndian(endianness, ints(n))
 
-    override def apply(n: Int): Boolean =
-      (elementAt(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
+    override def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (elementAt(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def newBitChunk(chunk: Chunk[Int], min: Int, max: Int): BitChunk[Int] =
       BitChunkInt(chunk, endianness, min, max)
@@ -2282,8 +2286,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override protected def elementAt(n: Int): Long =
       if (endianness == BitChunk.Endianness.BigEndian) longs(n) else java.lang.Long.reverse(longs(n))
 
-    def apply(n: Int): Boolean =
-      (elementAt(n >> bitsLog2) & (1L << (bits - 1 - (n & bits - 1)))) != 0
+    def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (elementAt(bitIndex >> bitsLog2) & (1L << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def newBitChunk(longs: Chunk[Long], min: Int, max: Int): BitChunk[Long] =
       BitChunkLong(longs, endianness, min, max)


### PR DESCRIPTION
Bug discovered thanks to CI failing in this PR: https://github.com/zio/zio/pull/10254

Analysis of the bug (generated with AI):

# BitChunk Bug Analysis: Scala 2.13.18 Update Failure

## Executive Summary

The CI failure in the `ChunkPackedBooleanSpec` test after updating Scala from 2.13.16 to 2.13.18 was caused by a **latent bug** in the `BitChunk` implementations that has existed since the code was originally written. The Scala update did not introduce the bug—it merely exposed it by changing the sequence of random test cases generated during property-based testing.

---

## The Bug

### Root Cause

The `apply(n: Int)` method in `BitChunkByte`, `BitChunkInt`, and `BitChunkLong` did not account for `minBitIndex` when accessing bits. This caused incorrect bit access when working with sliced or dropped `BitChunk` instances.

### Affected Code (Before Fix)

```scala
// BitChunkByte.apply - BUGGY
override def apply(n: Int): Boolean =
  (bytes(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
```

The problem: When a `BitChunk` is created via `drop()` or `slice()`, it stores `minBitIndex` to track the logical offset into the underlying array. However, `apply(n)` treated `n` as a raw index into the underlying array, ignoring `minBitIndex` entirely.

### Example of the Bug

```scala
val bytes = Chunk[Byte](0x81.toByte, 0xA3.toByte)  // "10000001 10100011"
val bitChunk = bytes.asBitsByte                     // BitChunkByte(bytes, min=0, max=16)
val sliced = bitChunk.drop(2).take(11)              // BitChunkByte(bytes, min=2, max=13)

// Bug: sliced.apply(0) should return bit 2, but it returned bit 0!
// Expected: sliced(0) = bit at position 2 (which is '0')
// Actual:   sliced(0) = bit at position 0 (which is '1')
```

### The Fix

```scala
// BitChunkByte.apply - FIXED
override def apply(n: Int): Boolean = {
  val bitIndex = n + minBitIndex  // Account for the logical offset
  (bytes(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
}
```

Additional fixes were required in:
- `BitChunk.foreach` - was passing raw indices to `apply()` instead of 0-based indices
- `BitChunkByte.bitwise` - was redundantly adding `minBitIndex`
- `BitChunkByte.negate` - same issue as `bitwise`

---

## Why the Scala Update Exposed the Bug

### The Key Insight

**The bug has existed in the code since the original implementation.** It was not introduced by Scala 2.13.17 or 2.13.18. The Scala update merely changed the *sequence of random test cases* generated during property-based testing, causing a test case that exercises the buggy code path to be generated.

### Scala 2.13.17's Breaking Change

[Scala 2.13.17](https://github.com/scala/scala/releases/tag/v2.13.17) introduced a significant change to case class `hashCode` computation ([PR #11023](https://github.com/scala/scala/pull/11023)):

> **Breaking Change**: The synthetic `hashCode` method of a case class no longer calls `productPrefix`. Instead, it mixes `productPrefix.hashCode` in statically at compile time.

#### Before Scala 2.13.17:
```scala
case class Foo(x: Int)
// hashCode computed by calling productPrefix() at runtime
```

#### After Scala 2.13.17:
```scala
case class Foo(x: Int)
// hashCode now uses MurmurHash3.caseClassHash with productPrefix mixed in statically
```

### How This Affects Property-Based Testing

ZIO Test uses deterministic pseudo-random number generators (PRNGs) for property-based testing. The sequence of test cases depends on:

1. **The initial seed** - often derived from hash-based computations
2. **How generators are combined** - `Gen.elements`, `Gen.oneOf`, etc. may use hashing internally
3. **Ordering in hash-based collections** - if generators or test values are stored in `HashMap`/`HashSet`

When case class `hashCode` values changed in Scala 2.13.17, this likely affected:

- The effective random seed initialization
- How `Gen.elements(booleanChunk, byteChunk, intChunk, longChunk)` selects which chunk type to generate
- The ordering of test case generation

### The Test That Failed

```scala
val genBoolChunk: Gen[Any, Chunk[Boolean]] =
  for {
    endianness   <- genEndianness
    booleanChunk <- Gen.listOf(Gen.boolean).map(Chunk.fromIterable)
    byteChunk    <- Gen.listOf(Gen.byte).map(Chunk.fromIterable).map(x => x.asBitsByte)
    intChunk     <- Gen.listOf(Gen.int).map(Chunk.fromIterable).map(x => x.asBitsInt(endianness))
    longChunk    <- Gen.listOf(Gen.long).map(Chunk.fromIterable).map(x => x.asBitsLong(endianness))
    oneOf        <- Gen.elements(booleanChunk, byteChunk, intChunk, longChunk)  // Hash-dependent selection!
  } yield oneOf
```

The `Gen.elements` call selects one of four chunk types. With Scala 2.13.16, the random sequence happened to mostly generate cases where `minBitIndex == 0` (no slicing) or cases that didn't trigger the comparison issue. With Scala 2.13.17+, the new random sequence generated a `BitChunkByte` with `drop(2).take(11)`, which directly exposed the bug.

### Proof That This Is a Latent Bug

The failing test case is deterministic and reproducible:

```
Input: (Chunk(true, false, false, false, false, false, false, true, ...), 2, 11)
       ^^^^ This is a BitChunkByte from bytes.asBitsByte  ^drop ^take

Expected: "1000000100000100"
Actual:   "1000000100000101"
           ^^^^^^^^^^^^^^^^
           Difference in last bit due to incorrect index calculation
```

The shrunk input `(chunk, drop=2, take=11)` creates a `BitChunkByte` with `minBitIndex=2`. When `toPackedByte` iterates over this chunk, it calls `apply(n)` with 0-based indices (0, 1, 2, ..., 10), but the buggy code interpreted these as raw bit indices (0, 1, 2, ...) instead of logical indices that should be offset by `minBitIndex`.

---

## Is This a Bug in Scala 2.13.17+?

**No.** This is not a bug in Scala itself. The Scala changes are:

1. **Intentional** - The `hashCode` change fixes a correctness issue where subclasses of case classes could violate the `equals`/`hashCode` contract
2. **Documented** - It's listed as a breaking change in the release notes
3. **Binary compatible** - Existing compiled code continues to work (though hash values may differ)

The fact that a different random sequence exposed a latent bug is actually a *feature* of property-based testing—it demonstrates that the test was insufficiently covering edge cases, and the new sequence found a real bug.

---

## Timeline of the Bug

| Date | Event |
|------|-------|
| ~2022 | `BitChunk` classes implemented with bug in `apply()` |
| 2022-2025 | Tests pass because random sequence doesn't generate problematic inputs |
| Oct 2025 | Scala 2.13.17 changes case class `hashCode` |
| Nov 2025 | ZIO updates to Scala 2.13.18, inheriting the 2.13.17 change |
| Nov 2025 | New random sequence generates `(chunk, drop=2, take=11)`, exposing the bug |
| Nov 2025 | Bug fixed by properly accounting for `minBitIndex` in `apply()` |

---

## Files Changed

| File | Changes |
|------|---------|
| `core/shared/src/main/scala/zio/Chunk.scala` | Fixed `apply()` in `BitChunkByte`, `BitChunkInt`, `BitChunkLong`; fixed `foreach()` in `BitChunk`; fixed `bitwise()` and `negate()` in `BitChunkByte` |

---

## Lessons Learned

1. **Property-based testing is powerful but not exhaustive** - The bug existed for years without being caught because the random sequence didn't generate the right inputs
2. **Scala minor version updates can change test behavior** - Even "binary compatible" updates can change hash codes, affecting deterministic PRNGs
3. **Always test with sliced/offset collections** - Edge cases involving `drop()`, `take()`, and `slice()` should be explicitly tested, not left to random generation
4. **The `apply(n)` contract must be 0-based** - Any `Seq`-like collection must treat index `0` as the first logical element, regardless of internal representation

---

## References

- [Scala 2.13.17 Release Notes](https://github.com/scala/scala/releases/tag/v2.13.17)
- [PR #11023: Mix productPrefix hash statically](https://github.com/scala/scala/pull/11023)
- [Case class hashing issue discussion](https://github.com/scala/bug/issues/10495)
- [ZIO Test Property-Based Testing](https://zio.dev/reference/test/property-testing/)
