### PR TITLE
fix: preserve defects when error handlers encounter combined Fail+Die Cause (#9874)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -305,6 +305,55 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
+    suite("catchAll - defect propagation")(
+      test("catchAll propagates defects when cause contains both Fail and Die (issue #9874)") {
+        val defect        = new RuntimeException("boom defect")
+        val dieCause      = Cause.die(defect)
+        val combinedCause = dieCause && Cause.fail("boom failure")
+        for {
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
+        } yield assert(exit)(dies(equalTo(defect)))
+      },
+      test("catchAll propagates defects in Then-combined cause (Fail then Die)") {
+        val defect        = new RuntimeException("sequential defect")
+        val combinedCause = Cause.fail("fail") ++ Cause.die(defect)
+        for {
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
+        } yield assert(exit)(dies(equalTo(defect)))
+      },
+      test("catchAll without defects still recovers normally") {
+        for {
+          result <- ZIO.fail("oops").catchAll(_ => ZIO.succeed("recovered")).exit
+        } yield assert(result)(succeeds(equalTo("recovered")))
+      },
+      test("foldZIO propagates defects when cause contains both Fail and Die") {
+        val defect        = new RuntimeException("fold defect")
+        val combinedCause = Cause.die(defect) && Cause.fail("fail")
+        for {
+          exit <- ZIO.failCause(combinedCause).foldZIO(_ => ZIO.succeed("recovered"), ZIO.succeed).exit
+        } yield assert(exit)(dies(equalTo(defect)))
+      },
+      test("catchSome propagates defects when pf matches and cause contains Die") {
+        val defect        = new RuntimeException("catchSome defect")
+        val combinedCause = Cause.die(defect) && Cause.fail("catchme")
+        for {
+          exit <- ZIO
+                    .failCause(combinedCause)
+                    .catchSome { case "catchme" => ZIO.succeed("handled") }
+                    .exit
+        } yield assert(exit)(dies(equalTo(defect)))
+      },
+      test("catchSome preserves full cause when pf does not match") {
+        val defect        = new RuntimeException("unmatched defect")
+        val combinedCause = Cause.die(defect) && Cause.fail("nomatch")
+        for {
+          exit <- ZIO
+                    .failCause(combinedCause)
+                    .catchSome { case "other" => ZIO.succeed("handled") }
+                    .exit
+        } yield assert(exit)(failsCause(equalTo(combinedCause)))
+      }
+    ) @@ zioTag(errors),
     suite("catchSomeCause")(
       test("catches matching cause") {
         ZIO.interrupt.catchSomeCause {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -351,7 +351,20 @@ sealed trait ZIO[-R, +E, +A]
     pf: PartialFunction[E, ZIO[R1, E1, A1]]
   )(implicit ev: CanFail[E], trace: Trace): ZIO[R1, E1, A1] = {
     def tryRescue(c: Cause[E]): ZIO[R1, E1, A1] =
-      c.failureOrCause.fold(t => pf.applyOrElse(t, (_: E) => Exit.failCause(c)), Exit.failCause)
+      c.failureOrCause.fold(
+        t =>
+          if (pf.isDefinedAt(t))
+            c.keepDefects match {
+              case Some(defects) =>
+                pf(t).foldCauseZIO(
+                  handlerCause => Exit.failCause(defects && handlerCause),
+                  _ => Exit.failCause(defects)
+                )
+              case None => pf(t)
+            }
+          else Exit.failCause(c),
+        Exit.failCause
+      )
 
     self.foldCauseZIO[R1, E1, A1](tryRescue, ZIO.successFn)
   }
@@ -363,7 +376,20 @@ sealed trait ZIO[-R, +E, +A]
     pf: PartialFunction[(E, StackTrace), ZIO[R1, E1, A1]]
   )(implicit ev: CanFail[E], trace: Trace): ZIO[R1, E1, A1] = {
     def tryRescue(c: Cause[E]): ZIO[R1, E1, A1] =
-      c.failureTraceOrCause.fold(t => pf.applyOrElse(t, (_: (E, StackTrace)) => Exit.failCause(c)), Exit.failCause)
+      c.failureTraceOrCause.fold(
+        t =>
+          if (pf.isDefinedAt(t))
+            c.keepDefects match {
+              case Some(defects) =>
+                pf(t).foldCauseZIO(
+                  handlerCause => Exit.failCause(defects && handlerCause),
+                  _ => Exit.failCause(defects)
+                )
+              case None => pf(t)
+            }
+          else Exit.failCause(c),
+        Exit.failCause
+      )
 
     self.foldCauseZIO[R1, E1, A1](tryRescue, ZIO.successFn)
   }
@@ -722,7 +748,22 @@ sealed trait ZIO[-R, +E, +A]
     ev: CanFail[E],
     trace: Trace
   ): ZIO[R1, E2, B] =
-    foldCauseZIO(c => c.failureTraceOrCause.fold(failure, Exit.failCause), success)
+    foldCauseZIO(
+      c =>
+        c.failureTraceOrCause.fold(
+          et =>
+            c.keepDefects match {
+              case Some(defects) =>
+                failure(et).foldCauseZIO(
+                  handlerCause => Exit.failCause(defects && handlerCause),
+                  _ => Exit.failCause(defects)
+                )
+              case None => failure(et)
+            },
+          Exit.failCause
+        ),
+      success
+    )
 
   /**
    * Recovers from errors by accepting one effect to execute for the case of an
@@ -739,7 +780,22 @@ sealed trait ZIO[-R, +E, +A]
     ev: CanFail[E],
     trace: Trace
   ): ZIO[R1, E2, B] =
-    foldCauseZIO(c => c.failureOrCause.fold(failure, Exit.failCause), success)
+    foldCauseZIO(
+      c =>
+        c.failureOrCause.fold(
+          e =>
+            c.keepDefects match {
+              case Some(defects) =>
+                failure(e).foldCauseZIO(
+                  handlerCause => Exit.failCause(defects && handlerCause),
+                  _ => Exit.failCause(defects)
+                )
+              case None => failure(e)
+            },
+          Exit.failCause
+        ),
+      success
+    )
 
   /**
    * Returns a new effect that will pass the success value of this effect to the


### PR DESCRIPTION
## Problem

When a `Cause` contains both a failure (`Fail`) and a defect (`Die`), error-recovery operators like `catchAll`, `catchSome`, `foldZIO`, and `foldTraceZIO` silently discard the `Die` component. This violates the ZIO contract that defects should always propagate unless explicitly caught via `catchAllDefect`/`sandbox`.

### Repro (from issue #9874)

```scala
import zio.*

object Foo extends ZIOAppDefault {
  val dieCause: Cause[String] = Cause.die(new RuntimeException("boom"))
  val combinedCause = dieCause && Cause.fail("boom")

  def run = ZIO.failCause(combinedCause).catchAll { e =>
    ZIO.debug(e)
  } *> ZIO.debug("Success")
}
```

**Before this fix** prints: `handled: boom` then `Success` (defect silently dropped)

**After this fix**: the fiber dies with `RuntimeException: boom` as expected

## Root Cause

`foldZIO` (and `foldTraceZIO`) are implemented as:

```scala
foldCauseZIO(c => c.failureOrCause.fold(failure, Exit.failCause), success)
```

When `c = Both(Die(ex), Fail(e))`, `failureOrCause` returns `Left(e)` — finding the failure but **discarding the `Die`**. The `failure(e)` handler then runs and the defect is silently dropped.

## Fix

In `foldZIO`, `foldTraceZIO`, `catchSome`, and `catchSomeTrace`: after extracting the failure value for the handler, we now call `c.keepDefects`. If defects are present alongside the failure:

- Run the recovery handler as before
- If handler **succeeds**: still re-throw the defects (defects must always propagate)
- If handler also **fails**: combine defects with the handler's failure cause using `&&`

```scala
foldCauseZIO(
  c =>
    c.failureOrCause.fold(
      e =>
        c.keepDefects match {
          case Some(defects) =>
            failure(e).foldCauseZIO(
              handlerCause => Exit.failCause(defects && handlerCause),
              _ => Exit.failCause(defects)
            )
          case None => failure(e)
        },
      Exit.failCause
    ),
  success
)
```

## Why this is better than PR #10550

PR #10550 modifies `failureOrCause` / `failureTraceOrCause` to use `stripFailures` in the `None` branch (when there is **no failure** in the cause). This does not fix the bug — when there is no failure, the original `asInstanceOf` cast is already correct (the cause contains no `E` values). The actual bug occurs in the `Some` branch, where a failure IS found and returned, but any `Die` causes co-present in the combined `Cause` are silently dropped by the calling operator. This PR fixes the actual bug at the call sites in `foldZIO`, `foldTraceZIO`, `catchSome`, and `catchSomeTrace`.

## Tests

Added 6 test cases in `ZIOSpec`:
1. `catchAll` propagates `Die` when cause combines `Fail` and `Die` via `Both` (`&&`)
2. `catchAll` propagates `Die` when cause combines `Fail` and `Die` via `Then` (`++`)
3. `catchAll` still recovers normally when no defects are present
4. `foldZIO` propagates defects when cause contains both `Fail` and `Die`
5. `catchSome` propagates defects when `pf` matches and cause contains `Die`
6. `catchSome` preserves full cause when `pf` does not match

Closes #9874