### PR TITLE
Optimize `ZEnvironment#prune` for single service tags

### DIFF
--- a/benchmarks/src/main/scala/zio/ZEnvironmentBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/ZEnvironmentBenchmark.scala
@@ -146,6 +146,10 @@ class ZEnvironmentBenchmark {
   def prune() =
     env.prune[Foo001 with Foo002 with Foo003]
 
+  @Benchmark
+  def pruneOne() =
+    env.prune[Foo001]
+
 }
 
 object BenchmarkedEnvironment {

--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -68,6 +68,27 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
 
       assertTrue(env == pruned)
     },
+    suite("pruning Scope when missing from the environment throws an error") {
+      final class Foo1
+      final class Foo2
+
+      def testPrune[R](implicit tagged: EnvironmentTag[R]): TestResult = {
+        val env = ZEnvironment(new Foo1, new Foo2).asInstanceOf[ZEnvironment[R]]
+        try {
+          env.prune[R]
+          assertNever("should have failed to prune scope")
+        } catch {
+          case t: Throwable =>
+            val msg = t.getMessage
+            assertTrue(msg.contains("Set(Scope) statically known to be contained within the environment are missing"))
+        }
+      }
+
+      List(
+        test("single tag")(testPrune[Scope]),
+        test("union tag")(testPrune[Scope & Foo1])
+      )
+    },
     test("get[Any] on an empty ZEnvironment returns Unit") {
       val value = ZEnvironment.empty.get[Any]
       assertTrue(value.isInstanceOf[Unit])

--- a/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZEnvironmentSpec.scala
@@ -58,6 +58,16 @@ object ZEnvironmentSpec extends ZIOBaseSpec {
 
       assertTrue(env == pruned)
     },
+    test("pruning a tag with multiple services") {
+      trait Foo
+      final class Foo1 extends Foo
+      final class Foo2 extends Foo
+
+      val env    = ZEnvironment(new Foo1, new Foo2)
+      val pruned = env.prune[Foo]
+
+      assertTrue(env == pruned)
+    },
     test("get[Any] on an empty ZEnvironment returns Unit") {
       val value = ZEnvironment.empty.get[Any]
       assertTrue(value.isInstanceOf[Unit])

--- a/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/UpdateOrderLinkedMapSpec.scala
@@ -24,7 +24,6 @@ object UpdateOrderLinkedMapSpec extends ZIOBaseSpec {
         UpdateOrderLinkedMap
           .newBuilder[String, Int]
           .addOne("a" -> 1)
-          .addOne("b" -> 2)
           .addOne("c" -> 3)
           .addOne("b" -> 4)
           .addOne("d" -> 5)

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -137,6 +137,13 @@ final class ZEnvironment[+R] private (
         s"Defect in zio.ZEnvironment: $tags statically known to be contained within the environment are missing"
       )
 
+    @inline
+    def returnScopeOrThrow(): Scope =
+      scope match {
+        case null => throwError(Set(ScopeTag))
+        case s    => s
+      }
+
     // Optimized pruning for a single service
     def pruneOne(tag: LightTypeTag): ZEnvironment[R1] = {
       val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
@@ -150,15 +157,15 @@ final class ZEnvironment[+R] private (
           builder addOne next
         }
       }
-      val isScopeTag0 = isScopeTag(tag)
-      val newMap      = builder.result()
+      val needsScope = isScopeTag(tag)
+      val newMap     = builder.result()
 
-      if (newMap.isEmpty && !isScopeTag0) throwError(Set(tag))
+      if (newMap.isEmpty && !needsScope) throwError(Set(tag))
 
       new ZEnvironment(
         newMap,
         cache = new ConcurrentHashMap[LightTypeTag, Any],
-        scope = if (isScopeTag0) scope else null
+        scope = if (needsScope) returnScopeOrThrow() else null
       )
     }
 
@@ -193,12 +200,21 @@ final class ZEnvironment[+R] private (
           }
         }
       }
