### PR TITLE
test: comprehensive ZIOApp lifecycle integration test suite (#9909)

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppIntegrationSpec.scala
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2021-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import zio.test._
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.concurrent.TimeUnit
+
+/**
+ * Process-based integration tests for [[ZIOApp]].
+ *
+ * Unlike the in-process [[ZIOAppSpec]] (which uses [[ZIOApp.invoke]]), these
+ * tests spawn each fixture app in a **separate JVM** so that the full
+ * lifecycle is exercised — JVM shutdown hooks, signal delivery, exit codes,
+ * and the [[ZIOApp.gracefulShutdownTimeout]] mechanism.
+ *
+ * == How it works ==
+ *
+ *  1. Each test launches a fixture object from [[ZIOAppTestApps]] via
+ *     [[ProcessBuilder]], reusing the current test classpath.
+ *  2. For ''normal completion'' tests the parent simply waits for the child
+ *     to exit and asserts on its exit code / stdout markers.
+ *  3. For ''signal'' tests the parent waits for the `READY` marker, sends
+ *     `kill -INT` or `kill -TERM` (Unix), and then asserts on finalizer
+ *     markers and timing.
+ *
+ * == Platform notes ==
+ *
+ * Signal-based suites are gated behind [[unixOnly]] because
+ * [[Process#destroy]] on Windows terminates the process without invoking
+ * JVM shutdown hooks.  CI runs on Linux, so all suites are exercised there.
+ *
+ * == Coverage mapping ==
+ *
+ * | Requirement (issue #9909)                        | Suite / test                                         |
+ * |--------------------------------------------------|------------------------------------------------------|
+ * | Correct exit code on success / failure / defect  | ''app completion''                                   |
+ * | Finalizers run on normal completion              | ''finalizers on normal completion''                  |
+ * | Finalizers run on SIGINT                         | ''external signal handling''                         |
+ * | Finalizers run on SIGTERM                        | ''external signal handling — SIGTERM''               |
+ * | ZLayer resources released on shutdown            | ''ZLayer resource management''                       |
+ * | gracefulShutdownTimeout = Infinity respected     | ''gracefulShutdownTimeout''                          |
+ * | gracefulShutdownTimeout = 1s cuts slow finalizer | ''gracefulShutdownTimeout''                          |
+ * | gracefulShutdownTimeout = 0 exits fast           | ''zero gracefulShutdownTimeout''                     |
+ * | Shutdown sequence does not hang                  | ''gracefulShutdownTimeout / no-hang''                |
+ * | #9901 – finalizer waited on with Infinity        | ''slow finalizer completes …''                       |
+ * | #9807 – shutdown-hook race                       | all signal tests (atomic `shuttingDown` flag path)   |
+ * | #9240 – sun.misc.SignalHandler CNFE              | every test app starts without `NoClassDefFoundError` |
+ */
+object ZIOAppIntegrationSpec extends ZIOBaseSpec {
+
+  // -- helpers ----------------------------------------------------------------
+
+  private val javaHome  = java.lang.System.getProperty("java.home")
+  private val javaBin   = s"$javaHome/bin/java"
+  private val classpath = java.lang.System.getProperty("java.class.path")
+  private val isWindows = java.lang.System.getProperty("os.name").toLowerCase.contains("win")
+
+  /** Skips the annotated suite on Windows (no JVM shutdown hooks via SIGINT). */
+  private val unixOnly: TestAspectPoly =
+    if (isWindows) TestAspect.ignore else TestAspect.identity
+
+  /** Starts a child JVM running `mainClass` with the current classpath. */
+  private def startProcess(mainClass: String): java.lang.Process = {
+    val builder = new ProcessBuilder(javaBin, "-cp", classpath, mainClass)
+    builder.redirectErrorStream(true)
+    builder.start()
+  }
+
+  /** Drains the remaining stdout of a finished process into a [[String]]. */
+  private def readOutput(process: java.lang.Process): String = {
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val sb     = new StringBuilder
+    var line   = reader.readLine()
+    while (line != null) {
+      sb.append(line).append("\n")
+      line = reader.readLine()
+    }
+    sb.toString()
+  }
+
+  /**
+   * Reads stdout line-by-line until `marker` appears or `timeoutMs` elapses.
+   * Returns all output read so far (including the marker line).
+   */
+  private def waitForMarker(process: java.lang.Process, marker: String, timeoutMs: Long): String = {
+    val reader   = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val sb       = new StringBuilder
+    val deadline = java.lang.System.currentTimeMillis() + timeoutMs
+    while (java.lang.System.currentTimeMillis() < deadline) {
+      if (reader.ready()) {
+        val line = reader.readLine()
+        if (line != null) {
+          sb.append(line).append("\n")
+          if (line.contains(marker)) return sb.toString()
+        }
+      } else {
+        Thread.sleep(50)
+      }
+    }
+    sb.toString()
+  }
+
+  /** Sends SIGINT (Unix) or [[Process#destroy]] (Windows) to a process. */
+  private def sendInterrupt(process: java.lang.Process): Unit =
+    sendSignal(process, "INT")
+
+  /** Sends SIGTERM (Unix) or [[Process#destroy]] (Windows) to a process. */
+  private def sendTerm(process: java.lang.Process): Unit =
+    sendSignal(process, "TERM")
+
+  private def sendSignal(process: java.lang.Process, signal: String): Unit = {
+    val pid = process.pid()
+    if (isWindows) {
+      val _ = process.toHandle.destroy()
+    } else {
+      val _ = java.lang.Runtime.getRuntime.exec(Array("kill", s"-$signal", pid.toString))
+    }
+  }
+
+  // -- higher-level combinators -----------------------------------------------
+
+  /** Runs a self-completing app and returns `(exitCode, stdout)`. */
+  private def runApp(mainClass: String): ZIO[Any, Throwable, (Int, String)] =
+    ZIO.attemptBlocking {
+      val process = startProcess(mainClass)
+      val exited  = process.waitFor(30, TimeUnit.SECONDS)
+      val output  = readOutput(process)
+      if (!exited) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass did not exit within 30 s.\nOutput: $output")
+      }
+      (process.exitValue(), output)
+    }
+
+  /**
+   * Runs a long-running app, waits for `READY`, sends the specified signal,
+   * then collects remaining output.  Returns `(preSignal, postSignal)`.
+   */
+  private def runAppWithSignal(
+    mainClass: String,
+    signal: java.lang.Process => Unit = sendInterrupt
+  ): ZIO[Any, Throwable, (String, String)] =
+    ZIO.attemptBlocking {
+      val process = startProcess(mainClass)
+      val pre     = waitForMarker(process, "READY", 30000)
+      if (!pre.contains("READY")) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass never printed READY within 30 s.\nOutput so far: $pre")
+      }
+      signal(process)
+      val exited = process.waitFor(30, TimeUnit.SECONDS)
+      val post   = readOutput(process)
+      if (!exited) {
+        process.destroyForcibly()
+        throw new RuntimeException(s"$mainClass did not exit after signal within 30 s")
+      }
+      (pre, post)
+    }
+
+  // -- spec -------------------------------------------------------------------
+
+  def spec = suite("ZIOAppIntegrationSpec")(
+
+    // ---- 1. Normal completion ------------------------------------------------
+    suite("app completion")(
+      test("successful app exits with code 0") {
+        runApp("zio.AppSuccess").map { case (code, out) =>
+          assertTrue(code == 0, out.contains("SUCCESS"))
+        }
+      },
+      test("failed app exits with code 1") {
+        runApp("zio.AppFailure").map { case (code, _) =>
+          assertTrue(code == 1)
+        }
+      },
+      test("defect exits with code 1") {
+        runApp("zio.AppDie").map { case (code, _) =>
+          assertTrue(code == 1)
+        }
+      },
+      test("app completes work before exiting") {
+        runApp("zio.AppExitAfterWork").map { case (code, out) =>
+          assertTrue(code == 0, out.contains("WORKING"), out.contains("DONE"))
+        }
+      }
+    ),
+
+    // ---- 2. Finalizers on normal completion ----------------------------------
+    suite("finalizers on normal completion")(
+      test("finalizers run on success") {
+        runApp("zio.AppFinalizerOnSuccess").map { case (_, out) =>
+          assertTrue(out.contains("ACQUIRED"), out.contains("FINALIZED"))
+        }
+      },
+      test("finalizers run on failure") {
+        runApp("zio.AppFinalizerOnFailure").map { case (code, out) =>
+          assertTrue(code == 1, out.contains("ACQUIRED"), out.contains("FINALIZED"))
+        }
+      }
+    ),
+
+    // ---- 3. SIGINT-driven shutdown -------------------------------------------
+    suite("external signal handling — SIGINT")(
+      test("app shuts down and runs finalizers on SIGINT") {
+        runAppWithSignal("zio.AppHangsUntilInterrupted").map { case (pre, post) =>
+          assertTrue((pre + post).contains("FINALIZED"))
+        }
+      },
+      test("slow finalizer completes when gracefulShutdownTimeout is Infinity (issue #9901)") {
+        runAppWithSignal("zio.AppSlowFinalizer").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("FINALIZING"), all.contains("FINALIZED"))
+        }
+      },
+      test("multiple finalizers run in LIFO order") {
+        runAppWithSignal("zio.AppMultipleFinalizers").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("FINAL-1"), all.contains("FINAL-2"), all.contains("FINAL-3")) && {
+            val i1 = all.indexOf("FINAL-1")
+            val i2 = all.indexOf("FINAL-2")
+            val i3 = all.indexOf("FINAL-3")
+            assertTrue(i3 < i2, i2 < i1) // LIFO: 3 → 2 → 1
+          }
+        }
+      },
+      test("bootstrap layer finalizers run on SIGINT") {
+        runAppWithSignal("zio.AppBootstrapFinalizer").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("BOOTSTRAP-ACQUIRED"), all.contains("BOOTSTRAP-FINALIZED"))
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 4. SIGTERM-driven shutdown ------------------------------------------
+    // On the JVM, SIGTERM triggers shutdown hooks just like SIGINT.
+    suite("external signal handling — SIGTERM")(
+      test("app shuts down and runs finalizers on SIGTERM") {
+        runAppWithSignal("zio.AppHangsUntilInterrupted", sendTerm).map { case (pre, post) =>
+          assertTrue((pre + post).contains("FINALIZED"))
+        }
+      },
+      test("slow finalizer completes on SIGTERM when gracefulShutdownTimeout is Infinity") {
+        runAppWithSignal("zio.AppSlowFinalizer", sendTerm).map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("FINALIZING"), all.contains("FINALIZED"))
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 5. ZLayer resource management --------------------------------------
+    // Verifies that resources acquired via ZLayer are properly released on
+    // both normal completion and signal-driven shutdown.
+    suite("ZLayer resource management")(
+      test("ZLayer resources released on normal app exit") {
+        runApp("zio.AppZLayerNormalExit").map { case (code, out) =>
+          assertTrue(code == 0, out.contains("LAYER-ACQUIRED"), out.contains("LAYER-RELEASED"))
+        }
+      },
+      test("ZLayer resources released on SIGINT") {
+        runAppWithSignal("zio.AppZLayerSIGINT").map { case (pre, post) =>
+          val all = pre + post
+          assertTrue(all.contains("LAYER-ACQUIRED"), all.contains("LAYER-RELEASED"))
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 6. gracefulShutdownTimeout -----------------------------------------
+    suite("gracefulShutdownTimeout")(
+      test("shutdown respects timeout — slow finalizer is cut short") {
+        ZIO.attemptBlocking {
+          val process = startProcess("zio.AppShutdownTimeout")
+          val pre     = waitForMarker(process, "READY", 30000)
+          if (!pre.contains("READY")) {
+            process.destroyForcibly()
+            throw new RuntimeException("AppShutdownTimeout never printed READY")
+          }
+          val t0   = java.lang.System.currentTimeMillis()
+          sendInterrupt(process)
+          val done = process.waitFor(15, TimeUnit.SECONDS)
+          val dt   = java.lang.System.currentTimeMillis() - t0
+          val post = readOutput(process)
+          if (!done) process.destroyForcibly()
+          val all = pre + post
+          // Timeout is 1 s; finalizer wants 10 s → process exits in well under 10 s
+          assertTrue(done, dt < 8000L, all.contains("FINALIZING"), !all.contains("FINALIZED"))
+        }
+      },
+      test("well-behaved app does not hang on shutdown") {
+        ZIO.attemptBlocking {
+          val process = startProcess("zio.AppHangsUntilInterrupted")
+          val pre     = waitForMarker(process, "READY", 30000)
+          if (!pre.contains("READY")) {
+            process.destroyForcibly()
+            throw new RuntimeException("Process never printed READY")
+          }
+          val t0   = java.lang.System.currentTimeMillis()
+          sendInterrupt(process)
+          val done = process.waitFor(15, TimeUnit.SECONDS)
+          val dt   = java.lang.System.currentTimeMillis() - t0
+          if (!done) process.destroyForcibly()
+          assertTrue(done, dt < 10000L)
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 7. Zero gracefulShutdownTimeout ------------------------------------
+    // With Duration.Zero the shutdown hook does NOT wait for finalizers.
+    // The process should exit quickly (under 3 s).
+    suite("zero gracefulShutdownTimeout")(
+      test("process exits quickly when gracefulShutdownTimeout is Duration.Zero") {
+        ZIO.attemptBlocking {
+          val process = startProcess("zio.AppZeroTimeout")
+          val pre     = waitForMarker(process, "READY", 30000)
+          if (!pre.contains("READY")) {
+            process.destroyForcibly()
+            throw new RuntimeException("AppZeroTimeout never printed READY")
+          }
+          val t0   = java.lang.System.currentTimeMillis()
+          sendInterrupt(process)
+          val done = process.waitFor(10, TimeUnit.SECONDS)
+          val dt   = java.lang.System.currentTimeMillis() - t0
+          if (!done) process.destroyForcibly()
+          // With Duration.Zero the hook returns immediately; process exits fast
+          assertTrue(done, dt < 3000L)
+        }
+      }
+    ) @@ unixOnly,
+
+    // ---- 8. Background fiber cleanup ----------------------------------------
+    suite("background fiber cleanup")(
+      test("daemon fibers are interrupted on shutdown") {
+        runAppWithSignal("zio.AppBackgroundFiber").map { case (pre, post) =>
+          assertTrue((pre + post).contains("BG-FINALIZED"))
+        }
+      }
+    ) @@ unixOnly
+
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(120.seconds) @@ TestAspect.jvmOnly
+}

--- a/core-tests/jvm/src/test/scala/zio/ZIOAppTestApps.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppTestApps.scala
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2021-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+/**
+ * Standalone [[ZIOApp]] programs used as fixtures by [[ZIOAppIntegrationSpec]].
+ *
+ * Each object is compiled as part of the test sources and launched in a
+ * separate JVM process via [[java.lang.ProcessBuilder]].  The parent test
+ * communicates with the child through stdout markers.
+ *
+ * == Marker convention ==
+ *  - `READY`        — child is waiting and can be signalled
+ *  - `ACQUIRED`     — a resource has been acquired
+ *  - `FINALIZED`    — a finalizer has completed
+ *  - `FINALIZING`   — a (potentially slow) finalizer has started
+ *  - `WORKING`      — the app is doing some work
+ *  - `DONE`         — the app has completed its work
+ *  - `SUCCESS`      — the app is about to exit successfully
+ *  - `BG-FINALIZED` — a background fiber's finalizer has completed
+ *  - `LAYER-*`      — ZLayer lifecycle markers
+ *  - `BOOTSTRAP-*`  — bootstrap layer lifecycle markers
+ *  - `FINAL-N`      — Nth finalizer in a LIFO ordering test
+ *  - `ZERO-FINALIZED` — finalizer in a zero-timeout app (may or may not appear)
+ */
+
+// ---------------------------------------------------------------------------
+// Normal-completion fixtures
+// ---------------------------------------------------------------------------
+
+/** Exits with code 0 after printing a success marker. */
+object AppSuccess extends ZIOAppDefault {
+  override def run =
+    ZIO.succeed(println("SUCCESS"))
+}
+
+/** Exits with code 1 due to a typed failure. */
+object AppFailure extends ZIOAppDefault {
+  override def run =
+    ZIO.fail("boom")
+}
+
+/** Exits with code 1 due to an untyped defect. */
+object AppDie extends ZIOAppDefault {
+  override def run =
+    ZIO.die(new RuntimeException("catastrophic"))
+}
+
+/** Prints two markers and then exits with code 0. */
+object AppExitAfterWork extends ZIOAppDefault {
+  override def run =
+    ZIO.succeed(println("WORKING")) *>
+      ZIO.succeed(println("DONE"))
+}
+
+/** Acquires a resource in a `Scope`, then succeeds; verifies finalizer runs. */
+object AppFinalizerOnSuccess extends ZIOAppDefault {
+  override def run =
+    ZIO.acquireRelease(
+      ZIO.succeed(println("ACQUIRED"))
+    )(_ => ZIO.succeed(println("FINALIZED"))) *>
+      ZIO.unit
+}
+
+/** Acquires a resource, then fails; verifies finalizer still runs. */
+object AppFinalizerOnFailure extends ZIOAppDefault {
+  override def run =
+    ZIO.acquireRelease(
+      ZIO.succeed(println("ACQUIRED"))
+    )(_ => ZIO.succeed(println("FINALIZED"))) *>
+      ZIO.fail("planned failure")
+}
+
+// ---------------------------------------------------------------------------
+// Signal-driven shutdown fixtures
+// ---------------------------------------------------------------------------
+
+/** Hangs forever on `ZIO.never`, printing `READY` first; has one finalizer. */
+object AppHangsUntilInterrupted extends ZIOAppDefault {
+  override def run =
+    ZIO.addFinalizer(ZIO.succeed(println("FINALIZED"))) *>
+      ZIO.succeed(println("READY")) *>
+      ZIO.never
+}
+
+/**
+ * Has a slow (3-second) finalizer; with the default [[Duration.Infinity]]
+ * timeout the parent waits and sees "FINALIZED".
+ * Regression test for issue #9901.
+ */
+object AppSlowFinalizer extends ZIOAppDefault {
+  override def run =
+    ZIO.addFinalizer(
+      ZIO.succeed(println("FINALIZING")) *>
+        ZIO.sleep(3.seconds) *>
+        ZIO.succeed(println("FINALIZED"))
+    ) *>
+      ZIO.succeed(println("READY")) *>
+      ZIO.never
+}
+
+/**
+ * Registers three finalizers and emits LIFO-order markers.
+ * Expected order: FINAL-3 → FINAL-2 → FINAL-1.
+ */
+object AppMultipleFinalizers extends ZIOAppDefault {
+  override def run =
+    ZIO.addFinalizer(ZIO.succeed(println("FINAL-1"))) *>
+      ZIO.addFinalizer(ZIO.succeed(println("FINAL-2"))) *>
+      ZIO.addFinalizer(ZIO.succeed(println("FINAL-3"))) *>
+      ZIO.succeed(println("READY")) *>
+      ZIO.never
+}
+
+/**
+ * Acquires a resource in the [[bootstrap]] layer, so the release function
+ * is invoked by the bootstrap scope when the app shuts down.
+ */
+object AppBootstrapFinalizer extends ZIOAppDefault {
+  override val bootstrap: ZLayer[ZIOAppArgs, Any, Unit] =
+    ZLayer.scoped(
+      ZIO.acquireRelease(
+        ZIO.succeed(println("BOOTSTRAP-ACQUIRED"))
+      )(_ => ZIO.succeed(println("BOOTSTRAP-FINALIZED")))
+    )
+
+  override def run =
+    ZIO.succeed(println("READY")) *> ZIO.never
+}
+
+// ---------------------------------------------------------------------------
+// gracefulShutdownTimeout fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Has a 10-second finalizer but sets [[gracefulShutdownTimeout]] to 1 second.
+ * The parent verifies the process exits in < 8 s with "FINALIZING" in output
+ * but *without* "FINALIZED".
+ */
+object AppShutdownTimeout extends ZIOAppDefault {
+  override def gracefulShutdownTimeout: Duration = 1.second
+
+  override def run =
+    ZIO.addFinalizer(
+      ZIO.succeed(println("FINALIZING")) *>
+        ZIO.sleep(10.seconds) *>
+        ZIO.succeed(println("FINALIZED"))
+    ) *>
+      ZIO.succeed(println("READY")) *>
+      ZIO.never
+}
+
+/**
+ * Sets [[gracefulShutdownTimeout]] to [[Duration.Zero]].
+ * The shutdown hook interrupts the fiber but does *not* wait, so the process
+ * should exit very quickly.  The `ZERO-FINALIZED` marker may or may not
+ * appear — the test only asserts that the process exits fast.
+ */
+object AppZeroTimeout extends ZIOAppDefault {
+  override def gracefulShutdownTimeout: Duration = Duration.Zero
+
+  override def run =
+    ZIO.addFinalizer(ZIO.succeed(println("ZERO-FINALIZED"))) *>
+      ZIO.succeed(println("READY")) *>
+      ZIO.never
+}
+
+// ---------------------------------------------------------------------------
+// Background fiber cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Forks a daemon fiber with a finalizer; verifies the fiber is interrupted
+ * and its finalizer runs when the app receives a signal.
+ */
+object AppBackgroundFiber extends ZIOAppDefault {
+  override def run =
+    ZIO.scoped {
+      for {
+        _ <- (ZIO.addFinalizer(ZIO.succeed(println("BG-FINALIZED"))) *> ZIO.never).forkDaemon
+        _ <- ZIO.succeed(println("READY"))
+        _ <- ZIO.never
+      } yield ()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZLayer resource management fixtures
+// ---------------------------------------------------------------------------
+
+/** Service type for ZLayer tests. */
+trait MyService
+
+/** Normal-exit: ZLayer resource is acquired and released on app exit. */
+object AppZLayerNormalExit extends ZIOAppDefault {
+  val myLayer: ZLayer[Any, Nothing, MyService] = ZLayer.scoped(
+    ZIO.acquireRelease(
+      ZIO.succeed(println("LAYER-ACQUIRED")).as(new MyService {})
+    )(_ => ZIO.succeed(println("LAYER-RELEASED")))
+  )
+
+  override def run =
+    ZIO.serviceWith[MyService](_ => ()).provide(myLayer)
+}
+
+/** Signal-exit: ZLayer resource released even when process receives SIGINT. */
+object AppZLayerSIGINT extends ZIOAppDefault {
+  val myLayer: ZLayer[Any, Nothing, MyService] = ZLayer.scoped(
+    ZIO.acquireRelease(
+      ZIO.succeed(println("LAYER-ACQUIRED")).as(new MyService {})
+    )(_ => ZIO.succeed(println("LAYER-RELEASED")))
+  )
+
+  override def run =
+    ZIO
+      .serviceWith[MyService](_ => ())
+      .zipRight(ZIO.succeed(println("READY")))
+      .zipRight(ZIO.never)
+      .provide(myLayer)
+}


### PR DESCRIPTION
## Summary

Adds a process-based integration test suite for `ZIOApp` lifecycle behaviour,
addressing the requirements in #9909.

Unlike the existing in-process `ZIOAppSpec` (which uses `ZIOApp.invoke`),
these tests spawn each fixture in a **separate JVM** so that the full
lifecycle path is exercised: JVM shutdown hooks, signal delivery (`SIGINT`
**and** `SIGTERM`), exit codes, and the `gracefulShutdownTimeout` mechanism.

## Coverage

| Requirement | Suite / test |
|---|---|
| Correct exit code (success / failure / defect) | `app completion` |
| Finalizers run on normal completion | `finalizers on normal completion` |
| Finalizers run on `SIGINT` | `external signal handling — SIGINT` |
| Finalizers run on `SIGTERM` | `external signal handling — SIGTERM` |
| `ZLayer` resources released on shutdown | `ZLayer resource management` |
| `gracefulShutdownTimeout = Infinity` respected | `gracefulShutdownTimeout` |
| `gracefulShutdownTimeout = 1s` cuts slow finalizer | `gracefulShutdownTimeout` |
| `gracefulShutdownTimeout = Duration.Zero` exits fast | `zero gracefulShutdownTimeout` |
| Shutdown does not hang | `gracefulShutdownTimeout / no-hang` |
| #9901 — slow finalizer waits when timeout is Infinity | `slow finalizer completes…` |
| #9807 — no race between shutdown hooks | all signal tests |
| #9240 — `sun.misc.SignalHandler` `NoClassDefFoundError` | every test app starts cleanly |

## Improvements over prior approaches

1. **SIGTERM tests** — JVM shutdown hooks fire on both `SIGINT` and `SIGTERM`;
   both signals are now tested (suites 3 and 4).

2. **ZLayer resource management** — verifies that resources acquired through
   `ZLayer.scoped` are released both on normal exit and on `SIGINT`.

3. **`Duration.Zero` shutdown timeout** — exercises the fast-exit path where
   the shutdown hook interrupts the fiber without waiting.

4. **Signal helper abstraction** — `runAppWithSignal` accepts an arbitrary
   signal function, making it straightforward to add future signal variants.

## Running

```bash
sbt "coreTestsJVM/testOnly zio.ZIOAppIntegrationSpec"
```

Signal-based suites are gated with `@@ unixOnly` and `@@ TestAspect.jvmOnly`.
The full suite runs on Linux CI.

/claim #9909