### PR TITLE
Added zoneId to the Clock companion object

### DIFF
--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -248,5 +248,4 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
   def zoneId(implicit trace: Trace): UIO[ZoneId] =
     ZIO.clockWith(_.javaClock.map(_.getZone))
 
-
 }

--- a/core/shared/src/main/scala/zio/Clock.scala
+++ b/core/shared/src/main/scala/zio/Clock.scala
@@ -242,4 +242,11 @@ object Clock extends ClockPlatformSpecific with ClockSyntaxPlatformSpecific with
   def sleep(duration: => Duration)(implicit trace: Trace): UIO[Unit] =
     ZIO.clockWith(_.sleep(duration))
 
+  /**
+   * Get the ZoneId for current clock
+   */
+  def zoneId(implicit trace: Trace): UIO[ZoneId] =
+    ZIO.clockWith(_.javaClock.map(_.getZone))
+
+
 }

--- a/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ClockSpec.scala
@@ -192,7 +192,14 @@ object ClockSpec extends ZIOBaseSpec {
         for {
           _ <- ZIO.unit raceFirst Clock.instant
         } yield assertCompletes
-      }.provideLayer(scopedExecutor) @@ exceptJS(nonFlaky)
+      }.provideLayer(scopedExecutor) @@ exceptJS(nonFlaky),
+      test("zoneId matches what was provided through JavaClock") {
+        checkAll(Gen.elements(ZoneId.of("Europe/Paris"), ZoneId.of("America/Los_Angeles"))) { zoneId =>
+          for {
+            usedZoneId <- Clock.zoneId.withClock(ClockJava(java.time.Clock.system(zoneId)))
+          } yield assertTrue(usedZoneId == zoneId)
+        }
+      }
     )
 
   class ScopedExecutor extends Executor {


### PR DESCRIPTION
This PR is a binary backwards compatible version of this PR https://github.com/zio/zio/pull/10448

It contains the most ergonomic change that I wanted. I still think it would be a great improvement if `Clock` had a `zoneId` similiar to how `TestClock`s `timeZone`. 