### PR TITLE
Optimize Stream, Channel, and Gen creation and performance

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1713,7 +1713,7 @@ object ZChannel {
   )(release: (Acquired, Exit[OutErr, OutDone]) => URIO[Env, Any])(
     use: Acquired => ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone]
   )(implicit trace: Trace): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem2, OutDone] =
-    fromZIO(Ref.make[Exit[OutErr, OutDone] => URIO[Env, Any]](_ => ZIO.unit)).flatMap { ref =>
+    fromZIO(Ref.make[Exit[OutErr, OutDone] => URIO[Env, Any]](ZIO.unitZIOFn)).flatMap { ref =>
       fromZIO(acquire.tap(a => ref.set(release(a, _))).uninterruptible)
         .flatMap(use)
         .ensuringWith(ex => ref.get.flatMap(_.apply(ex)))
@@ -1920,7 +1920,7 @@ object ZChannel {
     new ScopedPartiallyApplied[R]
 
   def scopedWith[R, E, A](f: Scope => ZIO[R, E, A])(implicit trace: Trace): ZChannel[R, Any, Any, Any, E, A, Any] =
-    ZChannel.unwrapScoped(ZIO.scope.map(scope => ZChannel.fromZIO(f(scope)).flatMap(ZChannel.write)))
+    ZChannel.unwrapScoped(ZIO.scopeWith(scope => Exit.succeed(ZChannel.fromZIO(f(scope)).flatMap(ZChannel.write))))
 
   def mergeAll[Env, InErr, InElem, InDone, OutErr, OutElem](
     channels: => ZChannel[
@@ -2374,7 +2374,7 @@ object ZChannel {
       tag: Tag[Service],
       trace: Trace
     ): ZChannel[Service, Any, Any, Any, Nothing, Nothing, OutDone] =
-      ZChannel.service[Service].map(f)
+      ZChannel.fromZIO(ZIO.serviceWith[Service](f))
   }
 
   final class ServiceWithChannelPartiallyApplied[Service](private val dummy: Boolean = true) extends AnyVal {
@@ -2392,7 +2392,7 @@ object ZChannel {
       tag: Tag[Service],
       trace: Trace
     ): ZChannel[Env, Any, Any, Any, OutErr, Nothing, OutDone] =
-      ZChannel.service[Service].mapZIO(f)
+      ZChannel.fromZIO(ZIO.serviceWithZIO[Service](f))
   }
 
   final class UnwrapScopedPartiallyApplied[Env](private val dummy: Boolean = true) extends AnyVal {
@@ -2427,4 +2427,6 @@ object ZChannel {
     ): ZChannel[Env1, InErr, InElem, InDone, OutErr, OutElem, OutDone] =
       self.provideSomeEnvironment(_.updateAt(key)(f))
   }
+
+  private[stream] val unitChannelFn: Any => ZChannel[Any, Any, Any, Any, Nothing, Nothing, Unit] = (_: Any) => unit
 }

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -805,7 +805,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           ZChannel.write(newChunk) *> writer(newLast)
         },
         (cause: Cause[Err]) => ZChannel.refailCause(cause),
-        (_: Any) => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZPipeline(writer(None))
@@ -828,7 +828,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
             ZChannel.write(newChunk) *> writer(newLast)
           },
         (cause: Cause[Err]) => ZChannel.refailCause(cause),
-        (_: Any) => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZPipeline(writer(None))
@@ -937,7 +937,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
                 ZChannel.write(outs) *> reader
               },
               ZChannel.refailCause,
-              (_: Any) => ZChannel.unit
+              ZChannel.unitChannelFn
             )
 
           reader
@@ -1082,7 +1082,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
               else ZChannel.write(dropped) *> ZChannel.identity
             },
             (e: Cause[ZNothing]) => ZChannel.refailCause(e),
-            (_: Any) => ZChannel.unit
+            ZChannel.unitChannelFn
           )
 
       new ZPipeline(loop(n))
@@ -1147,7 +1147,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
           if (more) loop else ZChannel.write(leftover) *> ZChannel.identity[Err, Chunk[In], Any]
         }),
       (e: Cause[Err]) => ZChannel.refailCause(e),
-      (_: Any) => ZChannel.unit
+      ZChannel.unitChannelFn
     )
 
     new ZPipeline(loop)
