### PR TITLE
[Bug] `BitChunk[Byte|Int|Long].apply(n)` treats `n` as a raw bit index into the underlying array, ignoring `minBitIndex`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkApplyBugSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkApplyBugSpec.scala
@@ -1,0 +1,77 @@
+package zio
+
+import zio.test._
+
+/**
+ * Tests exposing the bug in BitChunk.apply() where minBitIndex was not
+ * accounted for.
+ *
+ * The bug: BitChunk.apply(n) used 'n' directly instead of (n + minBitIndex).
+ * After drop(), minBitIndex > 0, so apply(0) returned the wrong bit.
+ *
+ * These tests FAIL with buggy code and PASS with the fix.
+ */
+object BitChunkApplyBugSpec extends ZIOBaseSpec {
+
+  def spec = suite("BitChunkApplyBugSpec")(
+    suite("BitChunkByte")(
+      test("apply(0) after drop(1)") {
+        // 0x80 = "10000000" - only the first bit is 1
+        // After drop(1), apply(0) should return bit 1 (which is 0), not bit 0 (which is 1)
+        val dropped = Chunk(0x80.toByte).asBitsByte.drop(1)
+
+        assertTrue(dropped(0) == false)
+      },
+      test("apply returns correct bits after drop(3)") {
+        // 0xF0 = "11110000"
+        // After drop(3), we should get bits 3-7: "10000" = true,false,false,false,false
+        val dropped = Chunk(0xf0.toByte).asBitsByte.drop(3)
+        val bits    = (0 until 5).map(dropped(_)).toList
+
+        assertTrue(bits == List(true, false, false, false, false))
+      },
+      test("toPackedByte after drop") {
+        // 0xFF, 0x00 = "11111111 00000000"
+        // After drop(4).take(8), we get bits 4-11: "11110000"
+        // Packed as byte: 0xF0 = -16
+        val packed = Chunk(0xff.toByte, 0x00.toByte).asBitsByte.drop(4).take(8).toPackedByte
+
+        assertTrue(packed(0) == 0xf0.toByte)
+      }
+    ),
+    suite("BitChunkInt")(
+      test("apply(0) after drop(1)") {
+        // 0x80000000 = MSB is 1, rest is 0
+        // After drop(1), apply(0) should return bit 1 (which is 0), not bit 0 (which is 1)
+        val dropped = Chunk(0x80000000).asBitsInt(Chunk.BitChunk.Endianness.BigEndian).drop(1)
+
+        assertTrue(dropped(0) == false)
+      },
+      test("apply returns correct bits after drop(4)") {
+        // 0xF0000000 = "11110000 00000000 00000000 00000000"
+        // After drop(4).take(4), we get bits 4-7: "0000" = all false
+        val dropped = Chunk(0xf0000000).asBitsInt(Chunk.BitChunk.Endianness.BigEndian).drop(4).take(4)
+        val bits    = (0 until 4).map(dropped(_)).toList
+
+        assertTrue(bits == List(false, false, false, false))
+      }
+    ),
+    suite("BitChunkLong")(
+      test("apply(0) after drop(1)") {
+        // 0x8000000000000000L = MSB is 1, rest is 0
+        // After drop(1), apply(0) should return bit 1 (which is 0), not bit 0 (which is 1)
+        val dropped = Chunk(0x8000000000000000L).asBitsLong(Chunk.BitChunk.Endianness.BigEndian).drop(1)
+
+        assertTrue(dropped(0) == false)
+      },
+      test("apply returns correct bits after drop(8)") {
+        // 0xFF00000000000000L = first 8 bits are 1, rest is 0
+        // After drop(8).take(8), we get bits 8-15: all 0s
+        val dropped = Chunk(0xff00000000000000L).asBitsLong(Chunk.BitChunk.Endianness.BigEndian).drop(8).take(8)
+        val bits    = (0 until 8).map(dropped(_)).toList
+
+        assertTrue(bits == List.fill(8)(false))
+      }
+    )
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
@@ -49,6 +49,41 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
         assert(actual)(equalTo(expected))
       }
     },
