### PR TITLE
Specialized fiber mailbox replacing ConcurrentLinkedQueue

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
@@ -1,0 +1,160 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.{ConcurrentLinkedQueue, TimeUnit}
+
+/**
+ * {{{
+ * sbt "benchmarks/Jmh/run -i 10 -wi 5 -f 2 -t 1 zio.internal.FiberMailboxBenchmark"
+ *
+ * JDK 21, Windows 11
+ * Benchmark                                    Mode  Cnt     Score     Error   Units
+ * FiberMailboxBenchmark.clqSingleAddPoll      thrpt    5    29.071 ±   0.323  ops/us
+ * FiberMailboxBenchmark.mailboxSingleAddPoll  thrpt    5    83.965 ±   1.598  ops/us  (+189%)
+ * FiberMailboxBenchmark.clqSteadyState        thrpt    5     0.407 ±   0.019  ops/us
+ * FiberMailboxBenchmark.mailboxSteadyState    thrpt    5     0.877 ±   0.020  ops/us  (+115%)
+ * FiberMailboxBenchmark.clqBurst4             thrpt    5     9.621 ±   0.536  ops/us
+ * FiberMailboxBenchmark.mailboxBurst4         thrpt    5     6.170 ±   0.874  ops/us
+ * FiberMailboxBenchmark.clqIsEmpty            thrpt    5  1342.038 ±  24.082  ops/us
+ * FiberMailboxBenchmark.mailboxIsEmpty        thrpt    5  1416.823 ± 111.643  ops/us
+ *
+ * ForkJoinBenchmark.zioForkJoin (before)     thrpt   20   648.195 ±  20.406  ops/s
+ * ForkJoinBenchmark.zioForkJoin (after)      thrpt   20   669.037 ±  16.345  ops/s   (+3.2%)
+ * }}}
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+class FiberMailboxBenchmark {
+
+  @Benchmark
+  def mailboxSingleAddPoll(bh: Blackhole): Unit = {
+    val mbox = new FiberMailbox()
+    mbox.add(FiberMailboxBenchmark.dummyMsg)
+    bh.consume(mbox.poll())
+  }
+
+  @Benchmark
+  def clqSingleAddPoll(bh: Blackhole): Unit = {
+    val clq = new ConcurrentLinkedQueue[FiberMessage]()
+    clq.add(FiberMailboxBenchmark.dummyMsg)
+    bh.consume(clq.poll())
+  }
+
+  @Benchmark
+  def mailboxBurst4(bh: Blackhole): Unit = {
+    val mbox = new FiberMailbox()
+    mbox.add(FiberMailboxBenchmark.dummyMsg)
+    mbox.add(FiberMailboxBenchmark.dummyMsg2)
+    mbox.add(FiberMailboxBenchmark.dummyMsg3)
+    mbox.add(FiberMailboxBenchmark.dummyMsg4)
+    bh.consume(mbox.poll())
+    bh.consume(mbox.poll())
+    bh.consume(mbox.poll())
+    bh.consume(mbox.poll())
+  }
+
+  @Benchmark
+  def clqBurst4(bh: Blackhole): Unit = {
+    val clq = new ConcurrentLinkedQueue[FiberMessage]()
+    clq.add(FiberMailboxBenchmark.dummyMsg)
+    clq.add(FiberMailboxBenchmark.dummyMsg2)
+    clq.add(FiberMailboxBenchmark.dummyMsg3)
+    clq.add(FiberMailboxBenchmark.dummyMsg4)
+    bh.consume(clq.poll())
+    bh.consume(clq.poll())
+    bh.consume(clq.poll())
+    bh.consume(clq.poll())
+  }
+
+  @Benchmark
+  def mailboxSteadyState(bh: Blackhole): Unit = {
+    val mbox = new FiberMailbox()
+    var i = 0
+    while (i < 100) {
+      mbox.add(FiberMailboxBenchmark.dummyMsg)
+      bh.consume(mbox.poll())
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def clqSteadyState(bh: Blackhole): Unit = {
+    val clq = new ConcurrentLinkedQueue[FiberMessage]()
+    var i = 0
+    while (i < 100) {
+      clq.add(FiberMailboxBenchmark.dummyMsg)
+      bh.consume(clq.poll())
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def mailboxIsEmpty(bh: Blackhole): Unit =
+    bh.consume(FiberMailboxBenchmark.emptyMailbox.isEmpty)
+
+  @Benchmark
+  def clqIsEmpty(bh: Blackhole): Unit =
+    bh.consume(FiberMailboxBenchmark.emptyCLQ.isEmpty)
+}
+
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+class FiberMailboxConcurrentBenchmark {
+
+  var mailbox: FiberMailbox                    = _
+  var clq: ConcurrentLinkedQueue[FiberMessage] = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    mailbox = new FiberMailbox()
+    clq = new ConcurrentLinkedQueue[FiberMessage]()
+  }
+
+  @Benchmark
+  @Group("mailboxMPSC")
+  @GroupThreads(4)
+  def mailboxProducer(): Unit =
+    mailbox.add(FiberMailboxBenchmark.dummyMsg)
+
+  @Benchmark
+  @Group("mailboxMPSC")
+  @GroupThreads(1)
+  def mailboxConsumer(bh: Blackhole): Unit = {
+    val msg = mailbox.poll()
+    if (msg ne null) bh.consume(msg)
+  }
+
+  @Benchmark
+  @Group("clqMPSC")
+  @GroupThreads(4)
+  def clqProducer(): Unit =
+    clq.add(FiberMailboxBenchmark.dummyMsg)
+
+  @Benchmark
+  @Group("clqMPSC")
+  @GroupThreads(1)
+  def clqConsumer(bh: Blackhole): Unit = {
+    val msg = clq.poll()
+    if (msg ne null) bh.consume(msg)
+  }
+}
+
+object FiberMailboxBenchmark {
+  val dummyMsg: FiberMessage  = FiberMessage.resumeUnit
+  val dummyMsg2: FiberMessage = FiberMessage.Stateful(_ => ())
+  val dummyMsg3: FiberMessage = FiberMessage.resumeUnit
+  val dummyMsg4: FiberMessage = FiberMessage.Stateful(_ => ())
+
+  val emptyMailbox = new FiberMailbox()
+  val emptyCLQ     = new ConcurrentLinkedQueue[FiberMessage]()
+}

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A specialized MPSC mailbox for fiber messages. Takes advantage of the fact
+ * that fibers almost always have at most one pending message at a time (the
+ * resume after fork/async). A dedicated head slot backed by AtomicReference
+ * handles this common case with a single CAS and zero allocation (no Node
+ * wrapper). A lazily-initialized ConcurrentLinkedQueue absorbs the rare
+ * overflow when multiple messages are pending concurrently.
+ */
+private[zio] final class FiberMailbox {
+
+  private[this] val head = new AtomicReference[FiberMessage]()
+
+  @volatile private[this] var tail: ConcurrentLinkedQueue[FiberMessage] = null
+
+  def add(message: FiberMessage): Unit =
+    if (!head.compareAndSet(null, message))
+      ensureTail().add(message)
+
+  def poll(): FiberMessage = {
+    val h = head.getAndSet(null)
+    if (h ne null) return h
+    val t = tail
+    if (t ne null) t.poll() else null
+  }
+
+  def isEmpty: Boolean =
+    (head.get() eq null) && {
+      val t = tail
+      (t eq null) || t.isEmpty
+    }
+
+  private[this] def ensureTail(): ConcurrentLinkedQueue[FiberMessage] = {
+    var t = tail
+    if (t eq null) {
+      synchronized {
+        t = tail
+        if (t eq null) {
+          t = new ConcurrentLinkedQueue[FiberMessage]()
+          tail = t
+        }
+      }
+    }
+    t
+  }
+}

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -26,6 +26,10 @@ import java.util.concurrent.atomic.AtomicReference
  * handles this common case with a single CAS and zero allocation (no Node
  * wrapper). A lazily-initialized ConcurrentLinkedQueue absorbs the rare
  * overflow when multiple messages are pending concurrently.
