### PR TITLE
Fix #9874: don't let typed error recovery drop defects/interruption

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -284,11 +284,10 @@ object ZIOSpec extends ZIOBaseSpec {
     ),
     suite("catchAll")(
       test("does not recover from typed errors when the cause contains defects (issue 9874)") {
-        val t            = new RuntimeException("boom")
-        val dieCause     = Cause.die(t)
-        val combined     = dieCause && Cause.fail("boom")
-        val effect =
-          ZIO.failCause(combined).catchAll(_ => ZIO.succeed("handled")).exit
+        val t        = new RuntimeException("boom")
+        val dieCause = Cause.die(t)
+        val combined = dieCause && Cause.fail("boom")
+        val effect   = ZIO.failCause(combined).catchAll(_ => ZIO.succeed("handled")).exit
 
         effect.map(exit => assert(exit)(dies(equalTo(t))))
       }

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -282,6 +282,17 @@ object ZIOSpec extends ZIOBaseSpec {
         zio.map(assert(_)(isTrue))
       }
     ),
+    suite("catchAll")(
+      test("does not recover from typed errors when the cause contains defects (issue 9874)") {
+        val t            = new RuntimeException("boom")
+        val dieCause     = Cause.die(t)
+        val combined     = dieCause && Cause.fail("boom")
+        val effect =
+          ZIO.failCause(combined).catchAll(_ => ZIO.succeed("handled")).exit
+
+        effect.map(exit => assert(exit)(dies(equalTo(t))))
+      }
+    ) @@ zioTag(errors),
     suite("catchAllDefect")(
       test("recovers from all defects") {
         val s   = "division by zero"

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -129,20 +129,32 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureOrCause: Either[E, Cause[Nothing]] =
+    if (self.isDie || self.isInterrupted) {
+      // If there are defects or interruptions, we must not allow typed error recovery
+      // to silently drop them. In that case, return the non-recoverable part.
+      Right(self.stripFailures)
+    } else {
+      failureOption match {
+        case Some(error) => Left(error)
+        case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
+    }
 
   /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] =
+    if (self.isDie || self.isInterrupted) {
+      Right(self.stripFailures)
+    } else {
+      failureTraceOption match {
+        case Some(errorAndTrace) => Left(errorAndTrace)
+        case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
+    }
 
   /**
    * Produces a list of all recoverable errors `E` in the `Cause`.


### PR DESCRIPTION
/claim #9874

## Problem
When a `Cause` contains both a typed failure (`Fail`) and a defect (`Die`) or interruption, `foldZIO` / `catchAll` uses `Cause.failureOrCause` and will recover from the typed error, silently dropping the defect/interruption.

Repro from the issue:
```scala
val t: Throwable       = new RuntimeException("boom")
val dieCause           = Cause.die(t)
val combinedCause      = dieCause && Cause.fail("boom")

ZIO.failCause(combinedCause).catchAll(_ => ZIO.debug("handled")) *> ZIO.debug("Success")
```

## Fix
Change `Cause.failureOrCause` (and `failureTraceOrCause`) to return the non-recoverable part (`stripFailures`) whenever the `Cause` contains defects or interruption.

This ensures typed error recovery cannot mask defects/interruption.

## Tests
Added regression test:
- `ZIOSpec > catchAll > does not recover from typed errors when the cause contains defects (issue 9874)`

Ran locally:
```bash
sbt -Dsbt.supershell=false "clean" \
  "coreTestsJVM/testOnly zio.ZIOSpec -- -t 9874"
```
