### PR TITLE
Fix catchAll to properly recover from defects (ZIO issue #9874)

### DIFF
--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -131,7 +131,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    */
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
     case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case None        => Right(self.stripFailures)
   }
 
   /**
@@ -141,7 +141,7 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
     case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case None                => Right(self.stripFailures)
   }
 
   /**


### PR DESCRIPTION
Use stripFailures instead of asInstanceOf in failureOrCause and failureTraceOrCause to ensure defects (Die cases) are not ignored during error recovery.

This ensures catchAll can recover from defects/dies even when a failure is present in the Cause.

/attempt #9874