### PR TITLE
Add `assertTrueZIO` smart assertion macro

### DIFF
--- a/docs/reference/test/assertions/smart-assertions.md
+++ b/docs/reference/test/assertions/smart-assertions.md
@@ -32,7 +32,7 @@ test("multiple assertions"){
 
 ## Asserting ZIO effects
 
-The `assertTrue` method can also be used to assert ZIO effects:
+The `assertTrue` method can also be used to assert ZIO effects by placing it in the `yield` of a for-comprehension:
 
 ```scala mdoc:compile-only
 import zio._
@@ -44,6 +44,17 @@ test("updating ref") {
     _ <- r.update(_ + 1)
     v <- r.get
   } yield assertTrue(v == 1)
+}
+```
+
+Note that `assertTrue` returns `TestResult`, not `ZIO`, so it cannot be used directly inside `flatMap`. If you need to use an assertion in the middle of a for-comprehension or inside `flatMap`, use `assertTrueZIO` instead, which returns `ZIO[Any, Nothing, TestResult]`:
+
+```scala mdoc:compile-only
+import zio._
+import zio.test.{test, _}
+
+test("using assertTrueZIO inside flatMap") {
+  ZIO.succeed(42).flatMap(result => assertTrueZIO(result == 42))
 }
 ```
 

--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -730,7 +730,10 @@ object SmartAssertionSpec extends ZIOBaseSpec {
           actual.length == 5 && actual == expected
         case _ => false
       }
-    )
+    ),
+    test("assertTrueZIO works inside flatMap") {
+      ZIO.succeed(1).flatMap(result => assertTrueZIO(result == 1))
+    }
   )
 
   // The implicit trace will be used by assertTrue to report the

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -33,9 +33,30 @@ trait CompileVariants {
 
   /**
    * Checks the assertion holds for the given value.
+   *
+   * Note: `assertTrue` returns [[TestResult]], not `ZIO`. If you need to use it
+   * inside `flatMap`, either use a for-comprehension:
+   * {{{
+   * for {
+   *   result <- myEffect
+   * } yield assertTrue(result == expected)
+   * }}}
+   * or use [[assertTrueZIO]] which returns `ZIO[Any, Nothing, TestResult]`.
    */
   def assertTrue(expr: Boolean, exprs: Boolean*): TestResult = macro SmartAssertMacros.assert_impl
   def assertTrue(expr: Boolean): TestResult = macro SmartAssertMacros.assertOne_impl
+
+  /**
+   * Like [[assertTrue]] but returns `ZIO[Any, Nothing, TestResult]`, making it
+   * usable inside `flatMap`:
+   * {{{
+   * myEffect.flatMap(result => assertTrueZIO(result == expected))
+   * }}}
+   */
+  def assertTrueZIO(expr: Boolean)(implicit trace: Trace): ZIO[Any, Nothing, TestResult] =
+    macro SmartAssertMacros.assertOneZIO_impl
+  def assertTrueZIO(expr: Boolean, exprs: Boolean*)(implicit trace: Trace): ZIO[Any, Nothing, TestResult] =
+    macro SmartAssertMacros.assertZIO_impl
 
   /**
    * Checks the assertion holds for the given value.

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -256,6 +256,16 @@ $TestResult($ast.withCode($codeString).meta(location = $location))
 """
   }
 
+  def assertOneZIO_impl(expr: Expr[Boolean])(trace: c.Expr[zio.Trace]): c.Tree = {
+    val result = assertOne_impl(expr)
+    q"_root_.zio.test.TestResult.liftTestResultToZIO($result)($trace)"
+  }
+
+  def assertZIO_impl(expr: c.Expr[Boolean], exprs: c.Expr[Boolean]*)(trace: c.Expr[zio.Trace]): c.Tree = {
+    val result = assert_impl(expr, exprs: _*)
+    q"_root_.zio.test.TestResult.liftTestResultToZIO($result)($trace)"
+  }
+
   object UnwrapImplicit {
     def unapply(tree: c.Tree): Option[c.Tree] = tree match {
       case q"$wrapper(...$lhs)" if wrapper.symbol != null && wrapper.symbol.isImplicit =>

--- a/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/CompileVariants.scala
@@ -45,6 +45,9 @@ trait CompileVariants {
   inline def assertTrue(inline exprs: => Boolean*): TestResult =
     ${ SmartAssertMacros.smartAssert('exprs) }
 
+  inline def assertTrueZIO(inline exprs: => Boolean*)(using trace: Trace): ZIO[Any, Nothing, TestResult] =
+    ${ SmartAssertMacros.smartAssertZIO('exprs, 'trace) }
+
   inline def assert[A](inline value: => A)(
     inline assertion: Assertion[A]
   )(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -31,6 +31,13 @@ object SmartAssertMacros {
   def smartAssert(exprs: Expr[Seq[Boolean]])(using Quotes): Expr[TestResult] =
     SmartAssertMacros.smartAssert_impl(exprs)
 
+  def smartAssertZIO(exprs: Expr[Seq[Boolean]], trace: Expr[Trace])(using
+    Quotes
+  ): Expr[ZIO[Any, Nothing, TestResult]] = {
+    val result = smartAssert_impl(exprs)
+    '{ TestResult.liftTestResultToZIO($result)(using $trace) }
+  }
+
   extension (using Quotes)(typeRepr: quotes.reflect.TypeRepr) {
     def typeTree: quotes.reflect.TypeTree = {
       import quotes.reflect._


### PR DESCRIPTION
## Summary

Fixes #8668

`assertTrue` is a Scala 2 blackbox macro returning `TestResult`, not `ZIO`. When used inside `flatMap`, the compiler produces the cryptic error `macro has not been expanded` because the expected type (`ZIO`) doesn't match the macro's declared return type (`TestResult`), preventing macro expansion.

This PR adds `assertTrueZIO`, a variant that returns `ZIO[Any, Nothing, TestResult]`, making it usable inside `flatMap` and similar contexts.

## Changes

- **Scala 2**: Added `assertOneZIO_impl` and `assertZIO_impl` macro implementations in `SmartAssertMacros` that wrap the result in `liftTestResultToZIO`
- **Scala 3**: Added `smartAssertZIO` macro in `SmartAssertMacros` with corresponding `inline def` in `CompileVariants`
- **Test**: Added `assertTrueZIO works inside flatMap` test in `SmartAssertionSpec`
- **Docs**: Updated `smart-assertions.md` with `assertTrueZIO` usage and explanation

## Usage

```scala
// Before (fails to compile in Scala 2):
ZIO.succeed(42).flatMap(result => assertTrue(result == 42))

// After:
ZIO.succeed(42).flatMap(result => assertTrueZIO(result == 42))
```

## Test plan

- [x] `SmartAssertionSpec` passes on Scala 2.12, 2.13, and 3
- [x] Full `testJVM` passes on all 3 Scala versions
- [x] `scalafmtCheck` passes
- [x] `docs/mdoc` compiles with 0 errors

/claim #8668