### PR TITLE
Clock: use Scheduler.fromScheduledExecutorService on jvm/native

### DIFF
--- a/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ClockPlatformSpecific.scala
@@ -24,42 +24,7 @@ import java.util.concurrent._
 private[zio] trait ClockPlatformSpecific {
   import Scheduler.CancelToken
 
-  private[zio] val globalScheduler: Scheduler = new Scheduler.Internal {
-
-    private[this] val service = makeService()
-
-    private[this] val ConstFalse = () => false
-
-    private final val MaxMillis = Long.MaxValue / 1000000L
-
-    def asScheduledExecutorService: ScheduledExecutorService =
-      service
-
-    def schedule(task: Runnable, duration: Duration)(implicit unsafe: Unsafe): CancelToken =
-      (duration: @unchecked) match {
-        case Duration.Infinity => ConstFalse
-        case d if d.isZero || d.isNegative =>
-          task.run()
-          ConstFalse
-        case d =>
-          val millis = d.toMillis
-          val future =
-            if (millis < MaxMillis)
-              service.schedule(
-                task,
-                d.toNanos,
-                TimeUnit.NANOSECONDS
-              )
-            else
-              service.schedule(
-                task,
-                millis,
-                TimeUnit.MILLISECONDS
-              )
-
-          () => future.cancel(true)
-      }
-  }
+  private[zio] val globalScheduler: Scheduler = Scheduler.fromScheduledExecutorService(makeService())
 
   private[this] def makeService(): ScheduledExecutorService = {
     val service = new ScheduledThreadPoolExecutor(1, new NamedThreadFactory("zio-timer", true))

--- a/core/jvm-native/src/main/scala/zio/Scheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/Scheduler.scala
@@ -28,13 +28,13 @@ sealed abstract class Scheduler {
 
 object Scheduler {
   type CancelToken = () => Boolean
+  private final val ConstFalse = () => false
+  private final val MaxMillis  = Long.MaxValue / 1000000L
 
   private[zio] abstract class Internal extends Scheduler
 
   def fromScheduledExecutorService(service: ScheduledExecutorService): Scheduler =
     new Scheduler {
-      val ConstFalse = () => false
-
       def asScheduledExecutorService: ScheduledExecutorService =
         service
 
@@ -45,13 +45,24 @@ object Scheduler {
             task.run()
             ConstFalse
           case d =>
-            val future = service.schedule(
-              task,
-              d.toNanos,
-              TimeUnit.NANOSECONDS
-            )
+            val millis = d.toMillis
+            val future =
+              if (millis < MaxMillis)
+                service.schedule(
+                  task,
+                  d.toNanos,
+                  TimeUnit.NANOSECONDS
+                )
+              else
+                service.schedule(
+                  task,
+                  millis,
+                  TimeUnit.MILLISECONDS
+                )
 
             () => future.cancel(true)
         }
+
+      override def toString() = s"Scheduler($service)"
     }
 }


### PR DESCRIPTION
This moves the implementation of the JVM Scheduler to the `fromScheduledExecutorService` method.