### PR TITLE
Queue: add shutdownCause and propagate shutdown cause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,48 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause with take fiber") {
+      val cause = Cause.die(new RuntimeException("queue-shutdown-take"))
+      for {
+        queue <- Queue.bounded[Int](3)
+        f     <- queue.take.fork
+        _     <- waitForSize(queue, -1)
+        _     <- queue.shutdownCause(cause)
+        res   <- f.join.sandbox.either
+      } yield assert(res.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause with offer fiber") {
+      val cause = Cause.die(new RuntimeException("queue-shutdown-offer"))
+      for {
+        queue <- Queue.bounded[Int](2)
+        _     <- queue.offer(1)
+        _     <- queue.offer(1)
+        f     <- queue.offer(1).fork
+        _     <- waitForSize(queue, 3)
+        _     <- queue.shutdownCause(cause)
+        res   <- f.join.sandbox.either
+      } yield assert(res.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause applies to future queue operations") {
+      val cause = Cause.die(new RuntimeException("queue-shutdown-future-ops"))
+      for {
+        queue    <- Queue.bounded[Int](1)
+        _        <- queue.shutdownCause(cause)
+        offerRes <- queue.offer(1).sandbox.either
+        takeRes  <- queue.take.sandbox.either
+      } yield assert(offerRes.left.map(_.untraced))(isLeft(equalTo(cause))) &&
+        assert(takeRes.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause preserves first cause") {
+      val cause1 = Cause.die(new RuntimeException("queue-first-cause"))
+      val cause2 = Cause.die(new RuntimeException("queue-second-cause"))
+      for {
+        queue <- Queue.bounded[Int](1)
+        _     <- queue.shutdownCause(cause1)
+        _     <- queue.shutdownCause(cause2)
+        res   <- queue.take.sandbox.either
+      } yield assert(res.left.map(_.untraced))(isLeft(equalTo(cause1)))
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Dequeue.scala
+++ b/core/shared/src/main/scala/zio/Dequeue.scala
@@ -45,6 +45,13 @@ sealed trait Dequeue[+A] extends Serializable {
   def shutdown(implicit trace: Trace): UIO[Unit]
 
   /**
+   * Fails any fibers that are suspended on `offer` or `take` with the provided
+   * cause. Future calls to `offer*` and `take*` will fail immediately with the
+   * same cause.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit]
+
+  /**
    * Retrieves the size of the queue. This may be negative if fibers are
    * suspended waiting for elements to be added to the queue or greater than the
    * capacity if fibers are suspended waiting to add elements to the queue.

--- a/core/shared/src/main/scala/zio/Enqueue.scala
+++ b/core/shared/src/main/scala/zio/Enqueue.scala
@@ -69,6 +69,13 @@ sealed trait Enqueue[-A] extends Serializable {
   def shutdown(implicit trace: Trace): UIO[Unit]
 
   /**
+   * Fails any fibers that are suspended on `offer` or `take` with the provided
+   * cause. Future calls to `offer*` and `take*` will fail immediately with the
+   * same cause.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit]
+
+  /**
    * Retrieves the size of the queue. This may be negative if fibers are
    * suspended waiting for elements to be added to the queue or greater than the
    * capacity if fibers are suspended waiting to add elements to the queue.

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -181,6 +181,8 @@ object Hub {
               scope.close(Exit.interrupt(fiberId)) *> strategy.shutdown
             }
         }.uninterruptible
+      def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit] =
+        shutdown
       def size(implicit trace: Trace): UIO[Int] =
         ZIO.suspendSucceed {
           if (shutdownFlag.get) ZIO.interrupt
@@ -258,6 +260,8 @@ object Hub {
                 }
             }
         }.uninterruptible
+      def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit] =
+        shutdown
       def size(implicit trace: Trace): UIO[Int] =
         ZIO.suspendSucceed {
           if (shutdownFlag.get) ZIO.interrupt

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -142,7 +142,7 @@ object Queue extends QueuePlatformSpecific {
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
-      new AtomicBoolean(false),
+      new AtomicReference[Cause[Nothing]](null),
       strategy
     )
   }
@@ -151,26 +151,32 @@ object Queue extends QueuePlatformSpecific {
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownCauseRef, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
   ) extends Queue[A] {
 
     override def capacity: Int = queue.capacity
 
+    private def shutdownCause: Cause[Nothing] =
+      shutdownCauseRef.get
+
+    private def interruptedIfShutdown(implicit trace: Trace): UIO[Nothing] =
+      ZIO.failCause(shutdownCause)
+
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownCause ne null) interruptedIfShutdown
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownCauseRef)
         }
       }
 
@@ -193,7 +199,7 @@ object Queue extends QueuePlatformSpecific {
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownCause ne null) interruptedIfShutdown
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -210,7 +216,7 @@ object Queue extends QueuePlatformSpecific {
               strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownCauseRef).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -221,32 +227,37 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCause ne null)
+          interruptedIfShutdown
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
-        if (shutdownFlag.compareAndSet(false, true)) {
+        shutdownCause(Cause.interrupt(fiberId))
+      }.uninterruptible
+
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit] =
+      ZIO.suspendSucceed {
+        if (shutdownCauseRef.compareAndSet(null, cause)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
           val it = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.completeWith(Exit.failCause(cause))
           }
-          strategy.shutdown(fiberId)
+          strategy.shutdown(cause)
         }
         Exit.unit
       }.uninterruptible
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownCause ne null)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          if (shutdownCause ne null) interruptedIfShutdown
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -279,8 +290,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCause ne null)
+          interruptedIfShutdown
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
@@ -294,8 +305,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCause ne null)
+          interruptedIfShutdown
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
@@ -309,8 +320,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCause ne null)
+          interruptedIfShutdown
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
@@ -329,7 +340,7 @@ object Queue extends QueuePlatformSpecific {
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      isShutdown: AtomicBoolean
+      shutdownCauseRef: AtomicReference[Cause[Nothing]]
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
@@ -339,7 +350,7 @@ object Queue extends QueuePlatformSpecific {
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -401,7 +412,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCauseRef: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
@@ -410,7 +421,8 @@ object Queue extends QueuePlatformSpecific {
             unsafeOffer(as, p)
             unsafeOnQueueEmptySpace(queue, takers)
             unsafeCompleteTakers(queue, takers)
-            if (isShutdown.get) ZIO.interrupt else p.await
+            val shutdownCause = shutdownCauseRef.get
+            if (shutdownCause eq null) p.await else ZIO.failCause(shutdownCause)
           }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
         }
 
@@ -464,11 +476,11 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = {
         var next = putters.poll()
         while (next ne null) {
           val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          if (isLast) promise.unsafe.completeWith(Exit.failCause(cause))
           next = putters.poll()
         }
       }
@@ -480,7 +492,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCauseRef: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
@@ -490,7 +502,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -498,7 +510,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCauseRef: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {
@@ -531,7 +543,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -6241,6 +6241,8 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
         dequeue.isShutdown
       def shutdown(implicit trace: Trace): UIO[Unit] =
         dequeue.shutdown
+      def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Unit] =
+        dequeue.shutdownCause(cause)
       def size(implicit trace: Trace): UIO[Int] =
         dequeue.size
       def take(implicit trace: Trace): UIO[B] =


### PR DESCRIPTION
/claim #9844

## Summary

This PR adds `shutdownCause(cause: Cause[Nothing])` support to `Queue` and propagates the selected shutdown cause consistently to pending and future queue operations.

### What changed

- Added `shutdownCause(cause: Cause[Nothing])` to `Enqueue` and `Dequeue`.
- Implemented `Queue.shutdownCause` with first-wins semantics via `AtomicReference[Cause[Nothing]]`.
- Updated `Queue.shutdown` to delegate to `shutdownCause(Cause.interrupt(fiberId))` to preserve current behavior.
- Propagated the shutdown cause to:
  - pending takers
  - pending backpressured putters
  - future queue operations (`offer*`, `take*`, `poll`, `size`)
- Added forwarding implementations where required by the new API:
  - `Hub` / hub subscription wrappers (delegate to existing `shutdown` behavior)
  - `ZStream.mapDequeue` wrapper

## Compatibility

This keeps existing `shutdown` behavior intact and avoids adding an extra type parameter to `Queue`, while enabling explicit cause propagation through `shutdownCause`.

## Tests

Added focused tests in `QueueSpec`:

- `shutdownCause with take fiber`
- `shutdownCause with offer fiber`
- `shutdownCause applies to future queue operations`
- `shutdownCause preserves first cause`

Validated with:

```bash
SBT_OPTS='-Xms1G -Xmx3G -Xss4M -XX:+UseG1GC' sbt "coreTestsJVM/testOnly zio.QueueSpec -- -t shutdownCause"
SBT_OPTS='-Xms1G -Xmx3G -Xss4M -XX:+UseG1GC' sbt "coreTestsJVM/testOnly zio.QueueSpec -- -t shutdown"
```
