### PR TITLE
Fix Gen.fromIterable to consume random state (fixes #9101)

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -672,6 +672,16 @@ object GenSpec extends ZIOBaseSpec {
       val actual     = exhaustive.zipWith(exhaustive)(_ + _)
       checkFinite(actual)(equalTo(expected))
     },
+    test("fromIterable combined with random generators produces different values") {
+      // Issue #9101: Gen.fromIterable generates the same data when placed after random generators
+      val gen = for {
+        id <- Gen.uuid
+        _ <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
+      } yield id
+      for {
+        ids <- gen.runCollectN(10)
+      } yield assert(ids.distinct)(hasSize(equalTo(10)))
+    },
     test("size can be modified locally") {
       val getSize = Gen.size.sample.map(_.value).runCollect.map(_.head)
       val result = for {

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -439,14 +439,28 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     uniform.map(n => -math.log(1 - n))
 
   /**
-   * Constructs a deterministic generator that only generates the specified
-   * fixed values.
+   * Constructs a deterministic generator that generates the specified fixed values.
+   * Each sample consumes random state to ensure proper interaction with other
+   * generators in flatMap compositions.
+   * See: https://github.com/zio/zio/issues/9101
    */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
-  )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+  )(implicit trace: Trace): Gen[R, A] = {
+    val vector = as.toVector
+    if (vector.isEmpty)
+      Gen.empty
+    else
+      Gen(
+        ZStream
+          .repeatZIO(ZIO.randomWith(_.nextIntBounded(vector.size)))
+          .map { idx =>
+            val a = vector(idx)
+            Sample.unfold(a)(a => (a, shrinker(a)))
+          }
+      )
+  }
 
   /**
    * Constructs a generator from a function that uses randomness. The returned


### PR DESCRIPTION
## Summary

This PR fixes issue #9101 where `Gen.fromIterable` combined with other generators in certain orders generates the same data every time.

### Problem
When creating a `Gen[Any, UUID]` using `for` comprehension with `fromIterable`, the generated output results in the same value every time due to not properly consuming the random state.

### Solution
Modified `fromIterable` to use `repeatZIO` + `nextIntBounded` for random sampling instead of the original implementation.

### Testing
Added test case to verify `fromIterable` works correctly with random generators.

---

/claim #9101