### PR TITLE
Fix race condition in `CyclicBarrier`

### DIFF
--- a/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
+++ b/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
@@ -1,6 +1,7 @@
 package zio.concurrent
 
 import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
  * A synchronization aid that allows a set of fibers to all wait for each other
@@ -16,26 +17,44 @@ import zio._
  * before any of the parties continue.
  */
 final class CyclicBarrier private (
-  private val _parties: Int,
-  private val _waiting: Ref[Int],
-  private val _lock: Ref[Promise[Unit, Unit]],
-  private val _action: UIO[Any],
-  private val _broken: Ref[Boolean]
-) {
-  private val break: UIO[Unit] =
-    _broken.set(true) *> fail
-
-  private val fail: UIO[Unit] =
-    _lock.get.flatMap(_.fail(()).unit)
-
-  private val succeed: UIO[Unit] =
-    _lock.get.flatMap(_.succeedUnit.unit)
-
   /** The number of parties required to trip this barrier. */
-  def parties: Int = _parties
+  val parties: Int,
+  _action: UIO[Any]
+) {
+  import CyclicBarrier.{newPromise, trace}
 
-  /** The number of parties currently waiting at the barrier. */
-  val waiting: UIO[Int] = _waiting.get
+  @volatile private var _broken: Boolean           = false
+  @volatile private var _lock: Promise[Unit, Unit] = newPromise
+  @volatile private var _waiting: Int              = 0
+
+  private val semaphore = Semaphore.unsafe.make(1)(Unsafe)
+
+  private val break: UIO[Unit] =
+    semaphore.withPermit(ZIO.succeed {
+      _broken = true
+      _lock.unsafe.done(Exit.failUnit)(Unsafe)
+      ()
+    })
+
+  private val succeedAndReset =
+    semaphore.withPermit(ZIO.succeed {
+      _lock.unsafe.done(Exit.unit)(Unsafe)
+      resetUnsafe()
+    })
+
+  /**
+   * Unsafely resets the barrier to its initial state. Breaks any waiting party.
+   *
+   * '''NOTE''': This method must only be called when holding a permit!
+   */
+  private def resetUnsafe(): Unit = {
+    if (_waiting != 0) {
+      _lock.unsafe.done(Exit.failUnit)(Unsafe)
+      _waiting = 0
+    }
+    _lock = newPromise
+    _broken = false
+  }
 
   /**
    * Waits until all parties have invoked await on this barrier. Fails if the
@@ -43,32 +62,53 @@ final class CyclicBarrier private (
    */
   val await: IO[Unit, Int] =
     ZIO.uninterruptibleMask { restore =>
-      _broken.get.flatMap(if (_) ZIO.fail(()) else ZIO.unit) *>
-        _waiting.modify {
-          case n if n + 1 == parties => (restore(_action) *> succeed.as(_parties - n - 1) <* reset)                      -> 0
-          case n                     => _lock.get.flatMap(l => restore(l.await).onInterrupt(break)).as(_parties - n - 1) -> (n + 1)
-        }.flatten
+      semaphore.withPermit {
+        ZIO.succeed {
+          if (_broken) Exit.failUnit
+          else {
+            val nParties = parties
+            val n = {
+              val n0 = _waiting + 1
+              if (n0 == nParties) _waiting = 0
+              else _waiting = n0
+              n0
+            }
+            val f =
+              if (n == nParties) restore(_action) *> succeedAndReset
+              else {
+                val lock = _lock
+                restore(lock.await).onInterrupt(break)
+              }
+            val out = nParties - n
+            f.as(out)
+          }
+        }
+      }.flatten
     }
+
+  /** Queries if this barrier is in a broken state. */
+  val isBroken: UIO[Boolean] =
+    ZIO.succeed(_broken)
+
+  /** The number of parties currently waiting at the barrier. */
+  val waiting: UIO[Int] =
+    ZIO.succeed(_waiting)
 
   /** Resets the barrier to its initial state. Breaks any waiting party. */
   val reset: UIO[Unit] =
-    (fail.whenZIO(waiting.map(_ > 0)) *>
-      Promise.make[Unit, Unit].flatMap(_lock.set) *>
-      _waiting.set(0) *>
-      _broken.set(false)).uninterruptible
+    semaphore.withPermit(ZIO.succeed(resetUnsafe()))
 
-  /** Queries if this barrier is in a broken state. */
-  val isBroken: UIO[Boolean] = _broken.get
 }
 
 object CyclicBarrier {
+  private implicit def trace: Trace = Trace.empty
+
   def make(parties: Int): UIO[CyclicBarrier] =
-    make(parties, ZIO.unit)
+    make(parties, Exit.unit)
 
   def make(parties: Int, action: UIO[Any]): UIO[CyclicBarrier] =
-    for {
-      waiting <- Ref.make(0)
-      broken  <- Ref.make(false)
-      lock    <- Promise.make[Unit, Unit].flatMap(Ref.make(_))
-    } yield new CyclicBarrier(parties, waiting, lock, action, broken)
+    ZIO.succeed(new CyclicBarrier(parties, action))
+
+  private def newPromise: Promise[Unit, Unit] =
+    Promise.unsafe.make(FiberId.None)(Unsafe)
 }

