### PR TITLE
Fix #10491: provideShared daemon fiber scope regression

### DIFF
--- a/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -1,7 +1,7 @@
 package zio.test.sbt
 
 import zio.test._
-import zio.{Scope, ZIO, ZLayer, durationInt}
+import zio.{Queue, Schedule, Scope, ZIO, ZLayer, durationInt}
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -237,5 +237,53 @@ object FrameworkSpecInstances {
         }
       )
     )
+  }
+
+  object SharedLayerWithDaemonFiber extends ZIOSpecDefault {
+    val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
+      for {
+        queue <- Queue.unbounded[Int]
+        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
+      } yield queue
+    }
+
+    override def spec = suite("#10491 daemon fiber suite")(
+      test("#10491 test 1 sees daemon fiber output") {
+        for {
+          queue <- ZIO.service[Queue[Int]]
+          _     <- queue.take
+        } yield assertTrue(true)
+      },
+      test("#10491 test 2 also sees daemon fiber output") {
+        for {
+          queue <- ZIO.service[Queue[Int]]
+          _     <- queue.take
+        } yield assertTrue(true)
+      }
+    ).provideLayerShared(sharedDaemonLayer) @@ TestAspect.withLiveClock @@ TestAspect.sequential
+  }
+
+  object SharedLayerWithDaemonFiberSome extends ZIOSpecDefault {
+    val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
+      for {
+        queue <- Queue.unbounded[Int]
+        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
+      } yield queue
+    }
+
+    override def spec = suite("#10491 daemon fiber some suite")(
+      test("#10491 test 1 sees daemon fiber output via provideSomeLayerShared") {
+        for {
+          queue <- ZIO.service[Queue[Int]]
+          _     <- queue.take
+        } yield assertTrue(true)
+      },
+      test("#10491 test 2 also sees daemon fiber output via provideSomeLayerShared") {
+        for {
+          queue <- ZIO.service[Queue[Int]]
+          _     <- queue.take
+        } yield assertTrue(true)
+      }
+    ).provideSomeLayerShared[Any](sharedDaemonLayer) @@ TestAspect.withLiveClock @@ TestAspect.sequential
   }
 }

--- a/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -243,7 +243,7 @@ object FrameworkSpecInstances {
     val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
       for {
         queue <- Queue.unbounded[Int]
-        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
+        _     <- queue.offer(1).repeat(Schedule.spaced(1.second)).forkScoped
       } yield queue
     }
 
@@ -267,7 +267,7 @@ object FrameworkSpecInstances {
     val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
       for {
         queue <- Queue.unbounded[Int]
-        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
+        _     <- queue.offer(1).repeat(Schedule.spaced(1.second)).forkScoped
       } yield queue
     }
 

--- a/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/FrameworkSpecInstances.scala
@@ -243,7 +243,7 @@ object FrameworkSpecInstances {
     val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
       for {
         queue <- Queue.unbounded[Int]
-        _     <- queue.offer(1).repeat(Schedule.spaced(1.second)).forkScoped
+        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
       } yield queue
     }
 
@@ -267,7 +267,7 @@ object FrameworkSpecInstances {
     val sharedDaemonLayer: ZLayer[Any, Nothing, Queue[Int]] = ZLayer.scoped {
       for {
         queue <- Queue.unbounded[Int]
-        _     <- queue.offer(1).repeat(Schedule.spaced(1.second)).forkScoped
+        _     <- queue.offer(1).repeat(Schedule.spaced(10.millis)).forkScoped
       } yield queue
     }
 
@@ -275,12 +275,14 @@ object FrameworkSpecInstances {
       test("#10491 test 1 sees daemon fiber output via provideSomeLayerShared") {
         for {
           queue <- ZIO.service[Queue[Int]]
+          _     <- queue.takeAll
           _     <- queue.take
         } yield assertTrue(true)
       },
       test("#10491 test 2 also sees daemon fiber output via provideSomeLayerShared") {
         for {
           queue <- ZIO.service[Queue[Int]]
+          _     <- queue.takeAll
           _     <- queue.take
         } yield assertTrue(true)
       }

--- a/test-sbt/shared/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
+++ b/test-sbt/shared/src/test/scala/zio/test/sbt/ZTestFrameworkSpec.scala
@@ -4,7 +4,7 @@ import sbt.testing.{Status, TestSelector}
 import zio.test.sbt.Colors.{green, red, yellow}
 import zio.test.sbt.ExecuteSpecs.{getEvents, getOutput, getOutputs}
 import zio.test.{Spec, TestAspect, TestEnvironment, TestResult, ZIOSpecDefault, assertTrue, assert}
-import zio.{Scope, ZIO}
+import zio.{Scope, ZIO, durationInt}
 
 object ZTestFrameworkSpec extends ZIOSpecDefault {
   override def spec: Spec[TestEnvironment with Scope, Any] = suite("test framework")(
@@ -189,6 +189,28 @@ object ZTestFrameworkSpec extends ZIOSpecDefault {
         medium <- testName("inner - test")
         long   <- testName("outer - inner - test")
       } yield verify(short) && verify(medium) && verify(long)
-    }
+    },
+    test("#10491 shared layer with daemon fibers keeps fibers alive for all tests (provideLayerShared)") {
+      for {
+        output <- getOutput(FrameworkSpecInstances.SharedLayerWithDaemonFiber)
+      } yield {
+        assertTrue(
+          output.exists(_.contains("#10491 test 1 sees daemon fiber output")),
+          output.exists(_.contains("#10491 test 2 also sees daemon fiber output")),
+          !output.exists(_.contains("Timeout"))
+        )
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("#10491 shared layer with daemon fibers keeps fibers alive for all tests (provideSomeLayerShared)") {
+      for {
+        output <- getOutput(FrameworkSpecInstances.SharedLayerWithDaemonFiberSome)
+      } yield {
+        assertTrue(
+          output.exists(_.contains("#10491 test 1 sees daemon fiber output via provideSomeLayerShared")),
+          output.exists(_.contains("#10491 test 2 also sees daemon fiber output via provideSomeLayerShared")),
+          !output.exists(_.contains("Timeout"))
+        )
+      }
+    } @@ TestAspect.timeout(30.seconds)
   )
 }


### PR DESCRIPTION
Fixes #10491

## Summary
- Add failing tests that reproduce the daemon fiber scope regression in `provideLayerShared` and `provideSomeLayerShared`
- Shared layers using `ZLayer.scoped` + `forkScoped` spawn background fibers that die prematurely when the first test's scope closes, causing subsequent tests to hang
- Tests cover both `provideLayerShared` and `provideSomeLayerShared` paths

## Test plan
- [ ] New tests currently fail (hang/timeout), confirming the bug exists
- [ ] After applying the fix (Part 2), both new tests pass
- [ ] Existing `"do not create layers for test with ignored tag"` test still passes
- [ ] All existing `ZTestFrameworkSpec` tests still pass