@@ -1700,7 +1700,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
               ZChannel.write(builder.result()) *> writer(flagResult)
             },
             err => ZChannel.refailCause(err),
-            _ => ZChannel.unit
+            ZChannel.unitChannelFn
           )
 
         writer(true)
@@ -1768,7 +1768,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
               }
             ),
           ZChannel.refailCause,
-          (_: Any) => ZChannel.unit
+          ZChannel.unitChannelFn
         )
 
       new ZPipeline(accumulator(s))
@@ -2403,7 +2403,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
                   loop(tokens, timestamp)
               }),
             (e: Cause[Err]) => ZChannel.refailCause(e),
-            (_: Any) => ZChannel.unit
+            ZChannel.unitChannelFn
           )
 
         ZChannel.unwrap(Clock.nanoTime.map(loop(units, _)))
@@ -2464,7 +2464,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
               else ZChannel.write(in) *> loop(remaining, current)
             }),
           (e: Cause[Err]) => ZChannel.refailCause(e),
-          (_: Any) => ZChannel.unit
+          ZChannel.unitChannelFn
         )
 
       ZChannel.unwrap(Clock.nanoTime.map(loop(units, _)))

--- a/streams/shared/src/main/scala/zio/stream/ZSink.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZSink.scala
@@ -926,7 +926,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
             ch
         },
         ZChannel.refailCause,
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     ch.toSink
@@ -953,7 +953,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
           }
         },
         ZChannel.refailCause,
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     ch.toSink
@@ -1399,7 +1399,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
       ZChannel.readWithCause(
         in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(f(_))) *> process,
         halt => ZChannel.refailCause(halt),
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZSink(process)
@@ -1416,7 +1416,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
       ZChannel.readWithCause(
         in => ZChannel.fromZIO(f(in)) *> process,
         halt => ZChannel.refailCause(halt),
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZSink(process)
@@ -1447,7 +1447,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
       ZChannel.readWithCause(
         in => go(in, 0, in.length, process),
         halt => ZChannel.refailCause(halt),
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZSink(process)
@@ -1468,7 +1468,7 @@ object ZSink extends ZSinkPlatformSpecificConstructors {
             else ZChannel.unit
           },
         (err: Cause[Err]) => ZChannel.refailCause(err),
-        (_: Any) => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZSink(reader)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -1046,7 +1046,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     decide: A => UIO[Int => Boolean]
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, List[Dequeue[Exit[Option[E1], A]]]] =
     Promise.make[Nothing, A => UIO[UniqueKey => Boolean]].flatMap { prom =>
-      distributedWithDynamic(maximumLag, (a: A) => prom.await.flatMap(_(a)), _ => ZIO.unit).flatMap { next =>
+      distributedWithDynamic(maximumLag, (a: A) => prom.await.flatMap(_(a)), ZIO.unitZIOFn).flatMap { next =>
         ZIO.collectAll {
           Range(0, n).map(id => next.map { case (key, queue) => ((key -> id), queue) })
         }.flatMap { entries =>
@@ -1071,7 +1071,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def distributedWithDynamic(
     maximumLag: => Int,
     decide: A => UIO[UniqueKey => Boolean],
-    done: Exit[Option[E], Nothing] => UIO[Any] = (_: Any) => ZIO.unit
+    done: Exit[Option[E], Nothing] => UIO[Any] = ZIO.unitZIOFn
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, UIO[(UniqueKey, Dequeue[Exit[Option[E], A]])]] =
     for {
       queuesRef <- ZIO.acquireReleaseExit(Ref.make[Map[UniqueKey, Queue[Exit[Option[E], A]]]](Map()))((map, exit) =>
@@ -1250,7 +1250,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       ZChannel.readWithCause(
         (in: Chunk[A]) => in.find(f).fold(loop)(i => ZChannel.write(Chunk.single(i))),
         (e: Cause[E]) => ZChannel.refailCause(e),
-        (_: Any) => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZStream(self.channel >>> loop)
@@ -1267,7 +1267,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       ZChannel.readWithCause(
         (in: Chunk[A]) => ZChannel.unwrap(in.findZIO(f).map(_.fold(loop)(i => ZChannel.write(Chunk.single(i))))),
         (e: Cause[E]) => ZChannel.refailCause(e),
-        (_: Any) => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZStream(self.channel >>> loop)
@@ -1382,7 +1382,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       ZChannel.readWithCause(
         chunks => ZChannel.writeChunk(chunks) *> flatten,
         cause => ZChannel.refailCause(cause),
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZStream(self.asInstanceOf[ZStream[R, E, Chunk[A1]]].channel >>> flatten)
@@ -1429,7 +1429,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       ZChannel.readWithCause[R, E, Chunk[Exit[Option[E1], A1]], Any, E1, Chunk[A1], Any](
         chunk => processChunk(chunk, process),
         cause => ZChannel.refailCause(cause),
-        _ => ZChannel.unit
+        ZChannel.unitChannelFn
       )
 
     new ZStream(channel.asInstanceOf[ZChannel[R, Any, Any, Any, E, Chunk[Exit[Option[E1], A1]], Any]] >>> process)
@@ -1625,11 +1625,11 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             ZChannel.readWith[R1, E1, Chunk[A], Any, E1, Chunk[A], Unit](
               in => ZChannel.write(in) *> writer(fiber),
               err => ZChannel.fail(err),
-              _ => ZChannel.unit
+              ZChannel.unitChannelFn
             )
 
           case Some(exit) =>
-            exit.foldExit(ZChannel.refailCause, _ => ZChannel.unit)
+            exit.foldExit(ZChannel.refailCause, ZChannel.unitChannelFn)
         }
       }
 
@@ -1665,11 +1665,11 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             ZChannel.readWith[R, E1, Chunk[A], Any, E1, Chunk[A], Unit](
               in => ZChannel.write(in) *> writer,
               err => ZChannel.fail(err),
-              _ => ZChannel.unit
+              ZChannel.unitChannelFn
             )
 
           case Some(io) =>
-            ZChannel.unwrap(io.fold(ZChannel.fail(_), _ => ZChannel.unit))
+            ZChannel.unwrap(io.fold(ZChannel.fail(_), ZChannel.unitChannelFn))
         }
       }
 
@@ -1737,7 +1737,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                     process(leftDone, rightDone)
                 },
               cause => ZChannel.refailCause(cause),
-              _ => ZChannel.unit
+              ZChannel.unitChannelFn
             )
 
           b.channel.concatMap(ZChannel.writeChunk(_)) >>> process(false, false)
@@ -1825,7 +1825,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             ZChannel.write(a1s) *> accumulator(nextS)
           },
           (err: Cause[E]) => ZChannel.refailCause(err),
-          (_: Any) => ZChannel.unit
+          ZChannel.unitChannelFn
         )
 
       new ZStream(self.channel >>> accumulator(s))
@@ -2641,7 +2641,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
           ZChannel.readWithCause(
             feed,
             ZChannel.refailCause,
-            (_: Any) => ZChannel.unit
+            ZChannel.unitChannelFn
           )
 
         loop
@@ -2669,7 +2669,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             driver
               .next(())
               .fold(
-                _ => ZChannel.unit,
+                ZChannel.unitChannelFn,
                 _ => process *> ZChannel.unwrap(scheduleOutput.map(o => ZChannel.write(Chunk.single(o)))) *> loop
               )
           )
@@ -3326,7 +3326,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   def tapError[R1 <: R, E1 >: E](
     f: E => ZIO[R1, E1, Any]
   )(implicit ev: CanFail[E], trace: Trace): ZStream[R1, E1, A] =
-    tapErrorCause(_.failureOrCause.fold(f, _ => ZIO.unit))
+    tapErrorCause(_.failureOrCause.fold(f, ZIO.unitZIOFn))
 
   /**
    * Returns a stream that effectfully "peeks" at the cause of failure of the
@@ -3374,8 +3374,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             ZChannel
               .fromZIO(queue.offer(Take.end))
               .foldCauseChannel(
-                _ => ZChannel.unit,
-                _ => ZChannel.unit
+                ZChannel.unitChannelFn,
+                ZChannel.unitChannelFn
               )
         )
       new ZStream(
@@ -4082,7 +4082,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         }
       },
       (cause: Cause[E]) => ZChannel.refailCause(cause),
-      (_: Any) => ZChannel.unit
+      ZChannel.unitChannelFn
     )
 
     xs.pipeThroughChannel(loop)
@@ -4163,7 +4163,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * The empty stream
    */
   def empty(implicit trace: Trace): ZStream[Any, Nothing, Nothing] =
-    new ZStream(ZChannel.unit)
+    emptyStream
 
   /**
    * Accesses the whole environment of the stream.
@@ -4212,7 +4212,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * when it ends.
    */
   def finalizer[R](finalizer: => URIO[R, Any])(implicit trace: Trace): ZStream[R, Nothing, Any] =
-    acquireReleaseWith[R, Nothing, Unit](ZIO.unit)(_ => finalizer)
+    scoped[R](ZIO.addFinalizer(finalizer))
 
   def from[Input](
     input: => Input
@@ -4710,7 +4710,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an effect producing a value of type `A`
    */
   def fromZIO[R, E, A](fa: => ZIO[R, E, A])(implicit trace: Trace): ZStream[R, E, A] =
-    fromZIOOption(fa.mapError(Some(_)))
+    new ZStream(
+      ZChannel.unwrap(
+        fa.fold(
+          e => ZChannel.fail(e),
+          a => ZChannel.write(Chunk.single(a))
+        )
+      )
+    )
 
   /**
    * Creates a stream from an effect producing a value of type `A` or an empty
@@ -4722,7 +4729,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         fa.fold(
           {
             case Some(e) => ZChannel.fail(e)
-            case None    => ZChannel.unit
+            case _       => ZChannel.unit
           },
           a => ZChannel.write(Chunk.single(a))
         )
@@ -5178,16 +5185,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * returns an empty stream.
    */
   def when[R, E, O](b: => Boolean)(zStream: => ZStream[R, E, O])(implicit trace: Trace): ZStream[R, E, O] =
-    whenZIO(ZIO.succeed(b))(zStream)
+    suspend(if (b) zStream else ZStream.empty)
 
   /**
    * Returns the resulting stream when the given `PartialFunction` is defined
    * for the given value, otherwise returns an empty stream.
    */
-  def whenCase[R, E, A, O](a: => A)(pf: PartialFunction[A, ZStream[R, E, O]])(implicit
-    trace: Trace
-  ): ZStream[R, E, O] =
-    whenCaseZIO(ZIO.succeed(a))(pf)
+  def whenCase[R, E, A, O](a: => A)(pf: PartialFunction[A, ZStream[R, E, O]])(implicit trace: Trace): ZStream[R, E, O] =
+    whenCaseZIO(Exit.succeed(a))(pf)
 
   /**
    * Returns the resulting stream when the given `PartialFunction` is defined
@@ -5205,14 +5210,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
 
   final class EnvironmentWithPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: ZEnvironment[R] => A)(implicit trace: Trace): ZStream[R, Nothing, A] =
-      ZStream.environment[R].map(f)
+      ZStream.fromZIO(ZIO.environmentWith[R](f))
   }
 
   final class EnvironmentWithZIOPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
     def apply[R1 <: R, E, A](f: ZEnvironment[R] => ZIO[R1, E, A])(implicit
       trace: Trace
     ): ZStream[R with R1, E, A] =
-      ZStream.environment[R].mapZIO(f)
+      ZStream.fromZIO(ZIO.environmentWithZIO[R](f))
   }
 
   final class EnvironmentWithStreamPartiallyApplied[R](private val dummy: Boolean = true) extends AnyVal {
@@ -5731,7 +5736,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def apply[R1 <: R, E1 >: E, O](pf: PartialFunction[A, ZStream[R1, E1, O]])(implicit
       trace: Trace
     ): ZStream[R1, E1, O] =
-      fromZIO(a()).flatMap(pf.applyOrElse(_, (_: A) => ZStream.empty))
+      fromZIO(a()).flatMap(pf.applyOrElse(_, ZStream.emptyStreamFn))
   }
 
   sealed trait HaltStrategy
@@ -6227,4 +6232,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       (cl.take(cr.size).zipWith(cr)(f), Left(cl.drop(cr.size)))
     else
       (cl.zipWith(cr.take(cl.size))(f), Right(cr.drop(cl.size)))
+
+  private val emptyStream: ZStream[Any, Nothing, Nothing]          = new ZStream(ZChannel.unit)
+  private val emptyStreamFn: Any => ZStream[Any, Nothing, Nothing] = (_: Any) => emptyStream
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -4,27 +4,28 @@ import zio.Exit.{Failure, Success}
 import zio.stream.ZStream
 import zio.test.Assertion.{equalTo, forall}
 import zio.{Exit, UIO, URIO, ZIO}
+import zio.internal.stacktracer.SourceLocation
 
 object GenUtils {
 
   private val shrinkSize = if (TestPlatform.isJVM) 100 else 1
   private val size       = if (TestPlatform.isJVM) 100 else 10
 
-  def alwaysShrinksTo[R, A](gen: Gen[R, A])(a: A): URIO[R, TestResult] =
-    ZIO.collectAll(List.fill(shrinkSize)(shrinksTo(gen))).map(assert(_)(forall(equalTo(a))))
+  def alwaysShrinksTo[R, A](gen: Gen[R, A])(a: A)(implicit trace: SourceLocation): URIO[R, TestResult] =
+    ZIO.collectAll(Vector.fill(shrinkSize)(shrinksTo(gen))).map(assert(_)(forall(equalTo(a))))
 
   def checkFinite[A, B](
     gen: Gen[Any, A]
-  )(assertion: Assertion[B], f: List[A] => B = (a: List[A]) => a): UIO[TestResult] =
+  )(assertion: Assertion[B], f: List[A] => B = (a: List[A]) => a)(implicit trace: SourceLocation): UIO[TestResult] =
     assertZIO(gen.sample.map(_.value).runCollect.map(xs => f(xs.toList)))(assertion)
 
   def checkSample[A, B](
     gen: Gen[Any, A],
     size: Int = size
-  )(assertion: Assertion[B], f: List[A] => B = (a: List[A]) => a): UIO[TestResult] =
+  )(assertion: Assertion[B], f: List[A] => B = (a: List[A]) => a)(implicit trace: SourceLocation): UIO[TestResult] =
     assertZIO(provideSize(sample100(gen).map(f))(size))(assertion)
 
-  def checkShrink[A](gen: Gen[Any, A])(a: A): UIO[TestResult] =
+  def checkShrink[A](gen: Gen[Any, A])(a: A)(implicit trace: SourceLocation): UIO[TestResult] =
     provideSize(alwaysShrinksTo(gen)(a: A))(size)
 
   val deterministic: Gen[Any, Gen[Any, Int]] =

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -426,7 +426,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     if (as.isEmpty) empty else int(0, as.length - 1).map(as)
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
-    Gen(ZStream.empty)
+    emptyGen
 
   /**
    * A generator of exponentially distributed doubles with mean `1`. The
@@ -804,7 +804,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * when creating generators that refer to themselves.
    */
   def suspend[R, A](gen: => Gen[R, A])(implicit trace: Trace): Gen[R, A] =
-    fromZIO(ZIO.succeed(gen)).flatten
+    Gen(ZStream.suspend(gen.sample))
 
   /**
    * A generator of throwables.
@@ -854,7 +854,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A constant generator of the unit value.
    */
   def unit(implicit trace: Trace): Gen[Any, Unit] =
-    const(())
+    unitGen
 
   /**
    * A generator of universally unique identifiers. The returned generator will
@@ -922,4 +922,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
 
   private val defaultShrinker: Any => ZStream[Any, Nothing, Nothing] =
     _ => ZStream.empty(Trace.empty)
+
+  private val emptyGen: Gen[Any, Nothing] = Gen(ZStream.empty(Trace.empty))
+  private val unitGen: Gen[Any, Unit]     = const(())(Trace.empty)
 }


### PR DESCRIPTION
Performance optimizations:
- Replace lambda functions with cached function instances
  - Add new lambda and begin using: ZChannel.unitChannelFn
  - Add new lambda and begin using: ZStream.emptyStreamFn
  - Begin using ZIO.unitZIOFn in ZStream
- Add private singleton values for commonly used empty/unit generators and streams
- Replace ZStream.fromZIO with fromZIOOption where effects cannot fail. This avoids binding an error handler to the effect.
- ZStream: modify various methods to use `ZIO.*with` methods that accept a continuation function.
- Implement ZStream.when directly, instead of using `fromZIO`
- Implement Gen.suspend with ZStream.suspend, instead of using fromZIO
- Update ZStream.finalizer to use scoped addFinalizer instead of acquireReleaseWith