### PR TITLE
Fix ZStream.buffer exact capacity semantics

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,60 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffer(1) does not prefetch a third element") {
+            for {
+              permit2      <- Promise.make[Nothing, Unit]
+              permit3      <- Promise.make[Nothing, Unit]
+              started2     <- Promise.make[Nothing, Unit]
+              started3     <- Promise.make[Nothing, Unit]
+              thirdStarted <- ZIO.scoped {
+                                for {
+                                  pull <- ZStream
+                                            .fromIterable(1 to 3)
+                                            .mapZIO {
+                                              case 1 => ZIO.succeed(1)
+                                              case 2 => started2.succeed(()) *> permit2.await.as(2)
+                                              case 3 => started3.succeed(()) *> permit3.await.as(3)
+                                            }
+                                            .buffer(1)
+                                            .toPull
+                                  _ <- pull
+                                  _ <- permit2.succeed(())
+                                  _ <- started2.await
+                                  _ <- ZIO.yieldNow.repeatN(32)
+                                  v <- started3.poll
+                                  _ <- permit3.succeed(())
+                                } yield v
+                              }
+            } yield assert(thirdStarted)(isNone)
+          } @@ nonFlaky,
+          test("buffer(2) can prefetch a third element") {
+            for {
+              permit2  <- Promise.make[Nothing, Unit]
+              permit3  <- Promise.make[Nothing, Unit]
+              started2 <- Promise.make[Nothing, Unit]
+              started3 <- Promise.make[Nothing, Unit]
+              thirdStarted <- ZIO.scoped {
+                                for {
+                                  pull <- ZStream
+                                            .fromIterable(1 to 3)
+                                            .mapZIO {
+                                              case 1 => ZIO.succeed(1)
+                                              case 2 => started2.succeed(()) *> permit2.await.as(2)
+                                              case 3 => started3.succeed(()) *> permit3.await.as(3)
+                                            }
+                                            .buffer(2)
+                                            .toPull
+                                  _ <- pull
+                                  _ <- permit2.succeed(())
+                                  _ <- started2.await
+                                  _ <- started3.await
+                                  v <- started3.poll
+                                  _ <- permit3.succeed(())
+                                } yield v
+                              }
+            } yield assert(thirdStarted)(isSome(anything))
           }
         ),
         suite("bufferChunks")(

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -610,10 +610,10 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           test("buffer(1) does not prefetch a third element") {
             for {
-              permit2      <- Promise.make[Nothing, Unit]
-              permit3      <- Promise.make[Nothing, Unit]
-              started2     <- Promise.make[Nothing, Unit]
-              started3     <- Promise.make[Nothing, Unit]
+              permit2  <- Promise.make[Nothing, Unit]
+              permit3  <- Promise.make[Nothing, Unit]
+              started2 <- Promise.make[Nothing, Unit]
+              started3 <- Promise.make[Nothing, Unit]
               thirdStarted <- ZIO.scoped {
                                 for {
                                   pull <- ZStream

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,23 +391,42 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def process(take: => UIO[Exit[Option[E], A]]): ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = {
+      lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+        ZChannel.fromZIO(take).flatMap { (exit: Exit[Option[E], A]) =>
+          exit.foldExit(
+            Cause
+              .flipCauseOption(_)
+              .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+            value => ZChannel.write(Chunk.single(value)) *> loop
+          )
+        }
+
+      loop
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
+        ZIO.suspendSucceed {
+          val capacity0 = capacity
+          if (capacity0 == 1)
+            for {
+              handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+              _ <- {
+                     lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                       ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                         in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))) *> writer,
+                         err => ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                         _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+                       )
 
-          process
+                     (self.channel >>> writer).drain.runScoped
+                   }.forkScoped
+            } yield process(handoff.take)
+          else if (capacity0 > 1)
+            self.toQueueOfElements(capacity0 - 1).map(queue => process(queue.take))
+          else
+            self.toQueueOfElements(capacity0).map(queue => process(queue.take))
         }
       }
     )


### PR DESCRIPTION
/claim #9810

## Summary

Fix `ZStream.buffer(n)` so the requested capacity matches the actual number of elements that can be prefetched.

- `buffer(1)` now uses a synchronous handoff path, so the producer cannot start a third element before the consumer asks for the second
- `buffer(n)` for `n > 1` uses an internal queue capacity of `n - 1`, which preserves exactly `n` total in-flight elements when combined with the consumer's current element
- adds regression tests covering the `buffer(1)` and `buffer(2)` distinction

## Validation

Ran:

```bash
sbt -Dsbt.supershell=false "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t buffer"
```

Result: 22 tests passed, 0 failed.

## Payout

If this bounty is rewarded, please attribute payout to `@hriszc` via the Algora account linked to this GitHub identity.

## Notes

This keeps the change local to `ZStream.buffer` rather than redesigning queue internals. It also follows the discussion on the issue that `buffer(1)` is the special case requiring synchronous handoff semantics.