### PR TITLE
Optimize `ZIO.attemptBlockingInterrupt`

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
@@ -46,7 +46,24 @@ object BlockingSpec extends ZIOBaseSpec {
         },
         test("can be interrupted") {
           assertZIO(ZIO.attemptBlockingInterrupt(Thread.sleep(50000)).timeout(Duration.Zero))(isNone)
-        } @@ nonFlaky
+        } @@ nonFlaky,
+        test("issues multiple thread interruptions") {
+          val interruptCount = new AtomicInteger(0)
+          val effect = ZIO.attemptBlockingInterrupt {
+            while (true) {
+              try {
+                Thread.sleep(Long.MaxValue)
+              } catch {
+                case t: InterruptedException =>
+                  if (interruptCount.incrementAndGet() >= 5) throw t
+              }
+            }
+          }
+          for {
+            _    <- Live.live(effect.timeout(50.millis))
+            count = interruptCount.get()
+          } yield assertTrue(count >= 5)
+        }
       ),
       suite("ZIO.blocking")(
         test("runs on blocking thread pool") {

--- a/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
@@ -2,47 +2,93 @@ package zio.internal
 
 import zio.ZIOBaseSpec
 import zio.test.Assertion._
+import zio.test.TestAspect.blocking
 import zio.test._
 
 object OneShotSpec extends ZIOBaseSpec {
 
   def spec = suite("OneShotSpec")(
     suite("OneShotSpec")(
-      suite("Make a new OneShot")(
-        test("set must accept a non-null value") {
+      test("set must accept a non-null value") {
+        val oneShot = OneShot.make[Int]
+        oneShot.set(1)
+
+        assert(oneShot.get())(equalTo(1))
+      },
+      test("set must not accept a null value") {
+        val oneShot = OneShot.make[Object]
+
+        assert(oneShot.set(null))(throwsA[Error])
+      },
+      test("isSet must report if a value is set") {
+        val oneShot = OneShot.make[Int]
+
+        val resultBeforeSet = oneShot.isSet
+
+        oneShot.set(1)
+
+        val resultAfterSet = oneShot.isSet
+
+        assert(resultBeforeSet)(isFalse) && assert(resultAfterSet)(isTrue)
+      },
+      test("cannot set value twice") {
+        val oneShot = OneShot.make[Int]
+        oneShot.set(1)
+
+        assert(oneShot.set(2))(throwsA[Error])
+      },
+      test("cannot set value while another thread holds the lock") {
+        val oneShot = OneShot.make[Unit]
+        val lock    = OneShot.make[Unit]
+
+        val t = new Thread(() => {
+          lock.set(())
+          oneShot.set(())
+        })
+
+        oneShot.lock()
+        t.start()
+        lock.get()
+        Thread.sleep(10L)
+        val isSet = oneShot.isSet
+        oneShot.unlock()
+
+        assertTrue(!isSet)
+      },
+      suite("get(timeout)")(
+        test("succeeds if value is set within the timeout") {
           val oneShot = OneShot.make[Int]
-          oneShot.set(1)
 
-          assert(oneShot.get())(equalTo(1))
+          new Thread(() => {
+            Thread.sleep(10L)
+            oneShot.set(1)
+          }).start()
+
+          assert(oneShot.get(20L))(equalTo(1))
         },
-        test("set must not accept a null value") {
-          val oneShot = OneShot.make[Object]
-
-          assert(oneShot.set(null))(throwsA[Error])
-        },
-        test("isSet must report if a value is set") {
-          val oneShot = OneShot.make[Int]
-
-          val resultBeforeSet = oneShot.isSet
-
-          oneShot.set(1)
-
-          val resultAfterSet = oneShot.isSet
-
-          assert(resultBeforeSet)(isFalse) && assert(resultAfterSet)(isTrue)
-        },
-        test("get must fail if no value is set") {
+        test("fails if no value is set") {
           val oneShot = OneShot.make[Object]
 
           assert(oneShot.get(10L))(throwsA[OneShot.TimeoutException])
-        },
-        test("cannot set value twice") {
-          val oneShot = OneShot.make[Int]
-          oneShot.set(1)
-
-          assert(oneShot.set(2))(throwsA[Error])
         }
-      )
+      ) @@ blocking,
+      suite("tryGet(timeout)")(
+        test("succeeds if value is set within the timeout") {
+          val oneShot = OneShot.make[Int]
+
+          new Thread(() => {
+            Thread.sleep(10L)
+            oneShot.set(1)
+          }).start()
+
+          assert(oneShot.tryGet(20L))(equalTo(1))
+        },
+        test("returns null if the value is not set within the timeout") {
+          val oneShot = OneShot.make[Object]
+
+          assert(oneShot.tryGet(10L))(equalTo(null))
+        }
+      ) @@ blocking
     )
   )
 }

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -104,7 +104,7 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
                    } catch {
                      case _: InterruptedException =>
                        ZIO.interrupt
-                     case t if nonFatal(t)=>
+                     case t if nonFatal(t) =>
                        ZIO.fail(t)
                    } finally {
                      end.set(BoxedUnit.UNIT)

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -26,6 +26,7 @@ import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
+import scala.runtime.BoxedUnit
 
 private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
   def toCompletableFuture[A1 >: A](implicit
@@ -63,68 +64,58 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
    * `attemptBlockingCancelable`.
    */
   def attemptBlockingInterrupt[A](effect: => A)(implicit trace: Trace): Task[A] =
-    ZIO.suspendSucceed {
+    ZIO.uninterruptibleMask { restore =>
+      val begin = OneShot.make[Thread]
+      val end   = OneShot.make[Object]
 
-      val lock   = new ReentrantLock()
-      val thread = new AtomicReference[Option[Thread]](None)
-      val begin  = OneShot.make[Unit]
-      val end    = OneShot.make[Unit]
-
-      def withMutex[B](b: => B): B =
-        try {
-          lock.lock(); b
-        } finally lock.unlock()
-
-      val interruptThread: UIO[Unit] =
-        ZIO.succeed {
-          begin.get()
-
-          var looping = true
+      /**
+       * Interrupts the thread running the blocking effect using thread
+       * interruption.
+       *
+       * This effect is run in the blocking threadpool because begin.get() and
+       * end.tryGet() hard-block the thread.
+       */
+      def interruptThread(): UIO[Unit] =
+        ZIO.succeedBlocking {
+          val thread  = begin.get()
+          var looping = !end.isSet
           var n       = 0L
-          val base    = 2L
+
           while (looping) {
-            withMutex(thread.get match {
-              case None         => looping = false; ()
-              case Some(thread) => thread.interrupt()
-            })
-
-            if (looping) {
-              n += 1
-              Thread.sleep(math.min(50, base * n))
+            end.lock()
+            try {
+              // `end` cannot be set while we're here, so we can safely interrupt
+              if (!end.isSet) thread.interrupt()
+            } finally {
+              end.unlock()
             }
-          }
 
-          end.get()
+            n += 1
+            looping = end.tryGet(math.min(50, 2L * n)) eq null
+          }
         }
 
-      ZIO.blocking(
-        ZIO.uninterruptibleMask(restore =>
-          for {
-            fiber <- ZIO.suspend {
-                       val current = Some(Thread.currentThread)
+      for {
+        fiber <- ZIO.blocking {
+                   begin.set(Thread.currentThread)
 
-                       withMutex(thread.set(current))
-
-                       begin.set(())
-
-                       try {
-                         val a = effect
-
-                         ZIO.succeed(a)
-                       } catch {
-                         case _: InterruptedException =>
-                           Thread.interrupted // Clear interrupt status
-                           ZIO.interrupt
-                         case t: Throwable =>
-                           ZIO.fail(t)
-                       } finally {
-                         withMutex { thread.set(None); end.set(()) }
-                       }
-                     }.forkDaemon
-            a <- restore(fiber.join).ensuring(interruptThread)
-          } yield a
-        )
-      )
+                   try {
+                     Exit.succeed(effect)
+                   } catch {
+                     case _: InterruptedException =>
+                       ZIO.interrupt
+                     case t: Throwable =>
+                       ZIO.fail(t)
+                   } finally {
+                     end.set(BoxedUnit.UNIT)
+                     Thread.interrupted() // Clear interrupt status
+                   }
+                 }.forkDaemon
+        a <- restore(fiber.await).exitWith {
+               case Exit.Success(exit)       => exit
+               case f: Exit.Failure[Nothing] => interruptThread() *> f
+             }
+      } yield a
     }
 
   def readFile(path: => Path)(implicit trace: Trace, d: DummyImplicit): ZIO[Any, IOException, String] =

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -104,7 +104,7 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
                    } catch {
                      case _: InterruptedException =>
                        ZIO.interrupt
-                     case t: Throwable =>
+                     case t if nonFatal(t)=>
                        ZIO.fail(t)
                    } finally {
                      end.set(BoxedUnit.UNIT)

--- a/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
@@ -65,19 +65,9 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
    *   exception
    */
   def get(timeout: Long): A =
-    if (value ne null) value
-    else {
-      this.lock()
-
-      try {
-        if (value eq null) this.isSetCondition.await(timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
-      } finally {
-        this.unlock()
-      }
-
-      if (value eq null) throw new OneShot.TimeoutException
-
-      value
+    tryGet(timeout) match {
+      case null => throw new OneShot.TimeoutException
+      case v    => v
     }
 
   /**

--- a/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/OneShot.scala
@@ -60,6 +60,9 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
    *   The maximum amount of time the thread will be blocked, in milliseconds.
    * @throws Error
    *   if the timeout is reached without the value being set.
+   * @see
+   *   [[tryGet]] for a variant that returns null instead of throwing a timeout
+   *   exception
    */
   def get(timeout: Long): A =
     if (value ne null) value
@@ -89,6 +92,28 @@ private[zio] final class OneShot[A] private () extends ReentrantLock(false) {
 
       try {
         while (value eq null) this.isSetCondition.await()
+      } finally {
+        this.unlock()
+      }
+
+      value
+    }
+
+  /**
+   * Attempts to retrieve the value of the variable, blocking if necessary up to
+   * the specified timeout. If the timeout is reached without the value being
+   * set, it returns null.
+   *
+   * @param timeout
+   *   The maximum amount of time the thread will be blocked, in milliseconds.
+   */
+  def tryGet(timeout: Long): A =
+    if (value ne null) value
+    else {
+      this.lock()
+
+      try {
+        if (value eq null) this.isSetCondition.await(timeout, java.util.concurrent.TimeUnit.MILLISECONDS)
       } finally {
         this.unlock()
       }


### PR DESCRIPTION
This PR optimizes `ZIO.attemptBlockingInterrupt` in several ways:
- Awaiting of the blocking effect is now performed on the current fiber / thread (instead of spawning a new one via `ZIO.blocking`
- Avoids creation of a `ReentrantLock` and an `AtomicReference` by using the two `OneShot`s for locking, synchronization and to store the `Thread` that runs the blocking code
- Reduces the number of effects required to evaluate the blocking code by ~6 or so
- Performs the interruption callback only when the main fiber is interrupted. Note that we have to spawn another blocking thread when we want to perform interruption, but that's a small price to pay.

@neko-kai what do you think about these changes? Do they address your issue? 