### PR TITLE
Temporarily stop using JDK25 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
       fail-fast: false
       matrix:
         scala: ['2.12.x', '2.13.x', '3.x']
-        java: ['25']
+        java: ['21']
         platform: ['JVM']
     steps:
     - name: Checkout current branch


### PR DESCRIPTION
See: https://github.com/scala/scala3/issues/24183