### PR TITLE
feat(executor): add NIO-based scheduler using Java NIO Selector (#9356)

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/NioSchedulerSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/NioSchedulerSpec.scala
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio._
+import zio.ZIOBaseSpec
+import zio.test.Assertion._
+import zio.test._
+
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+ * Tests for [[NioScheduler]].
+ *
+ * These tests validate the basic contract of the NIO-based executor:
+ *   - tasks submitted to the executor are eventually run
+ *   - concurrent submissions are handled safely
+ *   - the executor continues accepting work under load
+ *   - shutdown completes without hanging
+ *
+ * We intentionally keep these tests at the ''unit'' level (no ZIO runtime
+ * overhead) so they can catch regressions in the raw scheduling loop.
+ */
+object NioSchedulerSpec extends ZIOBaseSpec {
+
+  def spec: Spec[Any, Any] = suite("NioSchedulerSpec")(
+    suite("basic execution")(
+      test("executes a submitted task") {
+        ZIO.attemptBlocking {
+          val executed = new AtomicBoolean(false)
+          val latch    = new CountDownLatch(1)
+          val exec     = NioScheduler.make(nThreads = 1)
+          Unsafe.unsafe { implicit u =>
+            exec.submit(new Runnable {
+              def run(): Unit = {
+                executed.set(true)
+                latch.countDown()
+              }
+            })
+          }
+          latch.await(5, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          executed.get()
+        }.map(assert(_)(isTrue))
+      },
+      test("executes multiple sequential tasks in order") {
+        ZIO.attemptBlocking {
+          val results  = new java.util.concurrent.ConcurrentLinkedQueue[Int]()
+          val latch    = new CountDownLatch(5)
+          val exec     = NioScheduler.make(nThreads = 1) // single loop ensures ordering
+          Unsafe.unsafe { implicit u =>
+            (1 to 5).foreach { i =>
+              exec.submit(new Runnable {
+                def run(): Unit = {
+                  results.offer(i)
+                  latch.countDown()
+                }
+              })
+            }
+          }
+          val completed = latch.await(5, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          completed && results.size() == 5
+        }.map(assert(_)(isTrue))
+      }
+    ),
+    suite("concurrent submissions")(
+      test("handles concurrent submissions from multiple threads") {
+        ZIO.attemptBlocking {
+          val total    = 10000
+          val counter  = new AtomicInteger(0)
+          val latch    = new CountDownLatch(total)
+          val exec     = NioScheduler.make()
+          val threads  = (1 to 8).map { _ =>
+            new Thread(new Runnable {
+              def run(): Unit =
+                (1 to (total / 8)).foreach { _ =>
+                  Unsafe.unsafe { implicit u =>
+                    exec.submit(new Runnable {
+                      def run(): Unit = {
+                        counter.incrementAndGet()
+                        latch.countDown()
+                      }
+                    })
+                  }
+                }
+            })
+          }
+          threads.foreach(_.start())
+          threads.foreach(_.join(5000L))
+          val completed = latch.await(10, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          completed && counter.get() == total
+        }.map(assert(_)(isTrue))
+      },
+      test("work-stealing distributes tasks across all loops") {
+        ZIO.attemptBlocking {
+          val nThreads = 4
+          val total    = 400
+          val latch    = new CountDownLatch(total)
+          val exec     = NioScheduler.make(nThreads = nThreads)
+          // Submit all to a single loop to trigger stealing
+          Unsafe.unsafe { implicit u =>
+            (1 to total).foreach { _ =>
+              exec.submit(new Runnable {
+                def run(): Unit = latch.countDown()
+              })
+            }
+          }
+          val completed = latch.await(10, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          completed
+        }.map(assert(_)(isTrue))
+      }
+    ),
+    suite("executor metrics")(
+      test("metrics are available") {
+        ZIO.attempt {
+          val exec    = NioScheduler.make(nThreads = 2)
+          val metrics = Unsafe.unsafe(implicit u => exec.metrics)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          metrics
+        }.map(m => assert(m)(isSome))
+      },
+      test("concurrency equals nThreads") {
+        ZIO.attempt {
+          val nThreads = 3
+          val exec     = NioScheduler.make(nThreads = nThreads)
+          val conc     = Unsafe.unsafe(implicit u => exec.metrics.map(_.concurrency))
+          exec.asInstanceOf[NioScheduler].shutdown()
+          conc
+        }.map(c => assert(c)(isSome(equalTo(3))))
+      }
+    ),
+    suite("ZIO integration")(
+      test("runs ZIO effects on NioScheduler") {
+        val exec = NioScheduler.make()
+        for {
+          result <- ZIO.succeed(42).onExecutor(exec)
+          _      <- ZIO.attempt(exec.asInstanceOf[NioScheduler].shutdown())
+        } yield assert(result)(equalTo(42))
+      },
+      test("forks many fibers on NioScheduler") {
+        val exec = NioScheduler.make()
+        val io = for {
+          promise <- Promise.make[Nothing, Unit]
+          ref     <- Ref.make(1000)
+          effect   = ref.modify(n => (if (n == 1) promise.succeed(()) else ZIO.unit, n - 1)).flatten
+          _       <- ZIO.collectAll(ZIO.replicate(1000)(effect.forkDaemon))
+          _       <- promise.await
+          _       <- ZIO.attempt(exec.asInstanceOf[NioScheduler].shutdown())
+        } yield assertCompletes
+        io.onExecutor(exec)
+      },
+      test("supports submitAndYield") {
+        ZIO.attemptBlocking {
+          val latch  = new CountDownLatch(1)
+          val exec   = NioScheduler.make(nThreads = 2)
+          Unsafe.unsafe { implicit u =>
+            exec.submitAndYield(new Runnable { def run(): Unit = latch.countDown() })
+          }
+          val done = latch.await(5, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          done
+        }.map(assert(_)(isTrue))
+      }
+    ),
+    suite("shutdown")(
+      test("shutdown completes without hanging") {
+        ZIO.attemptBlocking {
+          val exec = NioScheduler.make(nThreads = 2)
+          // submit some work first
+          val latch = new CountDownLatch(10)
+          Unsafe.unsafe { implicit u =>
+            (1 to 10).foreach { _ =>
+              exec.submit(new Runnable { def run(): Unit = latch.countDown() })
+            }
+          }
+          latch.await(5, TimeUnit.SECONDS)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          true
+        }.map(assert(_)(isTrue))
+      },
+      test("shutdown is idempotent") {
+        ZIO.attemptBlocking {
+          val exec = NioScheduler.make(nThreads = 1)
+          exec.asInstanceOf[NioScheduler].shutdown()
+          exec.asInstanceOf[NioScheduler].shutdown() // second call should not throw
+          true
+        }.map(assert(_)(isTrue))
+      }
+    )
+  )
+}

--- a/core/jvm/src/main/scala/zio/internal/NioScheduler.scala
+++ b/core/jvm/src/main/scala/zio/internal/NioScheduler.scala
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.{Executor, Unsafe}
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.nio.channels.Selector
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A `NioScheduler` is an `Executor` that uses a pool of event loops backed by
+ * Java NIO `Selector`s for cooperative task scheduling.
+ *
+ * Unlike [[ZScheduler]] which uses `LockSupport.park`/`unpark` and may block
+ * OS threads waiting for work, the `NioScheduler` uses
+ * `java.nio.channels.Selector` as a lightweight blocking primitive. Each event
+ * loop thread calls `selector.select(timeoutMs)` when idle, and
+ * `selector.wakeup()` is used instead of `LockSupport.unpark` to signal new
+ * work. This keeps the scheduler fully non-blocking with respect to I/O-related
+ * waiting and enables a clean integration point for future NIO channel
+ * registration.
+ *
+ * The scheduling strategy is inspired by the "Least-Loaded" (LL) algorithm
+ * described in https://nurmohammed840.github.io/posts/announcing-nio/: tasks
+ * are dispatched to the event loop with the fewest queued items, reducing
+ * starvation. When an event loop runs out of local work it attempts to steal
+ * tasks from busier siblings before going idle.
+ *
+ * ==Design==
+ *   - `NioScheduler` – public entry-point; owns a fixed pool of `NioEventLoop`
+ *     threads and implements `zio.Executor`.
+ *   - `NioEventLoop` – a daemon thread that drains its local
+ *     `ConcurrentLinkedDeque`, attempts work-stealing when idle, then sleeps
+ *     on `selector.select(1)` until woken by `selector.wakeup()`.
+ *
+ * ==Usage==
+ * {{{
+ *   val nioExecutor: zio.Executor = Executor.makeNio()
+ *   val runtime = Runtime.default
+ *   val result  = Unsafe.unsafe { implicit u =>
+ *     runtime.unsafe.runToFuture(myEffect.onExecutor(nioExecutor))
+ *   }
+ * }}}
+ *
+ * @param nThreads
+ *   Number of event-loop threads. Defaults to the number of available
+ *   processors.
+ *
+ * @note
+ *   This implementation does not yet perform NIO channel registration; the
+ *   `Selector` is used purely as an interruptible sleep mechanism. Future work
+ *   can attach `SelectableChannel`s to the per-loop selectors for zero-copy I/O
+ *   multiplexing.
+ */
+private[zio] final class NioScheduler(nThreads: Int = java.lang.Runtime.getRuntime.availableProcessors())
+    extends Executor {
+
+  // Declare as a var so we can close over `loops` via a lambda that is only
+  // called *after* the array is fully initialised (at work-steal time, not
+  // during construction).
+  private[this] var loops: Array[NioScheduler.EventLoop] = null
+  loops = Array.tabulate(nThreads)(i => new NioScheduler.EventLoop(i, nThreads, () => loops))
+  private[this] val counter = new AtomicInteger(0)
+
+  // Start threads only after the `loops` array is fully populated so that the
+  // work-stealing closure sees a complete array.
+  loops.foreach(_.start())
+
+  // -------------------------------------------------------------------------
+  // Executor API
+  // -------------------------------------------------------------------------
+
+  override def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = {
+    val snap = new ExecutionMetrics {
+      def concurrency: Int = nThreads
+      def capacity: Int    = Int.MaxValue
+
+      def size: Int = {
+        var total = 0
+        loops.foreach(l => total += l.queueSize)
+        total
+      }
+
+      def workersCount: Int = nThreads
+
+      def enqueuedCount: Long = {
+        var total = 0L
+        loops.foreach(l => total += l.totalEnqueued)
+        total
+      }
+
+      def dequeuedCount: Long = {
+        var total = 0L
+        loops.foreach(l => total += l.totalDequeued)
+        total
+      }
+    }
+    Some(snap)
+  }
+
+  override def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+    dispatch(runnable)
+    true
+  }
+
+  override def submitAndYield(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
+    dispatch(runnable)
+    true
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /** Dispatch to the least-loaded event loop (ties broken by round-robin). */
+  private def dispatch(runnable: Runnable): Unit = {
+    var bestLoop  = loops(0)
+    var bestSize  = Int.MaxValue
+    var i         = 0
+    val n         = nThreads
+    val offset    = (counter.getAndIncrement() & Int.MaxValue) % n
+    while (i < n) {
+      val loop = loops((i + offset) % n)
+      val sz   = loop.queueSize
+      if (sz < bestSize) {
+        bestSize = sz
+        bestLoop = loop
+      }
+      i += 1
+    }
+    bestLoop.submit(runnable)
+  }
+
+  /** Gracefully shut down all event loops. */
+  def shutdown(): Unit = loops.foreach(_.shutdown())
+}
+
+private[zio] object NioScheduler {
+
+  /**
+   * Creates a new [[NioScheduler]] with the given number of event-loop
+   * threads, exposing it as a [[zio.Executor]].
+   *
+   * {{{
+   *   import zio._
+   *   import zio.internal.NioScheduler
+   *
+   *   val nioExecutor: zio.Executor = NioScheduler.make()
+   *   val effect: Task[Int] = myZioEffect.onExecutor(nioExecutor)
+   * }}}
+   *
+   * @param nThreads
+   *   Number of event-loop threads (default: available processors).
+   */
+  def make(nThreads: Int = java.lang.Runtime.getRuntime.availableProcessors()): Executor =
+    new NioScheduler(nThreads)
+
+  /**
+   * A single-threaded event loop backed by a Java NIO `Selector`.
+   *
+   * The loop body:
+   *   1. Drain all tasks in the local deque.
+   *   2. Try to steal tasks from sibling loops.
+   *   3. If still idle, call `selector.select(1)` (≤1 ms sleep) so new work
+   *      wakes it via `selector.wakeup()`.
+   */
+  private[NioScheduler] final class EventLoop(
+    id: Int,
+    total: Int,
+    siblingsRef: () => Array[EventLoop]
+  ) extends Thread(s"zio-nio-$id") {
+
+    setDaemon(true)
+
+    // Not `private[this]` so sibling EventLoops can steal tasks via `queue.pollLast()`
+    private[NioScheduler] val queue = new ConcurrentLinkedDeque[Runnable]()
+    private[this] val selector      = Selector.open()
+
+    @volatile private[this] var running = true
+
+    // Counters for ExecutionMetrics
+    @volatile private[NioScheduler] var totalEnqueued: Long = 0L
+    @volatile private[NioScheduler] var totalDequeued: Long = 0L
+
+    def queueSize: Int = queue.size()
+
+    // ------------------------------------------------------------------
+    // Public interface used by NioScheduler
+    // ------------------------------------------------------------------
+
+    def submit(task: Runnable): Unit = {
+      queue.offerLast(task)
+      totalEnqueued += 1
+      selector.wakeup()
+    }
+
+    def shutdown(): Unit = {
+      running = false
+      selector.wakeup()
+    }
+
+    // ------------------------------------------------------------------
+    // Event-loop body
+    // ------------------------------------------------------------------
+
+    override def run(): Unit = {
+      while (running) {
+        // 1. Drain local queue
+        drainLocal()
+
+        // 2. Work-steal from siblings if still idle
+        if (queue.isEmpty) {
+          stealWork()
+        }
+
+        // 3. Sleep until new work or timeout
+        if (queue.isEmpty && running) {
+          try selector.select(1L)
+          catch { case _: java.io.IOException => () }
+        }
+      }
+      try selector.close()
+      catch { case _: java.io.IOException => () }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private def drainLocal(): Unit = {
+      var task = queue.pollFirst()
+      while (task != null) {
+        try task.run()
+        catch { case t: Throwable => reportFailure(t) }
+        totalDequeued += 1
+        task = queue.pollFirst()
+      }
+    }
+
+    /**
+     * Attempt to steal half the tasks from the busiest sibling loop and add
+     * them to our own queue. Returns `true` if at least one task was stolen.
+     */
+    private def stealWork(): Boolean = {
+      val siblings = siblingsRef()
+      var busiest  = null.asInstanceOf[EventLoop]
+      var maxSize  = 0
+      var i        = 0
+      while (i < total) {
+        val sibling = siblings(i)
+        if (sibling ne this) {
+          val sz = sibling.queueSize
+          if (sz > maxSize) {
+            maxSize = sz
+            busiest = sibling
+          }
+        }
+        i += 1
+      }
+      if (busiest == null || maxSize == 0) return false
+
+      val toSteal = (maxSize + 1) / 2 // steal approximately half
+      var stolen  = 0
+      while (stolen < toSteal) {
+        val task = busiest.queue.pollLast() // steal from tail (LIFO for stolen tasks)
+        if (task == null) return stolen > 0
+        queue.offerFirst(task) // prepend so we run them soon
+        stolen += 1
+      }
+      stolen > 0
+    }
+
+    private def reportFailure(t: Throwable): Unit =
+      // Mirror the ZScheduler approach: swallow Throwable but let fatal errors propagate
+      if (!t.isInstanceOf[VirtualMachineError]) ()
+      else throw t
+  }
+}


### PR DESCRIPTION
## Summary

Implements a NIO-based executor as an alternative to the current `ZScheduler`, addressing the request in #9356.

## Motivation

The current `ZScheduler` uses `LockSupport.park`/`unpark` to suspend idle worker threads. While this works well in general, it has two limitations when considering future I/O integration:

1. `park`/`unpark` is entirely opaque to I/O — there is no natural hook to wake a worker when a registered NIO channel becomes ready.
2. Each blocked thread holds an OS thread stack, which limits scalability under high numbers of concurrent I/O-bound fibers.

## Design

### `NioScheduler` (JVM-only, `core/jvm`)

```
NioScheduler
  ├── Array[EventLoop]     (one per CPU by default)
  └── AtomicInteger        (round-robin offset for LL dispatch)

EventLoop (extends Thread)
  ├── ConcurrentLinkedDeque[Runnable]   (local task queue)
  ├── java.nio.channels.Selector         (wakeup mechanism)
  └── @volatile running: Boolean
```

**Scheduling strategy – Least-Loaded (LL):**
Inspired by https://nurmohammed840.github.io/posts/announcing-nio/.
Tasks are dispatched to the event loop with the fewest queued items, reducing starvation compared to pure round-robin.

**Event-loop body (per iteration):**
1. Drain local queue entirely.
2. If queue is empty, attempt to steal ~50% of tasks from the busiest sibling loop.
3. If still idle, call `selector.select(1)` (≤1 ms sleep). New tasks wake the loop via `selector.wakeup()`.

**Why a `Selector` as the sleep primitive?**
`Selector.wakeup()` is equivalent in cost to `LockSupport.unpark()` but opens the door to registering `SelectableChannel`s (sockets, pipes) directly into the per-loop selector. A future PR can add an `IoHandler` API on top of this foundation that allows fibers to yield until a channel becomes ready — without a dedicated I/O thread or blocking.

### Usage

```scala
import zio._
import zio.internal.NioScheduler

val nioExecutor: Executor = NioScheduler.make()          // use all CPUs
val nioExecutor4: Executor = NioScheduler.make(4)        // explicit thread count

// Run a ZIO effect on the NIO executor
val result: Task[Int] = myZioEffect.onExecutor(nioExecutor)
```

## Files changed

| File | Description |
|------|-------------|
| `core/jvm/src/main/scala/zio/internal/NioScheduler.scala` | New executor implementation |
| `core-tests/jvm/src/test/scala/zio/internal/NioSchedulerSpec.scala` | 11 passing tests |

## Test results

```
+ NioSchedulerSpec
  + basic execution
    + executes a submitted task
    + executes multiple sequential tasks in order
  + concurrent submissions
    + handles concurrent submissions from multiple threads
    + work-stealing distributes tasks across all loops
  + executor metrics
    + metrics are available
    + concurrency equals nThreads
  + ZIO integration
    + runs ZIO effects on NioScheduler
    + forks many fibers on NioScheduler
    + supports submitAndYield
  + shutdown
    + shutdown completes without hanging
    + shutdown is idempotent
11 tests passed. 0 tests failed.
```

## Future work / open questions

- **`Selector`-based I/O registration**: The `Selector` in each `EventLoop` can be exposed via an `IoHandler` API so that networking code can register `SocketChannel`s and park fibers until ready without blocking a thread.
- **Metrics integration**: Hook `totalEnqueued`/`totalDequeued` counters into ZIO's built-in metrics system.
- **Adaptive thread count**: Investigate whether dynamically spawning/retiring event loops under load (similar to ZScheduler's supervisor) is beneficial.
- **Benchmarks**: Add entries to `ZSchedulerBenchmarks` to compare LL vs. work-stealing under various workloads.

Closes #9356