### PR TITLE
Optimize `ZIO.foreachX`methods for single-item collections

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -25,6 +25,7 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
+import scala.collection.compat._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
@@ -3433,14 +3434,17 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   def foreach[R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
     f: A => ZIO[R, E, B]
   )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZIO[R, E, Collection[B]] =
-    if (in.isEmpty) ZIO.succeed(bf.fromSpecific(in)(Nil))
-    else
-      ZIO.suspendSucceed {
-        val iterator = in.iterator
-        val builder  = bf.newBuilder(in)
+    in.sizeCompare(1) match {
+      case -1 => ZIO.succeed(bf.fromSpecific(in)(Nil))
+      case 0  => ZIO.suspendSucceed(f(in.head).map(b => (bf.newBuilder(in) += b).result()))
+      case _ =>
+        ZIO.suspendSucceed {
+          val iterator = in.iterator
+          val builder  = bf.newBuilder(in)
 
-        ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
-      }
+          ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
+        }
+    }
 
   /**
    * Applies the function `f` to each element of the `Set[A]` and returns the
@@ -3450,14 +3454,18 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * the results, see `foreachDiscard` for a more efficient implementation.
    */
   final def foreach[R, E, A, B](in: Set[A])(f: A => ZIO[R, E, B])(implicit trace: Trace): ZIO[R, E, Set[B]] =
-    if (in.isEmpty) ZIO.succeed(Set.empty)
-    else
-      ZIO.suspendSucceed {
-        val iterator = in.iterator
-        val builder  = Set.newBuilder[B]
+    in.size match {
+      case 0 => ZIO.succeed(Set.empty[B])
+      case 1 => ZIO.suspendSucceed(f(in.head).map(Set(_)))
+      case n =>
+        ZIO.suspendSucceed {
+          val iterator = in.iterator
+          val builder  = Set.newBuilder[B]
+          builder.sizeHint(n)
 
-        ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
-      }
+          ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
+        }
+    }
 
   /**
    * Applies the function `f` to each element of the `Array[A]` and returns the
@@ -3547,10 +3555,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   )(f: A => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
     ZIO.suspendSucceed {
       val as0 = as
-      if (as0.isEmpty) Exit.unit
-      else {
-        val iterator = as0.iterator
-        ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(ZIO.unitFn)
+      as0.sizeCompare(1) match {
+        case -1 => Exit.unit
+        case 0  => f(as0.head).unit
+        case _ =>
+          val iterator = as0.iterator
+          ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(ZIO.unitFn)
       }
     }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -25,7 +25,6 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
-import scala.collection.compat._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
@@ -3433,7 +3432,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    */
   def foreach[R, E, A, B, Collection[+Element] <: Iterable[Element]](in: Collection[A])(
     f: A => ZIO[R, E, B]
-  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZIO[R, E, Collection[B]] =
+  )(implicit bf: BuildFrom[Collection[A], B, Collection[B]], trace: Trace): ZIO[R, E, Collection[B]] = {
+    import scala.collection.compat._
     in.sizeCompare(1) match {
       case -1 => ZIO.succeed(bf.fromSpecific(in)(Nil))
       case 0  => ZIO.suspendSucceed(f(in.head).map(b => (bf.newBuilder(in) += b).result()))
@@ -3445,6 +3445,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
           ZIO.whileLoop(iterator.hasNext)(f(iterator.next()))(builder += _).as(builder.result())
         }
     }
+  }
 
   /**
    * Applies the function `f` to each element of the `Set[A]` and returns the
@@ -3554,6 +3555,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     as: => Iterable[A]
   )(f: A => ZIO[R, E, Any])(implicit trace: Trace): ZIO[R, E, Unit] =
     ZIO.suspendSucceed {
+      import scala.collection.compat._
       val as0 = as
       as0.sizeCompare(1) match {
         case -1 => Exit.unit


### PR DESCRIPTION
When we first implemented these methods, we didn't have the `scala-collection-compat` package as a dependency so we couldn't use `sizeCompare`. Since now we have it, we can optimize these methods to avoid using a `WhileLoop` (which is arguably the effect that allocates the most) when we have a single-element collection