### PR TITLE
Add implicit tags for ZIO-provided services

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -78,7 +78,7 @@ trait Clock extends Serializable { self =>
 
 object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with Serializable {
 
-  val tag: Tag[Clock] = Tag[Clock]
+  implicit val tag: Tag[Clock] = Tag(EnvironmentTag.tagFromTagMacro[Clock])
 
   private[this] val rightExitUnit = Right(Exit.unit)
 

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -193,6 +193,11 @@ trait ConfigProvider {
 object ConfigProvider {
 
   /**
+   * The tag that describes the ConfigProvider service.
+   */
+  implicit val tag: Tag[ConfigProvider] = Tag(EnvironmentTag.tagFromTagMacro[ConfigProvider])
+
+  /**
    * A simplified config provider that knows only how to deal with flat
    * (key/value) properties. Because these providers are common, there is
    * special support for implementing them.
@@ -924,11 +929,6 @@ object ConfigProvider {
    */
   lazy val propsProvider: ConfigProvider =
     fromProps()
-
-  /**
-   * The tag that describes the ConfigProvider service.
-   */
-  lazy val tag: Tag[ConfigProvider] = Tag[ConfigProvider]
 
   private def indicesFrom(indices: Set[String]) =
     ZIO

--- a/core/shared/src/main/scala/zio/Console.scala
+++ b/core/shared/src/main/scala/zio/Console.scala
@@ -65,7 +65,7 @@ trait Console extends Serializable { self =>
 
 object Console extends Serializable {
 
-  val tag: Tag[Console] = Tag[Console]
+  implicit val tag: Tag[Console] = Tag(EnvironmentTag.tagFromTagMacro[Console])
 
   object ConsoleLive extends Console {
 

--- a/core/shared/src/main/scala/zio/DefaultServices.scala
+++ b/core/shared/src/main/scala/zio/DefaultServices.scala
@@ -24,21 +24,21 @@ object DefaultServices {
   /**
    * The default ZIO services.
    */
-  val live: ZEnvironment[Clock with Console with System with Random with ConfigProvider] =
+  val live: ZEnvironment[Clock & Console & System & Random & ConfigProvider] =
     ZEnvironment[Clock, Console, System, Random, ConfigProvider](
       Clock.ClockLive,
       Console.ConsoleLive,
       System.SystemLive,
       Random.RandomLive,
       ConfigProvider.defaultProvider
-    )(Clock.tag, Console.tag, System.tag, Random.tag, ConfigProvider.tag)
+    )
 
   private[zio] val currentServices: FiberRef.WithPatch[
-    ZEnvironment[Clock with Console with System with Random with ConfigProvider],
+    ZEnvironment[Clock & Console & System & Random & ConfigProvider],
     ZEnvironment.Patch[
-      Clock with Console with System with Random with ConfigProvider,
-      Clock with Console with System with Random with ConfigProvider
+      Clock & Console & System & Random & ConfigProvider,
+      Clock & Console & System & Random & ConfigProvider
     ]
   ] =
-    FiberRef.unsafe.makeEnvironment(live)(Unsafe.unsafe)
+    FiberRef.unsafe.makeEnvironment(live)(Unsafe)
 }

--- a/core/shared/src/main/scala/zio/Random.scala
+++ b/core/shared/src/main/scala/zio/Random.scala
@@ -144,7 +144,7 @@ trait Random extends Serializable { self =>
 
 object Random extends Serializable {
 
-  val tag: Tag[Random] = Tag[Random]
+  implicit val tag: Tag[Random] = Tag(EnvironmentTag.tagFromTagMacro[Random])
 
   object RandomLive extends Random {
 

--- a/core/shared/src/main/scala/zio/Scope.scala
+++ b/core/shared/src/main/scala/zio/Scope.scala
@@ -77,6 +77,8 @@ sealed trait Scope extends Serializable { self =>
 
 object Scope {
 
+  implicit val tag: Tag[Scope] = Tag(EnvironmentTag.tagFromTagMacro[Scope])
+
   sealed trait Closeable extends Scope { self =>
 
     /**

--- a/core/shared/src/main/scala/zio/System.scala
+++ b/core/shared/src/main/scala/zio/System.scala
@@ -101,7 +101,7 @@ trait System extends Serializable { self =>
 
 object System extends SystemPlatformSpecific {
 
-  val tag: Tag[System] = Tag[System]
+  implicit val tag: Tag[System] = Tag(EnvironmentTag.tagFromTagMacro[System])
 
   object SystemLive extends System {
     def env(variable: => String)(implicit trace: Trace): IO[SecurityException, Option[String]] =

--- a/core/shared/src/main/scala/zio/ZEnvironment.scala
+++ b/core/shared/src/main/scala/zio/ZEnvironment.scala
@@ -594,7 +594,7 @@ object ZEnvironment {
   }
 
   private val ScopeTag: LightTypeTag =
-    taggedTagType(EnvironmentTag[Scope])
+    Scope.tag.tag
 
   private val TaggedAny: LightTypeTag =
     taggedTagType(EnvironmentTag[Any])

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -29,7 +29,7 @@ trait Annotations extends Serializable {
 
 object Annotations {
 
-  val tag: Tag[Annotations] = Tag[Annotations]
+  implicit val tag: Tag[Annotations] = Tag(EnvironmentTag.tagFromTagMacro[Annotations])
 
   final case class Test(ref: Ref.Atomic[TestAnnotationMap]) extends Annotations {
     def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: Trace): UIO[Unit] =

--- a/test/shared/src/main/scala/zio/test/Live.scala
+++ b/test/shared/src/main/scala/zio/test/Live.scala
@@ -32,7 +32,7 @@ trait Live {
 
 object Live {
 
-  val tag: Tag[Live] = Tag[Live]
+  implicit val tag: Tag[Live] = Tag(EnvironmentTag.tagFromTagMacro[Live])
 
   final case class Test(zenv: ZEnvironment[Clock with Console with System with Random]) extends Live {
     def provide[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =

--- a/test/shared/src/main/scala/zio/test/Sized.scala
+++ b/test/shared/src/main/scala/zio/test/Sized.scala
@@ -12,7 +12,7 @@ trait Sized extends Serializable {
 
 object Sized {
 
-  val tag: Tag[Sized] = Tag[Sized]
+  implicit val tag: Tag[Sized] = Tag(EnvironmentTag.tagFromTagMacro[Sized])
 
   final case class Test(fiberRef: FiberRef[Int]) extends Sized {
     def size(implicit trace: Trace): UIO[Int] =

--- a/test/shared/src/main/scala/zio/test/TestConfig.scala
+++ b/test/shared/src/main/scala/zio/test/TestConfig.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{Exit, Tag, Trace, URIO, ZIO, ZIOAspect, ZLayer}
+import zio.{EnvironmentTag, Exit, Tag, Trace, URIO, ZIO, ZIOAspect, ZLayer}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 /**
@@ -59,7 +59,7 @@ trait TestConfig extends Serializable {
 
 object TestConfig {
 
-  val tag: Tag[TestConfig] = Tag[TestConfig]
+  implicit val tag: Tag[TestConfig] = Tag(EnvironmentTag.tagFromTagMacro[TestConfig])
 
   @deprecated("use TestV2", "2.1.8")
   final case class Test(repeats: Int, retries: Int, samples: Int, shrinks: Int) extends TestConfig

--- a/test/shared/src/main/scala/zio/test/TestServices.scala
+++ b/test/shared/src/main/scala/zio/test/TestServices.scala
@@ -25,21 +25,19 @@ object TestServices {
   /**
    * The default ZIO Test services.
    */
-  val test: ZEnvironment[Annotations with Live with Sized with TestConfig] =
+  val test: ZEnvironment[Annotations & Live & Sized & TestConfig] =
     ZEnvironment[Annotations, Live, Sized, TestConfig](
       Annotations.Test(Ref.unsafe.make(TestAnnotationMap.empty)(Unsafe)),
       Live.Test(DefaultServices.live),
       Sized.Test(FiberRef.unsafe.make(100)(Unsafe)),
       TestConfig.TestV2(100, 100, 200, 1000, ZIOAspect.identity)
-    )(Annotations.tag, Live.tag, Sized.tag, TestConfig.tag)
+    )
 
   private[zio] val currentServices: FiberRef.WithPatch[
-    ZEnvironment[
-      Annotations with Live with Sized with TestConfig
-    ],
+    ZEnvironment[Annotations & Live & Sized & TestConfig],
     ZEnvironment.Patch[
-      Annotations with Live with Sized with TestConfig,
-      Annotations with Live with Sized with TestConfig
+      Annotations & Live & Sized & TestConfig,
+      Annotations & Live & Sized & TestConfig
     ]
   ] =
     FiberRef.unsafe.makeEnvironment(test)(Unsafe)


### PR DESCRIPTION
Tags can be relatively expensive when created dynamically because they allocate ~3 objects and need to be parsed from a string.

For ZIO-provided services, we can add an implicit tag in the companion object to avoid this issue.

Note that the most important one is `Scope` as it's the only one that is likely to be used in code such as `ZIO.service[Scope]`, but I added it for all of them for completeness.