### PR TITLE
Add `ZIO.attemptBlockingInterruptOnce`

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
@@ -7,6 +7,7 @@ import zio.test._
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
 
 object BlockingSpec extends ZIOBaseSpec {
+  private implicit val unsafe: Unsafe = Unsafe.unsafe
 
   def spec =
     suite("BlockingSpec")(
@@ -63,6 +64,42 @@ object BlockingSpec extends ZIOBaseSpec {
             _    <- Live.live(effect.timeout(50.millis))
             count = interruptCount.get()
           } yield assertTrue(count >= 5)
+        }
+      ),
+      suite("attemptBlockingInterruptOnce")(
+        test("completes successfully") {
+          assertZIO(ZIO.attemptBlockingInterruptOnce(()))(isUnit)
+        },
+        test("runs on blocking thread pool") {
+          for {
+            name <- ZIO.attemptBlockingInterruptOnce(Thread.currentThread.getName)
+          } yield assert(name)(containsString("zio-default-blocking"))
+        },
+        test("can be interrupted") {
+          assertZIO(ZIO.attemptBlockingInterruptOnce(Thread.sleep(50000)).timeout(Duration.Zero))(isNone)
+        } @@ nonFlaky,
+        test("issues only one thread interruption") {
+          val interruptCount = new AtomicInteger(0)
+          val latch          = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+          val effect = ZIO.attemptBlockingInterruptOnce {
+            try {
+              latch.unsafe.done(Exit.succeed(()))
+              Thread.sleep(Long.MaxValue)
+            } catch {
+              case _: InterruptedException =>
+                interruptCount.incrementAndGet()
+                try {
+                  Thread.sleep(1000)
+                } catch {
+                  case _: InterruptedException =>
+                    interruptCount.incrementAndGet()
+                }
+            }
+          }
+          for {
+            _    <- Live.live(effect.fork.flatMap(latch.await *> _.interrupt))
+            count = interruptCount.get()
+          } yield assertTrue(count == 1)
         }
       ),
       suite("ZIO.blocking")(

--- a/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/BlockingSpec.scala
@@ -80,16 +80,16 @@ object BlockingSpec extends ZIOBaseSpec {
         } @@ nonFlaky,
         test("issues only one thread interruption") {
           val interruptCount = new AtomicInteger(0)
-          val latch          = Promise.unsafe.make[Nothing, Unit](FiberId.None)
+          val latchBegin     = Promise.unsafe.make[Nothing, Unit](FiberId.None)
           val effect = ZIO.attemptBlockingInterruptOnce {
             try {
-              latch.unsafe.done(Exit.succeed(()))
+              latchBegin.unsafe.succeed(())
               Thread.sleep(Long.MaxValue)
             } catch {
               case _: InterruptedException =>
                 interruptCount.incrementAndGet()
                 try {
-                  Thread.sleep(1000)
+                  Thread.sleep(100L)
                 } catch {
                   case _: InterruptedException =>
                     interruptCount.incrementAndGet()
@@ -97,10 +97,10 @@ object BlockingSpec extends ZIOBaseSpec {
             }
           }
           for {
-            _    <- Live.live(effect.fork.flatMap(latch.await *> _.interrupt))
+            _    <- effect.fork.flatMap(latchBegin.await *> _.interrupt)
             count = interruptCount.get()
           } yield assertTrue(count == 1)
-        }
+        } @@ nonFlaky(10)
       ),
       suite("ZIO.blocking")(
         test("runs on blocking thread pool") {

--- a/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -45,11 +45,48 @@ private[zio] trait ZIOCompanionPlatformSpecific { self: ZIO.type =>
    * If the returned `ZIO` is interrupted, the blocked thread running the
    * synchronous effect will be interrupted via `Thread.interrupt`.
    *
+   * `Thread.interrupt` will be called continuously every 50 milliseconds, until
+   * the target thread is unwound. This is done in attempt to guarantee thread
+   * interruption in presence of misbehaving underlying code, but is done at
+   * risk of possible resource leaks if interrupts aren't handled properly.
+   *
    * Note that this adds significant overhead. For performance sensitive
    * applications consider using `attemptBlocking` or
    * `attemptBlockingCancelable`.
+   *
+   * @see
+   *   [[attemptBlockingInterruptOnce]] for a version that uses
+   *   `Thread.interrupt` only once to avoid resource leaks.
+   *
+   * @note
+   *   On Scala.js, this method is an alias for `ZIO.attemptBlocking`
    */
   def attemptBlockingInterrupt[A](effect: => A)(implicit trace: Trace): Task[A] =
+    ZIO.attemptBlocking(effect)
+
+  /**
+   * Imports a synchronous effect that does blocking IO into a pure value.
+   *
+   * If the returned `ZIO` is interrupted, the blocked thread running the
+   * synchronous effect will be interrupted via `Thread.interrupt`.
+   *
+   * `Thread.interrupt` will be called only once on the target thread. If
+   * swallowed by misbehaving code, the thread will still linger on, but if the
+   * underlying code handles interrupts well, this would allow it to perform all
+   * necessary cleanups.
+   *
+   * Note that this adds significant overhead. For performance sensitive
+   * applications consider using `attemptBlocking` or
+   * `attemptBlockingCancelable`.
+   *
+   * @see
+   *   [[attemptBlockingInterrupt]] for a version that calls `Thread.interrupt`
+   *   continuously to attempt to rule out target thread lingering
+   *
+   * @note
+   *   On Scala.js, this method is an alias for `ZIO.attemptBlocking`
+   */
+  def attemptBlockingInterruptOnce[A](effect: => A)(implicit trace: Trace): Task[A] =
     ZIO.attemptBlocking(effect)
 
   /**

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -97,43 +97,17 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
   def attemptBlockingInterruptOnce[A](effect: => A)(implicit trace: Trace): Task[A] =
     attemptBlockingInterruptImpl(once = true, effect)
 
-  private[this] def attemptBlockingInterruptImpl[A](once: Boolean, effect: => A)(implicit trace: Trace): Task[A] =
+  @inline private[this] def attemptBlockingInterruptImpl[A](once: Boolean, effect: => A)(implicit
+    trace: Trace
+  ): Task[A] =
     ZIO.uninterruptibleMask { restore =>
-      val begin = OneShot.make[Thread]
-      val end   = OneShot.make[Object]
-
-      /**
-       * Interrupts the thread running the blocking effect using thread
-       * interruption.
-       *
-       * This effect is run in the blocking threadpool because begin.get() and
-       * end.tryGet() hard-block the thread.
-       */
-      def interruptThread(): UIO[Unit] =
-        ZIO.succeedBlocking {
-          val thread = begin.get()
-          if (once) thread.interrupt()
-          else {
-            var n       = 0L
-            var looping = !end.isSet
-            while (looping) {
-              end.lock()
-              try {
-                // `end` cannot be set while we're here, so we can safely interrupt
-                if (!end.isSet) thread.interrupt()
-              } finally {
-                end.unlock()
-              }
-
-              n += 1
-              looping = end.tryGet(math.min(50, 2L * n)) eq null
-            }
-          }
-        }
+      val threadState =
+        if (once) new ThreadInterruptionStrategy.Once()(trace, Unsafe)
+        else new ThreadInterruptionStrategy.Continuously()
 
       for {
         fiber <- ZIO.blocking {
-                   begin.set(Thread.currentThread)
+                   threadState.signalBegin(Thread.currentThread)
 
                    try {
                      Exit.succeed(effect)
@@ -143,16 +117,76 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
                      case t if nonFatal(t) =>
                        ZIO.fail(t)
                    } finally {
-                     end.set(BoxedUnit.UNIT)
+                     threadState.signalEnd()
+
                      Thread.interrupted() // Clear interrupt status
                    }
                  }.forkDaemon
         a <- restore(fiber.await).exitWith {
                case Exit.Success(exit)       => exit
-               case f: Exit.Failure[Nothing] => interruptThread() *> f
+               case f: Exit.Failure[Nothing] => threadState.interruptThread() *> f
              }
       } yield a
     }
+
+  private[this] sealed abstract class ThreadInterruptionStrategy {
+    def signalBegin(thread: Thread): Unit
+    def signalEnd(): Unit
+    def interruptThread(): UIO[Unit]
+  }
+
+  private[this] object ThreadInterruptionStrategy {
+    final class Once()(implicit trace: Trace, unsafe: Unsafe) extends ThreadInterruptionStrategy {
+      private val begin: Promise[Nothing, Thread] = Promise.unsafe.make(FiberId.None)
+      private val end: Promise[Nothing, Unit]     = Promise.unsafe.make(FiberId.None)
+
+      override def signalBegin(thread: Thread): Unit = begin.unsafe.done(Exit.Success(thread))
+      override def signalEnd(): Unit                 = end.unsafe.succeed(())
+      override def interruptThread(): UIO[Unit] = ZIO.suspendSucceed {
+        (begin.unsafe.poll match {
+          case Some(Exit.Success(thread)) =>
+            thread.interrupt()
+            ZIO.unit
+          case None =>
+            begin.await.flatMap(thread => ZIO.succeed(thread.interrupt()))
+        }) *> end.await
+      }
+    }
+
+    final class Continuously()(implicit trace: Trace) extends ThreadInterruptionStrategy {
+      private val begin: OneShot[Thread] = OneShot.make[Thread]
+      private val end: OneShot[Object]   = OneShot.make[Object]
+
+      override def signalBegin(thread: Thread): Unit = begin.set(thread)
+      override def signalEnd(): Unit                 = end.set(BoxedUnit.UNIT)
+
+      /**
+       * Interrupts the thread running the blocking effect using thread
+       * interruption.
+       *
+       * This effect is run in the blocking threadpool because begin.get() and
+       * end.tryGet() hard-block the thread.
+       */
+      override def interruptThread(): UIO[Unit] =
+        ZIO.succeedBlocking {
+          val thread  = begin.get()
+          var n       = 0L
+          var looping = !end.isSet
+          while (looping) {
+            end.lock()
+            try {
+              // `end` cannot be set while we're here, so we can safely interrupt
+              if (!end.isSet) thread.interrupt()
+            } finally {
+              end.unlock()
+            }
+
+            n += 1
+            looping = end.tryGet(math.min(50, 2L * n)) eq null
+          }
+        }
+    }
+  }
 
   def readFile(path: => Path)(implicit trace: Trace, d: DummyImplicit): ZIO[Any, IOException, String] =
     readFile(path.toString)

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -59,11 +59,45 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
    * If the returned `ZIO` is interrupted, the blocked thread running the
    * synchronous effect will be interrupted via `Thread.interrupt`.
    *
+   * `Thread.interrupt` will be called continuously every 50 milliseconds, until
+   * the target thread is unwound. This is done in attempt to guarantee thread
+   * interruption in presence of misbehaving underlying code, but is done at
+   * risk of possible resource leaks if interrupts aren't handled properly.
+   *
    * Note that this adds significant overhead. For performance sensitive
    * applications consider using `attemptBlocking` or
    * `attemptBlockingCancelable`.
+   *
+   * @see
+   *   [[attemptBlockingInterruptOnce]] for a version that uses
+   *   `Thread.interrupt` only once to avoid resource leaks.
    */
   def attemptBlockingInterrupt[A](effect: => A)(implicit trace: Trace): Task[A] =
+    attemptBlockingInterruptImpl(once = false, effect)
+
+  /**
+   * Imports a synchronous effect that does blocking IO into a pure value.
+   *
+   * If the returned `ZIO` is interrupted, the blocked thread running the
+   * synchronous effect will be interrupted via `Thread.interrupt`.
+   *
+   * `Thread.interrupt` will be called only once on the target thread. If
+   * swallowed by misbehaving code, the thread will still linger on, but if the
+   * underlying code handles interrupts well, this would allow it to perform all
+   * necessary cleanups.
+   *
+   * Note that this adds significant overhead. For performance sensitive
+   * applications consider using `attemptBlocking` or
+   * `attemptBlockingCancelable`.
+   *
+   * @see
+   *   [[attemptBlockingInterrupt]] for a version that calls `Thread.interrupt`
+   *   continuously to attempt to rule out target thread lingering
+   */
+  def attemptBlockingInterruptOnce[A](effect: => A)(implicit trace: Trace): Task[A] =
+    attemptBlockingInterruptImpl(once = true, effect)
+
+  private[this] def attemptBlockingInterruptImpl[A](once: Boolean, effect: => A)(implicit trace: Trace): Task[A] =
     ZIO.uninterruptibleMask { restore =>
       val begin = OneShot.make[Thread]
       val end   = OneShot.make[Object]
@@ -77,21 +111,23 @@ private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
        */
       def interruptThread(): UIO[Unit] =
         ZIO.succeedBlocking {
-          val thread  = begin.get()
-          var looping = !end.isSet
-          var n       = 0L
+          val thread = begin.get()
+          if (once) thread.interrupt()
+          else {
+            var n       = 0L
+            var looping = !end.isSet
+            while (looping) {
+              end.lock()
+              try {
+                // `end` cannot be set while we're here, so we can safely interrupt
+                if (!end.isSet) thread.interrupt()
+              } finally {
+                end.unlock()
+              }
 
-          while (looping) {
-            end.lock()
-            try {
-              // `end` cannot be set while we're here, so we can safely interrupt
-              if (!end.isSet) thread.interrupt()
-            } finally {
-              end.unlock()
+              n += 1
+              looping = end.tryGet(math.min(50, 2L * n)) eq null
             }
-
-            n += 1
-            looping = end.tryGet(math.min(50, 2L * n)) eq null
           }
         }
 


### PR DESCRIPTION
As a follow-up to https://github.com/zio/zio/pull/10483 - issuing interrupts continuously can lead to resource leaks, as demonstrated by ZIO's own unsafe.run misbehaving under those conditions before #10483

Adds a method `attemptBlockingInterruptOnce` to let the user choose to send only one interrupt, if they accept possible thread lingering for better behaving finalizers on the underlying thread.

This also lets us have parity with CE for `interop-cats`: CE's `interruptible` has a choice of strategies: Once/Many/Custom, while we only had Many/Custom via `attemptBlockingInterrupt`/`attemptBlockingCancelable`