+    test("pack byte - BitChunkByte after drop") {
+      // 0xFF, 0x00 = "11111111 00000000"
+      // After drop(4).take(8), bits 4-11 = "11110000", packed = 0xF0
+      val actual = Chunk(0xff.toByte, 0x00.toByte).asBitsByte.drop(4).take(8).toPackedByte.map(toBinaryString).mkString
+
+      assert(actual)(equalTo("11110000"))
+    },
+    test("pack byte - BitChunkInt after drop") {
+      // 0xF0000000 = "11110000 00000000 00000000 00000000"
+      // After drop(4).take(8), bits 4-11 = "00000000"
+      val actual =
+        Chunk(0xf0000000)
+          .asBitsInt(Chunk.BitChunk.Endianness.BigEndian)
+          .drop(4)
+          .take(8)
+          .toPackedByte
+          .map(toBinaryString)
+          .mkString
+
+      assert(actual)(equalTo("00000000"))
+    },
+    test("pack byte - BitChunkLong after drop") {
+      // 0xFF00000000000000L = "11111111 00000000 ..."
+      // After drop(8).take(8), bits 8-15 = "00000000"
+      val actual =
+        Chunk(0xff00000000000000L)
+          .asBitsLong(Chunk.BitChunk.Endianness.BigEndian)
+          .drop(8)
+          .take(8)
+          .toPackedByte
+          .map(toBinaryString)
+          .mkString
+
+      assert(actual)(equalTo("00000000"))
+    },
     test("pack int") {
       check(genBoolChunk, genEndianness, genInt, genInt) { (bls, endianness, drop, take) =>
         val bools    = bls.drop(drop).take(take)

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1989,24 +1989,36 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       newBitChunk(chunk.take(toTake), minBitIndex, index)
     }
 
+    // Iterates over bits in 3 phases:
+    // 1. Prefix bits: individual bits before the first full element
+    // 2. Full elements: process entire bytes/ints/longs efficiently via foreachElement
+    // 3. Suffix bits: individual bits after the last full element
     override def foreach[A](f: Boolean => A): Unit = {
-      val minLongIndex    = (minBitIndex + bits - 1) >> bitsLog2
-      val maxLongIndex    = maxBitIndex >> bitsLog2
-      val minFullBitIndex = (minLongIndex << bitsLog2) min maxBitIndex
-      val maxFullBitIndex = (maxLongIndex << bitsLog2) max minFullBitIndex
-      var i               = minBitIndex
-      while (i < minFullBitIndex) {
-        f(self.apply(i - minBitIndex))
+      val minElementIndex = (minBitIndex + bits - 1) >> bitsLog2 // first full element index
+      val maxElementIndex = maxBitIndex >> bitsLog2              // last full element index (exclusive)
+      val minFullBitIndex = (minElementIndex << bitsLog2) min maxBitIndex
+      val maxFullBitIndex = (maxElementIndex << bitsLog2) max minFullBitIndex
+      val prefixBits      = minFullBitIndex - minBitIndex        // count of leading bits before first full element
+      val suffixBitsStart = maxFullBitIndex - minBitIndex        // 0-based index where trailing bits start
+
+      // Phase 1: prefix bits (before first full element)
+      var i = 0
+      while (i < prefixBits) {
+        f(self.apply(i))
         i += 1
       }
-      i = minLongIndex
-      while (i < maxLongIndex) {
+
+      // Phase 2: full elements (processed efficiently without bit extraction)
+      i = minElementIndex
+      while (i < maxElementIndex) {
         foreachElement(f, elementAt(i))
         i += 1
       }
-      i = maxFullBitIndex
-      while (i < maxBitIndex) {
-        f(self.apply(i - minBitIndex))
+
+      // Phase 3: suffix bits (after last full element)
+      i = suffixBitsStart
+      while (i < length) {
+        f(self.apply(i))
         i += 1
       }
     }

--- a/core/shared/src/main/scala/zio/Chunk.scala
+++ b/core/shared/src/main/scala/zio/Chunk.scala
@@ -1996,7 +1996,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       val maxFullBitIndex = (maxLongIndex << bitsLog2) max minFullBitIndex
       var i               = minBitIndex
       while (i < minFullBitIndex) {
-        f(self.apply(i))
+        f(self.apply(i - minBitIndex))
         i += 1
       }
       i = minLongIndex
@@ -2006,7 +2006,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       }
       i = maxFullBitIndex
       while (i < maxBitIndex) {
-        f(self.apply(i))
+        f(self.apply(i - minBitIndex))
         i += 1
       }
     }
@@ -2067,8 +2067,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override val length: Int =
       maxBitIndex - minBitIndex
 
-    override def apply(n: Int): Boolean =
-      (bytes(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
+    override def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (bytes(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def elementAt(n: Int): Byte = bytes(n)
 
@@ -2134,7 +2136,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
         var mask       = 128
         var i          = 0
         while (i < leftovers) {
-          if (g(self.apply(offset + self.minBitIndex + i), that.apply(offset + that.minBitIndex + i)))
+          if (g(self.apply(offset + i), that.apply(offset + i)))
             last = (last | mask).asInstanceOf[Byte]
           i += 1
           mask >>= 1
@@ -2177,7 +2179,7 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
       }
 
       if (leftovers != 0) {
-        val offset     = bytes * 8 + self.minBitIndex
+        val offset     = bytes * 8
         var last: Byte = null.asInstanceOf[Byte]
         var mask       = 128
         var i          = 0
@@ -2208,8 +2210,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override protected def elementAt(n: Int): Int =
       respectEndian(endianness, ints(n))
 
-    override def apply(n: Int): Boolean =
-      (elementAt(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
+    override def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (elementAt(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def newBitChunk(chunk: Chunk[Int], min: Int, max: Int): BitChunk[Int] =
       BitChunkInt(chunk, endianness, min, max)
@@ -2282,8 +2286,10 @@ object Chunk extends ChunkFactory with ChunkPlatformSpecific {
     override protected def elementAt(n: Int): Long =
       if (endianness == BitChunk.Endianness.BigEndian) longs(n) else java.lang.Long.reverse(longs(n))
 
-    def apply(n: Int): Boolean =
-      (elementAt(n >> bitsLog2) & (1L << (bits - 1 - (n & bits - 1)))) != 0
+    def apply(n: Int): Boolean = {
+      val bitIndex = n + minBitIndex
+      (elementAt(bitIndex >> bitsLog2) & (1L << (bits - 1 - (bitIndex & bits - 1)))) != 0
+    }
 
     override protected def newBitChunk(longs: Chunk[Long], min: Int, max: Int): BitChunk[Long] =
       BitChunkLong(longs, endianness, min, max)


### PR DESCRIPTION
Bug discovered thanks to CI failing in this PR: https://github.com/zio/zio/pull/10254

# Analysis of the bug (AI generated)

## Summary

Fix a latent bug in `BitChunk.apply()` where `minBitIndex` was not accounted for when accessing bits in sliced/dropped BitChunks. The bug has existed since April 2020 but was only discovered when updating to Scala 2.13.18, which changed case class `hashCode` computation and altered the random sequence in property-based tests.

## The Bug

`BitChunkByte`, `BitChunkInt`, and `BitChunkLong.apply(n)` treated `n` as a raw bit index into the underlying array, ignoring `minBitIndex`. After `drop()` or `slice()`, this caused incorrect bit access:

```scala
val bytes = Chunk(0x80.toByte)       // "10000000"
val bits = bytes.asBitsByte.drop(1)  // Should be "0000000"
bits(0)  // BUG: returned true (bit 0), should return false (bit 1)
```

### Before (buggy)
```scala
override def apply(n: Int): Boolean =
  (bytes(n >> bitsLog2) & (1 << (bits - 1 - (n & bits - 1)))) != 0
```

### After (fixed)
```scala
override def apply(n: Int): Boolean = {
  val bitIndex = n + minBitIndex
  (bytes(bitIndex >> bitsLog2) & (1 << (bits - 1 - (bitIndex & bits - 1)))) != 0
}
```

## Why Scala 2.13.18 Exposed This

The bug was **not introduced** by Scala—it was exposed by it. Scala 2.13.17 changed case class `hashCode` computation ([PR #11023](https://github.com/scala/scala/pull/11023)), which altered the random sequence in property-based tests. The new sequence generated a test case (`drop(2).take(11)` on a BitChunkByte) that triggered the bug.

## Impact Assessment

| Factor | Assessment |
|--------|------------|
| **ZIO Internal Impact** | None - BitChunk not used in streams, runtime, or core |
| **User Impact** | Low to Medium - niche feature, specific usage pattern required |
| **Severity** | Medium - produces silently wrong results |
| **Detectability** | Low - wrong results may go unnoticed |

### Methods Affected

| Affected (wrong results) | Unaffected (accidentally worked) |
|--------------------------|----------------------------------|
| `apply(n)`, `chunk(i)` | `foreach`, `iterator` |
| `toArray`, `toList`, `toVector` | `toBinaryString` |
| `toPackedByte` (non-aligned) | `drop/take/slice` (slicing itself) |
| `and/or/xor/negate` (leftover bits) | |

### Who Is Affected

Users who:
1. Create a BitChunk via `asBitsByte`, `asBitsInt`, or `asBitsLong`
2. Call `drop(n)`, `take(n)`, or `slice()` with offset > 0
3. Access elements via direct indexing, `toArray`, or `toPackedByte`

## Changes

### Bug Fixes
- **`BitChunkByte.apply()`** - Add `minBitIndex` to index
- **`BitChunkInt.apply()`** - Add `minBitIndex` to index
- **`BitChunkLong.apply()`** - Add `minBitIndex` to index
- **`BitChunk.foreach()`** - Refactored to use 0-based indices (cleaner, no bug cancellation)

### New Regression Tests
- **`BitChunkApplyBugSpec`** - 7 deterministic tests for `apply()` on all BitChunk types
- **`ChunkPackedBooleanSpec`** - 3 deterministic tests for `toPackedByte` after `drop()`

All tests use hardcoded expected values to avoid the "two bugs cancel out" problem.

## Timeline

| Date | Event |
|------|-------|
| April 2020 | Bug introduced in `BitChunkByte` |
| May 2022 | Bug propagated to `BitChunkInt/Long` |
| November 2025 | Bug discovered via Scala 2.13.17+ `hashCode` change |

## Test Plan

- [x] All 46 BitChunk-related tests pass
- [x] New regression tests fail without fix, pass with fix
- [x] `BitChunkByteSpec`, `BitChunkIntSpec`, `BitChunkLongSpec` pass
- [x] `ChunkPackedBooleanSpec` passes

