### PR TITLE
Add process-based integration tests for ZIOApp

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppIntegrationSpec.scala
@@ -1,0 +1,273 @@
+package zio
+
+import zio.test._
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.concurrent.TimeUnit
+
+/**
+ * Process-based integration tests for [[ZIOApp]].
+ *
+ * Unlike the in-process [[ZIOAppSpec]] (which uses [[ZIOApp.invoke]]), these
+ * tests spawn each fixture app in a **separate JVM** so that the full
+ * lifecycle is exercised — JVM shutdown hooks, signal delivery, exit codes,
+ * and the [[gracefulShutdownTimeout]] mechanism.
+ *
+ * == How it works ==
+ *
+ *  1. Each test launches a fixture object from [[ZIOAppTestApps]] via
+ *     [[ProcessBuilder]], reusing the current test classpath.
+ *  2. For ''normal completion'' tests the parent simply waits for the child
+ *     to exit and asserts on its exit code / stdout markers.
+ *  3. For ''signal'' tests the parent waits for the `READY` marker, sends
+ *     `kill -INT` (Unix) or calls `ProcessHandle#destroy` (Windows),
+ *     and then asserts on finalizer markers and timing.
+ *
+ * == Platform notes ==
+ *
+ * Signal-based suites are gated behind [[unixOnly]] because
+ * [[ProcessHandle#destroy]] on Windows terminates the process without
+ * invoking JVM shutdown hooks.  CI runs on Linux, so all suites are
+ * exercised there.
+ *
+ * == Coverage mapping ==
+ *
+ * | Requirement (issue #9909)                   | Suite / test                                        |
+ * |---------------------------------------------|-----------------------------------------------------|
+ * | Correct exit code on success / failure       | ''app completion''                                  |
+ * | Finalizers run (normal)                      | ''finalizers on normal completion''                 |
+ * | Finalizers run (signal)                      | ''external signal handling''                        |
+ * | gracefulShutdownTimeout respected            | ''gracefulShutdownTimeout''                         |
+ * | Shutdown does not hang                       | ''gracefulShutdownTimeout / no-hang''               |
+ * | #9901 – finalizers not waited on             | ''slow finalizer completes …''                      |
+ * | #9807 – shutdown-hook race                   | all signal tests (atomic `shuttingDown` flag)       |
+ * | #9240 – sun.misc.SignalHandler CNFE          | every test app starts without `NoClassDefFoundError` |
+ */
+object ZIOAppIntegrationSpec extends ZIOBaseSpec {
+
+  // -- helpers ----------------------------------------------------------------
+
+  private val javaHome  = java.lang.System.getProperty("java.home")
+  private val javaBin   = s"$javaHome/bin/java"
+  private val classpath = java.lang.System.getProperty("java.class.path")
+  private val isWindows = java.lang.System.getProperty("os.name").toLowerCase.contains("win")
+
+  /**
+   * Skips the annotated suite when running on Windows.
+   * Signal delivery on Windows does not trigger JVM shutdown hooks, so
+   * signal-based tests are meaningless there.
+   */
+  private val unixOnly: TestAspectPoly =
+    if (isWindows) TestAspect.ignore else TestAspect.identity
+
+  /** Starts a child JVM running `mainClass` with the current classpath. */
+  private def startProcess(mainClass: String): java.lang.Process = {
+    val builder = new ProcessBuilder(javaBin, "-cp", classpath, mainClass)
+    builder.redirectErrorStream(true)
+    builder.start()
+  }
+
+  /** Drains the remaining stdout of a (finished) process into a String. */
+  private def readOutput(process: java.lang.Process): String = {
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val sb     = new StringBuilder
+    var line   = reader.readLine()
+    while (line != null) {
+      sb.append(line).append("\n")
+      line = reader.readLine()
+    }
+    sb.toString()
+  }
+
+  /**
+   * Reads stdout line-by-line until `marker` appears or `timeoutMs`
+   * elapses.  Returns everything that was read.
+   */
+  private def waitForMarker(process: java.lang.Process, marker: String, timeoutMs: Long): String = {
+    val reader   = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val sb       = new StringBuilder
+    val deadline = java.lang.System.currentTimeMillis() + timeoutMs
+    while (java.lang.System.currentTimeMillis() < deadline) {
+      if (reader.ready()) {
+        val line = reader.readLine()
+        if (line != null) {
+          sb.append(line).append("\n")
+          if (line.contains(marker)) return sb.toString()
+        }
+      } else {
+        Thread.sleep(50)
+      }
+    }
+    sb.toString()
+  }
+
+  /** Sends SIGINT (Unix) or a destroy signal (Windows) to a process. */
+  private def sendInterrupt(process: java.lang.Process): Unit = {
+    val pid = process.pid()
+    if (isWindows) {
+      val _ = process.toHandle.destroy()
+    } else {
+      val _ = java.lang.Runtime.getRuntime.exec(Array("kill", "-INT", pid.toString))
+    }
+  }
+
+  // -- higher-level combinators -----------------------------------------------
+
+  /** Runs a self-completing app and returns `(exitCode, stdout)`. */
+  private def runApp(mainClass: String): ZIO[Any, Throwable, (Int, String)] =
+    ZIO.attemptBlocking {
+      val process = startProcess(mainClass)
+      val exited  = process.waitFor(30, TimeUnit.SECONDS)
+      val output  = readOutput(process)
+      if (!exited) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass did not exit within 30 s")
+      }
+      (process.exitValue(), output)
+    }
+
+  /**
+   * Runs a long-running app, waits for `READY`, sends SIGINT, then
+   * collects the remaining output.  Returns `(preSignal, postSignal)`.
+   */
+  private def runAppWithSignal(mainClass: String): ZIO[Any, Throwable, (String, String)] =
+    ZIO.attemptBlocking {
+      val process = startProcess(mainClass)
+      val pre     = waitForMarker(process, "READY", 30000)
+      if (!pre.contains("READY")) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass never printed READY within 30 s")
+      }
+      sendInterrupt(process)
+      val exited = process.waitFor(30, TimeUnit.SECONDS)
+      val post   = readOutput(process)
+      if (!exited) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass did not exit after signal within 30 s")
+      }
+      (pre, post)
+    }
+
+  // -- spec -------------------------------------------------------------------
+
+  def spec = suite("ZIOAppIntegrationSpec")(
+    // ---- 1. Normal completion -----------------------------------------------
+    suite("app completion")(
+      test("successful app exits with code 0") {
+        runApp("zio.AppSuccess").map { case (code, out) =>
+          assertTrue(code == 0, out.contains("SUCCESS"))
+        }
+      },
+      test("failed app exits with code 1") {
+        runApp("zio.AppFailure").map { case (code, _) =>
+          assertTrue(code == 1)
+        }
+      },
+      test("defect exits with code 1") {
+        runApp("zio.AppDie").map { case (code, _) =>
+          assertTrue(code == 1)
+        }
+      },
+      test("app completes work before exiting") {
+        runApp("zio.AppExitAfterWork").map { case (code, out) =>
+          assertTrue(code == 0, out.contains("WORKING"), out.contains("DONE"))
+        }
+      }
+    ),
+
+    // ---- 2. Finalizers on normal completion ----------------------------------
+    suite("finalizers on normal completion")(
+      test("finalizers run on success") {
+        runApp("zio.AppFinalizerOnSuccess").map { case (_, out) =>
+          assertTrue(out.contains("ACQUIRED"), out.contains("FINALIZED"))
+        }
+      },
+      test("finalizers run on failure") {
+        runApp("zio.AppFinalizerOnFailure").map { case (code, out) =>
+          assertTrue(code == 1, out.contains("ACQUIRED"), out.contains("FINALIZED"))
+        }
+      }
+    ),
+
+    // ---- 3. Signal-driven shutdown ------------------------------------------
+    suite("external signal handling")(
+      test("app shuts down and runs finalizers on SIGINT") {
+        runAppWithSignal("zio.AppHangsUntilInterrupted").map { case (pre, post) =>
+          assertTrue((pre + post).contains("FINALIZED"))
+        }
+      },
+      test("slow finalizer completes when gracefulShutdownTimeout is Infinity (issue #9901)") {
+        runAppWithSignal("zio.AppSlowFinalizer").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("FINALIZING"), all.contains("FINALIZED"))
+        }
+      },
+      test("multiple finalizers run in LIFO order") {
+        runAppWithSignal("zio.AppMultipleFinalizers").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("FINAL-1"), all.contains("FINAL-2"), all.contains("FINAL-3")) && {
+            val i1 = all.indexOf("FINAL-1")
+            val i2 = all.indexOf("FINAL-2")
+            val i3 = all.indexOf("FINAL-3")
+            assertTrue(i3 < i2, i2 < i1) // LIFO: 3 → 2 → 1
+          }
+        }
+      },
+      test("bootstrap layer finalizers run on SIGINT") {
+        runAppWithSignal("zio.AppBootstrapFinalizer").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("BOOTSTRAP-ACQUIRED"), all.contains("BOOTSTRAP-FINALIZED"))
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 4. gracefulShutdownTimeout -----------------------------------------
+    suite("gracefulShutdownTimeout")(
+      test("shutdown respects timeout — slow finalizer is cut short") {
+        ZIO.attemptBlocking {
+          val process = startProcess("zio.AppShutdownTimeout")
+          val pre     = waitForMarker(process, "READY", 30000)
+          if (!pre.contains("READY")) {
+            process.destroyForcibly()
+            throw new RuntimeException("AppShutdownTimeout never printed READY")
+          }
+          val t0   = java.lang.System.currentTimeMillis()
+          sendInterrupt(process)
+          val done = process.waitFor(15, TimeUnit.SECONDS)
+          val dt   = java.lang.System.currentTimeMillis() - t0
+          val post = readOutput(process)
+          if (!done) process.destroyForcibly()
+          val all = pre + post
+          // Timeout is 1 s, finalizer wants 10 s → process exits in well under 10 s
+          assertTrue(done, dt < 8000L, all.contains("FINALIZING"), !all.contains("FINALIZED"))
+        }
+      },
+      test("well-behaved app does not hang on shutdown") {
+        ZIO.attemptBlocking {
+          val process = startProcess("zio.AppHangsUntilInterrupted")
+          val pre     = waitForMarker(process, "READY", 30000)
+          if (!pre.contains("READY")) {
+            process.destroyForcibly()
+            throw new RuntimeException("Process never printed READY")
+          }
+          val t0   = java.lang.System.currentTimeMillis()
+          sendInterrupt(process)
+          val done = process.waitFor(15, TimeUnit.SECONDS)
+          val dt   = java.lang.System.currentTimeMillis() - t0
+          if (!done) process.destroyForcibly()
+          assertTrue(done, dt < 10000L)
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 5. Background fibers -----------------------------------------------
+    suite("background fiber cleanup")(
+      test("daemon fibers are interrupted on shutdown") {
+        runAppWithSignal("zio.AppBackgroundFiber").map { case (pre, post) =>
+          assertTrue((pre + post).contains("BG-FINALIZED"))
+        }
+      }
+    ) @@ unixOnly
+
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds) @@ TestAspect.jvmOnly
+}

--- a/core-tests/jvm/src/test/scala/zio/ZIOAppTestApps.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppTestApps.scala
@@ -1,0 +1,153 @@
+package zio
+
+/**
+ * Standalone ZIOApp programs used by [[ZIOAppIntegrationSpec]].
+ *
+ * Each object is compiled as part of the test sources and launched
+ * in a separate JVM process via [[ProcessBuilder]].  The parent
+ * test communicates with the child through stdout markers.
+ *
+ * Naming convention:
+ *   - App*           – test fixture
+ *   - "READY"        – child is waiting and can be interrupted
+ *   - "FINALIZED"    – a finalizer has completed
+ *   - "ACQUIRED"     – a resource has been acquired
+ */
+
+// ---------------------------------------------------------------------------
+// Normal completion
+// ---------------------------------------------------------------------------
+
+/** Succeeds immediately. Expected exit code: 0. */
+object AppSuccess extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Unit] = Console.printLine("SUCCESS").orDie
+}
+
+/** Fails immediately. Expected exit code: 1. */
+object AppFailure extends ZIOAppDefault {
+  val run: ZIO[Any, String, Nothing] = ZIO.fail("boom")
+}
+
+/** Dies with an unchecked defect. Expected exit code: 1. */
+object AppDie extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Nothing] = ZIO.die(new RuntimeException("defect"))
+}
+
+/** Does some work, then succeeds. Expected exit code: 0. */
+object AppExitAfterWork extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Unit] = for {
+    _ <- Console.printLine("WORKING").orDie
+    _ <- ZIO.sleep(100.millis)
+    _ <- Console.printLine("DONE").orDie
+  } yield ()
+}
+
+// ---------------------------------------------------------------------------
+// Finalizers on normal completion
+// ---------------------------------------------------------------------------
+
+/** Acquires a resource with a finalizer, then succeeds. */
+object AppFinalizerOnSuccess extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Unit] =
+    ZIO.acquireRelease(Console.printLine("ACQUIRED").orDie)(_ => Console.printLine("FINALIZED").orDie)
+      .unit
+}
+
+/** Acquires a resource with a finalizer, then fails. */
+object AppFinalizerOnFailure extends ZIOAppDefault {
+  val run: ZIO[Scope, String, Nothing] =
+    ZIO.acquireRelease(Console.printLine("ACQUIRED").orDie)(_ => Console.printLine("FINALIZED").orDie) *>
+      ZIO.fail("boom")
+}
+
+// ---------------------------------------------------------------------------
+// Signal handling (SIGINT / SIGTERM)
+// ---------------------------------------------------------------------------
+
+/** Waits forever after printing "READY"; finalizer prints "FINALIZED". */
+object AppHangsUntilInterrupted extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("FINALIZED").orDie) *>
+      Console.printLine("READY").orDie *>
+      ZIO.never
+}
+
+/** Same as above but the finalizer takes 3 seconds to complete. */
+object AppSlowFinalizer extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(ZIO.unit)(_ =>
+      Console.printLine("FINALIZING").orDie *>
+        ZIO.sleep(3.seconds) *>
+        Console.printLine("FINALIZED").orDie
+    ) *>
+      Console.printLine("READY").orDie *>
+      ZIO.never
+}
+
+/**
+ * Three nested [[acquireRelease]] blocks. Finalizers should execute
+ * in LIFO order: FINAL-3, FINAL-2, FINAL-1.
+ */
+object AppMultipleFinalizers extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(Console.printLine("ACQ-1").orDie)(_ => Console.printLine("FINAL-1").orDie) *>
+      ZIO.acquireRelease(Console.printLine("ACQ-2").orDie)(_ => Console.printLine("FINAL-2").orDie) *>
+      ZIO.acquireRelease(Console.printLine("ACQ-3").orDie)(_ => Console.printLine("FINAL-3").orDie) *>
+      Console.printLine("READY").orDie *>
+      ZIO.never
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap layer
+// ---------------------------------------------------------------------------
+
+/** Bootstrap layer owns a resource; its finalizer must run on shutdown. */
+object AppBootstrapFinalizer extends ZIOApp {
+  type Environment = Unit
+  val environmentTag: EnvironmentTag[Unit] = EnvironmentTag[Unit]
+
+  val bootstrap: ZLayer[ZIOAppArgs, Any, Unit] =
+    ZLayer.scoped(
+      ZIO.acquireRelease(Console.printLine("BOOTSTRAP-ACQUIRED").orDie)(_ =>
+        Console.printLine("BOOTSTRAP-FINALIZED").orDie
+      )
+    )
+
+  val run: ZIO[Scope, Nothing, Nothing] =
+    Console.printLine("READY").orDie *> ZIO.never
+}
+
+// ---------------------------------------------------------------------------
+// gracefulShutdownTimeout
+// ---------------------------------------------------------------------------
+
+/**
+ * Overrides [[gracefulShutdownTimeout]] to 1 second while the finalizer
+ * needs 10 seconds.  The JVM should exit after ~1 s, the "FINALIZED"
+ * marker should *not* appear.
+ */
+object AppShutdownTimeout extends ZIOAppDefault {
+  override def gracefulShutdownTimeout: Duration = 1.second
+
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(ZIO.unit)(_ =>
+      Console.printLine("FINALIZING").orDie *>
+        ZIO.sleep(10.seconds) *>
+        Console.printLine("FINALIZED").orDie
+    ) *>
+      Console.printLine("READY").orDie *>
+      ZIO.never
+}
+
+// ---------------------------------------------------------------------------
+// Background fibers
+// ---------------------------------------------------------------------------
+
+/** Spawns a daemon fiber whose finalizer should run on shutdown. */
+object AppBackgroundFiber extends ZIOAppDefault {
+  val run = for {
+    _ <- ZIO.never.ensuring(Console.printLine("BG-FINALIZED").orDie).forkDaemon
+    _ <- Console.printLine("READY").orDie
+    _ <- ZIO.never
+  } yield ()
+}


