### PR TITLE
Ensure outgoing queue is shutdown in ZChannel.mapOutZIOPar

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2996,7 +2996,26 @@ object ZStreamSpec extends ZIOBaseSpec {
                   containsCause[DbError](Cause.fail(QtyTooLarge))
               )
             )
-          } @@ flaky
+          } @@ flaky,
+          test("does not freeze when output is only partially consumed (#10195)") {
+            val stream = ZStream.range(0, 100).mapZIOPar(8)(_ => ZIO.unit)
+            assertZIO(stream.take(1).runDrain.exit)(succeeds(anything))
+          } @@ TestAspect.timeout(2.seconds) @@ TestAspect.nonFlaky,
+          test("does not freeze on failure with mapZIOPar (#10088)") {
+            val stream =
+              ZStream
+                .range(0, 10000)
+                .mapZIOPar(8, bufferSize = 32)(i => ZIO.succeed(i))
+                .mapZIOPar(8, bufferSize = 32) { i =>
+                  Live.live(
+                    ZIO
+                      .fail(new RuntimeException(i.toString))
+                      .delay(10.millis)
+                  )
+                }
+
+            assertZIO(stream.runDrain.exit)(fails(anything))
+          } @@ TestAspect.timeout(2.seconds) @@ TestAspect.nonFlaky
         ),
         suite("mapZIOParUnordered")(
           test("foreachParN equivalence") {
@@ -3119,7 +3138,26 @@ object ZStreamSpec extends ZIOBaseSpec {
                 res <- f.join
               } yield assert(res)(equalTo(data.reverse))
             }
-          }
+          },
+          test("does not freeze when output is only partially consumed (#10195)") {
+            val stream = ZStream.range(0, 100).mapZIOParUnordered(8)(_ => ZIO.unit)
+            assertZIO(stream.take(1).runDrain.exit)(succeeds(anything))
+          } @@ TestAspect.timeout(2.seconds) @@ TestAspect.nonFlaky,
+          test("does not freeze on failure with mapZIOPar (#10088)") {
+            val stream =
+              ZStream
+                .range(0, 10000)
+                .mapZIOParUnordered(8, bufferSize = 32)(i => ZIO.succeed(i))
+                .mapZIOParUnordered(8, bufferSize = 32) { i =>
+                  Live.live(
+                    ZIO
+                      .fail(new RuntimeException(i.toString))
+                      .delay(10.millis)
+                  )
+                }
+
+            assertZIO(stream.runDrain.exit)(fails(anything))
+          } @@ TestAspect.timeout(2.seconds) @@ TestAspect.nonFlaky
         ),
         suite("mergeLeft/Right")(
           test("mergeLeft with HaltStrategy.Right terminates as soon as the right stream terminates") {

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -738,7 +738,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               }
             }
 
-          writer.embedInput(input)
+          writer.embedInput(input).ensuring(outgoing.shutdown)
         }
       }
     }
@@ -827,7 +827,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
             }
           }
 
-        writer.embedInput(input)
+        writer.embedInput(input).ensuring(outgoing.shutdown)
       }
     }
 


### PR DESCRIPTION
Fixes #10195 and #10088

When a stream using mapZIOPar/mapZIOParUnordered is only partially consumed (`take(n < size)`), the stream would hang forever.

The deadlock occurs because the queue shutdown is bound to the Scope, but the channel writer blocks the Scope from closing:

```
  Downstream (take(1))     Channel (Writer)           Scope (Parent)
  ────────────────────     ────────────────           ──────────────
           │                      │                         │
           │                      │                         │ 1. Registers finalizer:
           │                      │                         │    addFinalizer(outgoing.shutdown)
           │                      │                         │
  2. Pulls │ ◄─── (succeeds) ─────┤                         │
     Element                      │                         │
           │                      │                         │
  3. Compl-│ ────── (done) ──────►│                         │
     etes  │                      │                         │
           │                      │                         │
           │               4. Loops to next                 │
           │                  outgoing.take ──────────────┐ │
           │                      │                       │ │
           │                      │ (BLOCKED)             │ │
           │                      │ waiting for elements  │ │
           │                      │ or shutdown           │ │
           │                      │                       │ │
                                  │                       │ │
                                  │                       ▼ │
                           (Cannot terminate)    (Cannot close scope)
                                  │                       │
                                  │                       │
                           (Never runs ensuring) ◄── (Blocked finalizers)
```
Adding `.ensuring(outgoing.shutdown)` directly to the writer channel fixes the deadlock. When downstream completes (step 3), the writer gets interrupted, triggering the ensuring block which shuts down the queue, unblocking everything.