### PR TITLE
fix(test): Gen no longer overwrites Random seed when fromIterable is used

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -776,6 +776,67 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
-    }
+    },
+    suite("Gen.fromIterable does not overwrite Random seed (#9101)")(
+      test("fromIterable before uuid yields distinct UUIDs in check") {
+        // Regression test for https://github.com/zio/zio/issues/9101
+        // When fromIterable is flatMapped before uuid, uuid must still be random,
+        // not deterministic (i.e. not the same value each sample).
+        val gen = for {
+          _ <- Gen.fromIterable(1 to 5)
+          id <- Gen.uuid
+        } yield id
+
+        // Sample 10 values and assert at least 2 are distinct.
+        // Before the fix, all 10 would be the same UUID.
+        for {
+          uuids    <- gen.runCollectN(10)
+          distinct = uuids.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("uuid before fromIterable still yields distinct UUIDs in check") {
+        val gen = for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(1 to 5)
+        } yield id
+
+        for {
+          uuids <- gen.runCollectN(10)
+          distinct = uuids.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("fromIterable in deterministic mode (checkAll / runCollect) enumerates all values") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 3)
+          id <- Gen.uuid
+        } yield i
+
+        for {
+          is <- gen.runCollect
+        } yield assertTrue(is == List(1, 2, 3))
+      },
+      test("fromIterable in non-deterministic mode picks from the full range") {
+        val gen = for {
+          i <- Gen.fromIterable(1 to 10)
+        } yield i
+
+        for {
+          samples <- gen.runCollectN(50)
+          distinct = samples.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("nested fromIterable generators both produce distinct values in non-deterministic mode") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 100)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        for {
+          pairs    <- gen.runCollectN(20)
+          uuidSet  = pairs.map(_._2).toSet
+          indexSet = pairs.map(_._1).toSet
+        } yield assertTrue(uuidSet.size > 1) && assertTrue(indexSet.size > 1)
+      }
+    )
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -73,7 +73,7 @@ object GenUtils {
     Gen.const(Gen.int(-10, 10))
 
   def shrinks[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.forever.take(1).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runCollect.map(_.toList)
+    gen.samples(Some(1)).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runCollect.map(_.toList)
 
   def shrinksTo[R, A](gen: Gen[R, A]): URIO[R, A] =
     shrinks(gen).map(_.reverse.head)
@@ -81,10 +81,10 @@ object GenUtils {
   val smallInt: Gen[Any, Int] = Gen.int(-10, 10)
 
   def sample[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).runCollect.map(_.toList)
+    gen.runCollect
 
   def sample100[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).forever.take(size.toLong).runCollect.map(_.toList)
+    gen.runCollectN(size)
 
   def sampleEffect[E, A](
     gen: Gen[Any, ZIO[Any, E, A]],
@@ -93,13 +93,13 @@ object GenUtils {
     provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.exit)))(size)
 
   def shrink[R, A](gen: Gen[R, A]): URIO[R, A] =
-    gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
+    gen.samples(Some(1)).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
 
   val shrinkable: Gen[Any, Int] =
     Gen.fromRandomSample(_.nextIntBounded(90).map(_ + 10).map(Sample.shrinkIntegral(0)))
 
   def shrinkWith[R, A](gen: Gen[R, A])(f: A => Boolean): ZIO[R, Nothing, List[A]] =
-    gen.sample.take(1).flatMap(_.shrinkSearch(!f(_))).take(size * 10L).filter(!f(_)).runCollect.map(_.toList)
+    gen.samples(Some(1)).flatMap(_.shrinkSearch(!f(_))).take(size * 10L).filter(!f(_)).runCollect.map(_.toList)
 
   val three: Gen[Any, Int] = Gen(ZStream(Sample.unfold[Any, Int, Int](3) { n =>
     if (n == 0) (n, ZStream.empty)

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.Random._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{Chunk, NonEmptyChunk, Random, Trace, UIO, URIO, ZIO, Zippable}
+import zio._
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -32,6 +32,21 @@ import scala.math.Numeric.DoubleIsFractional
  * environment `R`. Generators may be random or deterministic.
  */
 final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
+
+  /**
+   * Returns a stream of samples from this generator. When `n` is `Some`, the
+   * stream is finite (non-deterministic mode: `Gen.deterministic` FiberRef is
+   * set to `false`). When `n` is `None`, the stream runs over the generator's
+   * natural finite output (deterministic mode: `Gen.deterministic` stays
+   * `true`).
+   *
+   * This is the entry-point that separates "run all values" (`checkAll`) from
+   * "run N random values" (`check`). Dual generators such as `fromIterable`
+   * inspect the FiberRef to decide their behaviour.
+   */
+  private[test] def samples(n: Option[Int])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
+    ZStream.scoped[R](Gen.deterministic.locallyScoped(n.isEmpty)) *>
+      n.fold(sample)(sample.forever.take(_))
 
   /**
    * A symbolic alias for `concat`.
@@ -147,20 +162,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect.map(_.toList)
+    samples(None).map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    samples(Some(n)).map(_.value).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.
    */
   def runHead(implicit trace: Trace): ZIO[R, Nothing, Option[A]] =
-    sample.map(_.value).runHead
+    samples(Some(1)).map(_.value).runHead
 
   /**
    * Composes this generator with the specified generator to create a cartesian
@@ -180,6 +195,35 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 }
 
 object Gen extends GenZIO with FunctionVariants with TimeVariants {
+
+  /**
+   * A `FiberRef` that tracks whether the current execution context is
+   * deterministic (i.e., running `checkAll` / consuming a finite generator's
+   * natural output) or non-deterministic (i.e., running `check` and sampling N
+   * random values).
+   *
+   * `fromIterable` (and other "dual" generators) inspect this ref so that:
+   *   - In deterministic mode they produce their values sequentially.
+   *   - In non-deterministic mode they randomly pick a single value each time,
+   *     behaving like `Gen.elements`, which does not overwrite the `Random`
+   *     state and allows subsequent generators to remain truly random.
+   */
+  private[test] val deterministic: FiberRef[Boolean] =
+    FiberRef.unsafe.make(true)(Unsafe.unsafe)
+
+  /**
+   * Constructs a "dual" generator that switches behaviour depending on whether
+   * the current execution is deterministic (`checkAll`) or non-deterministic
+   * (`check`).  Dual generators can be safely composed with both deterministic
+   * and non-deterministic generators without contaminating the `Random` state.
+   */
+  def dual[R, A](
+    deterministicGen: => Gen[R, A],
+    nondeterministicGen: => Gen[R, A]
+  )(implicit trace: Trace): Gen[R, A] =
+    Gen(ZStream.unwrap {
+      deterministic.get.map(if (_) deterministicGen.sample else nondeterministicGen.sample)
+    })
 
   /**
    * A generator of alpha characters.
@@ -426,7 +470,11 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).map(chunk)
+    }
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -439,14 +487,22 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     uniform.map(n => -math.log(1 - n))
 
   /**
-   * Constructs a deterministic generator that only generates the specified
-   * fixed values.
+   * A dual generator from the specified iterable of fixed values:
+   *   - In deterministic mode (`checkAll`): generates every value in
+   *     `as` sequentially, preserving the original enumeration behaviour.
+   *   - In non-deterministic mode (`check`): randomly picks one value per
+   *     sample using `Gen.elements`, which does NOT overwrite the `Random`
+   *     service state.  This prevents `fromIterable` from clobbering the
+   *     random seed of generators that come later in a `for`-comprehension
+   *     (fixes #9101).
    */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
-  )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+  )(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a))))),
+    Gen.elements(Chunk.fromIterable(as): _*)
+  )
 
   /**
    * Constructs a generator from a function that uses randomness. The returned

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -524,7 +524,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStream(rv.sample)(a => checkConstructor(test(a)))
+    checkStream(rv.samples(None))(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
@@ -652,7 +652,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+    checkStreamPar(rv.samples(None), parallelism)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAllPar` that accepts two random variables.
@@ -800,7 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(rv.samples(Some(n)), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Bug Fix

Fixes #9101 where using `Gen.fromIterable` before another generator in a for-comprehension caused subsequent generators (e.g. `Gen.uuid`) to always produce the same value.

## Root Cause

The test environment uses `TestRandom.deterministic` (a fixed-seed PRNG) to make property tests reproducible. `Gen.fromIterable` is a deterministic generator: it emits values by iterating over the provided sequence without consuming any random state. When flatMapped before a random generator (e.g. `Gen.uuid`), the outer stream runs the iteration for *all* values of the iterable — exhausting and resetting the deterministic TestRandom back to its initial seed each time — so the inner `uuid` generator always sees the same seed and produces the same output.

## Fix

The fix introduces a **dual-mode** design:

1. **`Gen.deterministic: FiberRef[Boolean]`** — tracks whether we are in deterministic mode (`checkAll`/`runCollect`) or non-deterministic mode (`check`/`runCollectN`). Defaults to `true`.

2. **`Gen#samples(n: Option[Int])`** — the new entry-point for all `check*` and `run*` methods. Sets the FiberRef:
   - `None` → deterministic mode (keep sequentially enumerating all values, used by `checkAll`/`runCollect`)
   - `Some(n)` → non-deterministic mode (random `n`-sample stream, used by `check`/`runCollectN`)

3. **`Gen.dual(deterministicGen, nondeterministicGen)`** — helper for building generators that behave differently in each mode.

4. **`Gen.fromIterable` becomes a dual generator**:
   - Deterministic mode: original sequential enumeration (no change to existing behavior)
   - Non-deterministic mode: delegates to `Gen.elements` which randomly picks one value using the `Random` service. This does **not** reset the TestRandom seed, so subsequent generators remain truly random.

5. **All `check*`, `run*`, and `GenUtils` helpers** updated to route through `samples()`.

## Tests Added

Regression tests covering the exact patterns from the issue:
- `Gen.fromIterable` before `Gen.uuid` → distinct UUIDs (the original bug)  
- `Gen.uuid` before `Gen.fromIterable` → distinct UUIDs
- deterministic mode (`runCollect`) still correctly enumerates all values
- non-deterministic mode picks values from the full provided range

## Alternatives Considered

The approach is conceptually identical to PR #9378 but with cleaner, more focused changes and without touching `Sample`, `filter`, `filterZIO`, `collect`, `boolean`, `option`, `concat`, `concatAll`, and `suspend` — reducing the blast radius of the change.

Closes #9101