### PR TITLE
Fix #9084: Add ZStream.fromInputStreamInterruptible

### DIFF
--- a/docs/reference/stream/zstream/creating-zio-streams.md
+++ b/docs/reference/stream/zstream/creating-zio-streams.md
@@ -459,7 +459,16 @@ val stream: ZStream[Any, IOException, Byte] =
   ZStream.fromInputStream(new FileInputStream("file.txt"))
 ```
 
+If interrupted while blocked on a read, `ZStream.fromInputStream` will wait for the `InputStream.read` call to return. Use `ZStream.fromInputStreamInterruptible` when blocked reads need to be interruptible.
+
 Note that the InputStream will not be explicitly closed after it is exhausted. Use `ZStream.fromInputStreamZIO`, or `ZStream.fromInputStreamScoped` instead.
+
+**ZStream.fromInputStreamInterruptible** — Creates a stream from a `java.io.InputStream` and closes it if interrupted while blocked on reading:
+
+```scala mdoc:silent:nest
+val interruptible: ZStream[Any, IOException, Byte] =
+  ZStream.fromInputStreamInterruptible(new FileInputStream("file.txt"))
+```
 
 **ZStream.fromInputStreamZIO** — Creates a stream from a `java.io.InputStream`. Ensures that the InputStream is closed after it is exhausted:
 

--- a/streams-tests/shared/src/test/scala/zio/stream/StreamLazinessSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/StreamLazinessSpec.scala
@@ -59,6 +59,7 @@ object StreamLazinessSpec extends ZIOBaseSpec {
         lazy2("fromHubWithShutdown")(ZStream.fromHubWithShutdown(_, _)),
         lazy2("fromHubScopedWithShutdown")(ZStream.fromHubScopedWithShutdown(_, _)),
         lazy2("fromInputStream")(ZStream.fromInputStream(_, _)),
+        lazy2("fromInputStreamInterruptible")(ZStream.fromInputStreamInterruptible(_, _)),
         lazy2("fromInputStreamZIO")(ZStream.fromInputStreamZIO(_, _)),
         lazy2("fromInputStreamScoped")(ZStream.fromInputStreamScoped(_, _)),
         lazy2("fromIterable")(ZStream.fromIterable(_, _)),

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -9,9 +9,9 @@ import zio.test.Assertion._
 import zio.test.TestAspect.{exceptJS, flaky, nonFlaky, scala2Only, withLiveClock}
 import zio.test._
 
-import java.io.{ByteArrayInputStream, IOException}
+import java.io.{ByteArrayInputStream, IOException, InputStream}
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 import scala.concurrent.ExecutionContext
 
 object ZStreamSpec extends ZIOBaseSpec {
@@ -5748,6 +5748,46 @@ object ZStreamSpec extends ZIOBaseSpec {
               ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
             }
           }
+        ),
+        suite("fromInputStreamInterruptible")(
+          test("example 1") {
+            val chunkSize = ZStream.DefaultChunkSize
+            val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
+            def is        = new ByteArrayInputStream(data)
+            ZStream.fromInputStreamInterruptible(is, chunkSize).runCollect map { bytes =>
+              assert(bytes.toArray)(equalTo(data))
+            }
+          },
+          test("interrupts a blocked read by closing the input stream") {
+            def awaitStarted(started: AtomicBoolean): UIO[Unit] =
+              ZIO.suspendSucceed {
+                if (started.get()) ZIO.unit
+                else ZIO.yieldNow *> awaitStarted(started)
+              }
+
+            val started = new AtomicBoolean(false)
+            val closed  = new AtomicBoolean(false)
+            val is = new InputStream {
+              override def read(): Int = -1
+
+              override def read(buffer: Array[Byte]): Int = {
+                started.set(true)
+                while (!closed.get()) ()
+                -1
+              }
+
+              override def close(): Unit =
+                closed.set(true)
+            }
+
+            (for {
+              fiber       <- ZStream.fromInputStreamInterruptible(is).runDrain.fork
+              _           <- awaitStarted(started)
+              interrupted <- fiber.interrupt.timeout(1.second).map(_.isDefined)
+              isClosed    <- ZIO.succeed(closed.get())
+            } yield assert(interrupted)(isTrue) && assert(isClosed)(isTrue))
+              .ensuring(ZIO.succeed(is.close()))
+          } @@ zioTag(interruption) @@ TestAspect.jvmOnly @@ withLiveClock
         ),
         test("fromIterable")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           def lazyL = l

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4384,7 +4384,11 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     }
 
   /**
-   * Creates a stream from a `java.io.InputStream`
+   * Creates a stream from a `java.io.InputStream`.
+   *
+   * Note that interruption of the stream does not interrupt a currently
+   * blocking `InputStream.read` call. Use [[fromInputStreamInterruptible]] if
+   * blocked reads need to be interruptible.
    */
   def fromInputStream(
     is: => InputStream,
@@ -4395,6 +4399,36 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         for {
           bufArray  <- ZIO.succeed(Array.ofDim[Byte](chunkSize))
           bytesRead <- ZIO.attemptBlockingIO(is.read(bufArray)).asSomeError
+          bytes <- if (bytesRead < 0)
+                     Exit.failNone
+                   else if (bytesRead == 0)
+                     Exit.emptyChunk
+                   else if (bytesRead < chunkSize)
+                     ZIO.succeed(Chunk.fromArray(bufArray).take(bytesRead))
+                   else
+                     ZIO.succeed(Chunk.fromArray(bufArray))
+        } yield bytes
+      }
+    }
+
+  /**
+   * Creates a stream from a `java.io.InputStream`.
+   *
+   * If the stream is interrupted while reading, the input stream is closed to
+   * unblock the current read.
+   */
+  def fromInputStreamInterruptible(
+    is: => InputStream,
+    chunkSize: => Int = ZStream.DefaultChunkSize
+  )(implicit trace: Trace): ZStream[Any, IOException, Byte] =
+    ZStream.succeed((is, chunkSize)).flatMap { case (is, chunkSize) =>
+      ZStream.repeatZIOChunkOption {
+        for {
+          bufArray <- ZIO.succeed(Array.ofDim[Byte](chunkSize))
+          bytesRead <- ZIO
+                         .attemptBlockingCancelable(is.read(bufArray))(ZIO.succeed(is.close()))
+                         .refineToOrDie[IOException]
+                         .asSomeError
           bytes <- if (bytesRead < 0)
                      Exit.failNone
                    else if (bytesRead == 0)


### PR DESCRIPTION
## Summary

This PR resolves #9084 by adding `ZStream.fromInputStreamInterruptible`.

### Changes

Added a new `ZStream` constructor that wraps a `java.io.InputStream` with interruptible semantics, allowing the stream to be safely interrupted without blocking indefinitely on `read()` calls.

Happy to address any feedback or make adjustments.

/claim #9084

### Demo

<video src="https://github.com/a4to/zio/releases/download/demo-9084-1772426419123/zio__zio__9084.mp4" controls width="100%"></video>