### PR TITLE
Fix buffer(1) prefetching by enforcing element-level queue backpressure

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,32 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffer(1) should not evaluate more than one element ahead") {
+            val started = new AtomicInteger(0)
+            val chunk   = new Chunk[Int] {
+              override def length: Int = 100
+
+              override def apply(n: Int): Int =
+                n + 1
+
+              override def chunkIterator: Chunk.ChunkIterator[Int] =
+                new Chunk.ChunkIterator[Int] {
+                  override def hasNextAt(index: Int): Boolean =
+                    index < 100
+
+                  override def nextAt(index: Int): Int = {
+                    started.incrementAndGet()
+                    index + 1
+                  }
+                }
+            }
+
+            for {
+              pull <- ZStream.fromChunk(chunk).buffer(1).toPull
+              _    <- pull
+              _    <- Live.live(ZIO.sleep(200.millis))
+            } yield assertTrue(started.get() <= 2)
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2970,7 +2970,10 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Unit] = {
     lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any] =
       ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any](
-        in => ZChannel.fromZIO(queue.offerAll(in.map(Exit.succeed(_)))) *> writer,
+        in =>
+          ZChannel.fromZIO(
+            ZIO.foreachDiscard(in)(a => queue.offer(Exit.succeed(a)))
+          ) *> writer,
         err => ZChannel.fromZIO(queue.offer(Exit.failCause(err.map(Some(_))))),
         _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
       )


### PR DESCRIPTION
## Summary
This PR fixes `ZStream#buffer` over-prefetch behavior where upstream effects could be evaluated more than one element ahead when `buffer(1)` is used.

Root cause: `runIntoQueueElementsScoped` used `queue.offerAll` for each incoming chunk, which allowed chunk-level eager evaluation before per-element backpressure kicked in.

## Changes
- Replace chunk `offerAll` with element-by-element `queue.offer` in `runIntoQueueElementsScoped`
- Add regression test in `ZStreamSpec`:
  - `buffer(1) should not evaluate more than one element ahead`

## Why this works
With per-element offer, producer must respect queue capacity at element granularity, so with `buffer(1)` it can only be one element ahead of the consumer.

## Notes
- The change is narrow and isolated to queue writing semantics for element buffering.

/claim #9810
