### PR TITLE
Runtime.unsafe.run: interrupt forked fiber if the current java Thread was interrupted while waiting for result

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/RuntimeSpecJVM.scala
@@ -3,6 +3,7 @@ package zio
 import zio.test._
 
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.Await
 import scala.concurrent.duration.SECONDS
 
@@ -57,6 +58,44 @@ object RuntimeSpecJVM extends ZIOBaseSpec {
           _ <- ZIO.succeed(promise.trySuccess(()))
           _ <- f.join
         } yield assertCompletes
-      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky
+      } @@ TestAspect.timeout(15.seconds) @@ TestAspect.nonFlaky,
+      test("Runtime.unsafe.run passes host thread's interruption to fork and waits for fork interruption to finish") {
+        val rtm                     = Runtime.default.unsafe
+        implicit val unsafe: Unsafe = Unsafe.unsafe
+        val started                 = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val interrupted             = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val proceedInterrupt        = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val threadExited            = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+        val effect =
+          ZIO.uninterruptibleMask(restore =>
+            ZIO.yieldNow *> started.succeed(())
+              *> restore(ZIO.never).onInterrupt {
+                interrupted.succeed(()) *>
+                  proceedInterrupt.await
+              }
+          )
+        val threadWasBlockedUntilFinalizationDone = new AtomicReference[Boolean]()
+
+        val thread = new Thread(() =>
+          try {
+            val _ = rtm.run(effect)
+          } finally {
+            threadWasBlockedUntilFinalizationDone.set(proceedInterrupt.unsafe.isDone)
+            threadExited.unsafe.succeed(())
+            ()
+          }
+        )
+        thread.setUncaughtExceptionHandler((_, _) => ())
+
+        for {
+          _ <- ZIO.attempt(thread.start())
+          _ <- started.await
+          _ <- ZIO.attempt(thread.interrupt())
+          _ <- interrupted.await
+          _ <- proceedInterrupt.succeed(())
+          _ <- threadExited.await
+          r <- ZIO.succeed(threadWasBlockedUntilFinalizationDone.get())
+        } yield assertTrue(r)
+      } @@ TestAspect.timeout(10.seconds) @@ TestAspect.nonFlaky(5)
     )
 }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -136,14 +136,18 @@ trait Runtime[+R] { self =>
           import internal.OneShot
           val result = OneShot.make[Exit[E, A]]
           fiber.unsafe.addObserver(result.set)
-          try {
-            scala.concurrent.blocking {
+          scala.concurrent.blocking {
+            try {
               result.get()
+            } catch {
+              case t: InterruptedException =>
+                val interrupted       = OneShot.make[Exit[Nothing, Exit[E, A]]]
+                val interruptionFiber = makeFiber(fiber.interruptAs(FiberId.None))
+                interruptionFiber.addObserver(interrupted.set)
+                interruptionFiber.start(fiber.interruptAs(FiberId.None))
+                interrupted.get()
+                throw t
             }
-          } catch {
-            case t: InterruptedException =>
-              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))
-              throw t
           }
         case Right(exit) => exit
       }

--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -137,7 +137,13 @@ trait Runtime[+R] { self =>
           val result = OneShot.make[Exit[E, A]]
           fiber.unsafe.addObserver(result.set)
           internal.Blocking.signalBlocking()
-          result.get()
+          try {
+            result.get()
+          } catch {
+            case t: InterruptedException =>
+              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))
+              throw t
+          }
         case Right(exit) => exit
       }
 


### PR DESCRIPTION
We're not propagating thread interruption in `.run` (unless the fiber never went async) which means the effect will continue running in background after e.g. pressing Ctrl-C in sbt