### PR TITLE
feat(promise): add Promise.become(fiber) to eliminate fork-await indirection (#9877)

### DIFF
--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -110,6 +110,18 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.completeWith(io)(Unsafe))
 
   /**
+   * Links this promise to the specified fiber so that it will be completed
+   * when the fiber completes. This eliminates the intermediate allocations
+   * that arise from the common pattern of forking a fiber and then awaiting a
+   * promise that the fiber eventually completes, replacing the callback
+   * indirection with a direct observer registration on the fiber.
+   *
+   * If the promise has already been completed, this is a no-op.
+   */
+  def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed(unsafe.become(fiber)(Unsafe))
+
+  /**
    * Fails the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
@@ -175,6 +187,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.succeedUnit(ev0, trace, Unsafe))
 
   private[zio] trait UnsafeAPI extends Serializable {
+    def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
@@ -206,6 +219,17 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
           case _ => false
         }
       loop()
+    }
+
+    def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
+      // Only register the observer if the promise is not yet complete.
+      // The observer directly completes this promise from the fiber's exit,
+      // eliminating allocations from the fork-then-await-promise pattern.
+      if (!isDone) {
+        fiber.unsafe.addObserver { exit =>
+          completeWith(ZIO.done(exit))
+        }
+      }
     }
 
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean =
@@ -344,3 +368,4 @@ object Promise {
     def make[E, A](fiberId: FiberId)(implicit unsafe: Unsafe): Promise[E, A] = new Promise[E, A](fiberId)
   }
 }
+


### PR DESCRIPTION
## Summary

Implements `Promise.become(fiber)` to address #9877.

The issue identifies that when a Fiber forks work which will eventually complete a Promise, and then awaits that Promise, we pay an unnecessary overhead:

1. The forked fiber allocates a callback to complete the promise  
2. `promise.await` allocates an `asyncInterrupt` callback to register itself  
3. These two callbacks communicate indirectly through the Promise state machine

## Solution

`Promise.become(fiber)` wires a fiber directly to a promise by registering an observer via `fiber.unsafe.addObserver`. When the fiber completes, the observer fires `completeWith(ZIO.done(exit))`, completing the promise with zero extra allocation on the completion path.

```scala
// Before: indirect, allocates intermediate callback
for {
  promise <- Promise.make[E, A]
  fiber   <- (work >>= promise.succeed).fork
  result  <- promise.await
} yield result

// After: direct observer registration, no intermediate callback
for {
  promise <- Promise.make[E, A]
  fiber   <- work.fork
  _       <- promise.become(fiber)
  result  <- promise.await
} yield result
```

## Implementation

```scala
// Public API (safe)
def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace): UIO[Unit] =
  ZIO.succeed(unsafe.become(fiber)(Unsafe))

// Unsafe implementation  
def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = {
  if (!isDone) {
    fiber.unsafe.addObserver { exit =>
      completeWith(ZIO.done(exit))
    }
  }
}
```

**Key properties:**
- **Race-safe**: `fiber.unsafe.addObserver` is designed to handle the race between registration and completion; if the fiber has already completed, the observer fires immediately
- **Idempotent completion**: `completeWith` uses CAS internally, so multiple observers or concurrent completions are safe
- **Short-circuit**: the `isDone` check avoids unnecessary observer registration when the promise is already complete

## Changes

- `Promise.scala`: Add `become` to the public API, `UnsafeAPI` trait, and the concrete `AtomicReference`-based implementation

Fixes #9877

/claim #9877