### PR TITLE
Optimizations for commonly used ZStream / ZChannel methods

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1298,7 +1298,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
    * value when succeeds
    */
   final def unit(implicit trace: Trace): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Unit] =
-    self.as(())
+    self *> ZChannel.unit
 
   /**
    * Updates a service in the environment of this channel.

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -484,7 +484,10 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
     ev: OutDone <:< ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2],
     trace: Trace
   ): ZChannel[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone2] =
-    self.flatMap(ev)
+    ZChannel.Fold(
+      self,
+      ZChannel.Fold.foldKIdentity[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone, OutDone2]
+    )
 
   /**
    * Folds over the result of this channel
@@ -1667,6 +1670,16 @@ object ZChannel {
       trace: Trace
     ): Cause[E] => ZChannel[Any, Any, Any, Any, E, Nothing, Nothing] =
       FailCauseIdentity.asInstanceOf[Cause[E] => ZChannel[Any, Any, Any, Any, E, Nothing, Nothing]]
+
+    private[this] val FoldKIdentity =
+      new Fold.K[Any, Any, Any, Any, Any, Any, Any, Any, Any](
+        v => v.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]],
+        FailCauseIdentity
+      )
+
+    private[stream] def foldKIdentity[Env1, InErr1, InElem1, InDone1, OutErr1, OutElem1, OutDone, OutDone2]
+      : Fold.K[Env1, InErr1, InElem1, InDone1, OutErr1, OutErr1, OutElem1, OutDone, OutDone2] =
+      FoldKIdentity.asInstanceOf[Fold.K[Env1, InErr1, InElem1, InDone1, OutErr1, OutErr1, OutElem1, OutDone, OutDone2]]
   }
 
   private[zio] final case class Bridge[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDone](

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1298,7 +1298,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
    * value when succeeds
    */
   final def unit(implicit trace: Trace): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Unit] =
-    self *> ZChannel.unit
+    self.flatMap(_ => ZChannel.unit)
 
   /**
    * Updates a service in the environment of this channel.

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1298,7 +1298,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
    * value when succeeds
    */
   final def unit(implicit trace: Trace): ZChannel[Env, InErr, InElem, InDone, OutErr, OutElem, Unit] =
