### PR TITLE
Fix race condition involving race and interruption

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2522,6 +2522,13 @@ object ZIOSpec extends ZIOBaseSpec {
           } yield assert(exit)(not(isInterrupted))
         }
       } @@ TestAspect.withLiveClock,
+      test("timeout with interrupt doesn't cause deadlock (i10255)") {
+        ZIO.never
+          .timeout(1.second)
+          .forkDaemon
+          .flatMap(_.interrupt)
+          .as(assertCompletes)
+      } @@ TestAspect.withLiveClock @@ nonFlaky(10000),
       test("catchAllCause") {
         val io =
           for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1466,6 +1466,9 @@ sealed trait ZIO[-R, +E, +A]
       val leftFiber  = ZIO.unsafe.makeChildFiber(trace, leftEff, parentFiber, flags, leftScope)(Unsafe)
       val rightFiber = ZIO.unsafe.makeChildFiber(trace, rightEff, parentFiber, flags, rightScope)(Unsafe)
 
+      val startLeft  = leftFiber.startSuspended()(Unsafe)
+      val startRight = rightFiber.startSuspended()(Unsafe)
+
       ZIO.async[R1, E2, C](
         { cb =>
           val raceIndicator = new AtomicBoolean()
@@ -1478,8 +1481,8 @@ sealed trait ZIO[-R, +E, +A]
             complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
           }(Unsafe)
 
-          leftFiber.startConcurrently(leftEff)
-          rightFiber.startConcurrently(rightEff)
+          startLeft(leftEff)
+          startRight(rightEff)
           ()
         },
         leftFiber.id <> rightFiber.id


### PR DESCRIPTION
/fixes #10255

There seems to be a race condition that if an interruption occurs right at the point where we call `ZIO.async` within `raceFibersWith` that causes the effect to hang as shown in the reproducer because `_asyncContWith` in the `FiberRuntime` hasn't been defined yet.