### PR TITLE
Reduce stack recursion in Fiber runtime loop

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1191,20 +1191,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               if (first eq ZIO.unit) cur = flatmap.successK(())
               else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
-
-                val result = runLoop(first, stackIndex, stackIndex, currentDepth + 1, ops)
-                ops += 1
-
-                if (null eq result) return null
-
-                stackIndex -= 1
-                popStackFrame(stackIndex)
-
-                result match {
-                  case s: Success[Any] => cur = flatmap.successK(s.value)
-                  case failure         => cur = failure
-                }
+                cur = first
               }
+
             case stateful: Stateful[Any, Any, Any] =>
               val trace = stateful.trace
               updateLastTrace(trace)
@@ -1218,22 +1207,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               updateLastTrace(fold.trace)
 
               stackIndex = pushStackFrame(fold, stackIndex)
-
-              val result = runLoop(fold.first, stackIndex, stackIndex, currentDepth + 1, ops)
-              ops += 1
-
-              if (null eq result) return null
-
-              stackIndex -= 1
-              popStackFrame(stackIndex)
-
-              result match {
-                case s: Success[Any] => cur = fold.successK(s.value)
-                case f: Failure[Any] =>
-                  val cause = f.cause
-                  if (shouldInterrupt()) cur = Exit.Failure(cause.stripFailures)
-                  else cur = fold.failureK(cause)
-              }
+              cur = fold.first
 
             case async: Async[Any, Any, Any] =>
               updateLastTrace(async.trace)
@@ -1278,22 +1252,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 val k = ZIO.UpdateRuntimeFlags(trace, revertFlags)
 
                 stackIndex = pushStackFrame(k, stackIndex)
-
-                val exit = runLoop(update0.f(oldRuntimeFlags), stackIndex, stackIndex, currentDepth + 1, ops)
-                ops += 1
-
-                if (null eq exit) return null
-
-                stackIndex -= 1
-                popStackFrame(stackIndex)
-
-                // Go backward, on the stack:
-                if (ignoreFlagsUpdate(revertFlags, stackIndex)) {
-                  cur = exit
-                } else {
-                  cur = patchRuntimeFlags(revertFlags, exit.causeOrNull, exit)
-                }
-
+                cur = update0.f(oldRuntimeFlags)
               }
 
             case iterate: WhileLoop[Any, Any, Any] =>


### PR DESCRIPTION
To the life of me, I don't understand how I (or anyone else) didn't see this before. Or perhaps there's something I'm really missing here.

It seems that the recursive call to `runLoop` on each continuation is completely redundant. This is because we will unwind the stack anyways whenever we reach a terminal effect (`Exit.Success`, `Exit.Fail` and `Sync`).

This change should also clean out flamegraphs massively, as we no longer need a recursive call to `runLoop` for continuations (`FlatMap`, `Fold` and `UpdateRuntimeFlagsWithin.DynamicNoBox`).

Am I missing something? Is it possible that it's _this simple_?

I will update this PR with some benchmarks, but some preliminary runs that I did show a fairly good speedup for some of the benchmarks