### PR TITLE
fix(native): avoid ConcurrentHashMap.newKeySet for concurrent set impl

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -19,7 +19,7 @@ package zio.internal
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{Collections, WeakHashMap, Map => JMap, Set => JSet}
+import java.util.{Collections, HashSet, WeakHashMap, Map => JMap, Set => JSet}
 
 private[zio] trait PlatformSpecific {
 
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.synchronizedSet(new HashSet[A]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.synchronizedSet(new HashSet[A](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
/claim #9681

## Proposed changes

This fixes the Scala Native `WeakConcurrentBag` crash path reported in #9681 by replacing the Native `newConcurrentSet` implementation from `ConcurrentHashMap.newKeySet` to `Collections.synchronizedSet(new HashSet(...))`.

Why this target:
- The observed stacktrace fails in `ConcurrentHashMap.treeifyBin` during concurrent `KeySetView.add` from `WeakConcurrentBag.addToLongTermStorage`.
- `WeakConcurrentBag` relies on `Platform.newConcurrentSet` for long-term storage (`graduates`).
- On Native, using a synchronized `HashSet` avoids this unstable `ConcurrentHashMap` path while preserving thread safety semantics.

### Files changed
- `core/native/src/main/scala/zio/internal/PlatformSpecific.scala`

## Proof

- Existing failing scenario in issue: `PromiseSpec - waiter stack safety` (10K forks) hits `WeakConcurrentBag -> ConcurrentHashMap.treeifyBin` NPE on Scala Native.
- This patch removes the `ConcurrentHashMap.newKeySet` usage specifically on Native for both overloads of `newConcurrentSet`.

> Local execution note: I could not run the full Scala build in this environment because `sbt` is not installed.

