### PR TITLE
Optimize Semaphore

### DIFF
--- a/benchmarks/src/main/scala/zio/SemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphoreBenchmark.scala
@@ -1,0 +1,68 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+import zio.BenchmarkUtil._
+import zio._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Semaphore => JSemaphore}
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(1)
+class SemaphoreBenchmark {
+  @Param(Array("1", "2", "5", "10"))
+  var fibers: Int = _
+
+  @Param(Array("1", "2", "5"))
+  var permits: Int = _
+
+  val ops: Int = 1000
+
+  @Benchmark
+  def catsSemaphore(): Unit = {
+    import cats.effect.std.Semaphore
+    import cats.effect.unsafe.implicits.global
+    import cats.effect.{Concurrent, IO => CIO}
+
+    (for {
+      sem   <- Semaphore(permits)(Concurrent[CIO])
+      fiber <- catsForkAll(Array.fill(fibers)(catsRepeat(ops)(sem.permit.use(_ => CIO(1)))))
+      _     <- fiber.join
+    } yield ()).unsafeRunSync()
+  }
+
+  @Benchmark
+  def zioSemaphore(bh: Blackhole): Unit =
+    unsafeRun(for {
+      sem   <- Semaphore.make(permits.toLong)
+      fiber <- ZIO.forkAllDiscard(Array.fill(fibers)(repeat(ops)(sem.withPermit(Exit.succeed(bh.consume(1))))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def javaSemaphoreFair(bh: Blackhole): Unit =
+    javaSemaphore(true, bh)
+
+  @Benchmark
+  def javaSemaphoreUnfair(bh: Blackhole): Unit =
+    javaSemaphore(false, bh)
+
+  private def javaSemaphore(fair: Boolean, bh: Blackhole) =
+    unsafeRun(for {
+      lock <- ZIO.succeed(new JSemaphore(permits, fair))
+      fiber <- ZIO.forkAllDiscard(Array.fill(fibers)(repeat(ops) {
+                 ZIO.succeed {
+                   lock.acquire()
+                   try bh.consume(1)
+                   finally lock.release()
+                 }
+               }))
+      _ <- fiber.join
+    } yield ())
+
+}

--- a/benchmarks/src/main/scala/zio/stm/TSemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/TSemaphoreBenchmark.scala
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit
 @Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
 @Measurement(iterations = 4, timeUnit = TimeUnit.SECONDS, time = 1)
 @Fork(4)
-class SemaphoreBenchmark {
+class TSemaphoreBenchmark {
 
   @Param(Array("1", "10"))
   var nSTM: Int = _

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -87,6 +87,199 @@ object SemaphoreSpec extends ZIOBaseSpec {
         _            <- promise.succeed(())
         waitingEnd   <- semaphore.awaiting.repeatUntil(_ == 0)
       } yield assertTrue(waitingStart == 10, waitingEnd == 0)
-    } @@ timeout(10.seconds)
-  ) @@ exceptJS(nonFlaky)
+    },
+    test("withPermits acquires multiple permits when available") {
+      for {
+        sem     <- Semaphore.make(5L)
+        result  <- sem.withPermits(3L)(ZIO.succeed("acquired"))
+        permits <- sem.available
+      } yield assertTrue(result == "acquired", permits == 5L)
+    },
+    test("withPermits blocks when not enough permits available") {
+      for {
+        sem      <- Semaphore.make(2L)
+        started  <- Promise.make[Nothing, Unit]
+        blocked  <- Promise.make[Nothing, Unit]
+        _        <- sem.withPermits(2L)(started.succeed(()) *> blocked.await).fork
+        _        <- started.await
+        fiber    <- sem.withPermits(2L)(ZIO.succeed("acquired")).fork
+        awaiting <- sem.awaiting.repeatUntil(_ > 0)
+        _        <- blocked.succeed(())
+        result   <- fiber.join
+        permits  <- sem.available
+      } yield assertTrue(awaiting > 0, result == "acquired", permits == 2L)
+    },
+    test("withPermits dies when n > max permits") {
+      for {
+        sem    <- Semaphore.make(3L)
+        result <- sem.withPermits(5L)(ZIO.unit).exit
+      } yield assert(result)(dies(isSubtype[IllegalArgumentException](anything)))
+    },
+    test("withPermitsScoped acquires multiple permits when available") {
+      for {
+        sem     <- Semaphore.make(5L)
+        result  <- ZIO.scoped(sem.withPermitsScoped(3L) *> ZIO.succeed("acquired"))
+        permits <- sem.available
+      } yield assertTrue(result == "acquired", permits == 5L)
+    },
+    test("withPermits releases multiple permits on interruption") {
+      for {
+        sem     <- Semaphore.make(3L)
+        started <- Promise.make[Nothing, Unit]
+        fiber   <- sem.withPermits(3L)(started.succeed(()) *> ZIO.never).fork
+        _       <- started.await
+        before  <- sem.available
+        _       <- fiber.interrupt
+        after   <- sem.available
+      } yield assertTrue(before == 0L, after == 3L)
+    },
+    test("withPermits releases correct permits after partial fulfillment and interruption") {
+      for {
+        sem      <- Semaphore.make(5L)
+        signal1  <- Promise.make[Nothing, Unit]
+        started1 <- Promise.make[Nothing, Unit]
+        fiber1   <- sem.withPermits(3L)(started1.succeed(()) *> signal1.await).fork
+        _        <- started1.await
+
+        started2 <- Promise.make[Nothing, Unit]
+        fiber2   <- (started2.succeed(()) *> sem.withPermits(4L)(ZIO.never)).fork
+        _        <- started2.await
+        _        <- sem.awaiting.repeatUntil(_ > 0)
+
+        _ <- signal1.succeed(())
+        _ <- fiber1.join
+
+        _         <- fiber2.interrupt
+        available <- sem.available
+      } yield assertTrue(available == 5L)
+    },
+    suite("State")(
+      test("apply creates a negative state") {
+        val state = Semaphore.State(2, 5)
+        assertTrue(state < 0)
+      },
+      test("available returns permits for positive state") {
+        assertTrue(
+          Semaphore.State.available(0L) == 0L,
+          Semaphore.State.available(5L) == 5L,
+          Semaphore.State.available(100L) == 100L
+        )
+      },
+      test("available returns 0 for negative state") {
+        val state = Semaphore.State(3, 10)
+        assertTrue(Semaphore.State.available(state) == 0L)
+      },
+      test("waiters extracts the correct waiter count") {
+        val state = Semaphore.State(3, 10)
+        assertTrue(Semaphore.State.waiters(state) == 3L)
+      },
+      test("waiters returns 0 for non-negative state") {
+        assertTrue(
+          Semaphore.State.waiters(0L) == 0L,
+          Semaphore.State.waiters(5L) == 0L,
+          Semaphore.State.waiters(100L) == 0L
+        )
+      },
+      test("demand extracts the correct permit count") {
+        val state = Semaphore.State(3, 10)
+        assertTrue(Semaphore.State.demand(state) == 10L)
+      },
+      test("demand returns 0 for non-negative state") {
+        assertTrue(
+          Semaphore.State.demand(0L) == 0L,
+          Semaphore.State.demand(5L) == 0L,
+          Semaphore.State.demand(100L) == 0L
+        )
+      },
+      test("awaited returns true for negative state") {
+        val state = Semaphore.State(3, 10)
+        assertTrue(Semaphore.State.awaited(state))
+      },
+      test("awaited returns false for non-negative state") {
+        assertTrue(
+          !Semaphore.State.awaited(0L),
+          !Semaphore.State.awaited(5L),
+          !Semaphore.State.awaited(100L)
+        )
+      },
+      test("roundtrip preserves waiters and demand") {
+        val waiters = 7L
+        val demand  = 42L
+        val state   = Semaphore.State(waiters, demand)
+        assertTrue(
+          Semaphore.State.waiters(state) == waiters,
+          Semaphore.State.demand(state) == demand
+        )
+      },
+      test("addWaiter from zero state creates state with 1 waiter") {
+        val state = Semaphore.State.addWaiter(0L)(5L)
+        assertTrue(
+          state < 0,
+          Semaphore.State.waiters(state) == 1L,
+          Semaphore.State.demand(state) == 5L
+        )
+      },
+      test("addWaiter from positive state consumes available permits") {
+        val state = Semaphore.State.addWaiter(10L)(13L)
+        assertTrue(
+          state < 0,
+          Semaphore.State.waiters(state) == 1L,
+          Semaphore.State.demand(state) == 3L
+        )
+      },
+      test("addWaiter to negative state increments waiter count and adds permits") {
+        val initial = Semaphore.State(2, 5)
+        val updated = Semaphore.State.addWaiter(initial)(3L)
+        assertTrue(
+          Semaphore.State.waiters(updated) == 3L,
+          Semaphore.State.demand(updated) == 8L
+        )
+      },
+      test("removeWaiter decrements waiter count and subtracts permits") {
+        val initial = Semaphore.State(3, 10)
+        val updated = Semaphore.State.removeWaiter(initial)(4L)
+        assertTrue(
+          Semaphore.State.waiters(updated) == 2L,
+          Semaphore.State.demand(updated) == 6L
+        )
+      },
+      test("removeWaiter returns 0 when last waiter is removed") {
+        val initial = Semaphore.State(1, 5)
+        val updated = Semaphore.State.removeWaiter(initial)(5L)
+        assertTrue(updated == 0L)
+      },
+      test("reduceDemand reduces demand without changing waiter count") {
+        val initial = Semaphore.State(2, 10)
+        val updated = Semaphore.State.reduceDemand(initial)(3L)
+        assertTrue(
+          Semaphore.State.waiters(updated) == 2L,
+          Semaphore.State.demand(updated) == 7L
+        )
+      },
+      test("release adds permits back to available pool") {
+        val result = Semaphore.State.release(5L)(3L, 100L)
+        assertTrue(result == 8L)
+      },
+      test("release caps at maxPermits") {
+        val result = Semaphore.State.release(5L)(10L, 10L)
+        assertTrue(result == 10L)
+      },
+      test("handles large waiter counts") {
+        val largeWaiters = 1000000L
+        val demand       = 5000000L
+        val state        = Semaphore.State(largeWaiters, demand)
+        assertTrue(
+          Semaphore.State.waiters(state) == largeWaiters,
+          Semaphore.State.demand(state) == demand
+        )
+      },
+      test("handles maximum values") {
+        val state = Semaphore.State(Semaphore.State.MaxWaiters, Semaphore.State.MaxDemand)
+        assertTrue(
+          Semaphore.State.waiters(state) == Semaphore.State.MaxWaiters,
+          Semaphore.State.demand(state) == Semaphore.State.MaxDemand
+        )
+      }
+    )
+  ) @@ exceptJS(nonFlaky(25)) @@ timeout(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -17,10 +17,10 @@
 package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.stm.TSemaphore
+
+import java.util.concurrent.atomic.AtomicLong
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{Queue => ScalaQueue}
 
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores
@@ -30,7 +30,7 @@ import scala.collection.immutable.{Queue => ScalaQueue}
  * become available.
  *
  * If you need functionality that `Semaphore` doesnt' provide, use a
- * [[TSemaphore]] and define it in a [[zio.stm.ZSTM]] transaction.
+ * [[zio.stm.TSemaphore]] and define it in a [[zio.stm.ZSTM]] transaction.
  */
 sealed trait Semaphore extends Serializable {
 
@@ -98,110 +98,327 @@ object Semaphore {
 
   object unsafe {
     def make(permits: Long)(implicit unsafe: Unsafe): Semaphore =
-      new Semaphore {
-        val ref = Ref.unsafe.make[Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]](Right(permits))
+      if (permits < 0)
+        throw new IllegalArgumentException(s"Unexpected negative `$permits` permits specified.")
+      else new Internal(permits)
+  }
 
-        def available(implicit trace: Trace): UIO[Long] =
-          ref.get.map {
-            case Left(_)        => 0L
-            case Right(permits) => permits
-          }
+  private sealed trait Waiter {
+    def promise: Promise[Nothing, Unit]
+    def permits: Long
+    def reducedBy(n: Long): Waiter
+  }
+  private object Waiter {
+    final class Single(val promise: Promise[Nothing, Unit]) extends Waiter {
+      def permits: Long = 1L
+      def reducedBy(n: Long): Waiter = {
+        assert(DisableAssertions)
+        this
+      }
+    }
 
-        override def awaiting(implicit trace: Trace): UIO[Long] =
-          ref.get.map {
-            case Left(queue) => queue.size.toLong
-            case Right(_)    => 0L
-          }
+    final class Multi(val promise: Promise[Nothing, Unit], initial: Long) extends AtomicLong(initial) with Waiter {
+      def permits: Long              = get()
+      def reducedBy(n: Long): Waiter = { addAndGet(-n); this }
+    }
+  }
 
-        def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          withPermits(1L)(zio)
+  /**
+   * For Scala 3, `-X-elide-below` is ignored, and therefore we need to use an
+   * '''inlinable''' build-time constant to disable assertions
+   */
+  private final val DisableAssertions = BuildInfo.optimizationsEnabled
 
-        def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          withPermitsScoped(1L)
+  /**
+   * State encoding: {{ state > 0: Available number of permits state == 0: No
+   * permits and no waiters state < 0: Waiters present (bit-packed) }}
+   *
+   * Bit layout for negative state (64 bits total):
+   * {{{
+   * ┌─────────────────────────────────┬─────────────────────────────────┐
+   * │     Upper 32 bits (bits 32-63)  │     Lower 32 bits (bits 0-31)   │
+   * ├─────────────────────────────────┼─────────────────────────────────┤
+   * │          -numWaiters            │         permitsAwaited          │
+   * └─────────────────────────────────┴─────────────────────────────────┘
+   * }}}
+   *
+   * Constraints:
+   *   - Max waiters: Int.MaxValue (~2.1 billion)
+   *   - Max demand: 0xffffffffL (~4.3 billion)
+   */
+  private[zio] object State {
+    private final val LowerMask: Long = 0xffffffffL // Lower 32 bits mask
+    private final val UpperShift: Int = 32
 
-        def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          ZIO.acquireReleaseWith(reserve(n))(_.release)(_.acquire *> zio)
+    // Maximum values are constrained by signed arithmetic in the encoding.
+    // The formula (-waiters << 32) only produces a negative result when
+    // waiters <= Int.MaxValue, because the lower 32 bits of -waiters must
+    // have bit 31 set for the result to be negative.
+    final val MaxWaiters: Long = Int.MaxValue.toLong
+    final val MaxDemand: Long  = LowerMask
 
-        def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          ZIO.acquireRelease(reserve(n))(_.release).flatMap(_.acquire)
+    /**
+     * Pack waiters count and permits count into a negative state value.
+     */
+    @inline
+    def apply(waiters: Long, demand: Long): Long = {
+      assert(
+        DisableAssertions || waiters >= 0 && waiters <= MaxWaiters,
+        s"waiters must be in [0, $MaxWaiters], got $waiters"
+      )
+      assert(
+        DisableAssertions || demand >= 0 && demand <= MaxDemand,
+        s"demand must be in [0, $MaxDemand], got $demand"
+      )
+      assert(DisableAssertions || demand >= waiters, s"demand ($demand) must be >= waiters ($waiters)")
+      (-waiters << UpperShift) | (demand & LowerMask)
+    }
 
-        override def tryWithPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
-          ZIO.acquireReleaseWith(tryReserve(n)) {
-            case Some(reservation) => reservation.release
-            case _                 => Exit.unit
-          } {
-            case _: Some[?] => zio.asSome
-            case _          => Exit.none
-          }
+    /**
+     * Extract the number of available permits. Returns 0 if state is negative
+     * (waiters present).
+     */
+    @inline
+    def available(state: Long): Long =
+      if (state > 0) state else 0L
 
-        case class Reservation(acquire: UIO[Unit], release: UIO[Any])
-        object Reservation {
-          private[zio] val zero = Reservation(ZIO.unit, ZIO.unit)
-        }
+    /**
+     * Extract the number of waiters from a packed state. Returns 0 if state is
+     * non-negative (no waiters).
+     */
+    @inline
+    def waiters(state: Long): Long =
+      if (state >= 0) 0L else -(state >> UpperShift)
 
-        def tryReserve(n: Long)(implicit trace: Trace): UIO[Option[Reservation]] =
-          if (n < 0) ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
-          else if (n == 0L) ZIO.succeed(Some(Reservation.zero))
-          else
-            ref.modify {
-              case Right(permits) if permits >= n =>
-                Some(Reservation(ZIO.unit, releaseN(n))) -> Right(permits - n)
-              case other => None -> other
-            }
+    /**
+     * Extract the total permits demanded by waiters. Returns 0 if state is
+     * non-negative (no waiters).
+     */
+    @inline
+    def demand(state: Long): Long =
+      if (state >= 0) 0L else state & LowerMask
 
-        def reserve(n: Long)(implicit trace: Trace): UIO[Reservation] =
-          if (n < 0)
-            ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
-          else if (n == 0L)
-            ZIO.succeed(Reservation.zero)
-          else
-            Promise.make[Nothing, Unit].flatMap { promise =>
-              ref.modify {
-                case Right(permits) if permits >= n =>
-                  Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
-                case Right(permits) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
-                case Left(queue) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
+    /**
+     * Returns true if there are waiters.
+     */
+    @inline
+    def awaited(state: Long): Boolean = state < 0
+
+    /**
+     * Add a new waiter requesting n permits. Consumes any currently available
+     * permits from state, then records only the remainder as "still needed".
+     */
+    @inline
+    def addWaiter(state: Long)(requested: Long): Long =
+      if (state >= 0) State(waiters = 1, demand = requested - state)
+      else State(waiters = waiters(state) + 1, demand = demand(state) + requested)
+
+    /**
+     * Remove a waiter and subtract permits from the waiting total. Called when
+     * a waiter is fulfilled.
+     */
+    @inline
+    def removeWaiter(state: Long)(requested: Long): Long = {
+      val currentWaiters = waiters(state)
+      if (currentWaiters <= 1) 0L // Last waiter removed, state becomes 0
+      else State(waiters = currentWaiters - 1, demand = demand(state) - requested)
+    }
+
+    /**
+     * Reduce the demand without changing waiter count. Used when partially
+     * satisfying a waiter's permit request.
+     */
+    @inline
+    def reduceDemand(state: Long)(permits: Long): Long =
+      if (state >= 0) 0 // { assert(DisableAssertions); 0 }
+      else State(waiters = waiters(state), demand = demand(state) - permits)
+
+    /**
+     * Release permits back to the available pool, capped at maxPermits. Only
+     * valid when state >= 0 (no waiters present).
+     */
+    @inline
+    def release(state: Long)(permits: Long, maxPermits: Long): Long =
+      Math.min(maxPermits, state + permits)
+  }
+
+  private final class Internal(permits: Long) extends AtomicLong(permits) with Semaphore {
+
+    private val waiters: internal.MutableConcurrentQueue[Waiter] =
+      internal.MutableConcurrentQueue.unbounded
+
+    override def available(implicit trace: Trace): UIO[Long] =
+      ZIO.succeed(State.available(get()))
+
+    override def awaiting(implicit trace: Trace): UIO[Long] =
+      ZIO.succeed(State.waiters(get()))
+
+    override def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      withPermits(1L)(zio)
+
+    override def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      withPermitsScoped(1L)
+
+    override def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      ZIO.suspendSucceed {
+        if (isZero(n)) zio
+        else if (tryAcquire(n)) ensuringRelease(n)(zio)
+        else ZIO.acquireReleaseWith(acquire(n))(_ => ZIO.succeed(releaseUnsafe(n)))(_ => zio)
+      }
+
+    override def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      ZIO.suspendSucceed {
+        if (isZero(n)) Exit.unit
+        else ZIO.acquireRelease(acquire(n))(_ => ZIO.succeed(releaseUnsafe(n)))
+      }
+
+    override def tryWithPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
+      ZIO.suspendSucceed {
+        if (n < 0) ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
+        else if (n == 0L) zio.asSome
+        else if (n > permits) Exit.none
+        else if (tryAcquire(n)) ensuringRelease(n)(zio).asSome
+        else Exit.none
+      }
+
+    private def ensuringRelease[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      ZIO.uninterruptibleMask { restore =>
+        restore(zio).foldCauseZIO(
+          cause => { releaseUnsafe(n); Exit.failCause(cause) },
+          a => { releaseUnsafe(n); Exit.succeed(a) }
+        )
+      }
+
+    private def isZero(n: Long): Boolean =
+      if (n < 0) throw new IllegalArgumentException(s"Unexpected negative `$n` permits requested.")
+      else if (n > permits)
+        throw new IllegalArgumentException(
+          s"Cannot acquire `$n` permits from a semaphore with only `$permits` permits."
+        )
+      else n == 0L
+
+    @tailrec
+    private def tryAcquire(n: Long): Boolean = {
+      val state = get()
+      if (state < n) false
+      else if (compareAndSet(state, state - n)) true
+      else tryAcquire(n)
+    }
+
+    private def acquire(n: Long)(implicit trace: Trace): UIO[Unit] = {
+
+      /**
+       * Attempts to acquire n permits. If all n permits are available, acquires
+       * them and returns Exit.unit. Otherwise, creates a Waiter entry, adds it
+       * to the queue, and awaits the waiter's promise.
+       */
+      @tailrec
+      def loop(n: Long): UIO[Unit] = {
+        val state = get()
+        if (state >= n) {
+          // All available: attempt to acquire immediately
+          if (compareAndSet(state, state - n)) Exit.unit
+          else loop(n)
+        } else {
+          // Not enough permits available, so we must wait
+          val updated = State.addWaiter(state)(n)
+          val demand  = n - State.available(state)
+
+          if (compareAndSet(state, updated)) {
+            val promise = Promise.unsafe.make[Nothing, Unit](FiberId.None)(Unsafe)
+            val waiter =
+              if (demand == 1L) new Waiter.Single(promise)
+              else new Waiter.Multi(promise, demand)
+            waiters.offer(waiter)
+            promise.await.onInterrupt {
+              ZIO.succeed {
+                // On interrupt, try to complete the promise ourselves.
+                // If we succeed, it means we weren't yet fulfilled, so we
+                // need to release our waiter slot and any permits we might
+                // have been holding. waiter.permits reads the current value,
+                // which may have been reduced by partial fulfillment.
+                if (promise.unsafe.completeWith(Exit.unit)(Unsafe)) {
+                  releaseUnsafe(waiter.permits)
+                }
               }
             }
-
-        def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =
-          ref.modify {
-            case Left(queue) =>
-              queue
-                .find(_._1 == promise)
-                .fold(releaseN(n) -> Left(queue)) { case (_, permits) =>
-                  releaseN(n - permits) -> Left(queue.filter(_._1 != promise))
-                }
-            case Right(permits) => ZIO.unit -> Right(permits + n)
-          }.flatten
-
-        def releaseN(n: Long)(implicit trace: Trace): UIO[Any] = {
-
-          @tailrec
-          def loop(
-            n: Long,
-            state: Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long],
-            acc: UIO[Any]
-          ): (UIO[Any], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
-            state match {
-              case Right(permits) => acc -> Right(permits + n)
-              case Left(queue) =>
-                queue.dequeueOption match {
-                  case None => acc -> Right(n)
-                  case Some(((promise, permits), queue)) =>
-                    if (n > permits)
-                      loop(n - permits, Left(queue), acc *> promise.succeedUnit)
-                    else if (n == permits)
-                      (acc *> promise.succeedUnit) -> Left(queue)
-                    else
-                      acc -> Left((promise -> (permits - n)) +: queue)
-                }
-            }
-
-          ref.modify(loop(n, _, ZIO.unit)).flatten
+          } else loop(n)
         }
       }
+      loop(n)
+    }
+
+    /**
+     * Releases n permits back to the semaphore. This method handles fulfilling
+     * waiters that can now proceed with their requested permits.
+     *
+     * Logic:
+     *   1. If there were waiters (state was negative), we need to fulfill them
+     *   1. Poll waiters from the queue and check if we have enough permits for
+     *      them
+     *   1. If we have enough, fulfill the waiter and continue with remaining
+     *      permits
+     *   1. If not enough, we need to put the waiter back and add permits to the
+     *      state
+     *   1. If there were no waiters, atomically add permits back to the state
+     */
+    private def releaseUnsafe(n: Long): Unit = {
+      @tailrec
+      def loop(remaining: Long): Unit =
+        if (remaining <= 0L) ()
+        else {
+          val state = get()
+          if (state >= permits) assert(DisableAssertions) // Already at max permits, should be unreachable
+          else if (state < 0L) {
+            // There are waiters - try to get one from the queue
+            // Note: There's a race between acquireUnsafe setting state and offering to queue,
+            // so the queue might be momentarily empty even though state says there are waiters.
+            // We will loop and keep trying to poll until we get a waiter, or just release the permits.
+            val waiter = waiters.poll(null)
+            if (waiter eq null) loop(remaining)
+            else {
+              val waiterPermits = waiter.permits
+
+              if (waiterPermits <= remaining) {
+                // We have enough permits to fulfill this waiter completely
+                fulfillWaiter(state, waiterPermits)
+                waiter.promise.unsafe.completeWith(Exit.unit)(Unsafe)
+                loop(remaining - waiterPermits)
+              } else {
+                // Not enough permits for this waiter, update state, then put back
+                if (tryReduceDemand(state, remaining, retries = 2)) {
+                  // we can only be operating on a Multi-waiter since (0 < remaining < waiter.permits)
+                  waiters.offer(waiter.reducedBy(remaining))
+                } else {
+                  // State changed due to race, put original back and retry
+                  // this is slightly unfair, as it puts the waiter back in the queue
+                  waiters.offer(waiter)
+                  loop(remaining)
+                }
+              }
+            }
+          } else if (compareAndSet(state, State.release(state)(remaining, permits))) ()
+          else loop(remaining)
+        }
+      loop(n)
+    }
+
+    /**
+     * Fulfills a waiter by removing it and its permits from the state.
+     */
+    @tailrec
+    private def fulfillWaiter(state: Long, permits: Long): Unit =
+      if (state >= 0) assert(DisableAssertions)
+      else if (compareAndSet(state, State.removeWaiter(state)(permits))) ()
+      else fulfillWaiter(get(), permits)
+
+    /**
+     * Reduces the demand without changing waiter count. Returns true if the CAS
+     * succeeded, false if state changed.
+     */
+    private def tryReduceDemand(state: Long, permits: Long, retries: Int): Boolean =
+      if (retries <= 0) false
+      else if (compareAndSet(state, State.reduceDemand(state)(permits))) true
+      else tryReduceDemand(get(), permits, retries - 1)
   }
 }


### PR DESCRIPTION
/fixes #9093 /claim #9093
Rewrite Semaphore to use a single AtomicLong instead of a Ref[Either[Queue, Long]].

The old implementation used an immutable Scala queue inside a Ref to track waiters. Every acquire/release went through ref.modify, which meant allocating new queue instances and ZIO effects even on the happy path.

The new implementation packs permit/waiter state into a single AtomicLong
- positive = available permits
- negative = waiters are present

The new implementation uses a MutableConcurrentQueue for pending waiters instead of copying immutable queues, though this could be changed for a more performant queue later.

The new `Waiter` trait is used to represent waiters requiring a single permit and multiple permits. This prevents allocating an AtomicLong per waiter in the most common case.

Benchmarks show a 30-100% performance improvement. See benchmarks here: https://jmh.morethan.io/?gists=5889786ef8c51621de513da9ec45091d,1b73e3a975d46b09f92936c30e3b83cb