### PR TITLE
Optimise `FiberRef::locallyScopedWith`

### DIFF
--- a/core/shared/src/main/scala/zio/FiberRef.scala
+++ b/core/shared/src/main/scala/zio/FiberRef.scala
@@ -169,7 +169,7 @@ sealed trait FiberRef[A] extends Serializable { self =>
    * Guarantees that fiber data is properly restored via `acquireRelease`.
    */
   def locallyWith[R, E, B](f: A => A)(zio: ZIO[R, E, B])(implicit trace: Trace): ZIO[R, E, B] =
-    getWith(a => locally(f(a))(zio))
+    ZIO.acquireReleaseWith(modify(a => (a, f(a))))(set)(_ => zio)
 
   /**
    * Returns a scoped workflow that sets the value associated with the curent


### PR DESCRIPTION
Again? 🤔
I thought I already did this here: https://github.com/zio/zio/pull/9483

I didn't find in the history of this file why this code went back as it was (unoptimized) 🤔
https://github.com/zio/zio/commits/fda2d2e753c9266d79ff619b2d2da1f8c1318457/core/shared/src/main/scala/zio/FiberRef.scala