### PR TITLE
feat: Add Promise.become to link fibers to promises

### DIFF
--- a/benchmarks/src/main/scala/zio/PromiseBecomeBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/PromiseBecomeBenchmark.scala
@@ -1,0 +1,56 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class PromiseBecomeBenchmark {
+
+  @Param(Array("1000", "10000", "100000"))
+  var n: Int = _
+
+  /**
+   * Traditional pattern: fork a fiber, flatMap the result to complete the
+   * promise, then await the promise. This creates extra allocations and
+   * indirection.
+   */
+  @Benchmark
+  def traditionalForkAwaitPromise(): Unit = {
+    val io = Promise
+      .make[Nothing, Int]
+      .flatMap { promise =>
+        ZIO.succeed(42).fork.flatMap { fiber =>
+          fiber.await.flatMap(exit => promise.done(exit)).fork *> promise.await
+        }
+      }
+      .repeatN(n)
+
+    unsafeRun(io)
+  }
+
+  /**
+   * Optimized pattern using Promise.become: fork a fiber, link the promise
+   * directly to the fiber, then await the promise. This avoids the extra fiber
+   * + flatMap overhead.
+   */
+  @Benchmark
+  def promiseBecomeForkAwait(): Unit = {
+    val io = Promise
+      .make[Nothing, Int]
+      .flatMap { promise =>
+        ZIO.succeed(42).fork.flatMap { fiber =>
+          promise.become(fiber) *> promise.await
+        }
+      }
+      .repeatN(n)
+
+    unsafeRun(io)
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -126,6 +126,40 @@ object PromiseSpec extends ZIOBaseSpec {
         d <- p.isDone
       } yield assert(d)(isTrue)
     } @@ zioTag(errors),
+    test("become completes promise with fiber success") {
+      for {
+        p     <- Promise.make[Nothing, Int]
+        fiber <- ZIO.succeed(42).fork
+        _     <- p.become(fiber)
+        v     <- p.await
+      } yield assert(v)(equalTo(42))
+    },
+    test("become completes promise with fiber failure") {
+      for {
+        p     <- Promise.make[String, Int]
+        fiber <- ZIO.fail("error").fork
+        _     <- p.become(fiber)
+        v     <- p.await.exit
+      } yield assert(v)(fails(equalTo("error")))
+    } @@ zioTag(errors),
+    test("become returns false for already completed promise") {
+      for {
+        p     <- Promise.make[Nothing, Int]
+        _     <- p.succeed(1)
+        fiber <- ZIO.succeed(42).fork
+        r     <- p.become(fiber)
+        v     <- p.await
+      } yield assert(r)(isFalse) && assert(v)(equalTo(1))
+    },
+    test("become with already completed fiber") {
+      for {
+        p     <- Promise.make[Nothing, Int]
+        fiber <- ZIO.succeed(99).fork
+        _     <- fiber.await
+        r     <- p.become(fiber)
+        v     <- p.await
+      } yield assert(r)(isTrue) && assert(v)(equalTo(99))
+    },
     test("waiter stack safety") {
       for {
         p      <- Promise.make[Nothing, Unit]

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -72,6 +72,18 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     }
 
   /**
+   * Links this promise to the specified fiber, so that when the fiber
+   * completes, this promise will be completed with the fiber's result. This
+   * eliminates the unnecessary allocations and indirection of the
+   * fork-and-await-promise pattern.
+   *
+   * Returns whether the link was established (i.e., the promise was still
+   * pending).
+   */
+  def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace): UIO[Boolean] =
+    ZIO.succeed(unsafe.become(fiber)(trace, Unsafe))
+
+  /**
    * Kills the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
@@ -175,6 +187,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.succeedUnit(ev0, trace, Unsafe))
 
   private[zio] trait UnsafeAPI extends Serializable {
+    def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace, unsafe: Unsafe): Boolean
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
@@ -192,6 +205,14 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   private[zio] def state: AtomicReference[Promise.internal.State[E, A]] =
     unsafe.asInstanceOf[AtomicReference[Promise.internal.State[E, A]]]
   private[zio] val unsafe: UnsafeAPI = new AtomicReference(Promise.internal.State.empty[E, A]) with UnsafeAPI { state =>
+    def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace, unsafe: Unsafe): Boolean =
+      state.get match {
+        case _: Done[_, _] => false
+        case _ =>
+          fiber.unsafe.addObserver(exit => completeWith(exit))
+          true
+      }
+
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean = {
       @annotation.tailrec
       def loop(): Boolean =


### PR DESCRIPTION
/fixes #9877
/claim #9877

## Context

A Promise awaiting completion is essentially a Fiber parked awaiting an async callback. When a Fiber forks work that will eventually complete a promise, then awaits that promise, we end up with an extra fiber + flatMap for the bridging:

```scala
fiber.await.flatMap(exit => promise.done(exit)).fork *> promise.await
```

This creates unnecessary allocations and indirection — the promise and fiber are doing the same job independently.

## Approach

`Promise.become(fiber)` wires a fiber's completion directly to a promise at the unsafe level using `fiber.unsafe.addObserver`. The observer callback calls `completeWith` on the promise when the fiber exits, so there's no intermediate `ZIO` value or extra fiber involved:

```scala
// Before (traditional pattern):
fiber.await.flatMap(exit => promise.done(exit)).fork *> promise.await

// After:
promise.become(fiber) *> promise.await
```

The implementation is ~20 lines in `Promise.scala`:
- Safe API: `def become(fiber: Fiber.Runtime[E, A]): UIO[Boolean]` — returns whether the link was established (promise was still pending)
- Unsafe impl: checks if the promise is `Done` (returns `false`), otherwise attaches the observer (returns `true`)

## Benchmarks

JMH benchmark comparing the full pattern (create promise → fork fiber → bridge → await) repeated `n` times:

```
Benchmark                                            (n)   Mode  Cnt     Score      Error  Units
PromiseBecomeBenchmark.promiseBecomeForkAwait        1000  thrpt    5  1863.917 ±  199.008  ops/s
PromiseBecomeBenchmark.promiseBecomeForkAwait       10000  thrpt    5   192.390 ±   43.869  ops/s
PromiseBecomeBenchmark.promiseBecomeForkAwait      100000  thrpt    5    14.736 ±    0.898  ops/s
PromiseBecomeBenchmark.traditionalForkAwaitPromise   1000  thrpt    5   681.232 ±  377.856  ops/s
PromiseBecomeBenchmark.traditionalForkAwaitPromise  10000  thrpt    5    96.271 ±   32.285  ops/s
PromiseBecomeBenchmark.traditionalForkAwaitPromise 100000  thrpt    5     4.774 ±    4.860  ops/s
```

| n | Traditional | Promise.become | Improvement |
|---|-------------|----------------|-------------|
| 1,000 | 681 ops/s | 1,864 ops/s | **+174%** |
| 10,000 | 96 ops/s | 192 ops/s | **+100%** |
| 100,000 | 4.8 ops/s | 14.7 ops/s | **+209%** |

The improvement holds (and actually grows) under load because `become` avoids creating the bridging fiber entirely.

To reproduce: `sbt 'benchmarks/Jmh/run PromiseBecomeBenchmark'`

## Tests

Four cases added to `PromiseSpec`:
- `become completes promise with fiber success` — happy path
- `become completes promise with fiber failure` — error propagation
- `become returns false for already completed promise` — idempotency
- `become with already completed fiber` — eager completion

## Files changed

- `core/shared/src/main/scala/zio/Promise.scala` — `become` + unsafe impl
- `core-tests/shared/src/test/scala/zio/PromiseSpec.scala` — 4 tests
- `benchmarks/src/main/scala/zio/PromiseBecomeBenchmark.scala` — JMH benchmark