-    self.flatMap(_ => ZChannel.unit)
+    self.flatMap(ZChannel.unitChannelFn)
 
   /**
    * Updates a service in the environment of this channel.

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -2730,7 +2730,7 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
         (_: Any) =>
           last match {
             case Some(value) =>
-              ZChannel.write(Chunk.single((value, None))) *> ZChannel.unit
+              ZChannel.write(Chunk.single((value, None)))
             case None =>
               ZChannel.unit
           }

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -773,7 +773,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                         case (Exit.Success(Halt(cause)), previous) =>
                           previous.interrupt as ZChannel.refailCause(cause)
                         case (Exit.Success(End(_)), previous) =>
-                          previous.join.map(ZChannel.write(_) *> ZChannel.unit)
+                          previous.join.map(ZChannel.write(_))
                         case (Exit.Failure(cause), previous) =>
                           previous.interrupt as ZChannel.refailCause(cause)
                       }
@@ -1324,11 +1324,21 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     trace: Trace
   ): ZStream[R1, E1, B] =
     new ZStream(
-      channel.concatMap(as =>
-        as.foldLeft[ZChannel[R1, Any, Any, Any, E1, zio.Chunk[B], Any]](ZChannel.unit) { case (acc, a) =>
-          acc *> f(a).channel
+      channel.concatMap { as =>
+        if (as.isEmpty) ZChannel.unit
+        else {
+          val it    = as.chunkIterator
+          val first = it.nextAt(0)
+          var acc   = ZChannel.suspend(f(first).channel)
+          var index = 1
+          while (it.hasNextAt(index)) {
+            val a = it.nextAt(index)
+            index += 1
+            acc = acc *> f(a).channel
+          }
+          acc
         }
-      )
+      }
     )
 
   /**
@@ -2435,7 +2445,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
             lazy val loop: ZChannel[Any, E, Chunk[A1], Any, E1, Chunk[A1], Unit] = ZChannel.readWithCause(
               (in: Chunk[A1]) => ZChannel.fromZIO(handoff.offer(Signal.Emit(in))) *> loop,
               (e: Cause[E]) => ZChannel.fromZIO(handoff.offer(Signal.Halt(e))) *> ZChannel.refailCause(e),
-              (_: Any) => ZChannel.fromZIO(handoff.offer(Signal.End)) *> ZChannel.unit
+              (_: Any) => ZChannel.fromZIO(handoff.offer(Signal.End))
             )
 
             ZSink.fromChannel(
@@ -3178,8 +3188,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
         (e: Cause[E]) => ZChannel.refailCause(e),
         (_: Any) => {
           if (leftovers.isEmpty) ZChannel.unit
-          else if (leftovers.find(f).isEmpty) ZChannel.write(Chunk.single(leftovers)) *> ZChannel.unit
-          else split(Chunk.empty)(leftovers) *> ZChannel.unit
+          else if (leftovers.find(f).isEmpty) ZChannel.write(Chunk.single(leftovers))
+          else split(Chunk.empty)(leftovers)
         }
       )
 
@@ -3255,7 +3265,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                 reader
               },
               halt = ZChannel.refailCause,
-              done = (_: Any) => ZChannel.write(queue.toChunk) *> ZChannel.unit
+              done = (_: Any) => ZChannel.write(queue.toChunk)
             )
 
           self.channel >>> reader
@@ -3382,7 +3392,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       new ZStream(
         ZChannel.fromZIO(promise.await) *> self.channel
           .pipeTo(loop)
-          .ensuring(queue.offer(Take.end).forkDaemon *> queue.awaitShutdown) *> ZChannel.unit
+          .ensuring(queue.offer(Take.end).forkDaemon *> queue.awaitShutdown)
       )
         .merge(ZStream.execute((promise.succeedUnit *> right.run(sink)).ensuring(queue.shutdown)), HaltStrategy.Both)
     }
@@ -4917,7 +4927,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def loop(s: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
       f(s) match {
         case (as, Some(s)) => ZChannel.write(as) *> loop(s)
-        case (as, None)    => ZChannel.write(as) *> ZChannel.unit
+        case (as, None)    => ZChannel.write(as)
       }
 
     new ZStream(ZChannel.suspend(loop(s)))
@@ -4935,7 +4945,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       ZChannel.unwrap {
         f(s).map {
           case (as, Some(s)) => ZChannel.write(as) *> loop(s)
-          case (as, None)    => ZChannel.write(as) *> ZChannel.unit
+          case (as, None)    => ZChannel.write(as)
         }
       }
 
@@ -5203,7 +5213,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream produced from an effect
    */
   def unwrap[R, E, A](fa: => ZIO[R, E, ZStream[R, E, A]])(implicit trace: Trace): ZStream[R, E, A] =
-    fromZIO(fa).flatten
+    new ZStream(
+      ZChannel.unwrap(
+        fa.fold(
+          e => ZChannel.fail(e),
+          a => a.channel
+        )
+      )
+    )
 
   /**
    * Creates a stream produced from a scoped [[ZIO]]

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4927,7 +4927,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     def loop(s: S): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
       f(s) match {
         case (as, Some(s)) => ZChannel.write(as) *> loop(s)
-        case (as, None)    => ZChannel.write(as)
+        case (as, _)       => ZChannel.write(as)
       }
 
     new ZStream(ZChannel.suspend(loop(s)))
@@ -4945,7 +4945,7 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
       ZChannel.unwrap {
         f(s).map {
           case (as, Some(s)) => ZChannel.write(as) *> loop(s)
-          case (as, None)    => ZChannel.write(as)
+          case (as, _)       => ZChannel.write(as)
         }
       }
 


### PR DESCRIPTION
- Cache `ZChannel.Fold.K` used by `ZChannel#flatten` (which is used by `ZChannel.unwrap`)
- Remove redundant `*> ZChannel.unit`
- Optimize `ZStream#flatMap` to use `ZChannel.suspend` instead of a `ZChannel#flatMap` (which is _A LOT_ more expensive)
- Optimize `ZStream.unwrap`
- Optimize `ZChannel#unit` (not really used, but still nice to have it optimized)