### PR TITLE
fix: Scala Native WeakConcurrentBag NPE

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -91,3 +91,4 @@ private[zio] trait PlatformSpecific {
 
 }
 
+

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,13 +84,9 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.synchronizedSet(new java.util.HashSet[A]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.synchronizedSet(new java.util.HashSet[A](initialCapacity))
 
-  private def blackhole(a: Any): Unit = {
-    val _ = a
-    ()
-  }
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -24,6 +24,15 @@ import java.util.{Collections, WeakHashMap, Map => JMap, Set => JSet}
 private[zio] trait PlatformSpecific {
 
   /**
+   * Helper method to prevent unused parameter warnings on Scala Native.
+   * This is a no-op that simply evaluates its argument.
+   */
+  private def blackhole(a: Any): Unit = {
+    val _ = a
+    ()
+  }
+
+  /**
    * Adds a shutdown hook that executes the specified action on shutdown.
    *
    * This is currently a no-op on Scala Native.

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -90,3 +90,4 @@ private[zio] trait PlatformSpecific {
     Collections.synchronizedSet(new java.util.HashSet[A](initialCapacity))
 
 }
+

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -24,8 +24,8 @@ import java.util.{Collections, WeakHashMap, Map => JMap, Set => JSet}
 private[zio] trait PlatformSpecific {
 
   /**
-   * Helper method to prevent unused parameter warnings on Scala Native.
-   * This is a no-op that simply evaluates its argument.
+   * Helper method to prevent unused parameter warnings on Scala Native. This is
+   * a no-op that simply evaluates its argument.
    */
   private def blackhole(a: Any): Unit = {
     val _ = a

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -90,5 +90,3 @@ private[zio] trait PlatformSpecific {
     Collections.synchronizedSet(new java.util.HashSet[A](initialCapacity))
 
 }
-
-


### PR DESCRIPTION
This PR fixes issue #9681 by replacing ConcurrentHashMap.newKeySet with Collections.synchronizedSet.

## Problem
Scala Native ConcurrentHashMap has a race condition causing NPE when forking 10K fibers.

## Solution  
Use synchronized HashSet instead of ConcurrentHashMap.newKeySet in Scala Native.

## Testing
- All 22 PromiseSpec tests pass on Scala Native
- Compilation successful

Closes #9681
/claim #9681