### PR TITLE
Add zoneId as part of Clock

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -43,6 +43,8 @@ trait Clock extends Serializable { self =>
 
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit]
 
+  def zoneId(implicit trace: Trace): UIO[ZoneId]
+
   trait UnsafeAPI extends Serializable {
     def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long
     def currentTime(unit: ChronoUnit)(implicit unsafe: Unsafe): Long
@@ -50,6 +52,7 @@ trait Clock extends Serializable { self =>
     def instant()(implicit unsafe: Unsafe): Instant
     def localDateTime()(implicit unsafe: Unsafe): LocalDateTime
     def nanoTime()(implicit unsafe: Unsafe): Long
+    def zoneId()(implicit unsafe: Unsafe): ZoneId
   }
 
   def unsafe: UnsafeAPI =
@@ -73,6 +76,9 @@ trait Clock extends Serializable { self =>
 
       def nanoTime()(implicit unsafe: Unsafe): Long =
         Runtime.default.unsafe.run(self.nanoTime(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
+
+      def zoneId()(implicit unsafe: Unsafe): ZoneId =
+        Runtime.default.unsafe.run(self.zoneId(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
     }
 }
 
@@ -105,6 +111,9 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
     def scheduler(implicit trace: Trace): UIO[Scheduler] =
       ClockLive.scheduler
 
+    def zoneId(implicit trace: Trace): UIO[ZoneId] =
+      ZIO.succeed(unsafe.zoneId()(Unsafe.unsafe))
+
     override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
@@ -124,6 +133,9 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
 
         override def nanoTime()(implicit unsafe: Unsafe): Long =
           currentTime(TimeUnit.NANOSECONDS)
+
+        override def zoneId()(implicit unsafe: Unsafe): ZoneId =
+          clock.getZone
       }
   }
 
@@ -175,6 +187,9 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
       ZIO.succeed(JavaClock(ZoneId.systemDefault))
     }
 
+    def zoneId(implicit trace: Trace): UIO[ZoneId] =
+      ZIO.succeed(ZoneId.systemDefault)
+
     override val unsafe: UnsafeAPI =
       new UnsafeAPI {
         override def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long =
@@ -194,6 +209,8 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
 
         override def nanoTime()(implicit unsafe: Unsafe): Long =
           JSystem.nanoTime
+        override def zoneId()(implicit unsafe: Unsafe): ZoneId =
+          ZoneId.systemDefault()
       }
   }
 
@@ -241,5 +258,11 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
    */
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit] =
     ZIO.clockWith(_.sleep(duration))
+
+  /**
+   * Get the ZoneId
+   */
+  def zoneId(implicit trace: Trace): UIO[ZoneId] =
+    ZIO.clockWith(_.zoneId)
 
 }

--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -43,7 +43,7 @@ trait Clock extends Serializable { self =>
 
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit]
 
-  final def zoneId(implicit trace: Trace): UIO[ZoneId] = ZIO.succeed(unsafe.zoneId()(Unsafe.unsafe))
+  def zoneId(implicit trace: Trace): UIO[ZoneId] = ZIO.succeed(unsafe.zoneId()(Unsafe.unsafe))
 
   trait UnsafeAPI extends Serializable {
     def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long
@@ -77,8 +77,6 @@ trait Clock extends Serializable { self =>
       def nanoTime()(implicit unsafe: Unsafe): Long =
         Runtime.default.unsafe.run(self.nanoTime(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
 
-      def zoneId()(implicit unsafe: Unsafe): ZoneId =
-        Runtime.default.unsafe.run(self.zoneId(Trace.empty))(Trace.empty, unsafe).getOrThrowFiberFailure()
     }
 }
 
@@ -185,7 +183,7 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
       ZIO.succeed(JavaClock(ZoneId.systemDefault))
     }
 
-    def zoneId(implicit trace: Trace): UIO[ZoneId] =
+    override def zoneId(implicit trace: Trace): UIO[ZoneId] =
       ZIO.succeed(ZoneId.systemDefault)
 
     override val unsafe: UnsafeAPI =
@@ -207,8 +205,6 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
 
         override def nanoTime()(implicit unsafe: Unsafe): Long =
           JSystem.nanoTime
-        override def zoneId()(implicit unsafe: Unsafe): ZoneId =
-          ZoneId.systemDefault()
       }
   }
 

