### PR TITLE
Runtime.unsafe.run: `tellInterrupt` immediately instead of spawning and running a fiber to interpret `fiber.interruptAs`

### DIFF
--- a/core/shared/src/main/scala/zio/Runtime.scala
+++ b/core/shared/src/main/scala/zio/Runtime.scala
@@ -52,7 +52,7 @@ trait Runtime[+R] { self =>
       ZIO.asyncInterrupt[Any, E, A] { callback =>
         val fiber = unsafe.fork(zio)(trace, Unsafe.unsafe)
         fiber.unsafe.addObserver(callback(_))(Unsafe.unsafe)
-        Left(ZIO.blocking(fiber.interruptAs(fiberId)))
+        Left(fiber.interruptAs(fiberId))
       }
     }
 
@@ -141,11 +141,8 @@ trait Runtime[+R] { self =>
               result.get()
             } catch {
               case t: InterruptedException =>
-                val interrupted       = OneShot.make[Exit[Nothing, Exit[E, A]]]
-                val interruptionFiber = makeFiber(fiber.interruptAs(FiberId.None))
-                interruptionFiber.addObserver(interrupted.set)
-                interruptionFiber.start(fiber.interruptAs(FiberId.None))
-                interrupted.get()
+                fiber.tellInterrupt(Cause.interrupt(FiberId.None, StackTrace(FiberId.None, Chunk.single(trace))))
+                result.get() // wait for interruption to finish
                 throw t
             }
           }
@@ -182,17 +179,14 @@ trait Runtime[+R] { self =>
       val p: scala.concurrent.Promise[A] = scala.concurrent.Promise[A]()
 
       val fiber = makeFiber(zio)
-
       fiber.addObserver(_.foldExit(cause => p.failure(cause.squashTraceWith(identity)), p.success))
-
       fiber.startConcurrently(zio)
 
       new CancelableFuture[A](p.future) {
         def cancel(): Future[Exit[Throwable, A]] = {
           val p: scala.concurrent.Promise[Exit[Throwable, A]] = scala.concurrent.Promise[Exit[Throwable, A]]()
-          val cancelFiber                                     = makeFiber(fiber.interruptAs(FiberId.None))
-          cancelFiber.addObserver(_.foldExit(cause => p.failure(cause.squashTraceWith(identity)), p.success))
-          cancelFiber.start(fiber.interruptAs(FiberId.None))
+          fiber.unsafe.addObserver(p.success)
+          fiber.tellInterrupt(Cause.interrupt(FiberId.None, StackTrace(FiberId.None, Chunk.single(trace))))
           p.future
         }
       }


### PR DESCRIPTION
Former behavior diverged  when `runtime.unsafe.run` was nested inside `ZIO.attemptBlockingInterrupt`. When barraged by repeated Thread interrupts, `interruptionFiber.start(...)` was interrupted before signalling interrupt to inner fiber. This is fixed by adding message directly to message box without `FiberRuntime` machinery - this avoids calling any JVM methods that may throw `InterruptedException`.

Note: I do not provide a repro or a new test case here, as making one is somewhat involved, but will write one if necessary. 