### PR TITLE
Add specialized primitive for `ZIO#map`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -118,7 +118,6 @@ object StackTracesSpec extends ZIOBaseSpec {
             if (TestVersion.isScala213 && BuildInfo.optimizationsEnabled)
               """java.util.NoSuchElementException: head of empty list
                 |	at zio.StackTracesSpec$.$anonfun$spec
-                |	at zio.ZIO.$anonfun$map
                 |	at zio.StackTracesSpec.spec.underlyingFailure
                 |	at zio.StackTracesSpec.spec
                 |""".stripMargin
@@ -126,7 +125,6 @@ object StackTracesSpec extends ZIOBaseSpec {
               """java.util.NoSuchElementException: head of empty list
                 |	at scala.collection.immutable.Nil$.head
                 |	at zio.StackTracesSpec$.$anonfun$spec
-                |	at zio.ZIO.$anonfun$map
                 |	at zio.StackTracesSpec.spec.underlyingFailure
                 |	at zio.StackTracesSpec.spec
                 |""".stripMargin
@@ -134,7 +132,6 @@ object StackTracesSpec extends ZIOBaseSpec {
               """java.util.NoSuchElementException: head of empty list
                 |	at scala.collection.immutable.Nil$.head
                 |	at zio.StackTracesSpec$.$anonfun
-                |	at zio.ZIO.map$$anonfun
                 |	at zio.StackTracesSpec.spec.underlyingFailure
                 |	at zio.StackTracesSpec.spec
                 |""".stripMargin

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -979,7 +979,7 @@ sealed trait ZIO[-R, +E, +A]
    * Returns an effect whose success is mapped by the specified `f` function.
    */
   def map[B](f: A => B)(implicit trace: Trace): ZIO[R, E, B] =
-    ZIO.MapF(trace, self, f)
+    ZIO.Mapped(trace, self, f)
 
   /**
    * Returns an effect whose success is mapped by the specified side effecting
@@ -6148,7 +6148,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   ) extends Continuation
       with ZIO[R, E, A2]
 
-  private[zio] final case class MapF[R, E, A1, A2](
+  private[zio] final case class Mapped[R, E, A1, A2](
     trace: Trace,
     first: ZIO[R, E, A1],
     successK: A1 => A2

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -188,7 +188,7 @@ sealed trait ZIO[-R, +E, +A]
    * Maps the success value of this effect to the specified constant value.
    */
   final def as[B](b: => B)(implicit trace: Trace): ZIO[R, E, B] =
-    self.flatMap(_ => Exit.succeed(b))
+    map(_ => b)
 
   /**
    * Maps the success value of this effect to a left value.
@@ -978,8 +978,8 @@ sealed trait ZIO[-R, +E, +A]
   /**
    * Returns an effect whose success is mapped by the specified `f` function.
    */
-  final def map[B](f: A => B)(implicit trace: Trace): ZIO[R, E, B] =
-    flatMap(a => Exit.succeed(f(a)))
+  def map[B](f: A => B)(implicit trace: Trace): ZIO[R, E, B] =
+    ZIO.MapF(trace, self, f)
 
   /**
    * Returns an effect whose success is mapped by the specified side effecting
@@ -2259,7 +2259,7 @@ sealed trait ZIO[-R, +E, +A]
    * unit.
    */
   final def unit(implicit trace: Trace): ZIO[R, E, Unit] =
-    self.flatMap(ZIO.unitZIOFn)
+    self.map(ZIO.unitFn)
 
   /**
    * Converts a `ZIO[R, Either[E, B], A]` into a `ZIO[R, E, Either[A, B]]`. The
@@ -6148,6 +6148,13 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   ) extends Continuation
       with ZIO[R, E, A2]
 
+  private[zio] final case class MapF[R, E, A1, A2](
+    trace: Trace,
+    first: ZIO[R, E, A1],
+    successK: A1 => A2
+  ) extends Continuation
+      with ZIO[R, E, A2]
+
   private[zio] sealed abstract class Continuation {
     def trace: Trace
   }
@@ -6609,6 +6616,9 @@ sealed trait Exit[+E, +A] extends ZIO[Any, E, A] { self =>
    */
   final def isSuccess: Boolean =
     self.isInstanceOf[Success[?]]
+
+  override final def map[B](f: A => B)(implicit trace: Trace): ZIO[Any, E, B] =
+    mapExit(f)
 
   /**
    * Maps over the value type.

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1123,8 +1123,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         try {
           cur match {
             case success: Exit.Success[Any] =>
-              val init  = success.value
-              var value = init
+              var value = success.value
 
               cur = null
 
@@ -1142,7 +1141,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
 
-                  case map: ZIO.MapF[Any, Any, Any, Any] =>
+                  case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
@@ -1154,7 +1153,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               if (cur eq null) {
                 return {
-                  if (init.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) success
+                  if (success.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) success
                   else Exit.succeed(value)
                 }
               }
@@ -1179,7 +1178,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
 
-                  case map: ZIO.MapF[Any, Any, Any, Any] =>
+                  case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
@@ -1210,7 +1209,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               stackIndex = pushStackFrame(fold, stackIndex)
               cur = fold.first
 
-            case map: MapF[Any, Any, Any, Any] =>
+            case map: Mapped[Any, Any, Any, Any] =>
               updateLastTrace(map.trace)
 
               stackIndex = pushStackFrame(map, stackIndex)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1123,7 +1123,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         try {
           cur match {
             case success: Exit.Success[Any] =>
-              val value = success.value
+              val init  = success.value
+              var value = init
 
               cur = null
 
@@ -1140,6 +1141,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+
+                  case map: ZIO.MapF[Any, Any, Any, Any] =>
+                    value = map.successK(value)
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
                     cur = patchRuntimeFlags(updateFlags.update, null, null)
@@ -1149,12 +1153,15 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               }
 
               if (cur eq null) {
-                return success
+                return {
+                  if (init.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) success
+                  else Exit.succeed(value)
+                }
               }
 
             case sync: Sync[Any] =>
               updateLastTrace(sync.trace)
-              val value = sync.eval()
+              var value = sync.eval()
 
               cur = null
 
@@ -1171,6 +1178,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+
+                  case map: ZIO.MapF[Any, Any, Any, Any] =>
+                    value = map.successK(value)
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
                     cur = patchRuntimeFlags(updateFlags.update, null, null)
@@ -1194,6 +1204,18 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 cur = first
               }
 
+            case fold: FoldZIO[Any, Any, Any, Any, Any] =>
+              updateLastTrace(fold.trace)
+
+              stackIndex = pushStackFrame(fold, stackIndex)
+              cur = fold.first
+
+            case map: MapF[Any, Any, Any, Any] =>
+              updateLastTrace(map.trace)
+
+              stackIndex = pushStackFrame(map, stackIndex)
+              cur = map.first
+
             case stateful: Stateful[Any, Any, Any] =>
               val trace = stateful.trace
               updateLastTrace(trace)
@@ -1202,12 +1224,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 self.asInstanceOf[FiberRuntime[Any, Any]],
                 Fiber.Status.Running(_runtimeFlags, trace)
               )
-
-            case fold: FoldZIO[Any, Any, Any, Any, Any] =>
-              updateLastTrace(fold.trace)
-
-              stackIndex = pushStackFrame(fold, stackIndex)
-              cur = fold.first
 
             case async: Async[Any, Any, Any] =>
               updateLastTrace(async.trace)


### PR DESCRIPTION
Keen to hear people's thoughts on this one. Currently, `ZIO#map` is implemented via a `FlatMap`, which ends up with 2 allocations; one for `Exit.Success` and another for the function in `self.flatmap(v => ...)`. We can avoid these two allocations by creating a new ZIO leaf case that's used for mapping non-effectual values.

I run some benchmarks, and AFAICT we're not incurring any noticeable penalty to flatmap-heavy benchmarks, while the `MapBenchmark`'s throughput is increased by ~20%.

So, what do we think about this one?