### PR TITLE
[POC] Remove ZIO.Sync — represent succeed(a) as FlatMap

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -161,6 +161,7 @@ object StackTracesSpec extends ZIOBaseSpec {
               |	at scala.runtime.java8.JFunction0$mcV$sp.apply
               |	at zio.StackTracesSpec$.assertThrows
               |	at zio.StackTracesSpec$.$anonfun$spec
+              |	at zio.ZIOCompanionVersionSpecific.$anonfun$succeed
               |""".stripMargin
           else
             """java.lang.String: boom
@@ -208,6 +209,7 @@ object StackTracesSpec extends ZIOBaseSpec {
               |	at scala.runtime.java8.JFunction0$mcV$sp.apply
               |	at zio.StackTracesSpec$.assertThrows
               |	at zio.StackTracesSpec$.$anonfun$spec
+              |	at zio.ZIOCompanionVersionSpecific.$anonfun$succeed
               |	at zio.internal.FiberRuntime.runLoop
               |	at zio.internal.FiberRuntime.evaluateEffect
               |	at zio.internal.FiberRuntime.evaluateMessageWhileSuspended
@@ -225,6 +227,7 @@ object StackTracesSpec extends ZIOBaseSpec {
               |	at scala.runtime.java8.JFunction0$mcV$sp.apply
               |	at zio.StackTracesSpec$.assertThrows
               |	at zio.StackTracesSpec$.$anonfun$spec
+              |	at zio.ZIOCompanionVersionSpecific.$anonfun$succeed
               |""".stripMargin
           else
             """java.lang.RuntimeException: boom

--- a/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ZIOCompanionVersionSpecific.scala
@@ -171,7 +171,7 @@ private[zio] trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   def succeed[A](a: => A)(implicit trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => a)
+    ZIO.FlatMap(trace, ZIO.unit, (_: Any) => Exit.succeed(a))
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOCompanionVersionSpecific.scala
@@ -172,7 +172,7 @@ private[zio] transparent trait ZIOCompanionVersionSpecific {
    * Returns an effect that models success with the specified value.
    */
   inline def succeed[A](inline a: Unsafe ?=> A)(implicit inline trace: Trace): ZIO[Any, Nothing, A] =
-    ZIO.Sync(trace, () => a(using Unsafe))
+    ZIO.FlatMap(trace, ZIO.unit, (_: Any) => Exit.succeed(a(using Unsafe)))
 
   /**
    * Returns a synchronous effect that does blocking and succeeds with the

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4428,6 +4428,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     async[Any, Nothing, Nothing](ZIO.unitFn)
 
   /**
+   * An effect that succeeds with a unit value.
+   */
+  val unit: UIO[Unit] =
+    ZIO.FlatMap(Trace.empty, Exit.unit, (_: Any) => Exit.unit)
+
+  /**
    * Returns an effect that succeeds with the `None` value.
    */
   val none: UIO[Option[Nothing]] =
@@ -4983,12 +4989,6 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ZIO.withFiberRuntime[R, E, A] { (fiberState, _) =>
       f(Grafter(fiberState))
     }
-
-  /**
-   * An effect that succeeds with a unit value.
-   */
-  val unit: UIO[Unit] =
-    succeed(())(Trace.empty)
 
   /**
    * Prefix form of `ZIO#uninterruptible`.
@@ -6181,7 +6181,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     failureK: Cause[E1] => ZIO[R, E2, A2]
   ) extends Continuation
       with ZIO[R, E2, A2]
-  private[zio] final case class Sync[A](trace: Trace, eval: () => A) extends ZIO[Any, Nothing, A]
+
   private[zio] final case class Async[R, E, A](
     trace: Trace,
     registerCallback: (ZIO[R, E, A] => Unit) => Either[URIO[R, Any], ZIO[R, E, A]],

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -971,18 +971,6 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       // No interrupt handler
       case null => callback.completeCause(cause)
 
-      // Shortcut cases where the interruption is a simple suspended function (most common)
-      case sync: Sync[Any] =>
-        if (callback.completeCause(cause)) {
-          updateLastTrace(sync.trace)
-          try {
-            sync.eval()
-          } catch {
-            case ex if nonFatal(ex) => addInterruptedCause(Cause.die(ex))
-            case fatal              => handleFatalError(fatal)
-          }
-        }
-
       // Can't shortcut, handle onInterrupt in runloop
       case onInterrupt =>
         val f = onInterrupt.foldCauseZIO(
@@ -1156,48 +1144,90 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 }
               }
 
-            case sync: Sync[Any] =>
-              updateLastTrace(sync.trace)
-              var value = sync.eval()
-
-              cur = null
-
-              while ((cur eq null) && stackIndex > minStackIndex) {
-                stackIndex -= 1
-
-                val continuation = _stack(stackIndex)
-
-                popStackFrame(stackIndex)
-
-                continuation match {
-                  case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
-                    cur = flatMap.successK(value)
-
-                  case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
-                    cur = foldZIO.successK(value)
-
-                  case map: ZIO.Mapped[Any, Any, Any, Any] =>
-                    value = map.successK(value)
-
-                  case update =>
-                    val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
-                    if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
-                      cur = patchRuntimeFlags(updateFlags.update, null, null)
-                    }
-                }
-              }
-
-              if (cur eq null) {
-                return Exit.succeed(value)
-              }
-
             case flatmap: FlatMap[Any, Any, Any, Any] =>
               updateLastTrace(flatmap.trace)
 
               val first = flatmap.first
 
-              if (first eq ZIO.unit) cur = flatmap.successK(())
-              else {
+              if (first eq Exit.unit) {
+                // This is ZIO.unit itself — the value is always ()
+                var value: Any = ()
+
+                cur = null
+
+                while ((cur eq null) && stackIndex > minStackIndex) {
+                  stackIndex -= 1
+
+                  val continuation = _stack(stackIndex)
+
+                  popStackFrame(stackIndex)
+
+                  continuation match {
+                    case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
+                      cur = flatMap.successK(value)
+
+                    case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
+                      cur = foldZIO.successK(value)
+
+                    case map: ZIO.Mapped[Any, Any, Any, Any] =>
+                      value = map.successK(value)
+
+                    case update =>
+                      val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
+                      if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
+                        cur = patchRuntimeFlags(updateFlags.update, null, null)
+                      }
+                  }
+                }
+
+                if (cur eq null) {
+                  return Exit.succeed(value)
+                }
+              } else if (first eq ZIO.unit) {
+                val result = flatmap.successK(())
+
+                result match {
+                  case success: Exit.Success[Any] =>
+                    var value = success.value
+
+                    cur = null
+
+                    while ((cur eq null) && stackIndex > minStackIndex) {
+                      stackIndex -= 1
+
+                      val continuation = _stack(stackIndex)
+
+                      popStackFrame(stackIndex)
+
+                      continuation match {
+                        case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
+                          cur = flatMap.successK(value)
+
+                        case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
+                          cur = foldZIO.successK(value)
+
+                        case map: ZIO.Mapped[Any, Any, Any, Any] =>
+                          value = map.successK(value)
+
+                        case update =>
+                          val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
+                          if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
+                            cur = patchRuntimeFlags(updateFlags.update, null, null)
+                          }
+                      }
+                    }
+
+                    if (cur eq null) {
+                      return {
+                        if (success.value.asInstanceOf[AnyRef] eq value.asInstanceOf[AnyRef]) success
+                        else Exit.succeed(value)
+                      }
+                    }
+
+                  case _ =>
+                    cur = result
+                }
+              } else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
                 cur = first
               }


### PR DESCRIPTION
## Summary

- Remove `ZIO.Sync` case class — `succeed(a)` is now `FlatMap(trace, ZIO.unit, _ => Exit.succeed(a))`
- `ZIO.unit` becomes `FlatMap(Trace.empty, Exit.unit, _ => Exit.unit)` (breaks the cycle since `succeed` references `ZIO.unit`)
- Removes `Sync` handling from the FiberRuntime runloop and interrupt handler
- Adds `Exit.unit` and `Exit.Success` fast-paths in the `FlatMap` handler to preserve single-iteration performance for `succeed` and `ZIO.unit`
- Updates `StackTracesSpec` expected traces for the new `succeed` lambda frame

## Known issue

`bufferSliding` / `bufferChunksSliding` "fast producer progress independently" stream tests hang. All other tests pass (~2878 core tests, all other buffer strategies). Root cause under investigation — help welcome.

The hang is specific to `Queue.Sliding.handleSurplus` which returns `ZIO.succeed { sideEffects }` (now a `FlatMap` instead of `Sync`). Other strategies like `Dropping` return `Exit.false` (a pre-allocated constant, unaffected by this change).

## Test plan

- [x] `sbt --client compile` passes
- [x] ~2878 core tests pass
- [x] StackTracesSpec updated and passing
- [ ] `bufferSliding` / `bufferChunksSliding` "fast producer" tests — **hanging, needs fix**

🤖 Generated with [Claude Code](https://claude.com/claude-code)