### PR TITLE
Avoid recursion in `TestTrace#withCode` when the argument is None

### DIFF
--- a/test/shared/src/main/scala/zio/test/TestTrace.scala
+++ b/test/shared/src/main/scala/zio/test/TestTrace.scala
@@ -117,10 +117,10 @@ sealed trait TestTrace[+A] { self =>
   /**
    * Apply the code to every node in the tree.
    */
-  final def withCode(fullCode: Option[String]): TestTrace[A] =
+  final def withCode(fullCode: Option[String]): TestTrace[A] = if (fullCode.isDefined) {
     self match {
       case node: TestTrace.Node[_] =>
-        node.copy(fullCode = fullCode.orElse(node.fullCode), children = node.children.map(_.withCode(fullCode)))
+        node.copy(fullCode = fullCode, children = node.children.map(_.withCode(fullCode)))
       case TestTrace.AndThen(left, right) =>
         TestTrace.AndThen(left.withCode(fullCode), right.withCode(fullCode))
       case and: TestTrace.And =>
@@ -130,6 +130,9 @@ sealed trait TestTrace[+A] { self =>
       case not: TestTrace.Not =>
         TestTrace.Not(not.trace.withCode(fullCode)).asInstanceOf[TestTrace[A]]
     }
+  } else {
+    self
+  }
 
   /**
    * Apply the code to every node in the tree.


### PR DESCRIPTION
This method was surprisingly noticeable in some test flamegraphs, and most of the time it's called with `None` as the argument.

This change doesn't alter the behaviour, just avoids the recursion when the argument is None. Note that I went with the simplest implementation to avoid too many LOC / tracked changes