### PR TITLE
Fix ZStream.buffer prefetch semantics

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,7 +607,43 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          },
+          test("buffer(1) does not run more than one element ahead") {
+            for {
+              started <- Ref.make(Chunk.empty[Int])
+              stream = ZStream
+                         .fromIterable(1 to 3)
+                         .mapZIO(i => started.update(_ :+ i).as(i))
+                         .buffer(1)
+              startedAfterFirst <- ZIO.scoped {
+                                    stream.toPull.flatMap { pull =>
+                                      for {
+                                        _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                        _ <- TestClock.adjust(50.millis)
+                                        s <- started.get
+                                      } yield s
+                                    }
+                                  }
+            } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2)))
+          } @@ TestAspect.timeout(5.seconds) @@ nonFlaky,
+          test("buffer(2) does not run more than two elements ahead") {
+            for {
+              started <- Ref.make(Chunk.empty[Int])
+              stream = ZStream
+                         .fromIterable(1 to 4)
+                         .mapZIO(i => started.update(_ :+ i).as(i))
+                         .buffer(2)
+              startedAfterFirst <- ZIO.scoped {
+                                    stream.toPull.flatMap { pull =>
+                                      for {
+                                        _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                        _ <- TestClock.adjust(50.millis)
+                                        s <- started.get
+                                      } yield s
+                                    }
+                                  }
+            } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2, 3)))
+          } @@ TestAspect.timeout(5.seconds) @@ nonFlaky
         ),
         suite("bufferChunks")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -616,14 +616,14 @@ object ZStreamSpec extends ZIOBaseSpec {
                          .mapZIO(i => started.update(_ :+ i).as(i))
                          .buffer(1)
               startedAfterFirst <- ZIO.scoped {
-                                    stream.toPull.flatMap { pull =>
-                                      for {
-                                        _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
-                                        _ <- TestClock.adjust(50.millis)
-                                        s <- started.get
-                                      } yield s
-                                    }
-                                  }
+                                     stream.toPull.flatMap { pull =>
+                                       for {
+                                         _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                         _ <- TestClock.adjust(50.millis)
+                                         s <- started.get
+                                       } yield s
+                                     }
+                                   }
             } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2)))
           } @@ TestAspect.timeout(5.seconds) @@ nonFlaky,
           test("buffer(2) does not run more than two elements ahead") {
@@ -634,14 +634,14 @@ object ZStreamSpec extends ZIOBaseSpec {
                          .mapZIO(i => started.update(_ :+ i).as(i))
                          .buffer(2)
               startedAfterFirst <- ZIO.scoped {
-                                    stream.toPull.flatMap { pull =>
-                                      for {
-                                        _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
-                                        _ <- TestClock.adjust(50.millis)
-                                        s <- started.get
-                                      } yield s
-                                    }
-                                  }
+                                     stream.toPull.flatMap { pull =>
+                                       for {
+                                         _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                         _ <- TestClock.adjust(50.millis)
+                                         s <- started.get
+                                       } yield s
+                                     }
+                                   }
             } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2, 3)))
           } @@ TestAspect.timeout(5.seconds) @@ nonFlaky
         ),

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,26 +391,109 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
-    new ZStream(
-      ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
+    val evaluatedCapacity = capacity
 
-          process
+    if (evaluatedCapacity <= 0) {
+      val queue = self.toQueueOfElements(evaluatedCapacity)
+      new ZStream(
+        ZChannel.unwrapScoped[R] {
+          queue.map { queue =>
+            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+              ZChannel.fromZIO {
+                queue.take
+              }.flatMap { (exit: Exit[Option[E], A]) =>
+                exit.foldExit(
+                  Cause
+                    .flipCauseOption(_)
+                    .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                  value => ZChannel.write(Chunk.single(value)) *> process
+                )
+              }
+
+            process
+          }
         }
-      }
-    )
+      )
+    } else if (evaluatedCapacity == 1) {
+      // Special case for `buffer(1)`: we need a synchronous handoff to avoid
+      // running one extra element ahead of the downstream consumer.
+      new ZStream(
+        ZChannel.unwrapScoped[R] {
+          for {
+            queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
+            _ <- {
+              lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                  in =>
+                    ZChannel.fromZIO {
+                      ZIO.foreachDiscard(in) { a =>
+                        for {
+                          taken <- Promise.make[Nothing, Unit]
+                          _     <- queue.offer((Exit.succeed(a), taken))
+                          _     <- taken.await
+                        } yield ()
+                      }
+                    } *> writer,
+                  err =>
+                    ZChannel.fromZIO {
+                      for {
+                        taken <- Promise.make[Nothing, Unit]
+                        _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
+                        _     <- taken.await
+                      } yield ()
+                    },
+                  _ =>
+                    ZChannel.fromZIO {
+                      for {
+                        taken <- Promise.make[Nothing, Unit]
+                        _     <- queue.offer((Exit.fail(None), taken))
+                        _     <- taken.await
+                      } yield ()
+                    }
+                )
+
+              (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
+            }
+          } yield {
+            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+              ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
+                ZChannel.fromZIO(taken.succeedUnit) *>
+                  exit.foldExit(
+                    Cause
+                      .flipCauseOption(_)
+                      .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                    value => ZChannel.write(Chunk.single(value)) *> process
+                  )
+              }
+
+            process
+          }
+        }
+      )
+    } else {
+      // For `buffer(n)` we need a queue of size `n - 1` because one element may
+      // be in-flight downstream at any time.
+      val queue = self.toQueueOfElements(evaluatedCapacity - 1)
+      new ZStream(
+        ZChannel.unwrapScoped[R] {
+          queue.map { queue =>
+            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+              ZChannel.fromZIO {
+                queue.take
+              }.flatMap { (exit: Exit[Option[E], A]) =>
+                exit.foldExit(
+                  Cause
+                    .flipCauseOption(_)
+                    .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                  value => ZChannel.write(Chunk.single(value)) *> process
+                )
+              }
+
+            process
+          }
+        }
+      )
+    }
   }
 
   /**

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -390,111 +390,104 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val evaluatedCapacity = capacity
-
-    if (evaluatedCapacity <= 0) {
-      val queue = self.toQueueOfElements(evaluatedCapacity)
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
+    ZStream.suspend {
       new ZStream(
         ZChannel.unwrapScoped[R] {
-          queue.map { queue =>
-            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-              ZChannel.fromZIO {
-                queue.take
-              }.flatMap { (exit: Exit[Option[E], A]) =>
-                exit.foldExit(
-                  Cause
-                    .flipCauseOption(_)
-                    .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                  value => ZChannel.write(Chunk.single(value)) *> process
-                )
-              }
+          ZIO.suspendSucceed {
+          val evaluatedCapacity = capacity
 
-            process
-          }
-        }
-      )
-    } else if (evaluatedCapacity == 1) {
-      // Special case for `buffer(1)`: we need a synchronous handoff to avoid
-      // running one extra element ahead of the downstream consumer.
-      new ZStream(
-        ZChannel.unwrapScoped[R] {
-          for {
-            queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
-            _ <- {
-              lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
-                ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
-                  in =>
-                    ZChannel.fromZIO {
-                      ZIO.foreachDiscard(in) { a =>
-                        for {
-                          taken <- Promise.make[Nothing, Unit]
-                          _     <- queue.offer((Exit.succeed(a), taken))
-                          _     <- taken.await
-                        } yield ()
-                      }
-                    } *> writer,
-                  err =>
-                    ZChannel.fromZIO {
-                      for {
-                        taken <- Promise.make[Nothing, Unit]
-                        _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
-                        _     <- taken.await
-                      } yield ()
-                    },
-                  _ =>
-                    ZChannel.fromZIO {
-                      for {
-                        taken <- Promise.make[Nothing, Unit]
-                        _     <- queue.offer((Exit.fail(None), taken))
-                        _     <- taken.await
-                      } yield ()
-                    }
-                )
-
-              (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
-            }
-          } yield {
-            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-              ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
-                ZChannel.fromZIO(taken.succeedUnit) *>
+          if (evaluatedCapacity <= 0) {
+            self.toQueueOfElements(evaluatedCapacity).map { queue =>
+              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                ZChannel.fromZIO {
+                  queue.take
+                }.flatMap { (exit: Exit[Option[E], A]) =>
                   exit.foldExit(
                     Cause
                       .flipCauseOption(_)
                       .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
                     value => ZChannel.write(Chunk.single(value)) *> process
                   )
-              }
+                }
 
-            process
+              process
+            }
+          } else if (evaluatedCapacity == 1) {
+            // Special case for `buffer(1)`: we need a synchronous handoff to avoid
+            // running one extra element ahead of the downstream consumer.
+            for {
+              queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
+              _ <- {
+                lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                  ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                    in =>
+                      ZChannel.fromZIO {
+                        ZIO.foreachDiscard(in) { a =>
+                          for {
+                            taken <- Promise.make[Nothing, Unit]
+                            _     <- queue.offer((Exit.succeed(a), taken))
+                            _     <- taken.await
+                          } yield ()
+                        }
+                      } *> writer,
+                    err =>
+                      ZChannel.fromZIO {
+                        for {
+                          taken <- Promise.make[Nothing, Unit]
+                          _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
+                          _     <- taken.await
+                        } yield ()
+                      },
+                    _ =>
+                      ZChannel.fromZIO {
+                        for {
+                          taken <- Promise.make[Nothing, Unit]
+                          _     <- queue.offer((Exit.fail(None), taken))
+                          _     <- taken.await
+                        } yield ()
+                      }
+                  )
+
+                (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
+              }
+            } yield {
+              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
+                  ZChannel.fromZIO(taken.succeedUnit) *>
+                    exit.foldExit(
+                      Cause
+                        .flipCauseOption(_)
+                        .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                      value => ZChannel.write(Chunk.single(value)) *> process
+                    )
+                }
+
+              process
+            }
+          } else {
+            // For `buffer(n)` we need a queue of size `n - 1` because one element may
+            // be in-flight downstream at any time.
+            self.toQueueOfElements(evaluatedCapacity - 1).map { queue =>
+              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                ZChannel.fromZIO {
+                  queue.take
+                }.flatMap { (exit: Exit[Option[E], A]) =>
+                  exit.foldExit(
+                    Cause
+                      .flipCauseOption(_)
+                      .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                    value => ZChannel.write(Chunk.single(value)) *> process
+                  )
+                }
+
+              process
+            }
           }
         }
-      )
-    } else {
-      // For `buffer(n)` we need a queue of size `n - 1` because one element may
-      // be in-flight downstream at any time.
-      val queue = self.toQueueOfElements(evaluatedCapacity - 1)
-      new ZStream(
-        ZChannel.unwrapScoped[R] {
-          queue.map { queue =>
-            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-              ZChannel.fromZIO {
-                queue.take
-              }.flatMap { (exit: Exit[Option[E], A]) =>
-                exit.foldExit(
-                  Cause
-                    .flipCauseOption(_)
-                    .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                  value => ZChannel.write(Chunk.single(value)) *> process
-                )
-              }
-
-            process
-          }
-        }
-      )
+      }
+    )
     }
-  }
 
   /**
    * Allows a faster producer to progress independently of a slower consumer by

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -395,98 +395,98 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       new ZStream(
         ZChannel.unwrapScoped[R] {
           ZIO.suspendSucceed {
-          val evaluatedCapacity = capacity
+            val evaluatedCapacity = capacity
 
-          if (evaluatedCapacity <= 0) {
-            self.toQueueOfElements(evaluatedCapacity).map { queue =>
-              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-                ZChannel.fromZIO {
-                  queue.take
-                }.flatMap { (exit: Exit[Option[E], A]) =>
-                  exit.foldExit(
-                    Cause
-                      .flipCauseOption(_)
-                      .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                    value => ZChannel.write(Chunk.single(value)) *> process
-                  )
-                }
-
-              process
-            }
-          } else if (evaluatedCapacity == 1) {
-            // Special case for `buffer(1)`: we need a synchronous handoff to avoid
-            // running one extra element ahead of the downstream consumer.
-            for {
-              queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
-              _ <- {
-                lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
-                  ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
-                    in =>
-                      ZChannel.fromZIO {
-                        ZIO.foreachDiscard(in) { a =>
-                          for {
-                            taken <- Promise.make[Nothing, Unit]
-                            _     <- queue.offer((Exit.succeed(a), taken))
-                            _     <- taken.await
-                          } yield ()
-                        }
-                      } *> writer,
-                    err =>
-                      ZChannel.fromZIO {
-                        for {
-                          taken <- Promise.make[Nothing, Unit]
-                          _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
-                          _     <- taken.await
-                        } yield ()
-                      },
-                    _ =>
-                      ZChannel.fromZIO {
-                        for {
-                          taken <- Promise.make[Nothing, Unit]
-                          _     <- queue.offer((Exit.fail(None), taken))
-                          _     <- taken.await
-                        } yield ()
-                      }
-                  )
-
-                (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
-              }
-            } yield {
-              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-                ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
-                  ZChannel.fromZIO(taken.succeedUnit) *>
+            if (evaluatedCapacity <= 0) {
+              self.toQueueOfElements(evaluatedCapacity).map { queue =>
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO {
+                    queue.take
+                  }.flatMap { (exit: Exit[Option[E], A]) =>
                     exit.foldExit(
                       Cause
                         .flipCauseOption(_)
                         .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
                       value => ZChannel.write(Chunk.single(value)) *> process
                     )
-                }
+                  }
 
-              process
-            }
-          } else {
-            // For `buffer(n)` we need a queue of size `n - 1` because one element may
-            // be in-flight downstream at any time.
-            self.toQueueOfElements(evaluatedCapacity - 1).map { queue =>
-              lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-                ZChannel.fromZIO {
-                  queue.take
-                }.flatMap { (exit: Exit[Option[E], A]) =>
-                  exit.foldExit(
-                    Cause
-                      .flipCauseOption(_)
-                      .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                    value => ZChannel.write(Chunk.single(value)) *> process
-                  )
-                }
+                process
+              }
+            } else if (evaluatedCapacity == 1) {
+              // Special case for `buffer(1)`: we need a synchronous handoff to avoid
+              // running one extra element ahead of the downstream consumer.
+              for {
+                queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
+                _ <- {
+                  lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                    ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                      in =>
+                        ZChannel.fromZIO {
+                          ZIO.foreachDiscard(in) { a =>
+                            for {
+                              taken <- Promise.make[Nothing, Unit]
+                              _     <- queue.offer((Exit.succeed(a), taken))
+                              _     <- taken.await
+                            } yield ()
+                          }
+                        } *> writer,
+                      err =>
+                        ZChannel.fromZIO {
+                          for {
+                            taken <- Promise.make[Nothing, Unit]
+                            _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
+                            _     <- taken.await
+                          } yield ()
+                        },
+                      _ =>
+                        ZChannel.fromZIO {
+                          for {
+                            taken <- Promise.make[Nothing, Unit]
+                            _     <- queue.offer((Exit.fail(None), taken))
+                            _     <- taken.await
+                          } yield ()
+                        }
+                    )
 
-              process
+                  (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
+                }
+              } yield {
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
+                    ZChannel.fromZIO(taken.succeedUnit) *>
+                      exit.foldExit(
+                        Cause
+                          .flipCauseOption(_)
+                          .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                        value => ZChannel.write(Chunk.single(value)) *> process
+                      )
+                  }
+
+                process
+              }
+            } else {
+              // For `buffer(n)` we need a queue of size `n - 1` because one element may
+              // be in-flight downstream at any time.
+              self.toQueueOfElements(evaluatedCapacity - 1).map { queue =>
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO {
+                    queue.take
+                  }.flatMap { (exit: Exit[Option[E], A]) =>
+                    exit.foldExit(
+                      Cause
+                        .flipCauseOption(_)
+                        .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                      value => ZChannel.write(Chunk.single(value)) *> process
+                    )
+                  }
+
+                process
+              }
             }
           }
         }
-      }
-    )
+      )
     }
 
   /**


### PR DESCRIPTION
/claim #9810

## Summary
Fix `ZStream.buffer(n)` prefetch semantics so it doesn’t run more than `n` elements ahead.

- For `n > 1`, internal queue capacity is adjusted to `n - 1` to account for the single in-flight element downstream.
- For `n == 1`, use a synchronous handoff (ack per element) so the upstream cannot advance beyond one element.

## Proof
### Tests
```bash
sbt "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t buffer"
```

Includes new regression tests:
- `buffer(1) does not run more than one element ahead`
- `buffer(2) does not run more than two elements ahead`