+ *
+ * Once the queue is created (first collision), all subsequent `add` calls go
+ * directly to the queue, preventing later messages from jumping ahead of
+ * messages already waiting in the queue via the head slot.
  */
 private[zio] final class FiberMailbox {
 
@@ -33,22 +37,34 @@ private[zio] final class FiberMailbox {
 
   @volatile private[this] var tail: ConcurrentLinkedQueue[FiberMessage] = null
 
-  def add(message: FiberMessage): Unit =
-    if (!head.compareAndSet(null, message))
-      ensureTail().add(message)
-
-  def poll(): FiberMessage = {
-    val h = head.getAndSet(null)
-    if (h ne null) return h
+  def add(message: FiberMessage): Unit = {
     val t = tail
-    if (t ne null) t.poll() else null
+    if (t ne null) t.add(message)
+    else if (!head.compareAndSet(null, message))
+      ensureTail().add(message)
   }
 
-  def isEmpty: Boolean =
-    (head.get() eq null) && {
-      val t = tail
-      (t eq null) || t.isEmpty
+  def poll(): FiberMessage = {
+    val t = tail
+    if (t ne null) {
+      val h = head.get()
+      if (h ne null) {
+        head.lazySet(null)
+        return h
+      }
+      return t.poll()
     }
+    head.getAndSet(null)
+  }
+
+  def isEmpty: Boolean = {
+    val t = tail
+    if (t ne null) {
+      (head.get() eq null) && t.isEmpty
+    } else {
+      head.get() eq null
+    }
+  }
 
   private[this] def ensureTail(): ConcurrentLinkedQueue[FiberMessage] = {
     var t = tail

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -22,7 +22,6 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
@@ -42,7 +41,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _blockingOn     = FiberRuntime.notBlockingOn
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
-  private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
+  private val inbox           = new FiberMailbox()
   private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]


### PR DESCRIPTION
## Summary

Replace the generic `ConcurrentLinkedQueue[FiberMessage]` in `FiberRuntime` with a specialized `FiberMailbox` that exploits the MPSC access pattern of ZIO fibers.

Fibers almost always have at most one pending message at a time (the resume after fork/async). `FiberMailbox` handles this common case with a single CAS on an `AtomicReference` head slot — zero `Node` allocation, zero queue overhead. A lazily-initialized `ConcurrentLinkedQueue` absorbs the rare overflow when multiple messages arrive concurrently.

### FIFO ordering fix

Once the overflow queue (`tail`) is created, all subsequent `add()` calls go directly to it. This prevents new messages from sneaking into the emptied head slot and jumping ahead of messages already waiting in the queue. The head is drained at most once after transition — after that `head.get()` is just a cache-local load with no contention.

### Changes

- **`FiberMailbox.scala`** (new) — specialized MPSC mailbox with `add`, `poll`, `isEmpty`
- **`FiberRuntime.scala`** — swap `ConcurrentLinkedQueue` → `FiberMailbox` (2-line change, API-compatible)
- **`FiberMailboxBenchmark.scala`** (new) — JMH micro-benchmarks + concurrent MPSC benchmark

### Benchmark results

JDK 21, Windows 11:

```
Benchmark                                    Mode  Cnt     Score     Error   Units
FiberMailboxBenchmark.clqSingleAddPoll      thrpt   20    29.037 ±   0.338  ops/us
FiberMailboxBenchmark.mailboxSingleAddPoll  thrpt   20    84.151 ±   0.415  ops/us  (+190%)
FiberMailboxBenchmark.clqSteadyState        thrpt   20     0.415 ±   0.003  ops/us
FiberMailboxBenchmark.mailboxSteadyState    thrpt   20     0.879 ±   0.004  ops/us  (+112%)
FiberMailboxBenchmark.clqBurst4             thrpt   20     9.712 ±   0.062  ops/us
FiberMailboxBenchmark.mailboxBurst4         thrpt   20     8.191 ±   0.062  ops/us
FiberMailboxBenchmark.clqIsEmpty            thrpt   20  1354.591 ±   8.134  ops/us
FiberMailboxBenchmark.mailboxIsEmpty        thrpt   20  1467.136 ±   7.025  ops/us
```

The single add/poll hot path — which is the dominant case during fiber execution — is ~2.9x faster with zero allocation. Burst performance is within 16% of CLQ (improved from 36% gap after the FIFO fix). All 568 ZIOSpec tests pass.

/claim #8807