### PR TITLE
Disable inlining of `MurmurHash3.productHash` in `ZEnvironment`

### DIFF
--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -124,7 +124,7 @@ final class ZEnvironment[+R] private (
     else scope
 
   override lazy val hashCode: Int =
-    MurmurHash3.productHash((map, scope))
+    MurmurHash3.productHash((map, scope)): @noinline // See https://github.com/zio/zio/pull/10363 why `@noinline`
 
   /**
    * Prunes the environment to the set of services statically known to be


### PR DESCRIPTION
In Scala 2.13.17+ the `MurmurHash3.productHash` is a proxy method for the `caseClassHash` method. The Scala 2.13 optimizer deems that the method is simple enough to be inlined even when it's not annotated with `@inline` 🤦‍♂️ . This means that the compiled code is not binary compatible with Scala versions up to 2.13.16.

While this is not a problem when using `sbt`, it can be an issue for other build tools that don't enforce a minimum Scala version requirement depending on what the library is compiled with (see https://github.com/zio/zio/issues/10359).

Note that this PR doesn't fix the reported issue per-se, just the binary incompatibility caused by the inlining of the method.