### PR TITLE
zio-test: Isolate daemon fibers during shared layer build to fix TestClock hang

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SpecSpec.scala
@@ -121,6 +121,16 @@ object SpecSpec extends ZIOBaseSpec {
         for {
           summary <- execute(spec)
         } yield assertTrue(summary.success == 2)
+      },
+      test("shared layer with daemon fibers does not interfere with TestClock") {
+        val sharedLayer: ULayer[Unit] =
+          ZLayer(ZIO.unit.repeat(Schedule.fixed(1.second)).forkDaemon.unit)
+        val spec = suite("suite")(
+          test("test") {
+            TestClock.adjust(1.hour).as(assertCompletes)
+          }
+        ).provideLayerShared(sharedLayer) @@ TestAspect.timeout(3.seconds)
+        assertZIO(succeeded(spec))(isTrue)
       }
     ),
     suite("provideSomeLayerShared")(
@@ -260,6 +270,16 @@ object SpecSpec extends ZIOBaseSpec {
         for {
           summary <- execute(spec)
         } yield assertTrue(summary.success == 2)
+      },
+      test("shared layer with daemon fibers does not interfere with TestClock") {
+        val sharedLayer: ULayer[Unit] =
+          ZLayer(ZIO.unit.repeat(Schedule.fixed(1.second)).forkDaemon.unit)
+        val spec = suite("suite")(
+          test("test") {
+            TestClock.adjust(1.hour).as(assertCompletes)
+          }
+        ).provideSomeLayerShared[TestEnvironment](sharedLayer) @@ TestAspect.timeout(3.seconds)
+        assertZIO(succeeded(spec))(isTrue)
       }
     ),
     suite("iterable constructor") {

--- a/test/shared/src/main/scala/zio/test/Spec.scala
+++ b/test/shared/src/main/scala/zio/test/Spec.scala
@@ -341,8 +341,14 @@ final case class Spec[-R, +E](caseValue: SpecCase[R, E, Spec[R, E]]) extends Spe
                 layer.extendScope
               )
               .memoize
-              .map { memoizedLayer =>
-                Spec.multiple(specs.map(_.provideLayer(memoizedLayer)))
+              .flatMap { memoizedLayer =>
+                DefaultServices.currentServices.get.map { suiteServices =>
+                  val suiteClock = suiteServices.get(Clock.tag)
+                  val wrappedLayer = ZLayer.fromZIOEnvironment(
+                    Spec.buildWithClockIsolation(memoizedLayer, scope, suiteClock)
+                  )
+                  Spec.multiple(specs.map(_.provideLayer(wrappedLayer)))
+                }
               }
           }
         }
@@ -533,8 +539,14 @@ object Spec {
                   layer.extendScope
                 )
                 .memoize
-                .map { memoizedLayer =>
-                  Spec.multiple(specs.map(_.provideSomeLayer[R0](memoizedLayer)))
+                .flatMap { memoizedLayer =>
+                  DefaultServices.currentServices.get.map { suiteServices =>
+                    val suiteClock = suiteServices.get(Clock.tag)
+                    val wrappedLayer = ZLayer.fromZIOEnvironment(
+                      Spec.buildWithClockIsolation(memoizedLayer, scope, suiteClock)
+                    )
+                    Spec.multiple(specs.map(_.provideSomeLayer[R0](wrappedLayer)))
+                  }
                 }
             }
           }
@@ -561,5 +573,29 @@ object Spec {
     )(implicit tag: Tag[Map[Key, Service]], trace: Trace): Spec[R1, E] =
       self.provideSomeEnvironment(_.updateAt(key)(f))
   }
+
+  // Builds a memoized layer with clock isolation to prevent daemon fibers from
+  // interfering with per-test TestClock. Sets suite-level Clock on the build fiber
+  // so child fibers inherit it naturally, and replaces the supervisor chain with
+  // Supervisor.none to prevent TestAspect.fibers from tracking build-time fibers.
+  // Uses update+restore instead of locally on DefaultServices to preserve
+  // ZIO.memoize's diffFiberRefs patch capture.
+  private def buildWithClockIsolation[R, E, A](
+    memoizedLayer: ZLayer[R, E, A],
+    scope: Scope,
+    suiteClock: Clock
+  )(implicit trace: Trace): ZIO[R, E, ZEnvironment[A]] =
+    for {
+      testServices <- DefaultServices.currentServices.get
+      testClock     = testServices.get(Clock.tag)
+      env <- (
+               DefaultServices.currentServices.update(_.add(suiteClock)(Clock.tag)) *>
+                 FiberRef.currentSupervisor.locally(Supervisor.none)(
+                   memoizedLayer.build(scope)
+                 )
+             ).ensuring(
+               DefaultServices.currentServices.update(_.add(testClock)(Clock.tag))
+             )
+    } yield env
 
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/zio/zio/issues/10491

