### PR TITLE
Fix Config list parsing failure with withDefault (#10442)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -1037,6 +1037,23 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           result <- configProvider.load(config)
         } yield assertTrue(result == Nil)
       } +
+      // Test for issue #10442: failure propagation in list config with withDefault
+      test("failure propagation in list config with withDefault") {
+        final case class Person(name: String, age: Int)
+
+        // When a list element has a missing field (e.g., "agr" instead of "age"),
+        // withDefault should return an error, not the default value
+        val configProvider = ConfigProvider.fromMap(
+          Map("values[0].name" -> "John", "values[0].agr" -> "9")
+        )
+
+        val person: Config[Person] = (Config.string("name") ++ Config.int("age")).map(Person.tupled)
+        val people: Config[List[Person]] = Config.listOf("values", person).withDefault(Nil)
+
+        for {
+          exit <- configProvider.load(people).exit
+        } yield assert(exit)(failsWithA[Config.Error])
+      } +
       // FIXME: Failing test
       test("empty list within indexed list") {
         val configProvider =

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -133,9 +133,12 @@ sealed trait Config[+A] { self =>
   /**
    * Returns a new config that describes the same structure as this one, but has
    * the specified default value in case the information cannot be found.
+   * Note: This will NOT use the default if the error indicates that a list element
+   * or nested field is missing (e.g., "values[0].name"). It only uses the default
+   * when the entire configuration path is truly missing.
    */
   def withDefault[A1 >: A](default: => A1): Config[A1] =
-    self.orElseIf(_.isMissingDataOnly)(Config.succeed(default))
+    self.orElseIf(e => e.isMissingDataOnly && !e.hasIndexedPath)(Config.succeed(default))
 
   /**
    * A named version of `++`.
@@ -426,6 +429,14 @@ object Config {
     final def isMissingDataOnly: Boolean =
       foldContext(())(Folder.IsMissingDataOnly)
 
+    /**
+     * Checks if the error contains any path with a numeric index (e.g., "values[0]").
+     * This is used to distinguish between "the list itself is missing" vs
+     * "the list exists but some elements are missing".
+     */
+    final def hasIndexedPath: Boolean =
+      foldContext(())(Folder.HasIndexedPath)
+
     def prefixed(prefix: Chunk[String]): Error
 
     override def getMessage(): String = toString()
@@ -487,6 +498,23 @@ object Config {
           cause: Cause[Throwable]
         ): Boolean = false
         def unsupportedCase(context: Any, path: Chunk[String], message: String): Boolean = false
+      }
+
+      case object HasIndexedPath extends Folder[Any, Boolean] {
+        private def hasIndex(path: Chunk[String]): Boolean =
+          path.exists(_.matches(".*\\[\\d+\\].*"))
+
+        def andCase(context: Any, left: Boolean, right: Boolean): Boolean                = left || right
+        def invalidDataCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
+        def missingDataCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
+        def orCase(context: Any, left: Boolean, right: Boolean): Boolean                 = left || right
+        def sourceUnavailableCase(
+          context: Any,
+          path: Chunk[String],
+          message: String,
+          cause: Cause[Throwable]
+        ): Boolean = hasIndex(path)
+        def unsupportedCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #10442: When using `Config.listOf("values", person).withDefault(Nil)`, if a list element has a missing field (e.g., typo in field name `agr` instead of `age`), the expected behavior is to return a config error, but the actual behavior was returning an empty list (the default value).

## Changes

1. Add `hasIndexedPath` method to `Config.Error` to detect if error path contains indexed paths (e.g., `values[0].name`)
2. Modify `withDefault` to not use default value when errors contain indexed paths, indicating the list exists but some elements are missing
3. Add test case for issue #10442

## Test

```scala
test("failure propagation in list config with withDefault") {
  final case class Person(name: String, age: Int)
  val configProvider = ConfigProvider.fromMap(
    Map("values[0].name" -> "John", "values[0].agr" -> "9")
  )
  val person: Config[Person] = (Config.string("name") ++ Config.int("age")).map(Person.tupled)
  val people: Config[List[Person]] = Config.listOf("values", person).withDefault(Nil)
  
  for {
    exit <- configProvider.load(people).exit
  } yield assert(exit)(failsWithA[Config.Error])
}
```
/claim #10442
