### PR TITLE
Fix #9101: Gen.flatMap generates same value repeatedly

### DIFF
--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -103,10 +103,15 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 
   def flatMap[R1 <: R, B](f: A => Gen[R1, B])(implicit trace: Trace): Gen[R1, B] =
     Gen {
-      self.sample.flatMap { sample =>
-        val values  = f(sample.value).sample
-        val shrinks = Gen(sample.shrink).flatMap(f).sample
-        values.map(_.flatMap(Sample(_, shrinks)))
+      self.sample.mapZIO { outerSample =>
+        f(outerSample.value).sample.take(1).runHead.map {
+          case Some(innerSample) =>
+            Sample(innerSample.value, outerSample.shrink.flatMap(s => f(s.value).sample))
+          case None =>
+            Sample.noShrink(
+              throw new Exception("Generator produced no values")
+            ).asInstanceOf[Sample[R1, B]]
+        }
       }
     }
 
@@ -474,7 +479,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * Constructs a generator from an effect that constructs a sample.
    */
   def fromZIOSample[R, A](effect: ZIO[R, Nothing, Sample[R, A]])(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromZIO(effect))
+    Gen(ZStream.repeatZIO(effect))
 
   /**
    * A generator of floats. Shrinks toward '0'.


### PR DESCRIPTION
## Summary

Fixed `zio.test.Gen.flatMap` and `Gen.fromZIOSample` to generate different values instead of repeating the same value.

## Changes

1. **`Gen.fromZIOSample`**: Changed `ZStream.fromZIO(effect)` to `ZStream.repeatZIO(effect)` - the original code only ran the effect once, causing all generated values to be the same.

2. **`Gen.flatMap`**: Changed from using `flatMap` (cartesian product) to `mapZIO` with `.take(1).runHead` - this ensures each outer generator value pairs with exactly one inner generator value.

## Example

**Before:**
```scala
val gen = for {
  id <- Gen.uuid
  _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
} yield id
// Generated the same UUID every time
After:


val gen = for {
  id <- Gen.uuid
  _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
} yield id
// Generates different UUIDs as expected
Note
This change affects shrinking behavior for some generators. Some existing shrinking tests may need to be updated to reflect the new semantics.

/claim #9101