- `provideLayerShared` with daemon-spawning layers causes `TestClock.adjust` to hang since v2.1.23
- The v2.1.23 lazy build optimization moved layer construction from suite-level scope into per-test scope, causing daemon fibers to (1) be tracked by `TestAspect.fibers` and (2) inherit the per-test `TestClock`
- Fix: set suite-level Clock on the build fiber directly and replace the supervisor with `Supervisor.none` during the build, restoring v2.1.22 behavior

## Problem

Since v2.1.23, `provideLayerShared` with a layer that spawns daemon fibers causes `TestClock.adjust` to hang:

```scala
val sharedLayer: ULayer[Unit] =
  ZLayer(ZIO.unit.repeat(Schedule.fixed(1.second)).forkDaemon.unit)

suite("suite")(
  test("test") {
    TestClock.adjust(1.hour).as(assertCompletes) // hangs until timeout
  }
).provideLayerShared(sharedLayer)
```

This worked in v2.1.22.

## Root cause

#10234 optimized `provideLayerShared` to avoid building layers for filtered/ignored suites by changing the `MultipleCase` handler from eager `.build` to lazy `.memoize`:

```scala
// v2.1.22 — eager: builds the layer immediately within Spec.scoped
layer.memoize.flatMap(layer => layer.mapError(TestFailure.fail).build.map(...))

// v2.1.23 — lazy: defers build until first test evaluates the layer
ZLayer.makeSome[R0, R](...).memoize.map(memoizedLayer => Spec.multiple(specs.map(_.provideLayer(memoizedLayer))))
```

This moved the layer build from the suite-level `Spec.scoped` context into the per-test execution context, causing two problems:

### Background: Two levels of TestClock

`TestExecutor` wraps the spec with `provideSomeLayer(freshLayerPerSpec)`, which uses `Spec.transform`. For `ScopedCase`, `transform` applies `f(ScopedCase(scoped.map(_.transform(f))))` — wrapping both the scoped ZIO itself and recursing into the result. This means `freshLayerPerSpec.build` runs at **two** levels:

1. **Suite-level** (ScopedCase): installs TestClock-A into `DefaultServices.currentServices` for the duration of the suite scope
2. **Per-test** (TestCase): installs a fresh TestClock-B for each individual test

### Factor 1: Fiber tracking

`TestAspect.fibers` is a `PerTest` aspect that wraps each `TestCase`'s ZIO with `supervised(Supervisor.fibersIn(...))` via `Spec.transform`. When `transform` encounters a `ScopedCase`, it applies the transformation to the **result** of the scoped ZIO (`scoped.map(_.transform(f))`), not to the scoped ZIO itself.

In v2.1.22, the eager `.build` ran as part of the `ScopedCase`'s scoped ZIO — **before** the result spec was produced and transformed. So the build executed without `Supervisor.fibersIn`, and daemon fibers were invisible to `awaitSuspended`.

In v2.1.23, the lazy `.memoize` defers the build: `provideLayer(memoizedLayer)` injects `memoizedLayer.build` into each `TestCase`'s test ZIO. After `transform`, that test ZIO is wrapped with `supervised(...)`, so the deferred build now runs **inside** the supervised context. Daemon fibers are tracked by `Supervisor.fibersIn`, and `TestClock.adjust` → `awaitSuspended` waits for them — but a daemon running `Schedule.fixed(1.second)` keeps waking up, so `awaitSuspended` never settles.

### Factor 2: TestClock inheritance

In v2.1.22, the eager build ran inside the ScopedCase scope, where **TestClock-A** (suite-level) was active. Daemon fibers inherited TestClock-A. Since `TestClock.adjust` in each test operates on **TestClock-B** (per-test), the daemon's sleeps were registered on a different clock instance and didn't interfere.

In v2.1.23, the deferred build runs inside the TestCase scope, where **TestClock-B** (per-test) is active. Daemon fibers inherit TestClock-B. Now daemon sleeps and `TestClock.adjust` operate on the **same** clock. Even if factor 1 were addressed alone, `adjust(1.hour)` would still process 3,600 daemon sleeps, each calling `awaitSuspended` with `ClockLive.sleep(2ms)` — totaling ~14 seconds of wall-clock time.

### Combined effect

Both factors must be present for the hang: factor 1 makes `awaitSuspended` wait for the daemon, and factor 2 makes each wait take real wall-clock time. In v2.1.22, neither factor was present.

## Fix

We introduce `buildWithClockIsolation`, which wraps the memoized layer build to restore v2.1.22 behavior:

