### PR TITLE
Reduce branches in ZIO's runloop

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1326,7 +1326,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               cur = patchRuntimeFlags(updateRuntimeFlags.update, null, Exit.unit)
 
             case effect =>
-              throw new MatchError("Invalid effect type in ZIO's runloop: " + effect.getClass.getName)
+              throw new MatchError(effect)
           }
         } catch {
           // TODO: ClosedByInterruptException (but Scala.js??)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -333,11 +333,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             cur = Exit.Failure(cause)
           }
 
-        case FiberMessage.Resume(_) =>
+        case _ =>
           assert(DisableAssertions, "It is illegal to have multiple concurrent run loops in a single fiber")
-
-        case FiberMessage.YieldNow =>
-          assert(DisableAssertions)
       }
 
       message = inbox.poll()
@@ -371,7 +368,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
           resumption = nextEffect0.asInstanceOf[ZIO.Erased]
 
-        case FiberMessage.YieldNow =>
+        case _ =>
           assert(DisableAssertions)
 
       }
@@ -509,7 +506,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         if (exit eq null) EvaluationSignal.YieldNow
         else EvaluationSignal.Continue
 
-      case FiberMessage.YieldNow =>
+      case _ =>
         // Will raise an error during tests, but assertion disappears when we publish
         // Kept just in case someone in the ecosystem as adding YieldNow messages manually
         assert(DisableAssertions)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1141,10 +1141,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
 
-                  case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
-                    cur = patchRuntimeFlags(updateFlags.update, null, null)
-
-                  case _ => ()
+                  case update =>
+                    val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
+                    if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
+                      cur = patchRuntimeFlags(updateFlags.update, null, null)
+                    }
                 }
               }
 
@@ -1172,10 +1173,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
 
-                  case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
-                    cur = patchRuntimeFlags(updateFlags.update, null, null)
-
-                  case _ => ()
+                  case update =>
+                    val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
+                    if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
+                      cur = patchRuntimeFlags(updateFlags.update, null, null)
+                    }
                 }
               }
 
@@ -1229,8 +1231,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               result match {
                 case s: Success[Any] => cur = fold.successK(s.value)
-                case f: Failure[Any] =>
-                  val cause = f.cause
+                case f =>
+                  val cause = f.asInstanceOf[Failure[Any]].cause
                   if (shouldInterrupt()) cur = Exit.Failure(cause.stripFailures)
                   else cur = fold.failureK(cause)
               }
@@ -1342,8 +1344,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 popStackFrame(stackIndex)
 
                 continuation match {
-                  case _: ZIO.FlatMap[Any, Any, Any, Any] =>
-
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     if (shouldInterrupt()) {
                       cause = cause.stripFailures
@@ -1369,15 +1369,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               updateLastTrace(updateRuntimeFlags.trace)
               cur = patchRuntimeFlags(updateRuntimeFlags.update, null, Exit.unit)
 
-            case gen0: GenerateStackTrace =>
-              updateLastTrace(gen0.trace)
-              cur = Exit.succeed(generateStackTrace())
-
-            // Should be unreachable, but we keep it to be backwards compatible
-            case update0: UpdateRuntimeFlagsWithin[Any, Any, Any] =>
-              assert(DisableAssertions) // Will raise an error in tests but not in released artifact
-              cur = UpdateRuntimeFlagsWithin.DynamicNoBox(update0.trace, update0.update, update0.scope(_))
-
+            case effect =>
+              throw new MatchError("Invalid effect type in ZIO's runloop: " + effect.getClass.getName)
           }
         } catch {
           // TODO: ClosedByInterruptException (but Scala.js??)


### PR DESCRIPTION
We can cut down a few branches in the runloop to make it easier for the C2 compiler to optimize things