### PR TITLE
Micro-optimization for `Scope.addFinalizer`

### DIFF
--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -105,7 +105,7 @@ object Scope {
    * Accesses a scope in the environment and adds a finalizer to it.
    */
   def addFinalizer(finalizer: => UIO[Any])(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-    ZIO.serviceWithZIO(_.addFinalizer(finalizer))
+    addFinalizerExit(_ => finalizer)
 
   /**
    * Accesses a scope in the environment and adds a finalizer to it.
@@ -113,7 +113,7 @@ object Scope {
   def addFinalizerExit(finalizer: Exit[Any, Any] => UIO[Any])(implicit
     trace: Trace
   ): ZIO[Scope, Nothing, Unit] =
-    ZIO.serviceWithZIO(_.addFinalizerExit(finalizer))
+    ZIO.environmentWithZIO[Scope](_.getScope.addFinalizerExit(finalizer))
 
   /**
    * A layer that constructs a scope and closes it when the workflow the layer
@@ -136,13 +136,13 @@ object Scope {
    */
   val global: Scope.Closeable =
     new Scope.Closeable {
-      def addFinalizerExit(finalizer: Exit[Any, Any] => UIO[Any])(implicit trace: Trace): UIO[Unit] =
+      final def addFinalizerExit(finalizer: Exit[Any, Any] => UIO[Any])(implicit trace: Trace): UIO[Unit] =
         ZIO.unit
-      def close(exit: => Exit[Any, Any])(implicit trace: Trace): UIO[Unit] =
+      final def close(exit: => Exit[Any, Any])(implicit trace: Trace): UIO[Unit] =
         ZIO.unit
-      def forkWith(executionStrategy: => ExecutionStrategy)(implicit trace: Trace): UIO[Scope.Closeable] =
+      final def forkWith(executionStrategy: => ExecutionStrategy)(implicit trace: Trace): UIO[Scope.Closeable] =
         makeWith(executionStrategy)
-      def size: Int = 0
+      final def size: Int = 0
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -120,8 +120,10 @@ final class ZEnvironment[+R] private (
    * the `ZEnvironment` is not statically known to contain a `Scope`
    */
   private[zio] def getScope(implicit ev: R <:< Scope): Scope =
-    if (scope eq null) throw new Error(s"Defect in zio.ZEnvironment: Could not find Scope inside $self")
-    else scope
+    scope match {
+      case null => throw new Error(s"Defect in zio.ZEnvironment: Could not find Scope inside $self")
+      case v    => v
+    }
 
   override lazy val hashCode: Int =
     MurmurHash3.productHash((map, scope)): @noinline // See https://github.com/zio/zio/pull/10363 why `@noinline`


### PR DESCRIPTION
While reviewing a PR in zio-http I realised that `Scope.addFinalizer` is not very optimized because it uses `ZIO.serviceX[Scope]`, which requires parsing of the Scope tag + lookup in the ZEnvironment's cache.

Anyways we optimize it by using `ZIO.environmentX` instead and calling the `getScope` method on it.

Also did some other very minor optimizations that I saw here and there