### PR TITLE
Fix Project Links on The Landing Page

### DIFF
--- a/website/src/components/sections/Ecosystem/data.js
+++ b/website/src/components/sections/Ecosystem/data.js
@@ -61,7 +61,7 @@ export const ecosystemProjects = [
       'Built-in codecs for JSON, Protobuf, Avro, and Thrift',
       'Schema transformations and migrations',
     ],
-    link: '/reference/schema',
+    link: '/zio-schema',
     icon: '🧬'
   },
   {
@@ -73,7 +73,7 @@ export const ecosystemProjects = [
       'Automatic documentation generation',
       'Validation with detailed error reporting'
     ],
-    link: '/ecosystem/officials/zio-config',
+    link: '/zio-config',
     icon: '⚙️'
   },
   {
@@ -85,7 +85,7 @@ export const ecosystemProjects = [
       'Context-aware logging with MDC support',
       'Log correlation across async boundaries'
     ],
-    link: '/ecosystem/officials/zio-logging',
+    link: '/zio-logging',
     icon: '📝'
   }
 ];


### PR DESCRIPTION
This pull request updates the documentation links for several ecosystem projects in the `website/src/components/sections/Ecosystem/data.js` file to point to their new top-level routes, making navigation more direct and user-friendly.

Documentation link updates:

* Changed the `link` for the ZIO Schema project from `/reference/schema` to `/zio-schema`.
* Changed the `link` for the ZIO Config project from `/ecosystem/officials/zio-config` to `/zio-config`.
* Changed the `link` for the ZIO Logging project from `/ecosystem/officials/zio-logging` to `/zio-logging`.

fixes #10420 