--- a/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
+++ b/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
@@ -29,7 +29,7 @@ final class CyclicBarrier private (
 
   private val semaphore = Semaphore.unsafe.make(1)(Unsafe)
 
-  private val break: UIO[Unit] =
+  private def break: UIO[Unit] =
     semaphore.withPermit(ZIO.succeed {
       _broken = true
       _lock.unsafe.done(Exit.failUnit)(Unsafe)
@@ -67,35 +67,35 @@ final class CyclicBarrier private (
           if (_broken) Exit.failUnit
           else {
             val nParties = parties
-            val n = {
-              val n0 = _waiting + 1
-              if (n0 == nParties) _waiting = 0
-              else _waiting = n0
-              n0
+            val waiting = {
+              val waiting0 = _waiting + 1
+              if (waiting0 == nParties) _waiting = 0
+              else _waiting = waiting0
+              waiting0
             }
             val f =
-              if (n == nParties) restore(_action) *> succeedAndReset
+              if (waiting == nParties) restore(_action) *> succeedAndReset
               else {
                 val lock = _lock
                 restore(lock.await).onInterrupt(break)
               }
-            val out = nParties - n
-            f.as(out)
+            val remaining = nParties - waiting
+            f.as(remaining)
           }
         }
       }.flatten
     }
 
   /** Queries if this barrier is in a broken state. */
-  val isBroken: UIO[Boolean] =
+  def isBroken: UIO[Boolean] =
     ZIO.succeed(_broken)
 
   /** The number of parties currently waiting at the barrier. */
-  val waiting: UIO[Int] =
+  def waiting: UIO[Int] =
     ZIO.succeed(_waiting)
 
   /** Resets the barrier to its initial state. Breaks any waiting party. */
-  val reset: UIO[Unit] =
+  def reset: UIO[Unit] =
     semaphore.withPermit(ZIO.succeed(resetUnsafe()))
 
 }

--- a/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
+++ b/concurrent/src/main/scala/zio/concurrent/CyclicBarrier.scala
@@ -24,7 +24,7 @@ final class CyclicBarrier private (
   import CyclicBarrier.{newPromise, trace}
 
   @volatile private var _broken: Boolean           = false
-  @volatile private var _lock: Promise[Unit, Unit] = newPromise
+  @volatile private var _lock: Promise[Unit, Unit] = newPromise()
   @volatile private var _waiting: Int              = 0
 
   private val semaphore = Semaphore.unsafe.make(1)(Unsafe)
@@ -52,7 +52,7 @@ final class CyclicBarrier private (
       _lock.unsafe.done(Exit.failUnit)(Unsafe)
       _waiting = 0
     }
-    _lock = newPromise
+    _lock = newPromise()
     _broken = false
   }
 
@@ -109,6 +109,6 @@ object CyclicBarrier {
   def make(parties: Int, action: UIO[Any]): UIO[CyclicBarrier] =
     ZIO.succeed(new CyclicBarrier(parties, action))
 
-  private def newPromise: Promise[Unit, Unit] =
+  private def newPromise(): Promise[Unit, Unit] =
     Promise.unsafe.make(FiberId.None)(Unsafe)
 }

--- a/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
+++ b/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
@@ -1,8 +1,11 @@
 package zio.concurrent
 
-import zio.test.Assertion._
-import zio.test._
 import zio._
+import zio.test.Assertion._
+import zio.test.TestAspect.{nonFlaky, timed, timeout}
+import zio.test._
+
+import java.util.concurrent.atomic.AtomicInteger
 
 object CyclicBarrierSpec extends ZIOSpecDefault {
   private val parties = 100
@@ -17,7 +20,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
         } yield assert(barrier.parties)(equalTo(parties)) &&
           assert(isBroken)(equalTo(false)) &&
           assert(waiting)(equalTo(0))
-      },
+      } @@ nonFlaky(10000),
       test("Releases the barrier") {
         for {
           barrier <- CyclicBarrier.make(2)
@@ -28,7 +31,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           ticket2 <- f2.join
         } yield assert(ticket1)(equalTo(1)) &&
           assert(ticket2)(equalTo(0))
-      },
+      } @@ nonFlaky(10000),
       test("Releases the barrier and performs the action") {
         for {
           promise    <- Promise.make[Nothing, Unit]
@@ -40,7 +43,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           _          <- f2.join
           isComplete <- promise.isDone
         } yield assert(isComplete)(isTrue)
-      },
+      } @@ nonFlaky(10000),
       test("Releases the barrier and cycles") {
         for {
           barrier <- CyclicBarrier.make(2)
@@ -58,7 +61,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           assert(ticket2)(equalTo(0)) &&
           assert(ticket3)(equalTo(1)) &&
           assert(ticket4)(equalTo(0))
-      },
+      } @@ nonFlaky(10000),
       test("Breaks on reset") {
         for {
           barrier <- CyclicBarrier.make(parties)
@@ -70,7 +73,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           res1    <- f1.await
           res2    <- f2.await
         } yield assert(res1)(fails(isUnit)) && assert(res2)(fails(isUnit))
-      },
+      } @@ nonFlaky(1000),
       test("Breaks on party interruption") {
         for {
           barrier   <- CyclicBarrier.make(parties)
@@ -87,7 +90,44 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           assert(isBroken2)(isTrue) &&
           assert(res1)(succeeds(isNone)) &&
           assert(res2)(fails(isUnit))
-      }
-    )
+      } @@ nonFlaky,
+      suite("is stable under high contention")(
+        test("when fibers == parties") {
+          final class Counter {
+            private val ref = new AtomicInteger(0)
+
+            def inc(n: Int): Unit = {
+              val newN = ref.updateAndGet(_ + n)
+              if (newN < -1 || newN > 1) throw new IllegalStateException(s"invalid ref state: $newN")
+            }
+
+            def get: Int = ref.get
+          }
+
+          def make1(cb: CyclicBarrier, ref: Counter)(n: Int) =
+            cb.await.tap(_ => ZIO.succeed(ref.inc(n))).repeatN(10000)
+
+          for {
+            ref <- ZIO.succeed(new Counter)
+            cb  <- CyclicBarrier.make(2)
+            make = make1(cb, ref)(_)
+            _   <- ZIO.collectAllParDiscard(List(make(1), make(-1)))
+            v    = ref.get
+          } yield assertTrue(v == 0)
+        },
+        test("when fibers > parties") {
+          val nFibers  = 20
+          val nParties = 4
+          for {
+            cb <- CyclicBarrier.make(4)
+            // We can't guarantee that the last n - 1 fibers will be completed
+            latch <- CountdownLatch.make(nFibers - nParties + 1)
+            f     <- ZIO.foreachParDiscard(1 to nFibers)(_ => cb.await.repeatN(1000) *> latch.countDown).fork
+            _     <- latch.await
+            _     <- f.interrupt
+          } yield assertCompletes
+        }
+      ) @@ nonFlaky @@ timeout(30.seconds)
+    ) @@ timed
 
 }