```scala
private def buildWithClockIsolation[R, E, A](
  memoizedLayer: ZLayer[R, E, A],
  scope: Scope,
  suiteClock: Clock
)(implicit trace: Trace): ZIO[R, E, ZEnvironment[A]] =
  for {
    testServices <- DefaultServices.currentServices.get
    testClock     = testServices.get(Clock.tag)
    env          <- (
                      DefaultServices.currentServices.update(_.add(suiteClock)(Clock.tag)) *>
                      FiberRef.currentSupervisor.locally(Supervisor.none)(
                        memoizedLayer.build(scope)
                      )
                    ).ensuring(
                      DefaultServices.currentServices.update(_.add(testClock)(Clock.tag))
                    )
  } yield env
```

**Clock isolation (factor 2):** `DefaultServices.currentServices.get` at the ScopedCase scope captures **TestClock-A** (suite-level). Before the build, we `update` the build fiber's `DefaultServices` to use TestClock-A. Child fibers forked during the build naturally inherit TestClock-A, restoring v2.1.22 behavior. After the build, `ensuring` restores the per-test TestClock-B so test assertions use the correct clock.

This approach sets the Clock directly on the build fiber rather than relying on `Supervisor.onStart` injection. This is more robust because `makeChildFiber` skips `onStart` when `supervisor eq Supervisor.none` — if any layer in the composition uses `locallyScoped(Supervisor.none)` internally, a supervisor-based approach would be silently bypassed.

**Fiber tracking (factor 1):** `FiberRef.currentSupervisor.locally(Supervisor.none)` replaces the per-test supervisor chain (including `Supervisor.fibersIn` from `TestAspect.fibers`) during the build. Daemon fibers forked during the build are not tracked, so `awaitSuspended` does not wait for them. After the build, `locally` restores the original supervisor for the test's own fibers.

**Preserving `diffFiberRefs`:** We use `update` + `ensuring` restore instead of `locally`/`locallyWith` on `DefaultServices.currentServices`. This is critical because `ZIO.memoize` captures `FiberRefs.Patch` via `diffFiberRefs`. Using `locally` would save/restore the `DefaultServices` value, preventing the layer's own changes (e.g., `withRandomScoped`) from appearing in the diff. With `update`, the Clock is already set to TestClock-A before `diffFiberRefs` starts, so the patch captures only the layer's changes — not the Clock swap.

### Why not simpler approaches?

- **Just prevent fiber tracking (no clock injection):** Addressing factor 1 alone is insufficient. The daemon still registers sleeps on TestClock-B, and `adjust` still processes 3,600 sleeps with `ClockLive.sleep(2ms)` per iteration — ~14 seconds total.

- **`DefaultServices.currentServices.locally(suiteServices)`** — Too broad. Replaces all default services, undoing any `DefaultServices` changes the layer itself makes (e.g., `withRandomScoped`).

- **`DefaultServices.currentServices.locallyWith(_.add(suiteClock)(Clock.tag))`** — Breaks `ZIO.memoize`. `memoize` captures `FiberRefs.Patch` via `diffFiberRefs` and replays it for subsequent callers. The `locallyWith` save/restore prevents the layer's `DefaultServices` changes from appearing in the diff.

- **Custom `Supervisor` with `onStart` clock injection** — `makeChildFiber` skips `onStart` entirely when `supervisor eq Supervisor.none`. If the layer composition internally uses `locallyScoped(Supervisor.none)`, the clock injection is silently bypassed.

### Theoretical breaking cases

The only theoretical case where this change could be observable is if a user intentionally expects daemon fibers from a shared layer to interact with the per-test TestClock. However, this pattern cannot work correctly even without this PR:

1. The daemon is created once (on first test), so only the first test's TestClock would be bound.
2. Subsequent tests would inherit a stale TestClock reference that no longer corresponds to the active test.
3. This makes the pattern inherently broken regardless of this change.

In practice, code that worked correctly before will continue to work, and code that hung will now complete.

Feedback welcome on whether this is the right level to fix this, or whether a more general solution at `ZIO.memoize` or `TestClock` level would be preferable.

## Test plan

- [x] `SpecSpec`: 19 passed, 0 failed
- [x] Full `testTestsJVM`: 922 passed, 0 failed, 29 ignored
- [x] New regression tests: `shared layer with daemon fibers does not interfere with TestClock` in both `provideLayerShared` and `provideSomeLayerShared` suites (~30ms each)
- [x] Existing `propagates the scope to multiple tests` passes — confirms `diffFiberRefs` patch capture is preserved

## Changes

- **`test/shared/src/main/scala/zio/test/Spec.scala`**
  - `provideLayerShared` `MultipleCase`: wrap build in `buildWithClockIsolation`
  - `provideSomeLayerShared` `MultipleCase`: same change
  - Add private `buildWithClockIsolation` helper method

- **`test-tests/shared/src/test/scala/zio/test/SpecSpec.scala`**
  - Add regression test in both `provideLayerShared` and `provideSomeLayerShared` suites