### PR TITLE
Render StackTrace.none as such

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -231,6 +231,10 @@ object CauseSpec extends ZIOBaseSpec {
               |)""".stripMargin
           ),
           (
+            Fail("Boom", StackTrace.none),
+            "Fail(Boom,StackTrace.none)"
+          ),
+          (
             Interrupt(fiberId, stackTrace),
             """Interrupt(Runtime(123,456000,),Stack trace for thread "zio-fiber-123":
               |)""".stripMargin

--- a/core/shared/src/main/scala/zio/StackTrace.scala
+++ b/core/shared/src/main/scala/zio/StackTrace.scala
@@ -57,7 +57,8 @@ final case class StackTrace(
   }
 
   override def toString(): String =
-    prettyPrint("Stack trace for thread \"" + fiberId.threadName + "\":")
+    if (isEmpty) "StackTrace.none"
+    else prettyPrint("Stack trace for thread \"" + fiberId.threadName + "\":")
 }
 
 object StackTrace {

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -390,7 +390,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A constant generator of the specified sample.
    */
   def constSample[R, A](sample: => Sample[R, A])(implicit trace: Trace): Gen[R, A] =
-    fromZIOSample(ZIO.succeed(sample))
+    Gen(ZStream.succeed(sample))
 
   /**
    * A generator of currency.


### PR DESCRIPTION
/fixes https://github.com/zio/zio/issues/10302

This prevents `Cause.fail`/`Exit.fail` as:

```scala
Fail(value,Stack trace for thread "zio-fiber-":)
```

Instead:
```scala
Fail(value,StackTrace.none)
```