--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -43,7 +43,7 @@ trait Clock extends Serializable { self =>
 
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit]
 
-  def zoneId(implicit trace: Trace): UIO[ZoneId]
+  final def zoneId(implicit trace: Trace): UIO[ZoneId] = ZIO.succeed(unsafe.zoneId()(Unsafe.unsafe))
 
   trait UnsafeAPI extends Serializable {
     def currentTime(unit: TimeUnit)(implicit unsafe: Unsafe): Long
@@ -52,7 +52,7 @@ trait Clock extends Serializable { self =>
     def instant()(implicit unsafe: Unsafe): Instant
     def localDateTime()(implicit unsafe: Unsafe): LocalDateTime
     def nanoTime()(implicit unsafe: Unsafe): Long
-    def zoneId()(implicit unsafe: Unsafe): ZoneId
+    def zoneId()(implicit unsafe: Unsafe): ZoneId = ZoneId.systemDefault()
   }
 
   def unsafe: UnsafeAPI =
@@ -111,8 +111,6 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
     def scheduler(implicit trace: Trace): UIO[Scheduler] =
       ClockLive.scheduler
 
-    def zoneId(implicit trace: Trace): UIO[ZoneId] =
-      ZIO.succeed(unsafe.zoneId()(Unsafe.unsafe))
 
     override val unsafe: UnsafeAPI =
       new UnsafeAPI {

--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -192,7 +192,14 @@ object ClockSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.unit raceFirst Clock.instant
         } yield assertCompletes
-      }.provideLayer(scopedExecutor) @@ exceptJS(nonFlaky)
+      }.provideLayer(scopedExecutor) @@ exceptJS(nonFlaky),
+      test("zoneId matches what was provided through JavaClock") {
+        checkAll(Gen.elements(ZoneId.of("Europe/Paris"), ZoneId.of("America/Los_Angeles"))) { zoneId =>
+          for {
+            usedZoneId <- Clock.zoneId.withClock(ClockJava(java.time.Clock.system(zoneId)))
+          } yield assertTrue(usedZoneId == zoneId)
+        }
+      }
     )
 
   class ScopedExecutor extends Executor {

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -233,7 +233,7 @@ object TestClock extends Serializable {
     /**
      * Returns the time zone.
      */
-    def zoneId(implicit trace: Trace): UIO[ZoneId] =
+    override def zoneId(implicit trace: Trace): UIO[ZoneId] =
       clockState.get.map(_.timeZone)
 
     override def unsafe: UnsafeAPI =

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -94,7 +94,7 @@ trait TestClock extends Clock with Restorable {
   def setTime(instant: Instant)(implicit trace: Trace): UIO[Unit]
   def setTimeZone(zone: ZoneId)(implicit trace: Trace): UIO[Unit]
   def sleeps(implicit trace: Trace): UIO[List[Instant]]
-  def timeZone(implicit trace: Trace): UIO[ZoneId]
+  final def timeZone(implicit trace: Trace): UIO[ZoneId] = zoneId
 }
 
 object TestClock extends Serializable {
@@ -233,7 +233,7 @@ object TestClock extends Serializable {
     /**
      * Returns the time zone.
      */
-    def timeZone(implicit trace: Trace): UIO[ZoneId] =
+    def zoneId(implicit trace: Trace): UIO[ZoneId] =
       clockState.get.map(_.timeZone)
 
     override def unsafe: UnsafeAPI =
@@ -259,6 +259,9 @@ object TestClock extends Serializable {
 
         override def nanoTime()(implicit unsafe: Unsafe): Long =
           currentTime(ChronoUnit.NANOS)
+
+        override def zoneId()(implicit unsafe: Unsafe): ZoneId =
+          clockState.unsafe.get.timeZone
       }
 
     /**


### PR DESCRIPTION
There are many cases where I need to know what `ZoneId` was used while using `zio.Clock`. Right now it is an implementation detail that it will always be `ZoneId.systemDefault`, except when provided through a `ClockJava`. 

There are many places in our code base where we do `Clock.javaClock.map(_.getZone)`. I think `Clock.zoneId` is a great improvement in readability.

I'm not sure about `TestClock`s `timeZone`. Can it be removed in favor of `zoneId`? I prefer the name `zoneId` since it matches the other methods in `Clock` which mirror java time names.