### PR TITLE
ZScheduler: Support `scala.concurrent.blocking`

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
@@ -2,6 +2,10 @@ package zio
 
 import zio.test._
 
+import java.util.concurrent.CountDownLatch
+import scala.concurrent.Await
+import scala.concurrent.duration.SECONDS
+
 object RuntimeSpecJVM extends ZIOBaseSpec {
   def spec =
     suite("RuntimeSpecJVM")(
@@ -17,6 +21,42 @@ object RuntimeSpecJVM extends ZIOBaseSpec {
           _ <- promise.succeed(())
           _ <- f.join
         } yield assertCompletes
-      } @@ TestAspect.timeout(5.seconds) @@ TestAspect.nonFlaky(100)
+      } @@ TestAspect.timeout(5.seconds) @@ TestAspect.nonFlaky(100),
+      test("ZScheduler supports scala.concurrent.blocking and scala.concurrent.Await") {
+        val promise = scala.concurrent.Promise[Unit]()
+        val latch   = new CountDownLatch(50)
+        val effects = List.fill(50)(ZIO.succeed {
+          latch.countDown()
+          // Await uses `blocking` underneath
+          Await.result(promise.future, scala.concurrent.duration.Duration(5, SECONDS))
+        })
+
+        for {
+          f <- ZIO.collectAllPar(effects).forkDaemon
+          _ <- ZIO.attemptBlocking(latch.await())
+          _ <- ZIO.succeed(promise.trySuccess(()))
+          _ <- f.join
+        } yield assertCompletes
+      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky(100),
+      test("ZScheduler supports scala.concurrent.blocking") {
+        val promise = scala.concurrent.Promise[Unit]()
+        val latch   = new CountDownLatch(50)
+        val effects = List.fill(50)(ZIO.succeed {
+          scala.concurrent.blocking {
+            latch.countDown()
+            latch.await()
+            while (!promise.isCompleted) {
+              Thread.sleep(0L, 10)
+            }
+          }
+        })
+
+        for {
+          f <- ZIO.collectAllPar(effects).forkDaemon
+          _ <- ZIO.attemptBlocking(latch.await())
+          _ <- ZIO.succeed(promise.trySuccess(()))
+          _ <- f.join
+        } yield assertCompletes
+      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky(100)
     )
 }

--- a/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
@@ -21,7 +21,7 @@ object RuntimeSpecJVM extends ZIOBaseSpec {
           _ <- promise.succeed(())
           _ <- f.join
         } yield assertCompletes
-      } @@ TestAspect.timeout(5.seconds) @@ TestAspect.nonFlaky(100),
+      } @@ TestAspect.timeout(5.seconds) @@ TestAspect.nonFlaky,
       test("ZScheduler supports scala.concurrent.blocking and scala.concurrent.Await") {
         val promise = scala.concurrent.Promise[Unit]()
         val latch   = new CountDownLatch(50)
@@ -37,7 +37,7 @@ object RuntimeSpecJVM extends ZIOBaseSpec {
           _ <- ZIO.succeed(promise.trySuccess(()))
           _ <- f.join
         } yield assertCompletes
-      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky(100),
+      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky,
       test("ZScheduler supports scala.concurrent.blocking") {
         val promise = scala.concurrent.Promise[Unit]()
         val latch   = new CountDownLatch(50)
@@ -57,6 +57,6 @@ object RuntimeSpecJVM extends ZIOBaseSpec {
           _ <- ZIO.succeed(promise.trySuccess(()))
           _ <- f.join
         } yield assertCompletes
-      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky(100)
+      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky
     )
 }

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
 import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.{ConcurrentLinkedQueue, ThreadLocalRandom}
 import scala.collection.mutable
+import scala.concurrent.{BlockContext, CanAwait}
 
 /**
  * A `ZScheduler` is an `Executor` that is optimized for running ZIO
@@ -533,7 +534,7 @@ private object ZScheduler {
    * A `Worker` is a `Thread` that is responsible for executing actions
    * submitted to the scheduler.
    */
-  private sealed abstract class Worker extends Thread {
+  private sealed abstract class Worker extends Thread with BlockContext {
 
     val submittedLocations: Locations
 
@@ -582,5 +583,10 @@ private object ZScheduler {
 
     final def setName(i: Int): Unit =
       setName(s"ZScheduler-Worker-$i")
+
+    override def blockOn[T](thunk: => T)(implicit permission: CanAwait): T = {
+      markAsBlocking()
+      thunk
+    }
   }
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.{FiberRuntime, FiberScope, IsFatal, Platform}
+import zio.internal.{FiberRuntime, FiberScope, Platform}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import scala.concurrent.Future
@@ -133,11 +133,12 @@ trait Runtime[+R] { self =>
     def run[E, A](zio: ZIO[R, E, A])(implicit trace: Trace, unsafe: Unsafe): Exit[E, A] =
       runOrFork(zio) match {
         case Left(fiber) =>
-          import internal.{FiberMessage, OneShot}
+          import internal.OneShot
           val result = OneShot.make[Exit[E, A]]
           fiber.unsafe.addObserver(result.set)
-          internal.Blocking.signalBlocking()
-          result.get()
+          scala.concurrent.blocking {
+            result.get()
+          }
         case Right(exit) => exit
       }
 


### PR DESCRIPTION
Not sure why we don't support it, given that you, @kyri-petrou, already added the mechanism for it before in https://github.com/zio/zio/pull/8955?..