### PR TITLE
Replace WeakConcurrentBag with lock-free FiberSet

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
@@ -1,0 +1,165 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.{Collections, TimeUnit}
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{WeakHashMap, Set => JSet}
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+class FiberSetBenchmark {
+
+  @Param(Array("1000"))
+  var elements: Int = _
+
+  var fiberSet: FiberSet[FiberSetBenchmark.FakeEntry]       = _
+  var syncWeakSet: JSet[FiberSetBenchmark.FakeEntry]        = _
+  var weakBag: WeakConcurrentBag[FiberSetBenchmark.FakeEntry] = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    import FiberSetBenchmark._
+    val nCpu = Runtime.getRuntime.availableProcessors()
+    fiberSet = FiberSet[FakeEntry](elements, nCpu * 2, isAlive)
+    syncWeakSet = Collections.synchronizedSet(
+      Collections.newSetFromMap(new WeakHashMap[FakeEntry, java.lang.Boolean]())
+    )
+    weakBag = WeakConcurrentBag[FakeEntry](elements, isAlive)
+  }
+
+  @Benchmark
+  @Threads(1)
+  def fiberSetAddSerial(): Unit =
+    fiberSet.add(FiberSetBenchmark.FakeEntry())
+
+  @Benchmark
+  @Threads(8)
+  def fiberSetAddConcurrent(): Unit =
+    fiberSet.add(FiberSetBenchmark.FakeEntry())
+
+  @Benchmark
+  @Threads(1)
+  def syncWeakSetAddSerial(): Unit =
+    syncWeakSet.add(FiberSetBenchmark.FakeEntry())
+
+  @Benchmark
+  @Threads(8)
+  def syncWeakSetAddConcurrent(): Unit =
+    syncWeakSet.add(FiberSetBenchmark.FakeEntry())
+
+  @Benchmark
+  @Threads(1)
+  def weakBagAddSerial(): Unit =
+    weakBag.add(FiberSetBenchmark.FakeEntry())
+
+  @Benchmark
+  @Threads(8)
+  def weakBagAddConcurrent(): Unit =
+    weakBag.add(FiberSetBenchmark.FakeEntry())
+}
+
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+class FiberSetAddRemoveBenchmark {
+
+  var fiberSet: FiberSet[FiberSetBenchmark.FakeEntry]       = _
+  var syncWeakSet: JSet[FiberSetBenchmark.FakeEntry]        = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    import FiberSetBenchmark._
+    fiberSet = FiberSet[FakeEntry](256, 1, isAlive)
+    syncWeakSet = Collections.synchronizedSet(
+      Collections.newSetFromMap(new WeakHashMap[FakeEntry, java.lang.Boolean]())
+    )
+  }
+
+  @Benchmark
+  @Threads(1)
+  def fiberSetAddRemove(bh: Blackhole): Unit = {
+    val e = FiberSetBenchmark.FakeEntry()
+    fiberSet.add(e)
+    bh.consume(fiberSet.remove(e))
+  }
+
+  @Benchmark
+  @Threads(1)
+  def syncWeakSetAddRemove(bh: Blackhole): Unit = {
+    val e = FiberSetBenchmark.FakeEntry()
+    syncWeakSet.add(e)
+    bh.consume(syncWeakSet.remove(e))
+  }
+}
+
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+class FiberSetIterateBenchmark {
+
+  @Param(Array("100", "1000"))
+  var elements: Int = _
+
+  var fiberSet: FiberSet[FiberSetBenchmark.FakeEntry]        = _
+  var syncWeakSet: JSet[FiberSetBenchmark.FakeEntry]         = _
+  var refs: Array[FiberSetBenchmark.FakeEntry]               = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    import FiberSetBenchmark._
+    fiberSet = FiberSet[FakeEntry](elements, 1, isAlive)
+    syncWeakSet = Collections.synchronizedSet(
+      Collections.newSetFromMap(new WeakHashMap[FakeEntry, java.lang.Boolean]())
+    )
+    refs = (0 until elements).map(_ => FakeEntry()).toArray
+    refs.foreach { e =>
+      fiberSet.add(e)
+      syncWeakSet.add(e)
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  def fiberSetIterate(bh: Blackhole): Unit =
+    fiberSet.forEach(e => bh.consume(e))
+
+  @Benchmark
+  @Threads(1)
+  def syncWeakSetIterate(bh: Blackhole): Unit =
+    syncWeakSet.synchronized {
+      val it = syncWeakSet.iterator()
+      while (it.hasNext) bh.consume(it.next())
+    }
+}
+
+object FiberSetBenchmark {
+  private val counter = new AtomicInteger(0)
+
+  val isAlive: FiberSet.IsAlive[FakeEntry] = _.alive
+
+  final class FakeEntry {
+    val id: Int       = counter.getAndIncrement()
+    var alive: Boolean = true
+    override def hashCode(): Int       = id
+    override def equals(obj: Any): Boolean = obj match {
+      case that: FakeEntry => this.id == that.id
+      case _               => false
+    }
+    def isAlive(): Boolean = alive
+  }
+
+  object FakeEntry {
+    def apply(): FakeEntry = new FakeEntry()
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
@@ -1,0 +1,170 @@
+package zio.internal
+
+import zio.test._
+import zio.test.TestAspect.{flaky, jvmOnly, nonFlaky}
+import zio.ZIOBaseSpec
+
+object FiberSetSpec extends ZIOBaseSpec {
+
+  final case class Entry(id: Int) {
+    @volatile private var alive = true
+    def isAlive(): Boolean = alive
+    def kill(): Unit       = alive = false
+  }
+
+  private val isAlive: FiberSet.IsAlive[Entry] = _.isAlive()
+
+  def spec = suite("FiberSetSpec")(
+    test("add and iterate single element") {
+      val set   = FiberSet[Entry](16, 1, isAlive)
+      val entry = Entry(1)
+      set.add(entry)
+      assertTrue(set.iterator.toList == List(entry))
+    },
+    test("add multiple and iterate") {
+      val set     = FiberSet[Entry](64, 1, isAlive)
+      val entries = (1 to 50).map(Entry(_)).toList
+      entries.foreach(set.add)
+      val result = set.iterator.toSet
+      assertTrue(result == entries.toSet)
+    },
+    test("size tracks entries") {
+      val set     = FiberSet[Entry](32, 1, isAlive)
+      val entries = (1 to 10).map(Entry(_)).toList
+      entries.foreach(set.add)
+      assertTrue(set.size >= 10)
+    },
+    test("isEmpty on empty set") {
+      val set = FiberSet[Entry](16, 1, isAlive)
+      assertTrue(set.isEmpty)
+    },
+    test("isEmpty after add") {
+      val set   = FiberSet[Entry](16, 1, isAlive)
+      val entry = Entry(1)
+      set.add(entry)
+      assertTrue(!set.isEmpty)
+    },
+    test("remove by identity") {
+      val set = FiberSet[Entry](32, 1, isAlive)
+      val a   = Entry(1)
+      val b   = Entry(2)
+      set.add(a)
+      set.add(b)
+      val removed = set.remove(a)
+      assertTrue(removed && set.iterator.toList == List(b))
+    },
+    test("remove returns false for missing element") {
+      val set = FiberSet[Entry](16, 1, isAlive)
+      val a   = Entry(1)
+      assertTrue(!set.remove(a))
+    },
+    test("dead entries filtered during iteration") {
+      val set     = FiberSet[Entry](64, 1, isAlive)
+      val entries = (1 to 20).map(Entry(_)).toList
+      entries.foreach(set.add)
+      entries.filter(_.id % 2 == 0).foreach(_.kill())
+      val alive = set.iterator.toList
+      assertTrue(alive.forall(_.id % 2 == 1) && alive.size == 10)
+    },
+    test("forEach visits all live entries") {
+      val set     = FiberSet[Entry](64, 1, isAlive)
+      val entries = (1 to 30).map(Entry(_)).toList
+      entries.foreach(set.add)
+      entries.filter(_.id % 3 == 0).foreach(_.kill())
+      var visited = List.empty[Entry]
+      set.forEach(e => visited = e :: visited)
+      assertTrue(visited.size == 20 && visited.forall(_.isAlive()))
+    },
+    test("eviction preserves live entries") {
+      val set     = FiberSet[Entry](8, 1, isAlive)
+      val entries = (1 to 20).map(Entry(_)).toList
+      entries.foreach(set.add)
+      val result = set.iterator.toSet
+      assertTrue(result == entries.toSet)
+    },
+    test("gc cleans dead graduates") {
+      val set     = FiberSet[Entry](8, 1, isAlive)
+      val entries = (1 to 20).map(Entry(_)).toList
+      entries.foreach(set.add)
+      entries.take(10).foreach(_.kill())
+      set.gc()
+      val alive = set.iterator.toList
+      assertTrue(alive.size == 10 && alive.forall(_.id > 10))
+    },
+    test("unreachable entries are collected") {
+      val set = FiberSet[Entry](8, 1, isAlive)
+      (1 to 100).foreach(i => set.add(Entry(i)))
+      System.gc()
+      set.gc()
+      assertTrue(set.size <= 100)
+    } @@ flaky @@ jvmOnly,
+    test("concurrent add from multiple threads") {
+      import java.util.concurrent.{CountDownLatch, Executors}
+      val nThreads = 8
+      val perThread = 500
+      val set       = FiberSet[Entry](256, nThreads, isAlive)
+      val entries   = (1 to (nThreads * perThread)).map(Entry(_)).toArray
+      val latch     = new CountDownLatch(1)
+      val executor  = Executors.newFixedThreadPool(nThreads)
+
+      (0 until nThreads).foreach { t =>
+        executor.submit(new Runnable {
+          def run(): Unit = {
+            latch.await()
+            var i = t * perThread
+            val end = i + perThread
+            while (i < end) {
+              set.add(entries(i))
+              i += 1
+            }
+          }
+        })
+      }
+      latch.countDown()
+      executor.shutdown()
+      executor.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS)
+
+      val result = set.iterator.toSet
+      assertTrue(result == entries.toSet)
+    } @@ nonFlaky(3),
+    test("mixed concurrent add and remove") {
+      import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+      val n        = 2000
+      val set      = FiberSet[Entry](256, 4, isAlive)
+      val entries  = (1 to n).map(Entry(_)).toArray
+      val latch    = new CountDownLatch(1)
+      val executor = Executors.newFixedThreadPool(4)
+
+      (0 until 2).foreach { t =>
+        executor.submit(new Runnable {
+          def run(): Unit = {
+            latch.await()
+            var i = t * (n / 2)
+            val end = i + (n / 2)
+            while (i < end) { set.add(entries(i)); i += 1 }
+          }
+        })
+      }
+      (0 until 2).foreach { t =>
+        executor.submit(new Runnable {
+          def run(): Unit = {
+            latch.await()
+            Thread.sleep(1)
+            var i = t * (n / 2)
+            val end = i + (n / 2)
+            while (i < end) {
+              if (entries(i).id % 2 == 0) set.remove(entries(i))
+              i += 1
+            }
+          }
+        })
+      }
+      latch.countDown()
+      executor.shutdown()
+      executor.awaitTermination(10, TimeUnit.SECONDS)
+
+      val odd = set.iterator.toList.filter(_.id % 2 == 1)
+      assertTrue(odd.nonEmpty)
+    } @@ nonFlaky(3)
+  )
+}

--- a/core/js/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/js/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,7 @@
+package zio.internal
+
+import zio.Duration
+
+private object FiberSetGc {
+  def start[A <: AnyRef](set: FiberSet[A], every: Duration): Unit = ()
+}

--- a/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,33 @@
+package zio.internal
+
+import zio.Duration
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+private final class FiberSetGc[A <: AnyRef] private (
+  set: FiberSet[A],
+  sleepFor: Duration
+) extends Thread {
+  override def run(): Unit = {
+    val sleepForNanos = sleepFor.toNanos
+    while (!isInterrupted) {
+      LockSupport.parkNanos(sleepForNanos)
+      set.gc(false)
+    }
+  }
+}
+
+private object FiberSetGc {
+  private val i = new AtomicInteger(0)
+
+  def start[A <: AnyRef](set: FiberSet[A], every: Duration): Unit = {
+    assert(every.toMillis >= 1000, "Auto-gc interval must be >= 1 second")
+
+    val thread = new FiberSetGc(set, every)
+    thread.setName(s"zio.internal.FiberSet.GcThread-${i.getAndIncrement()}")
+    thread.setPriority(4)
+    thread.setDaemon(true)
+    thread.start()
+  }
+}

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -21,7 +21,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import scala.concurrent.Future
-import zio.internal.WeakConcurrentBag
+import zio.internal.FiberSet
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a
@@ -1070,7 +1070,9 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
-    WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
+  private[zio] val _roots: FiberSet[Fiber.Runtime[_, _]] = {
+    val nCpu = java.lang.Runtime.getRuntime.availableProcessors()
+    FiberSet[Fiber.Runtime[_, _]](10000, nCpu * 4, _.isAlive())
       .withAutoGc(5.seconds)
+  }
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -24,7 +24,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
@@ -43,7 +42,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
   private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var _children       = null.asInstanceOf[FiberSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
   private var _stack          = null.asInstanceOf[Array[Continuation]]
@@ -84,7 +83,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       )
   }
 
-  private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
+  private[this] def childrenChunk(children: FiberSet[Fiber.Runtime[_, _]]): Chunk[Fiber.Runtime[_, _]] =
     // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
     if (children eq null) Chunk.empty
     else {
@@ -568,11 +567,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def getChildren(): JavaSet[Fiber.Runtime[_, _]] = {
+  private def getChildren(): FiberSet[Fiber.Runtime[_, _]] = {
     // executed by the fiber itself, no risk of racing with transferChildren
     var children = _children
     if (children eq null) {
-      children = Platform.newConcurrentWeakSet[Fiber.Runtime[_, _]]()(Unsafe)
+      children = FiberSet[Fiber.Runtime[_, _]](256, 1, _.isAlive())
       _children = children
     }
     children
@@ -738,7 +737,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    */
   private def interruptAllChildren(): UIO[Any] =
     if (sendInterruptSignalToAllChildren(_children)) {
-      val iterator = _children.iterator()
+      val iter = _children.iterator
       _children = null
 
       var curr: Fiber.Runtime[_, _] = null
@@ -746,8 +745,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       // this finds the next operable child fiber and stores it in the `curr` variable
       def skip() = {
         var next: Fiber.Runtime[_, _] = null
-        while (iterator.hasNext && (next eq null)) {
-          next = iterator.next()
+        while (iter.hasNext && (next eq null)) {
+          next = iter.next()
           if ((next ne null) && !next.isAlive())
             next = null
         }
@@ -787,14 +786,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private def hasChildrenAliveUnsafe: Boolean = {
     val children0 = _children
     if ((children0 eq null) || (_exitValue ne null)) false
-    else {
-      val it = children0.iterator()
-      while (it.hasNext) {
-        val child = it.next()
-        if ((child ne null) && child.isAlive()) return true
-      }
-      false
-    }
+    else !children0.isEmpty
   }
 
   /**
@@ -1358,21 +1350,17 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private def sendInterruptSignalToAllChildren(
-    children: JavaSet[Fiber.Runtime[_, _]]
+    children: FiberSet[Fiber.Runtime[_, _]]
   ): Boolean =
     if ((children eq null) || children.isEmpty) false
     else {
       // Initiate asynchronous interruption of all children:
-      val iterator = children.iterator()
-      var told     = false
-      val cause    = Cause.interrupt(fiberId)
+      var told  = false
+      val cause = Cause.interrupt(fiberId)
 
-      while (iterator.hasNext) {
-        val next = iterator.next()
-
-        if ((next ne null) && next.isAlive()) {
+      children.forEach { next =>
+        if (next.isAlive()) {
           next.tellInterrupt(cause)
-
           told = true
         }
       }

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.internal.FiberSet.IsAlive
+import zio.{Duration, Unsafe}
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenceArray}
+
+/**
+ * A [[FiberSet]] is a lock-free concurrent bag that keeps elements in a striped
+ * nursery of strong references, only wrapping them in `WeakReference` when they
+ * are evicted from the nursery. Short-lived entries that become dead (per
+ * `isAlive`) before eviction never allocate a weak ref at all.
+ *
+ * The larger the nursery, the fewer weak references are created, at the cost
+ * of higher memory usage. `concurrencyLevel` controls striping for the nursery
+ * to reduce contention under concurrent `add` calls.
+ */
+private[zio] final class FiberSet[A <: AnyRef](
+  nurseryCapacity: Int,
+  concurrencyLevel: Int,
+  isAlive: IsAlive[A]
+) { self =>
+
+  private[this] val nParts: Int = {
+    val raw = FiberSet.nextPow2(concurrencyLevel.max(1))
+    raw.min(FiberSet.nextPow2(nurseryCapacity) / 2).max(1)
+  }
+  private[this] val partMask = nParts - 1
+
+  private[this] val partCap: Int = FiberSet.nextPow2((nurseryCapacity / nParts).max(2))
+  private[this] val slotMask    = partCap - 1
+
+  private[this] val slots   = Array.tabulate(nParts)(_ => new AtomicReferenceArray[AnyRef](partCap))
+  private[this] val cursors = Array.fill(nParts)(new AtomicInteger(0))
+
+  private[this] val grads  = Platform.newConcurrentSet[WeakReference[A]](nurseryCapacity.max(16))(Unsafe.unsafe)
+  private[this] val refQ   = new ReferenceQueue[A]()
+  private[this] val gcFlag = new AtomicBoolean(false)
+
+  private[this] val autoGcStarted = new AtomicBoolean(false)
+
+  def withAutoGc(every: Duration): FiberSet[A] = {
+    if (autoGcStarted.compareAndSet(false, true))
+      FiberSetGc.start(self, every)
+    self
+  }
+
+  /**
+   * Adds a new value, graduating the evicted nursery occupant to long-term
+   * storage if it is still alive.
+   */
+  final def add(a: A): Unit = {
+    val p    = ThreadLocalRandom.current().nextInt() & partMask
+    val arr  = slots(p)
+    val idx  = cursors(p).getAndIncrement() & slotMask
+    val prev = arr.getAndSet(idx, a)
+
+    if (prev ne null) {
+      val prevA = prev.asInstanceOf[A]
+      if (isAlive(prevA))
+        grads.add(new WeakReference[A](prevA, refQ))
+    }
+
+    if (grads.size() > nParts * partCap) gc(false)
+  }
+
+  final def remove(a: A): Boolean = {
+    var p = 0
+    while (p < nParts) {
+      val arr = slots(p)
+      var s   = 0
+      while (s < partCap) {
+        val v = arr.get(s)
+        if ((v ne null) && (v eq a)) {
+          if (arr.compareAndSet(s, v, null)) return true
+        }
+        s += 1
+      }
+      p += 1
+    }
+    val it = grads.iterator()
+    while (it.hasNext) {
+      val ref = it.next()
+      val v   = ref.get()
+      if (v eq a) {
+        it.remove()
+        return true
+      }
+    }
+    false
+  }
+
+  final def gc(): Unit = gc(true)
+
+  final def gc(force: Boolean): Unit = {
+    val acquired = gcFlag.compareAndSet(false, true)
+    try {
+      if (force || acquired) {
+        var ref = refQ.poll()
+        while (ref ne null) {
+          grads.remove(ref)
+          ref = refQ.poll()
+        }
+        val it = grads.iterator()
+        while (it.hasNext) {
+          val entry = it.next()
+          val v     = entry.get()
+          if ((v eq null) || !isAlive(v)) it.remove()
+        }
+      }
+    } finally {
+      if (acquired) gcFlag.set(false)
+    }
+  }
+
+  /**
+   * Applies `f` to every live element. Dead graduate entries are cleaned up
+   * opportunistically during the traversal.
+   */
+  final def forEach(f: A => Unit): Unit = {
+    var p = 0
+    while (p < nParts) {
+      val arr = slots(p)
+      var s   = 0
+      while (s < partCap) {
+        val v = arr.get(s)
+        if (v ne null) {
+          val a = v.asInstanceOf[A]
+          if (isAlive(a)) f(a)
+        }
+        s += 1
+      }
+      p += 1
+    }
+    val it = grads.iterator()
+    while (it.hasNext) {
+      val ref = it.next()
+      val v   = ref.get()
+      if ((v ne null) && isAlive(v)) f(v)
+      else it.remove()
+    }
+  }
+
+  final def iterator: Iterator[A] = new Iterator[A] {
+    private var pIdx   = 0
+    private var sIdx   = 0
+    private var inGrad = false
+    private var gradIt: java.util.Iterator[WeakReference[A]] = _
+    private var _next: A = prefetch()
+
+    private def prefetch(): A = {
+      if (!inGrad) {
+        while (pIdx < nParts) {
+          val arr = slots(pIdx)
+          while (sIdx < partCap) {
+            val v = arr.get(sIdx)
+            sIdx += 1
+            if (v ne null) {
+              val a = v.asInstanceOf[A]
+              if (isAlive(a)) return a
+            }
+          }
+          sIdx = 0
+          pIdx += 1
+        }
+        inGrad = true
+        gradIt = grads.iterator()
+      }
+      while (gradIt.hasNext) {
+        val ref = gradIt.next()
+        val v   = ref.get()
+        if ((v ne null) && isAlive(v)) return v
+        else gradIt.remove()
+      }
+      null.asInstanceOf[A]
+    }
+
+    def hasNext: Boolean = _next ne null
+
+    def next(): A = {
+      if (_next eq null)
+        throw new NoSuchElementException("next on empty FiberSet iterator")
+      val r = _next
+      _next = prefetch()
+      r
+    }
+  }
+
+  final def isEmpty: Boolean = {
+    var p = 0
+    while (p < nParts) {
+      val arr = slots(p)
+      var s   = 0
+      while (s < partCap) {
+        val v = arr.get(s)
+        if (v ne null) {
+          val a = v.asInstanceOf[A]
+          if (isAlive(a)) return false
+        }
+        s += 1
+      }
+      p += 1
+    }
+    val it = grads.iterator()
+    while (it.hasNext) {
+      val ref = it.next()
+      val v   = ref.get()
+      if ((v ne null) && isAlive(v)) return false
+      else it.remove()
+    }
+    true
+  }
+
+  def size: Int = {
+    var count = 0
+    var p     = 0
+    while (p < nParts) {
+      val arr = slots(p)
+      var s   = 0
+      while (s < partCap) {
+        if (arr.get(s) ne null) count += 1
+        s += 1
+      }
+      p += 1
+    }
+    count + grads.size()
+  }
+
+  override def toString: String = iterator.mkString("FiberSet(", ", ", ")")
+}
+
+private[zio] object FiberSet {
+
+  def apply[A <: AnyRef](
+    nurseryCapacity: Int,
+    concurrencyLevel: Int = 1,
+    isAlive: IsAlive[A] = IsAlive.always
+  ): FiberSet[A] = new FiberSet(nurseryCapacity, concurrencyLevel, isAlive)
+
+  /** Specialized Function1 that doesn't cause boxing of the Boolean */
+  trait IsAlive[-A] {
+    def apply(value: A): Boolean
+  }
+
+  object IsAlive {
+    val always: IsAlive[Any] = _ => true
+  }
+
+  private[internal] def nextPow2(n: Int): Int = {
+    if (n <= 1) return 1
+    var v = n - 1
+    v |= v >> 1
+    v |= v >> 2
+    v |= v >> 4
+    v |= v >> 8
+    v |= v >> 16
+    v + 1
+  }
+}


### PR DESCRIPTION
/claim #8861

## Summary

Introduces `FiberSet`, a lock-free concurrent bag optimized for fiber lifecycle tracking. It replaces `WeakConcurrentBag` for `Fiber._roots` and `Platform.newConcurrentWeakSet` for `FiberRuntime._children`.

### Key design decisions

- **Nursery of strong references**: New entries land in a striped array of `AtomicReferenceArray` slots. Only when a slot is overwritten does the evicted entry graduate to a `WeakReference`. Short-lived fibers that complete before eviction skip weak ref allocation entirely.
- **Lock-free**: All mutations use `getAndSet`, `compareAndSet`, or `getAndIncrement` — no `synchronized`, no `ReentrantLock`. Fully compatible with virtual threads (Loom).
- **Striped partitions**: `concurrencyLevel` controls the number of independent nursery partitions, reducing contention for concurrent `add` calls.
- **GC integration**: A `ReferenceQueue` drains collected weak refs, and a periodic background sweep removes dead entries. The daemon GC thread matches the existing `WeakConcurrentBagGc` pattern.

### Changes

| File | What |
|------|------|
| `core/shared/.../FiberSet.scala` | Core data structure |
| `core/jvm-native/.../FiberSetGc.scala` | Daemon GC thread |
| `core/js/.../FiberSetGc.scala` | JS no-op shim |
| `core/shared/.../Fiber.scala` | `_roots` now uses `FiberSet` |
| `core/shared/.../FiberRuntime.scala` | `_children` now uses `FiberSet` |
| `core-tests/shared/.../FiberSetSpec.scala` | 14 tests (unit + concurrent) |
| `benchmarks/.../FiberSetBenchmark.scala` | JMH benchmarks vs WeakConcurrentBag and synchronizedSet(WeakHashMap) |

### Test plan

- [x] FiberSetSpec — 14 tests covering add, remove, iteration, gc, emptiness, concurrent add, mixed concurrent add/remove
- [x] Existing ZIOSpec, FiberSpec, ScopeSpec pass with FiberSet integration
- [ ] JMH benchmarks (instructions in benchmark file)
- [ ] Demo video