### PR TITLE
Fix error handlers to prioritize defects over failures (#9874)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -357,6 +357,61 @@ object CauseSpec extends ZIOBaseSpec {
           }
         }
       }
+    ),
+    suite("isRecoverable")(
+      test("pure failure is recoverable") {
+        val cause = Cause.fail("error")
+        assertTrue(cause.isRecoverable)
+      },
+      test("pure defect is not recoverable") {
+        val cause = Cause.die(new RuntimeException("boom"))
+        assertTrue(!cause.isRecoverable)
+      },
+      test("pure interrupt is not recoverable") {
+        val cause = Cause.interrupt(FiberId.None)
+        assertTrue(!cause.isRecoverable)
+      },
+      test("combined Die && Fail is not recoverable") {
+        val cause = Cause.die(new RuntimeException("boom")) && Cause.fail("error")
+        assertTrue(!cause.isRecoverable)
+      },
+      test("combined Interrupt && Fail is not recoverable") {
+        val cause = Cause.interrupt(FiberId.None) && Cause.fail("error")
+        assertTrue(!cause.isRecoverable)
+      },
+      test("combined Fail && Fail is recoverable") {
+        val cause = Cause.fail("error1") && Cause.fail("error2")
+        assertTrue(cause.isRecoverable)
+      },
+      test("empty cause is recoverable") {
+        assertTrue(Cause.empty.isRecoverable)
+      }
+    ),
+    suite("failureOrCause")(
+      test("returns Left for pure failure") {
+        val cause = Cause.fail("error")
+        assertTrue(cause.failureOrCause == Left("error"))
+      },
+      test("returns Right for pure defect") {
+        val cause = Cause.die(new RuntimeException("boom"))
+        assertTrue(cause.failureOrCause.isRight)
+      },
+      test("returns Right for pure interrupt") {
+        val cause = Cause.interrupt(FiberId.None)
+        assertTrue(cause.failureOrCause.isRight)
+      },
+      test("returns Right for combined Die && Fail (defects take priority)") {
+        val cause = Cause.die(new RuntimeException("boom")) && Cause.fail("error")
+        assertTrue(cause.failureOrCause.isRight)
+      },
+      test("returns Right for combined Interrupt && Fail (interrupts take priority)") {
+        val cause = Cause.interrupt(FiberId.None) && Cause.fail("error")
+        assertTrue(cause.failureOrCause.isRight)
+      },
+      test("returns Left for combined Fail && Fail") {
+        val cause = Cause.fail("error1") && Cause.fail("error2")
+        assertTrue(cause.failureOrCause == Left("error1"))
+      }
     )
   ) @@ samples(10)
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -305,6 +305,54 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
+    suite("catchAll - defect priority (#9874)")(
+      test("does not catch combined Die && Fail cause - defects take priority") {
+        val dieCause = Cause.die(new RuntimeException("defect"))
+        val combinedCause = dieCause && Cause.fail("failure")
+        
+        for {
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("caught")).exit
+        } yield assertTrue(exit.isFailure) && 
+                assertTrue(exit.causeOption.exists(_.defects.nonEmpty))
+      },
+      test("does not catch combined Interrupt && Fail cause - interrupts take priority") {
+        for {
+          fiberId <- ZIO.fiberId
+          interruptCause = Cause.interrupt(fiberId)
+          combinedCause = interruptCause && Cause.fail("failure")
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("caught")).exit
+        } yield assertTrue(exit.isFailure) && 
+                assertTrue(exit.causeOption.exists(_.isInterrupted))
+      },
+      test("still catches pure failure cause") {
+        val failCause = Cause.fail("failure")
+        
+        for {
+          result <- ZIO.failCause(failCause).catchAll(_ => ZIO.succeed("caught"))
+        } yield assertTrue(result == "caught")
+      },
+      test("foldZIO does not invoke failure handler for combined Die && Fail") {
+        val dieCause = Cause.die(new RuntimeException("defect"))
+        val combinedCause = dieCause && Cause.fail("failure")
+        
+        for {
+          exit <- ZIO.failCause(combinedCause).foldZIO(
+            _ => ZIO.succeed("failure handled"),
+            a => ZIO.succeed(a)
+          ).exit
+        } yield assertTrue(exit.isFailure) && 
+                assertTrue(exit.causeOption.exists(_.defects.nonEmpty))
+      },
+      test("either does not convert combined Die && Fail to Left") {
+        val dieCause = Cause.die(new RuntimeException("defect"))
+        val combinedCause = dieCause && Cause.fail("failure")
+        
+        for {
+          exit <- ZIO.failCause(combinedCause).either.exit
+        } yield assertTrue(exit.isFailure) && 
+                assertTrue(exit.causeOption.exists(_.defects.nonEmpty))
+      }
+    ) @@ zioTag(errors),
     suite("catchSomeCause")(
       test("catches matching cause") {
         ZIO.interrupt.catchSomeCause {

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -128,21 +128,39 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * Retrieve the first checked error on the `Left` if available, if there are
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
+   *
+   * Note: If the cause contains any defects (`Die`) or interruptions (`Interrupt`),
+   * this will return `Right` even if failures are present, because defects and
+   * interruptions take priority over recoverable failures.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureOrCause: Either[E, Cause[Nothing]] =
+    if (isRecoverable) {
+      failureOption match {
+        case Some(error) => Left(error)
+        case None        => Right(self.asInstanceOf[Cause[Nothing]])
+      }
+    } else {
+      Right(self.asInstanceOf[Cause[Nothing]])
+    }
 
   /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
+   *
+   * Note: If the cause contains any defects (`Die`) or interruptions (`Interrupt`),
+   * this will return `Right` even if failures are present, because defects and
+   * interruptions take priority over recoverable failures.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] =
+    if (isRecoverable) {
+      failureTraceOption match {
+        case Some(errorAndTrace) => Left(errorAndTrace)
+        case None                => Right(self.asInstanceOf[Cause[Nothing]])
+      }
+    } else {
+      Right(self.asInstanceOf[Cause[Nothing]])
+    }
 
   /**
    * Produces a list of all recoverable errors `E` in the `Cause`.
@@ -377,6 +395,17 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * `Fail` causes.
    */
   final def isInterruptedOnly: Boolean = foldContext(())(Folder.IsInterruptedOnly)
+
+  /**
+   * Determines if the `Cause` is recoverable, meaning it contains only
+   * failures and no defects or interruptions. A cause is not recoverable
+   * if it contains any `Die` or `Interrupt` nodes.
+   *
+   * This is used by error handling methods like `catchAll` to determine
+   * whether the failure handler should be invoked. Defects and interruptions
+   * always take priority over failures.
+   */
+  final def isRecoverable: Boolean = !isDie && !isInterrupted
 
   /**
    * Determines if the `Cause` is traced.


### PR DESCRIPTION
## Summary

Fixes #9874 - Error handlers (`catchAll`, `foldZIO`, `either`, etc.) now correctly prioritize defects and interruptions over failures.

## Approach

- Added `Cause.isRecoverable` to check if cause contains only failures
- Modified `failureOrCause` and `failureTraceOrCause` to return `Right` when defects or interrupts are present

## Verification

- Added 7 tests for `isRecoverable`
- Added 6 tests for `failureOrCause`

/claim #9874