### PR TITLE
fix: ZStream.buffer(1) buffering 2 elements instead of 1

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,7 +607,43 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          },
+          test("buffer(1) does not run more than one element ahead") {
+            for {
+              started <- Ref.make(Chunk.empty[Int])
+              stream = ZStream
+                         .fromIterable(1 to 3)
+                         .mapZIO(i => started.update(_ :+ i).as(i))
+                         .buffer(1)
+              startedAfterFirst <- ZIO.scoped {
+                                     stream.toPull.flatMap { pull =>
+                                       for {
+                                         _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                         _ <- TestClock.adjust(50.millis)
+                                         s <- started.get
+                                       } yield s
+                                     }
+                                   }
+            } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2)))
+          } @@ TestAspect.timeout(5.seconds) @@ nonFlaky,
+          test("buffer(2) does not run more than two elements ahead") {
+            for {
+              started <- Ref.make(Chunk.empty[Int])
+              stream = ZStream
+                         .fromIterable(1 to 4)
+                         .mapZIO(i => started.update(_ :+ i).as(i))
+                         .buffer(2)
+              startedAfterFirst <- ZIO.scoped {
+                                     stream.toPull.flatMap { pull =>
+                                       for {
+                                         _ <- pull.map(_.head).catchAll(_ => ZIO.dieMessage("Unexpected end of stream"))
+                                         _ <- TestClock.adjust(50.millis)
+                                         s <- started.get
+                                       } yield s
+                                     }
+                                   }
+            } yield assert(startedAfterFirst.toList)(equalTo(List(1, 2, 3)))
+          } @@ TestAspect.timeout(5.seconds) @@ nonFlaky
         ),
         suite("bufferChunks")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -390,28 +390,104 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
-    new ZStream(
-      ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
+    ZStream.suspend {
+      new ZStream(
+        ZChannel.unwrapScoped[R] {
+          ZIO.suspendSucceed {
+            val evaluatedCapacity = capacity
 
-          process
+            if (evaluatedCapacity <= 0) {
+              self.toQueueOfElements(evaluatedCapacity).map { queue =>
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO {
+                    queue.take
+                  }.flatMap { (exit: Exit[Option[E], A]) =>
+                    exit.foldExit(
+                      Cause
+                        .flipCauseOption(_)
+                        .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                      value => ZChannel.write(Chunk.single(value)) *> process
+                    )
+                  }
+
+                process
+              }
+            } else if (evaluatedCapacity == 1) {
+              // Special case for `buffer(1)`: we need a synchronous handoff to avoid
+              // running one extra element ahead of the downstream consumer.
+              for {
+                queue <- ZIO.acquireRelease(Queue.bounded[(Exit[Option[E], A], Promise[Nothing, Unit])](1))(_.shutdown)
+                _ <- {
+                  lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                    ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                      in =>
+                        ZChannel.fromZIO {
+                          ZIO.foreachDiscard(in) { a =>
+                            for {
+                              taken <- Promise.make[Nothing, Unit]
+                              _     <- queue.offer((Exit.succeed(a), taken))
+                              _     <- taken.await
+                            } yield ()
+                          }
+                        } *> writer,
+                      err =>
+                        ZChannel.fromZIO {
+                          for {
+                            taken <- Promise.make[Nothing, Unit]
+                            _     <- queue.offer((Exit.failCause(err.map(Some(_))), taken))
+                            _     <- taken.await
+                          } yield ()
+                        },
+                      _ =>
+                        ZChannel.fromZIO {
+                          for {
+                            taken <- Promise.make[Nothing, Unit]
+                            _     <- queue.offer((Exit.fail(None), taken))
+                            _     <- taken.await
+                          } yield ()
+                        }
+                    )
+
+                  (self.channel >>> writer).drain.runScoped.unit.forkScoped.unit
+                }
+              } yield {
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO(queue.take).flatMap { case (exit, taken) =>
+                    ZChannel.fromZIO(taken.succeedUnit) *>
+                      exit.foldExit(
+                        Cause
+                          .flipCauseOption(_)
+                          .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                        value => ZChannel.write(Chunk.single(value)) *> process
+                      )
+                  }
+
+                process
+              }
+            } else {
+              // For `buffer(n)` we need a queue of size `n - 1` because one element may
+              // be in-flight downstream at any time.
+              self.toQueueOfElements(evaluatedCapacity - 1).map { queue =>
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO {
+                    queue.take
+                  }.flatMap { (exit: Exit[Option[E], A]) =>
+                    exit.foldExit(
+                      Cause
+                        .flipCauseOption(_)
+                        .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                      value => ZChannel.write(Chunk.single(value)) *> process
+                    )
+                  }
+
+                process
+              }
+            }
+          }
         }
-      }
-    )
-  }
+      )
+    }
 
   /**
    * Allows a faster producer to progress independently of a slower consumer by


### PR DESCRIPTION
## Summary
Fix `ZStream.buffer(1)` so it only buffers exactly 1 element instead of 2.

Fixes #9810

## Problem
`ZStream.buffer(1)` was incorrectly buffering 2 elements instead of 1, due to the asynchronous nature of the underlying queue implementation. This occurred because the queue allowed concurrent `offer` and `take` operations, leading to a race condition.

## Solution
- For `buffer(1)`: use a synchronous handoff to ensure only one element is buffered at any time
- For `buffer(n)` where `n > 1`: use queue capacity of `n - 1` to account for the in-flight element

## Test plan
- [x] Added regression tests for buffer(1) behavior
- [x] Added regression tests for buffer(2) behavior

/claim #9810