### PR TITLE
fix: use ConcurrentLinkedDeque from Scala Native

### DIFF
--- a/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
 private[zio] trait QueuePlatformSpecific {
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS or Scala Native, so we use an ArrayDeque instead
+  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS, so we use an ArrayDeque instead
   type ConcurrentDeque[A] = java.util.ArrayDeque[A]
 }

--- a/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,27 +1,5 @@
 package zio
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.mutable
-
 private[zio] trait QueuePlatformSpecific {
-
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in Scala Native, so we need to createa custom `addFirst` method
-  private[zio] final class ConcurrentDeque[A <: AnyRef] extends ConcurrentLinkedQueue[A] {
-
-    def addFirst(a: A): Unit = {
-      var popped = poll()
-      if (popped eq null) {
-        offer(a)
-      } else {
-        val buf = new mutable.ArrayBuffer[A]
-        while (popped ne null) {
-          buf += popped
-          popped = poll()
-        }
-        offer(a)
-        buf.foreach(offer)
-      }
-    }
-
-  }
+  type ConcurrentDeque[A] = java.util.concurrent.ConcurrentLinkedDeque[A]
 }


### PR DESCRIPTION
## Summary

Scala Native 0.5.6+ now includes `java.util.concurrent.ConcurrentLinkedDeque` (merged in [scala-native/scala-native#4046](https://github.com/scala-native/scala-native/pull/4046)), so we can remove the custom workaround implementation and use the same type alias as JVM.

This enables more code sharing between JVM and Native ports of ZIO, as requested in #9189.

### Changes:
- **Native**: Removed custom `ConcurrentDeque` class that extended `ConcurrentLinkedQueue` with a workaround `addFirst` method. Now uses `java.util.concurrent.ConcurrentLinkedDeque[A]` type alias (same as JVM).
- **JS**: Updated comment to remove outdated mention of Scala Native not supporting `ConcurrentLinkedDeque`.

### Testing:
- Native module compiles successfully
- JVM Queue tests pass (128 tests)
- Native tests pass (some stress tests have timeouts which appear to be pre-existing platform limitations)

Fixes #9189