--- a/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
+++ b/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
@@ -2,7 +2,7 @@ package zio.concurrent
 
 import zio._
 import zio.test.Assertion._
-import zio.test.TestAspect.{jvm, nonFlaky, timed, timeout}
+import zio.test.TestAspect._
 import zio.test._
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -20,7 +20,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
         } yield assert(barrier.parties)(equalTo(parties)) &&
           assert(isBroken)(equalTo(false)) &&
           assert(waiting)(equalTo(0))
-      } @@ nonFlaky(10000),
+      } @@ exceptJS(nonFlaky(10000)),
       test("Releases the barrier") {
         for {
           barrier <- CyclicBarrier.make(2)
@@ -31,7 +31,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           ticket2 <- f2.join
         } yield assert(ticket1)(equalTo(1)) &&
           assert(ticket2)(equalTo(0))
-      } @@ nonFlaky(10000),
+      } @@ exceptJS(nonFlaky(10000)),
       test("Releases the barrier and performs the action") {
         for {
           promise    <- Promise.make[Nothing, Unit]
@@ -43,7 +43,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           _          <- f2.join
           isComplete <- promise.isDone
         } yield assert(isComplete)(isTrue)
-      } @@ nonFlaky(10000),
+      } @@ exceptJS(nonFlaky(10000)),
       test("Releases the barrier and cycles") {
         for {
           barrier <- CyclicBarrier.make(2)
@@ -61,7 +61,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           assert(ticket2)(equalTo(0)) &&
           assert(ticket3)(equalTo(1)) &&
           assert(ticket4)(equalTo(0))
-      } @@ nonFlaky(10000),
+      } @@ exceptJS(nonFlaky(10000)),
       test("Breaks on reset") {
         for {
           barrier <- CyclicBarrier.make(parties)
@@ -73,7 +73,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           res1    <- f1.await
           res2    <- f2.await
         } yield assert(res1)(fails(isUnit)) && assert(res2)(fails(isUnit))
-      } @@ nonFlaky(1000),
+      } @@ exceptJS(nonFlaky(1000)),
       test("Breaks on party interruption") {
         for {
           latch     <- Promise.make[Nothing, Unit]
@@ -92,7 +92,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           assert(isBroken2)(isTrue) &&
           assert(res1)(succeeds(isNone)) &&
           assert(res2)(fails(isUnit))
-      } @@ nonFlaky,
+      } @@ exceptJS(nonFlaky),
       suite("is stable under high contention")(
         test("when fibers == parties") {
           final class Counter {

--- a/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
+++ b/concurrent/src/test/scala/zio/concurrent/CyclicBarrierSpec.scala
@@ -2,7 +2,7 @@ package zio.concurrent
 
 import zio._
 import zio.test.Assertion._
-import zio.test.TestAspect.{nonFlaky, timed, timeout}
+import zio.test.TestAspect.{jvm, nonFlaky, timed, timeout}
 import zio.test._
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -76,13 +76,15 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
       } @@ nonFlaky(1000),
       test("Breaks on party interruption") {
         for {
+          latch     <- Promise.make[Nothing, Unit]
           barrier   <- CyclicBarrier.make(parties)
-          f1        <- barrier.await.timeout(1.second).fork
+          f1        <- barrier.await.timeout(1.second).tap(_ => latch.succeedUnit).fork
           f2        <- barrier.await.fork
           _         <- f1.status.repeatWhile(!_.isInstanceOf[Fiber.Status.Suspended])
           _         <- f2.status.repeatWhile(!_.isInstanceOf[Fiber.Status.Suspended])
           isBroken1 <- barrier.isBroken
           _         <- TestClock.adjust(1.second)
+          _         <- latch.await
           isBroken2 <- barrier.isBroken
           res1      <- f1.await
           res2      <- f2.await
@@ -105,7 +107,7 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
           }
 
           def make1(cb: CyclicBarrier, ref: Counter)(n: Int) =
-            cb.await.tap(_ => ZIO.succeed(ref.inc(n))).repeatN(10000)
+            cb.await.as(ref.inc(n)).repeatN(1000)
 
           for {
             ref <- ZIO.succeed(new Counter)
@@ -122,12 +124,12 @@ object CyclicBarrierSpec extends ZIOSpecDefault {
             cb <- CyclicBarrier.make(4)
             // We can't guarantee that the last n - 1 fibers will be completed
             latch <- CountdownLatch.make(nFibers - nParties + 1)
-            f     <- ZIO.foreachParDiscard(1 to nFibers)(_ => cb.await.repeatN(1000) *> latch.countDown).fork
+            f     <- ZIO.foreachParDiscard(1 to nFibers)(_ => cb.await.repeatN(500) *> latch.countDown).fork
             _     <- latch.await
             _     <- f.interrupt
           } yield assertCompletes
         }
-      ) @@ nonFlaky @@ timeout(30.seconds)
+      ) @@ jvm(nonFlaky) @@ timeout(30.seconds)
     ) @@ timed
 
 }


### PR DESCRIPTION
/fixes #10351

There seems to be a race condition in `CyclicBarrier` under high contention, where it was possible for a fiber to re-enter the `await` block before the "winning" fiber run the `reset` effect and cause an invalid state.

I rewrote the implementation of `CyclicBarrier` using volatile variables and a `Semaphore` to ensure exclusive access to certain parts of the codepath that might lead to invalid states if concurrent access is allowed