### PR TITLE
Fix #9874: do not recover from defects/interrupts in catchAll / catchSome / either

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -305,6 +305,26 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
+    suite("issue #9874 - do not recover from defects/interrupts in catchAll")(
+      test("catchAll should not recover when Cause contains Die and Fail") {
+        val combined = Cause.die(new RuntimeException("Defect")) && Cause.fail("Error")
+        assertZIO(ZIO.failCause(combined).catchAll(_ => ZIO.succeed("recovered")).exit)(
+          dies(hasMessage(equalTo("Defect")))
+        )
+      },
+      test("either should not produce Right when Cause contains Die and Fail") {
+        val combined = Cause.die(new RuntimeException("Defect")) && Cause.fail("Error")
+        assertZIO(ZIO.failCause(combined).either.exit)(
+          dies(hasMessage(equalTo("Defect")))
+        )
+      },
+      test("catchSome should not recover when Cause contains Die and Fail") {
+        val combined = Cause.die(new RuntimeException("Defect")) && Cause.fail("Error")
+        assertZIO(ZIO.failCause(combined).catchSome { case "Error" => ZIO.succeed("recovered") }.exit)(
+          dies(hasMessage(equalTo("Defect")))
+        )
+      }
+    ) @@ zioTag(errors),
     suite("catchSomeCause")(
       test("catches matching cause") {
         ZIO.interrupt.catchSomeCause {

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -129,20 +129,26 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureOrCause: Either[E, Cause[Nothing]] =
+    if (isDie || isInterrupted) Right(self.asInstanceOf[Cause[Nothing]])
+    else
+      failureOption match {
+        case Some(error) => Left(error)
+        case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
 
   /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] =
+    if (isDie || isInterrupted) Right(self.asInstanceOf[Cause[Nothing]])
+    else
+      failureTraceOption match {
+        case Some(errorAndTrace) => Left(errorAndTrace)
+        case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
 
   /**
    * Produces a list of all recoverable errors `E` in the `Cause`.

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -130,7 +130,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * only `Die` or `Interrupt` causes.
    */
   final def failureOrCause: Either[E, Cause[Nothing]] =
-    if (isDie || isInterrupted) Right(self.asInstanceOf[Cause[Nothing]])
+    if (isDie || isInterruptedOnly) Right(self.asInstanceOf[Cause[Nothing]])
     else
       failureOption match {
         case Some(error) => Left(error)
@@ -143,7 +143,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * to contain only `Die` or `Interrupt` causes.
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] =
-    if (isDie || isInterrupted) Right(self.asInstanceOf[Cause[Nothing]])
+    if (isDie || isInterruptedOnly) Right(self.asInstanceOf[Cause[Nothing]])
     else
       failureTraceOption match {
         case Some(errorAndTrace) => Left(errorAndTrace)


### PR DESCRIPTION
When a `Cause` contains a `Die` or `Interrupt` alongside a typed `Fail`,
recovery operators must not treat it as a recoverable failure.

Previously, `failureOrCause` / `failureTraceOrCause` would extract the typed
failure even if the `Cause` also contained a defect or interruption,
allowing operators like `catchAll`, `catchSome`, and `either` to incorrectly recover.

This change ensures that if the `Cause` contains any `Die` or `Interrupt`,
the original `Cause` is returned instead of a typed failure.

Adds regression tests in `ZIOSpec`.
Fixes  #9874 
/claim #9874 


