### PR TITLE
test: add ZIOApp main shutdown hook behavior specs

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/ZIOAppMainSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/ZIOAppMainSpec.scala
@@ -1,0 +1,95 @@
+package zio
+
+import zio.test._
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+object ZIOAppMainSpec extends ZIOBaseSpec {
+
+  def spec = suite("ZIOAppMainSpec")(
+    test("simulated shutdown signal interrupts app and runs finalizers") {
+      val harness = new MainHarness(Duration.Infinity, ZIO.unit)
+
+      for {
+        _ <- ZIO.attempt(harness.start())
+        _ <- awaitLatch(harness.started, "app start")
+        hook <- awaitHook(harness)
+        _ <- ZIO.attemptBlocking(hook())
+        _ <- awaitLatch(harness.finalized, "finalizer completion")
+        _ <- awaitLatch(harness.mainDone, "main completion")
+      } yield assertTrue(harness.exitCode.get() == ExitCode.failure)
+    },
+    test("gracefulShutdownTimeout bounds shutdown hook wait time") {
+      val finalizerDelay = 800.millis
+      val harness = new MainHarness(50.millis, ZIO.uninterruptible(ZIO.sleep(finalizerDelay)))
+
+      for {
+        _ <- ZIO.attempt(harness.start())
+        _ <- awaitLatch(harness.started, "app start")
+        hook <- awaitHook(harness)
+        elapsedMs <- ZIO.attemptBlocking {
+                       val startedAt = java.lang.System.nanoTime()
+                       hook()
+                       (java.lang.System.nanoTime() - startedAt) / 1000000L
+                     }
+        _ <- awaitLatch(harness.finalized, "finalizer completion")
+        _ <- awaitLatch(harness.mainDone, "main completion")
+      } yield assertTrue(elapsedMs < 400L) && assertTrue(harness.exitCode.get() == ExitCode.failure)
+    }
+  )
+
+  private final class MainHarness(timeout: Duration, finalizer: UIO[Any]) {
+    val started: CountDownLatch   = new CountDownLatch(1)
+    val finalized: CountDownLatch = new CountDownLatch(1)
+    val mainDone: CountDownLatch  = new CountDownLatch(1)
+
+    val hook: AtomicReference[() => Unit] = new AtomicReference[() => Unit](null)
+    val exitCode: AtomicReference[ExitCode] = new AtomicReference[ExitCode](null)
+
+    private val app = new ZIOAppDefault {
+      override val gracefulShutdownTimeout: Duration = timeout
+
+      override protected[zio] def registerShutdownHook(callback: () => Unit)(implicit unsafe: Unsafe): Unit =
+        hook.set(callback)
+
+      override protected[zio] def exitUnsafe(code: ExitCode)(implicit unsafe: Unsafe): Unit =
+        exitCode.set(code)
+
+      override protected[zio] def interruptRootFibers(mainFiberId: FiberId)(implicit trace: Trace): UIO[Unit] =
+        ZIO.unit
+
+      override val run: ZIO[ZIOAppArgs & Scope, Any, Any] =
+        ZIO.succeed(started.countDown()) *> ZIO.never.ensuring(finalizer *> ZIO.succeed(finalized.countDown()))
+    }
+
+    def start(): Unit = {
+      val thread = new Thread(
+        () => {
+          try app.main(Array.empty)
+          finally mainDone.countDown()
+        },
+        "zio-app-main-spec"
+      )
+      thread.setDaemon(true)
+      thread.start()
+    }
+  }
+
+  private def awaitLatch(latch: CountDownLatch, label: String): ZIO[Any, Throwable, Unit] =
+    ZIO
+      .attemptBlocking(latch.await(5, TimeUnit.SECONDS))
+      .flatMap(ok => ZIO.fail(new RuntimeException(s"timed out waiting for $label")).unless(ok).unit)
+
+  private def awaitHook(harness: MainHarness): ZIO[Any, Throwable, () => Unit] =
+    ZIO.attemptBlocking {
+      val deadlineNanos = java.lang.System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+      var callback: (() => Unit) = harness.hook.get()
+      while (callback == null && java.lang.System.nanoTime() < deadlineNanos) {
+        Thread.sleep(10)
+        callback = harness.hook.get()
+      }
+      callback
+    }.flatMap(callback => ZIO.fromOption(Option(callback)).orElseFail(new RuntimeException("shutdown hook not installed")))
+}

--- a/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOAppPlatformSpecific.scala
@@ -5,6 +5,9 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
 
+  protected[zio] def registerShutdownHook(hook: () => Unit)(implicit unsafe: Unsafe): Unit =
+    Platform.addShutdownHook(hook)
+
   /**
    * The Scala main function, intended to be called only by the Scala runtime.
    */
@@ -17,7 +20,7 @@ private[zio] trait ZIOAppPlatformSpecific { self: ZIOApp =>
     val shutdownLatch = internal.OneShot.make[Unit]
 
     def shutdownHook(fiberId: FiberId, fiber: Fiber.Runtime[Nothing, ExitCode]): Unit =
-      Platform.addShutdownHook { () =>
+      registerShutdownHook { () =>
         if (shuttingDown.compareAndSet(false, true)) {
           if (FiberRuntime.catastrophicFailure.get) {
             println(


### PR DESCRIPTION
## Summary
- add `ZIOAppMainSpec` in `core-tests/jvm-native` to validate shutdown-flow behavior through `main`
- cover simulated external-shutdown path to ensure interruption produces failure exit and app finalizers run
- cover `gracefulShutdownTimeout` behavior by verifying shutdown hook returns quickly even when finalizers are still running
- add a small test seam in `ZIOAppPlatformSpecific` (`registerShutdownHook`) so shutdown hooks can be injected/observed in tests without changing runtime behavior

## Why this lane
This targets the lifecycle areas called out in #9909 and the linked historical regressions around shutdown/finalizer behavior (#9901, #9807).

## Test commands
```bash
sbt 'coreTestsJVM/testOnly zio.ZIOAppMainSpec'
sbt 'coreTestsJVM/testOnly zio.ZIOAppSpec'
```

## Notes
- tests are JVM-specific and live under `core-tests/jvm-native`
- the hook-timeout spec intentionally verifies bounded wait behavior while finalization is still in progress

/claim #9909