-      val scopeTags = set.filter(isScopeTag)
-      scopeTags.foreach(found.add)
+
+      var needsScope = false
+      val it         = set.iterator
+      while (it.hasNext) {
+        val tag = it.next()
+        if (isScopeTag(tag)) {
+          needsScope = true
+          found.add(tag)
+        }
+      }
+
       val newMap = builder.result()
 
       if (set.size > found.size) {
-        val missing = set.subtractAll(found)
+        val missing = set --= found
 
         // We need to check whether one of the services we added is a subtype of the missing service
         val newTags = newMap.keySet
@@ -212,7 +228,7 @@ final class ZEnvironment[+R] private (
       new ZEnvironment(
         newMap,
         cache = new ConcurrentHashMap[LightTypeTag, Any],
-        scope = if (scopeTags.isEmpty) null else scope
+        scope = if (needsScope) returnScopeOrThrow() else null
       )
     }
 
@@ -458,9 +474,7 @@ object ZEnvironment {
             case AddScope(scope)          => loop(env.unsafe.addScope(scope)(Unsafe), patches.tail)
             case AddService(service, tag) => loop(env.unsafe.addService(tag, service)(Unsafe), patches.tail)
             case AndThen(first, second)   => loop(env, erase(first) :: erase(second) :: patches.tail)
-            case _: Empty[?]              => loop(env, patches.tail)
-            case _: RemoveService[?, ?]   => loop(env, patches.tail)
-            case _: UpdateService[?, ?]   => loop(env, patches.tail)
+            case _ /* Empty[?] */         => loop(env, patches.tail)
           }
 
       val env0 = environment.asInstanceOf[ZEnvironment[Out]]

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -131,21 +131,49 @@ final class ZEnvironment[+R] private (
    * contained within it.
    */
   def prune[R1 >: R](implicit tagged: EnvironmentTag[R1]): ZEnvironment[R1] = {
-    val tag = taggedTagType(tagged)
 
-    // Mutable set lookups are much faster. It also iterates faster. We're better off just allocating here
-    // Why are immutable set lookups so slow???
-    val set = new mutable.HashSet ++= taggedGetServices(tag)
+    def throwError(tags: collection.Set[LightTypeTag]) =
+      throw new Error(
+        s"Defect in zio.ZEnvironment: $tags statically known to be contained within the environment are missing"
+      )
 
-    if (set.isEmpty || self.isEmpty) self
-    else {
+    // Optimized pruning for a single service
+    def pruneOne(tag: LightTypeTag): ZEnvironment[R1] = {
+      val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
+
+      val it0 = self.map.iterator
+      while (it0.hasNext) {
+        val next    = it0.next()
+        val leftTag = next._1
+
+        if (taggedIsSubtype(leftTag, tag)) {
+          builder addOne next
+        }
+      }
+      val isScopeTag0 = isScopeTag(tag)
+      val newMap      = builder.result()
+
+      if (newMap.isEmpty && !isScopeTag0) throwError(Set(tag))
+
+      new ZEnvironment(
+        newMap,
+        cache = new ConcurrentHashMap[LightTypeTag, Any],
+        scope = if (isScopeTag0) scope else null
+      )
+    }
+
+    def pruneMany(iSet: Set[LightTypeTag]): ZEnvironment[R1] = {
+      // Mutable set lookups are much faster. It also iterates faster. We're better off just allocating here
+      // Why are immutable set lookups so slow???
+      val set     = new mutable.HashSet ++= iSet
       val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
       val found   = new mutable.HashSet[LightTypeTag]
       found.sizeHint(set.size)
 
       val it0 = self.map.iterator
       while (it0.hasNext) {
-        val next @ (leftTag, _) = it0.next()
+        val next    = it0.next()
+        val leftTag = next._1
 
         if (set.contains(leftTag)) {
           // Exact match, no need to loop
@@ -170,7 +198,7 @@ final class ZEnvironment[+R] private (
       val newMap = builder.result()
 
       if (set.size > found.size) {
-        val missing = set -- found
+        val missing = set.subtractAll(found)
 
         // We need to check whether one of the services we added is a subtype of the missing service
         val newTags = newMap.keySet
@@ -178,10 +206,7 @@ final class ZEnvironment[+R] private (
           if (newTags.exists(taggedIsSubtype(_, tag))) missing.remove(tag)
         }
 
-        if (missing.nonEmpty)
-          throw new Error(
-            s"Defect in zio.ZEnvironment: ${missing} statically known to be contained within the environment are missing"
-          )
+        if (!missing.isEmpty) throwError(missing)
       }
 
       new ZEnvironment(
@@ -190,6 +215,13 @@ final class ZEnvironment[+R] private (
         scope = if (scopeTags.isEmpty) null else scope
       )
     }
+
+    val tag  = taggedTagType(tagged)
+    val iSet = taggedGetServices(tag)
+
+    if (iSet.isEmpty || self.isEmpty) self
+    else if (iSet.size == 1) pruneOne(iSet.head)
+    else pruneMany(iSet)
   }
 
   /**
@@ -225,8 +257,8 @@ final class ZEnvironment[+R] private (
       var newMap = self.map
       val it     = that.map.iterator
       while (it.hasNext) {
-        val (k, v) = it.next()
-        newMap = newMap.updated(k, v)
+        val kv = it.next()
+        newMap = newMap.updated(kv._1, kv._2)
       }
       val newScope = if (that.scope eq null) self.scope else that.scope
       // Reuse the cache of the right hand-side

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -145,36 +145,44 @@ final class ZEnvironment[+R] private (
       }
 
     // Optimized pruning for a single service
-    def pruneOne(tag: LightTypeTag): ZEnvironment[R1] = {
-      val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
+    def pruneOne(tag: LightTypeTag): ZEnvironment[R1] =
+      if (isScopeTag(tag)) {
+        new ZEnvironment(
+          UpdateOrderLinkedMap.empty[LightTypeTag, Any],
+          cache = new ConcurrentHashMap[LightTypeTag, Any],
+          scope = returnScopeOrThrow()
+        )
+      } else {
+        val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
 
-      val it0 = self.map.iterator
-      while (it0.hasNext) {
-        val next    = it0.next()
-        val leftTag = next._1
+        val it0 = self.map.iterator
+        while (it0.hasNext) {
+          val next    = it0.next()
+          val leftTag = next._1
 
-        if (taggedIsSubtype(leftTag, tag)) {
-          builder addOne next
+          if (taggedIsSubtype(leftTag, tag)) {
+            builder addOne next
+          }
         }
+        val newMap = builder.result()
+
+        if (newMap.isEmpty) throwError(Set(tag))
+
+        new ZEnvironment(
+          newMap,
+          cache = new ConcurrentHashMap[LightTypeTag, Any],
+          scope = null
+        )
       }
-      val needsScope = isScopeTag(tag)
-      val newMap     = builder.result()
-
-      if (newMap.isEmpty && !needsScope) throwError(Set(tag))
-
-      new ZEnvironment(
-        newMap,
-        cache = new ConcurrentHashMap[LightTypeTag, Any],
-        scope = if (needsScope) returnScopeOrThrow() else null
-      )
-    }
 
     def pruneMany(iSet: Set[LightTypeTag]): ZEnvironment[R1] = {
       // Mutable set lookups are much faster. It also iterates faster. We're better off just allocating here
       // Why are immutable set lookups so slow???
-      val set     = new mutable.HashSet ++= iSet
-      val builder = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
-      val found   = new mutable.HashSet[LightTypeTag]
+      val set        = new mutable.HashSet ++= iSet
+      val tagsAsList = iSet.toList // Lists iterate much faster than sets
+      val builder    = UpdateOrderLinkedMap.newBuilder[LightTypeTag, Any]
+      val found      = new mutable.HashSet[LightTypeTag]
+      val nil        = Nil
       found.sizeHint(set.size)
 
       val it0 = self.map.iterator
@@ -188,27 +196,29 @@ final class ZEnvironment[+R] private (
           builder addOne next
         } else {
           // Need to check whether it's a subtype
-          var loop = true
-          val it1  = set.iterator
-          while (it1.hasNext && loop) {
-            val rightTag = it1.next()
+          var rem = tagsAsList
+          while (rem ne nil) {
+            val rightTag = rem.head
             if (taggedIsSubtype(leftTag, rightTag)) {
               found.add(rightTag)
               builder addOne next
-              loop = false
+              rem = nil
+            } else {
+              rem = rem.tail
             }
           }
         }
       }
 
       var needsScope = false
-      val it         = set.iterator
-      while (it.hasNext) {
-        val tag = it.next()
+      var rem        = tagsAsList
+      while (rem ne nil) {
+        val tag = rem.head
         if (isScopeTag(tag)) {
           needsScope = true
           found.add(tag)
         }
+        rem = rem.tail
       }
 
       val newMap = builder.result()

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -16,11 +16,20 @@
 
 package zio.internal
 
+import zio.BuildInfo
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
 import scala.annotation.tailrec
+import scala.collection.AbstractIterator
 import scala.collection.immutable.{HashMap, VectorBuilder}
-import scala.collection.{AbstractIterator, mutable}
+import scala.collection.mutable.ListBuffer
 import scala.util.hashing.MurmurHash3
 
+/**
+ * This Map is optimized for use with ZEnvironment.
+ *
+ * '''DO NOT''' use for any other purposes.
+ */
 private[zio] final class UpdateOrderLinkedMap[K, +V] private (
   fields: Vector[Any],
   underlying: Map[K, UpdateOrderLinkedMap.Entry[V]]
@@ -88,8 +97,10 @@ private[zio] final class UpdateOrderLinkedMap[K, +V] private (
     else self
 
   def iterator: Iterator[(K, V)] =
-    if (size == 1) underlying.iterator.map { case (k, v) => (k, v.value) }
-    else iteratorLz.iterator
+    if (underlying.size == 1) {
+      val kv = underlying.head
+      Iterator.single((kv._1, kv._2.value))
+    } else iteratorLz.iterator
 
   @transient
   private[this] lazy val iteratorLz: LzList[(K, V)] = {
@@ -123,8 +134,10 @@ private[zio] final class UpdateOrderLinkedMap[K, +V] private (
   }
 
   def reverseIterator: Iterator[(K, V)] =
-    if (size == 1) underlying.iterator.map { case (k, v) => (k, v.value) }
-    else reverseIteratorLz.iterator
+    if (underlying.size == 1) {
+      val kv = underlying.head
+      Iterator.single((kv._1, kv._2.value))
+    } else reverseIteratorLz.iterator
 
   @transient
   private[this] lazy val reverseIteratorLz: LzList[(K, V)] = {
@@ -192,7 +205,9 @@ private[zio] object UpdateOrderLinkedMap {
     val mapBuilder    = HashMap.newBuilder[K, Entry[V]]
     var i             = 0
     while (it.hasNext) {
-      val (k, v) = it.next()
+      val kv = it.next()
+      val k  = kv._1
+      val v  = kv._2
       vectorBuilder += k
       mapBuilder += ((k, Entry(i, v)))
       i += 1
@@ -203,31 +218,38 @@ private[zio] object UpdateOrderLinkedMap {
   def newBuilder[K, V]: UpdateOrderLinkedMap.Builder[K, V] = new UpdateOrderLinkedMap.Builder[K, V]
 
   final class Builder[K, V] { self =>
-    private[this] var entries: List[(K, V)] = Nil
+    private[this] val entries = ListBuffer.empty[(K, V)]
 
+    /**
+     * Adds a single element to the builder.
+     *
+     * '''NOTE''': The elements added to this builder MUST be unique!
+     */
     def addOne(elem: (K, V)): UpdateOrderLinkedMap.Builder[K, V] = {
-      entries = elem :: entries
+      entries += elem
       this
     }
 
     def clear(): Unit =
-      entries = Nil
+      entries.clear()
 
-    def result(): UpdateOrderLinkedMap[K, V] =
-      entries match {
-        case head :: (_: Nil.type) =>
+    def result(): UpdateOrderLinkedMap[K, V] = {
+      val entries = this.entries
+      entries.length match {
+        case 0 =>
+          empty
+        case 1 =>
+          val head = entries.toList.head // faster than calling `entries.head`
           single(head._1, head._2)
-        case rem =>
-          var reversed  = List.empty[(K, V)]
-          var remaining = rem
-          val set       = mutable.HashSet.empty[K]
-          while (remaining ne Nil) {
-            val head = remaining.head
-            if (set.add(head._1)) reversed = head :: reversed
-            remaining = remaining.tail
-          }
-          fromUnsafe(reversed.iterator)
+        case _ =>
+          // NOTE: The compiler removes this assertion in release mode
+          assert(
+            BuildInfo.optimizationsEnabled || entries.map(_._1).distinct.size == entries.size,
+            "Entries added to UpdateOrderLinkedMap.Builder were not unique"
+          )
+          fromUnsafe(entries.toList.iterator)
       }
+    }
   }
 
   private sealed trait LzList[+A] { self =>

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -17,32 +17,32 @@
 package zio.internal
 
 import scala.annotation.tailrec
-import scala.collection.{AbstractIterator, mutable}
 import scala.collection.immutable.{HashMap, VectorBuilder}
+import scala.collection.{AbstractIterator, mutable}
 import scala.util.hashing.MurmurHash3
 
 private[zio] final class UpdateOrderLinkedMap[K, +V](
   fields: Vector[Any],
-  underlying: HashMap[K, (Int, V)]
+  underlying: Map[K, UpdateOrderLinkedMap.Entry[V]]
 ) extends Serializable { self =>
   import UpdateOrderLinkedMap._
 
   def size: Int = underlying.size
 
-  def isEmpty: Boolean = size == 0
+  def isEmpty: Boolean = underlying.isEmpty
 
   def keySet: Set[K] = underlying.keySet
 
   def updated[V1 >: V](key: K, value: V1): UpdateOrderLinkedMap[K, V1] = {
     val existing = underlying.getOrElse(key, null)
     if (existing eq null) {
-      new UpdateOrderLinkedMap(fields :+ key, underlying.updated(key, (fields.size, value)))
-    } else if (existing._1 == fields.size - 1) {
+      new UpdateOrderLinkedMap(fields :+ key, underlying.updated(key, Entry(fields.size, value)))
+    } else if (existing.idx == fields.size - 1) {
       // If the entry to be added is at the tail of the fields, we can just update the value
-      new UpdateOrderLinkedMap(fields, underlying.updated(key, existing.copy(_2 = value)))
+      new UpdateOrderLinkedMap(fields, underlying.updated(key, existing.copy(value = value)))
     } else {
       var fs     = fields
-      val oldIdx = existing._1
+      val oldIdx = existing.idx
 
       // Calculate next of kin
       val next = fs(oldIdx + 1) match {
@@ -72,7 +72,7 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
         fs = fs.updated(oldIdx, Tombstone(next - oldIdx))
       }
 
-      new UpdateOrderLinkedMap(fs :+ key, underlying.updated(key, (fs.length, value))).maybeReindex()
+      new UpdateOrderLinkedMap(fs :+ key, underlying.updated(key, Entry(fs.length, value))).maybeReindex()
     }
   }
 
@@ -87,7 +87,9 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
     if (self.fields.size - size > 10000) fromUnsafe(iterator0)
     else self
 
-  def iterator: Iterator[(K, V)] = iteratorLz.iterator
+  def iterator: Iterator[(K, V)] =
+    if (size == 1) underlying.iterator.map { case (k, v) => (k, v.value) }
+    else iteratorLz.iterator
 
   @transient
   private[this] lazy val iteratorLz: LzList[(K, V)] = {
@@ -110,17 +112,19 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
           k.asInstanceOf[K]
       }
 
-    override def hasNext: Boolean = slot < fieldsLength - 1
+    override final def hasNext: Boolean = slot < fieldsLength - 1
 
-    override def next(): (K, V) =
+    override final def next(): (K, V) =
       if (!hasNext) Iterator.empty.next()
       else {
         val key = findNextKey(slot + 1)
-        (key, underlying(key)._2)
+        (key, underlying(key).value)
       }
   }
 
-  def reverseIterator: Iterator[(K, V)] = reverseIteratorLz.iterator
+  def reverseIterator: Iterator[(K, V)] =
+    if (size == 1) underlying.iterator.map { case (k, v) => (k, v.value) }
+    else reverseIteratorLz.iterator
 
   @transient
   private[this] lazy val reverseIteratorLz: LzList[(K, V)] = {
@@ -147,13 +151,13 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
           k.asInstanceOf[K]
       }
 
-    override def hasNext: Boolean = remaining > 0
+    override final def hasNext: Boolean = remaining > 0
 
-    override def next(): (K, V) =
+    override final def next(): (K, V) =
       if (!hasNext) Iterator.empty.next()
       else {
         val key    = findNextKey(slot - 1)
-        val result = (key, underlying(key)._2)
+        val result = (key, underlying(key).value)
         result
       }
   }
@@ -165,25 +169,32 @@ private[zio] final class UpdateOrderLinkedMap[K, +V](
 
 private[zio] object UpdateOrderLinkedMap {
   private final case class Tombstone(distance: Int)
+  private final case class Entry[+V](idx: Int, value: V)
 
   private[this] final val EmptyMap: UpdateOrderLinkedMap[Nothing, Nothing] =
-    new UpdateOrderLinkedMap[Nothing, Nothing](Vector.empty[Nothing], HashMap.empty[Nothing, (Int, Nothing)])
+    new UpdateOrderLinkedMap[Nothing, Nothing](Vector.empty[Nothing], Map.empty[Nothing, Entry[Nothing]])
 
   def empty[K, V]: UpdateOrderLinkedMap[K, V] = EmptyMap.asInstanceOf[UpdateOrderLinkedMap[K, V]]
 
   def fromMap[K, V](map: Map[K, V]): UpdateOrderLinkedMap[K, V] = fromUnsafe(map.iterator)
+
+  def single[K, V](key: K, value: V): UpdateOrderLinkedMap[K, V] =
+    new UpdateOrderLinkedMap(
+      Vector.empty[K] :+ key, // More efficient than `Vector(key)`
+      new Map.Map1(key, Entry(0, value))
+    )
 
   /**
    * Keys in the iterator '''MUST be unique'''!
    */
   private def fromUnsafe[K, V](it: Iterator[(K, V)]): UpdateOrderLinkedMap[K, V] = {
     val vectorBuilder = new VectorBuilder[K]
-    val mapBuilder    = HashMap.newBuilder[K, (Int, V)]
+    val mapBuilder    = HashMap.newBuilder[K, Entry[V]]
     var i             = 0
     while (it.hasNext) {
       val (k, v) = it.next()
       vectorBuilder += k
-      mapBuilder += ((k, (i, v)))
+      mapBuilder += ((k, Entry(i, v)))
       i += 1
     }
     new UpdateOrderLinkedMap(vectorBuilder.result(), mapBuilder.result())
@@ -192,38 +203,31 @@ private[zio] object UpdateOrderLinkedMap {
   def newBuilder[K, V]: UpdateOrderLinkedMap.Builder[K, V] = new UpdateOrderLinkedMap.Builder[K, V]
 
   final class Builder[K, V] { self =>
-    private[this] var entries: List[(K, V)]               = Nil
-    private[this] var aliased: UpdateOrderLinkedMap[K, V] = _
+    private[this] var entries: List[(K, V)] = Nil
 
     def addOne(elem: (K, V)): UpdateOrderLinkedMap.Builder[K, V] = {
-      if (aliased ne null) {
-        aliased = aliased.updated(elem._1, elem._2)
-      } else {
-        // Place them in reverse order, we'll reverse them back during `result()`
-        entries = elem :: entries
-      }
+      entries = elem :: entries
       this
     }
 
-    def clear(): Unit = {
+    def clear(): Unit =
       entries = Nil
-      aliased = null
-    }
 
-    def result(): UpdateOrderLinkedMap[K, V] = {
-      if (aliased eq null) {
-        var reversed  = List.empty[(K, V)]
-        var remaining = entries
-        val set       = mutable.HashSet.empty[K]
-        while (remaining ne Nil) {
-          val head = remaining.head
-          if (set.add(head._1)) reversed = head :: reversed
-          remaining = remaining.tail
-        }
-        aliased = fromUnsafe(reversed.iterator)
+    def result(): UpdateOrderLinkedMap[K, V] =
+      entries match {
+        case head :: (_: Nil.type) =>
+          single(head._1, head._2)
+        case rem =>
+          var reversed  = List.empty[(K, V)]
+          var remaining = rem
+          val set       = mutable.HashSet.empty[K]
+          while (remaining ne Nil) {
+            val head = remaining.head
+            if (set.add(head._1)) reversed = head :: reversed
+            remaining = remaining.tail
+          }
+          fromUnsafe(reversed.iterator)
       }
-      aliased
-    }
   }
 
   private sealed trait LzList[+A] { self =>

--- a/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
+++ b/core/shared/src/main/scala/zio/internal/UpdateOrderLinkedMap.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.{HashMap, VectorBuilder}
 import scala.collection.{AbstractIterator, mutable}
 import scala.util.hashing.MurmurHash3
 
-private[zio] final class UpdateOrderLinkedMap[K, +V](
+private[zio] final class UpdateOrderLinkedMap[K, +V] private (
   fields: Vector[Any],
   underlying: Map[K, UpdateOrderLinkedMap.Entry[V]]
 ) extends Serializable { self =>


### PR DESCRIPTION
It's fairly common to prune the `ZEnvironment` using a single tag, especially when composing ZLayers. This PR optimizes this path by avoiding unnecessary allocations that are necessary when pruning an environment for multiple tags as well as some other optimizations that are applicable to both single-service and multi-service pruning.

Also fixed a bug where using `prune[Scope]` on an environment that doesn't contain a Scope wouldn't throw an error.

Added benchmark shows ~200-300% throughput increase.