### PR TITLE
Implement runtime operation logging (RuntimeFlag.OpLog)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -127,6 +127,34 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                 name <- ZIO.succeed(Thread.currentThread().getName)
               } yield assertTrue(name.startsWith("ZScheduler-Worker"))
             }.provide(Runtime.enableFlags(RuntimeFlag.EagerShiftBack))
-        } @@ TestAspect.jvmOnly
+        } @@ TestAspect.jvmOnly +
+        suite("OpLog") {
+          test("render produces expected strings for each ZIO instruction type") {
+            import ZIO._
+
+            val syncEffect    = ZIO.succeed(1).asInstanceOf[ZIO.Erased]
+            val flatMapEffect = ZIO.succeed(1).flatMap(n => ZIO.succeed(n + 1)).asInstanceOf[ZIO.Erased]
+            val foldEffect    = ZIO.fail("err").foldZIO(_ => ZIO.succeed(0), n => ZIO.succeed(n)).asInstanceOf[ZIO.Erased]
+
+            assertTrue(render(syncEffect).startsWith("Sync(trace=")) &&
+            assertTrue(render(flatMapEffect).startsWith("FlatMap(trace=")) &&
+            assertTrue(render(flatMapEffect).contains("first=Sync(trace=")) &&
+            assertTrue(render(foldEffect).startsWith("FoldZIO(trace=")) &&
+            assertTrue(render(foldEffect).contains("first=")) &&
+            assertTrue(render(Exit.succeed(0).asInstanceOf[ZIO.Erased]) == "Exit.Success(value=0)") &&
+            assertTrue(render(Exit.fail("boom").asInstanceOf[ZIO.Erased]).startsWith("Exit.Failure(cause="))
+          } +
+            test("enabling OpLog causes effects to be logged") {
+              for {
+                _      <- ZIO.succeed(1).flatMap(n => ZIO.succeed(n + 1))
+                output <- ZTestLogger.logOutput
+              } yield {
+                val opLogMessages = output.filter(_.logLevel == LogLevel.Debug)
+                assertTrue(opLogMessages.nonEmpty) &&
+                assertTrue(opLogMessages.exists(entry => entry.message().contains("FlatMap("))) &&
+                assertTrue(opLogMessages.exists(entry => entry.message().contains("Sync(")))
+              }
+            }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
+        }
     }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6331,6 +6331,30 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     }
   }
 
+  private[zio] def render(zio: ZIO.Erased): String = zio match {
+    case sync: Sync[_] => s"Sync(trace=${sync.trace})"
+    case flatMap: FlatMap[_, _, _, _] =>
+      s"FlatMap(trace=${flatMap.trace}, first=${render(flatMap.first.asInstanceOf[ZIO.Erased])})"
+    case foldZIO: FoldZIO[_, _, _, _, _] =>
+      s"FoldZIO(trace=${foldZIO.trace}, first=${render(foldZIO.first.asInstanceOf[ZIO.Erased])})"
+    case mapped: Mapped[_, _, _, _] =>
+      s"Mapped(trace=${mapped.trace}, first=${render(mapped.first.asInstanceOf[ZIO.Erased])})"
+    case stateful: Stateful[_, _, _]     => s"Stateful(trace=${stateful.trace})"
+    case async: Async[_, _, _]           => s"Async(trace=${async.trace})"
+    case whileLoop: WhileLoop[_, _, _]   => s"WhileLoop(trace=${whileLoop.trace})"
+    case yieldNow: YieldNow              => s"YieldNow(trace=${yieldNow.trace}, forceAsync=${yieldNow.forceAsync})"
+    case updateFlags: UpdateRuntimeFlags => s"UpdateRuntimeFlags(trace=${updateFlags.trace})"
+    case within: UpdateRuntimeFlagsWithin.Interruptible[_, _, _] =>
+      s"Interruptible(trace=${within.trace}, effect=${render(within.effect.asInstanceOf[ZIO.Erased])})"
+    case within: UpdateRuntimeFlagsWithin.Uninterruptible[_, _, _] =>
+      s"Uninterruptible(trace=${within.trace}, effect=${render(within.effect.asInstanceOf[ZIO.Erased])})"
+    case _: UpdateRuntimeFlagsWithin.Dynamic[_, _, _]      => s"Dynamic"
+    case _: UpdateRuntimeFlagsWithin.DynamicNoBox[_, _, _] => s"DynamicNoBox"
+    case success: Exit.Success[_]                          => s"Exit.Success(value=${success.value})"
+    case failure: Exit.Failure[_]                          => s"Exit.Failure(cause=${failure.cause})"
+    case _                                                 => zio.getClass.getSimpleName
+  }
+
   private[zio] val someFatal   = Some(LogLevel.Fatal)
   private[zio] val someError   = Some(LogLevel.Error)
   private[zio] val someWarning = Some(LogLevel.Warning)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1107,6 +1107,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         self.getSupervisor().onEffect(self, cur)(Unsafe)
       }
 
+      if (RuntimeFlags.opLog(_runtimeFlags)) {
+        val safeCur = cur
+        log(() => ZIO.render(safeCur), Cause.empty, ZIO.someDebug, safeCur.trace)
+      }
+
       cur = drainQueueWhileRunning(cur)
 
       ops += 1


### PR DESCRIPTION
## Summary

Implements the feature described in #9170: logging each ZIO effect evaluated inside `runLoop` when the `OpLog` runtime flag is enabled.

/claim #9170

## Changes

### `ZIO.render` (ZIO.scala)
- Pattern-matches each ZIO instruction type (`Sync`, `FlatMap`, `FoldZIO`, `Mapped`, `Stateful`, `Async`, `WhileLoop`, `YieldNow`, `UpdateRuntimeFlags`, `Interruptible`, `Uninterruptible`, `Exit.Success`, `Exit.Failure`) to produce a human-readable debug string with trace information.

### `FiberRuntime.runLoop` (FiberRuntime.scala)
- Added an `OpLog` check (follows the existing `opSupervision` pattern): when the flag is enabled, each effect is logged at `Debug` level before evaluation.

### Tests (RuntimeFlagsSpec.scala)
- **`render produces expected strings`** — verifies `ZIO.render` output for Sync, FlatMap, FoldZIO, Exit.Success, and Exit.Failure instructions.
- **`enabling OpLog causes effects to be logged`** — integration test that enables `RuntimeFlag.OpLog` via `Runtime.enableFlags`, runs a flatMap effect, and verifies `ZTestLogger.logOutput` contains the expected debug log entries.

All 14 tests in RuntimeFlagsSpec pass.

## Demo

The feature adds zero overhead when disabled (the `RuntimeFlags.opLog` check is a simple bitwise operation). When enabled:

```scala
ZIO.succeed(1).flatMap(n => ZIO.succeed(n + 1))
  .provide(Runtime.enableFlags(RuntimeFlag.OpLog))
```

Produces debug log entries like:
```
FlatMap(trace=..., first=Sync(trace=...))
Sync(trace=...)
```