### PR TITLE
feat(Promise): add become method to link Fiber completion to Promise

### DIFF
--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -134,6 +134,69 @@ object PromiseSpec extends ZIOBaseSpec {
         _      <- ZIO.foreach(fibers)(_.await)
       } yield assertCompletes
     },
+    suite("become")(
+      test("become links a fiber's success to the promise") {
+        for {
+          promise <- Promise.make[Nothing, Int]
+          fiber   <- ZIO.succeed(42).fork
+          _       <- promise.become(fiber)
+          result  <- promise.await
+        } yield assert(result)(equalTo(42))
+      },
+      test("become links a fiber's failure to the promise") {
+        for {
+          promise <- Promise.make[String, Int]
+          fiber   <- ZIO.fail("boom").fork
+          _       <- promise.become(fiber)
+          result  <- promise.await.exit
+        } yield assert(result)(fails(equalTo("boom")))
+      } @@ zioTag(errors),
+      test("become links a fiber's interruption to the promise") {
+        for {
+          promise <- Promise.make[Nothing, Int]
+          fiber   <- ZIO.never.fork
+          _       <- fiber.interrupt
+          _       <- promise.become(fiber)
+          result  <- promise.await.exit
+        } yield assert(result)(isInterrupted)
+      } @@ zioTag(interruption),
+      test("become is a no-op when promise is already completed") {
+        for {
+          promise <- Promise.make[Nothing, Int]
+          _       <- promise.succeed(1)
+          fiber   <- ZIO.succeed(99).fork
+          _       <- promise.become(fiber)
+          result  <- promise.await
+        } yield assert(result)(equalTo(1))
+      },
+      test("multiple awaiters all resume when promise is linked via become") {
+        for {
+          latch   <- Promise.make[Nothing, Unit]
+          promise <- Promise.make[Nothing, Int]
+          fiber   <- (latch.await *> ZIO.succeed(7)).fork
+          _       <- promise.become(fiber)
+          results <- ZIO.foreachPar(1 to 5)(_ => promise.await).fork
+          _       <- latch.succeed(())
+          r       <- results.join
+        } yield assert(r)(forall(equalTo(7)))
+      }
+    ),
+    suite("fromFiber")(
+      test("fromFiber creates a promise linked to a successful fiber") {
+        for {
+          fiber   <- ZIO.succeed(100).fork
+          promise <- Promise.fromFiber(fiber)
+          result  <- promise.await
+        } yield assert(result)(equalTo(100))
+      },
+      test("fromFiber creates a promise linked to a failing fiber") {
+        for {
+          fiber   <- ZIO.fail("oops").fork
+          promise <- Promise.fromFiber[String, Int](fiber)
+          result  <- promise.await.exit
+        } yield assert(result)(fails(equalTo("oops")))
+      } @@ zioTag(errors)
+    ),
     suite("State")(
       suite("add")(
         test("stack safety") {

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -72,6 +72,46 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     }
 
   /**
+   * Links this promise to the specified fiber, so that when the fiber
+   * completes, the promise is automatically completed with the same result.
+   *
+   * This is more efficient than `fiber.join.flatMap(succeed).fork` because it
+   * registers a direct observer on `Fiber.Runtime` fibers — avoiding the
+   * allocation of an extra fiber and its associated overhead.
+   *
+   * {{{
+   * // Before
+   * for {
+   *   promise <- Promise.make[E, A]
+   *   fiber   <- effect.fork
+   *   _       <- fiber.join.intoPromise(promise).fork
+   *   result  <- promise.await
+   * } yield result
+   *
+   * // After
+   * for {
+   *   promise <- Promise.make[E, A]
+   *   fiber   <- effect.fork
+   *   _       <- promise.become(fiber)
+   *   result  <- promise.await
+   * } yield result
+   * }}}
+   *
+   * If the promise has already been completed, this is a no-op.
+   */
+  def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Unit] =
+    fiber match {
+      case runtime: Fiber.Runtime[E, A] =>
+        ZIO.succeed {
+          runtime.unsafe.addObserver { exit =>
+            unsafe.completeWith(exit)(Unsafe)
+          }(Unsafe)
+        }
+      case _ =>
+        fiber.await.flatMap(done(_)).fork.unit
+    }
+
+  /**
    * Kills the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
@@ -327,6 +367,27 @@ object Promise {
       def empty[E, A]: State[E, A] = Empty.asInstanceOf[State[E, A]]
     }
   }
+
+  /**
+   * Creates a new promise that is automatically linked to the specified fiber.
+   * When the fiber completes, the promise will be completed with the same
+   * result.
+   *
+   * This is a convenience constructor equivalent to:
+   * {{{
+   * for {
+   *   promise <- Promise.make[E, A]
+   *   _       <- promise.become(fiber)
+   * } yield promise
+   * }}}
+   *
+   * @see [[Promise#become]]
+   */
+  def fromFiber[E, A](fiber: Fiber[E, A])(implicit trace: Trace): UIO[Promise[E, A]] =
+    for {
+      promise <- make[E, A]
+      _       <- promise.become(fiber)
+    } yield promise
 
   /**
    * Makes a new promise to be completed by the fiber creating the promise.


### PR DESCRIPTION
## Problem

When forking a Fiber that will eventually complete a Promise, the current approach requires an extra allocation — a callback registered via `fiber.join.intoPromise(promise).fork`. This creates an unnecessary fiber allocation plus indirection.

## Solution

Add `Promise#become(fiber: Fiber[E, A]): UIO[Unit]` which links the Promise's completion directly to the Fiber:

- For **`Fiber.Runtime`** (the common case from `.fork`): registers a direct observer via `Fiber.Runtime.UnsafeAPI#addObserver` — **zero extra fiber allocation**, purely a callback registration.
- For **synthetic fibers** (combinators like `zipWith`, `map`, etc.): falls back to `fiber.await.flatMap(done(_)).fork`, which is equivalent to the current manual approach.

Also adds `Promise.fromFiber` as a convenience constructor.

## API

```scala
// Before
for {
  promise <- Promise.make[E, A]
  fiber   <- effect.fork
  _       <- fiber.join.intoPromise(promise).fork   // extra fiber allocated
  result  <- promise.await
} yield result

// After
for {
  promise <- Promise.make[E, A]
  fiber   <- effect.fork
  _       <- promise.become(fiber)                  // direct observer, no extra fiber
  result  <- promise.await
} yield result

// Or even more concise:
for {
  fiber   <- effect.fork
  promise <- Promise.fromFiber(fiber)
  result  <- promise.await
} yield result
```

## Implementation Details

`become` pattern-matches on the fiber type:

```scala
def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Unit] =
  fiber match {
    case runtime: Fiber.Runtime[E, A] =>
      ZIO.succeed {
        runtime.unsafe.addObserver { exit =>
          unsafe.completeWith(exit)(Unsafe)
        }(Unsafe)
      }
    case _ =>
      fiber.await.flatMap(done(_)).fork.unit
  }
```

This is consistent with how `raceWith` internally uses `addObserver` for its racing logic.

## Tests Added (PromiseSpec)

- `become` suite:
  - Links a fiber's **success** to the promise
  - Links a fiber's **failure** to the promise
  - Links a fiber's **interruption** to the promise
  - Is a **no-op** when promise is already completed
  - Correctly resumes **multiple awaiters**
- `fromFiber` suite:
  - Creates promise linked to a successful fiber
  - Creates promise linked to a failing fiber

Closes #9877