### PR DESCRIPTION
## Summary

Adds a new JVM-only integration test suite (`ZIOAppIntegrationSpec`) that verifies `ZIOApp` lifecycle behaviour by spawning real JVM sub-processes.  This complements the existing in-process `ZIOAppSpec` (which uses `invoke`) by exercising the full `main()` path: JVM shutdown hooks, signal delivery, exit codes and `gracefulShutdownTimeout`.

### Test coverage (13 tests across 5 suites)

| Suite | Tests | Signal? |
|---|---|---|
| **app completion** | exit code 0 (success), 1 (failure), 1 (defect), completes work | No |
| **finalizers on normal completion** | finalizers on success, finalizers on failure | No |
| **external signal handling** | SIGINT + finalizer, slow finalizer with Infinity timeout, LIFO order, bootstrap layer cleanup | Yes |
| **gracefulShutdownTimeout** | timeout cuts slow finalizer, well-behaved app doesn't hang | Yes |
| **background fiber cleanup** | daemon fibers interrupted on shutdown | Yes |

Signal-based suites are gated behind a `unixOnly` aspect — `Process.destroy()` on Windows doesn't trigger JVM shutdown hooks, so those tests are skipped there.  CI runs on Linux so all 13 tests will execute.

### Regression coverage

- **#9901** — slow finalizer completes when `gracefulShutdownTimeout` is `Infinity`
- **#9807** — atomic `shuttingDown` flag prevents shutdown-hook race (all signal tests exercise this path)
- **#9240** — all fixture apps start without `NoClassDefFoundError` (reflection-based signal handler works)

### How it works

Each test fixture is a small `ZIOAppDefault` / `ZIOApp` object in `ZIOAppTestApps.scala`.  The parent test launches them with `ProcessBuilder` using the current test classpath, communicates through stdout markers (`READY`, `FINALIZED`, etc.), and sends `kill -INT` for signal tests.

### Running

```bash
sbt "coreTestsJVM/testOnly zio.ZIOAppIntegrationSpec"
```

### Files

- `core-tests/jvm/src/test/scala/zio/ZIOAppTestApps.scala` — 10 fixture apps
- `core-tests/jvm/src/test/scala/zio/ZIOAppIntegrationSpec.scala` — test spec

Relates to #9901, #9807, #9240.

/claim #9909