### PR TITLE
fix(ZStream): buffer(n) buffers exactly n elements (not n+1)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,7 +607,74 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          },
+          test("buffer(1) prefetches exactly 1 element - not 2") {
+            // Regression test for https://github.com/zio/zio/issues/9810
+            // With buffer(1), once element 1 is handed to the consumer the
+            // producer must not start element 3 until the consumer has requested
+            // element 2.  We block element 2 behind a permit and verify that
+            // element 3 never starts while element 1 is still being "processed".
+            for {
+              permit2      <- Promise.make[Nothing, Unit]
+              started2     <- Promise.make[Nothing, Unit]
+              started3     <- Promise.make[Nothing, Unit]
+              permit3      <- Promise.make[Nothing, Unit]
+              thirdStarted <- ZIO.scoped {
+                                for {
+                                  pull <- ZStream
+                                            .fromIterable(1 to 3)
+                                            .mapZIO {
+                                              case 1 => ZIO.succeed(1)
+                                              case 2 => started2.succeed(()) *> permit2.await.as(2)
+                                              case 3 => started3.succeed(()) *> permit3.await.as(3)
+                                            }
+                                            .buffer(1)
+                                            .toPull
+                                  // consume element 1
+                                  _ <- pull
+                                  // unblock element 2 production
+                                  _ <- permit2.succeed(())
+                                  _ <- started2.await
+                                  // yield several times – if element 3 were being
+                                  // prefetched it would have started by now
+                                  _   <- ZIO.yieldNow.repeatN(32)
+                                  res <- started3.poll
+                                  _   <- permit3.succeed(())
+                                } yield res
+                              }
+            } yield assert(thirdStarted)(isNone)
+          } @@ nonFlaky,
+          test("buffer(2) can prefetch a third element") {
+            // With buffer(2) the producer is allowed 2 elements ahead, so
+            // element 3 should start as soon as element 2 is unblocked.
+            for {
+              permit2      <- Promise.make[Nothing, Unit]
+              started2     <- Promise.make[Nothing, Unit]
+              started3     <- Promise.make[Nothing, Unit]
+              permit3      <- Promise.make[Nothing, Unit]
+              thirdStarted <- ZIO.scoped {
+                                for {
+                                  pull <- ZStream
+                                            .fromIterable(1 to 3)
+                                            .mapZIO {
+                                              case 1 => ZIO.succeed(1)
+                                              case 2 => started2.succeed(()) *> permit2.await.as(2)
+                                              case 3 => started3.succeed(()) *> permit3.await.as(3)
+                                            }
+                                            .buffer(2)
+                                            .toPull
+                                  // consume element 1
+                                  _ <- pull
+                                  // unblock element 2; element 3 should be started immediately after
+                                  _ <- permit2.succeed(())
+                                  _ <- started2.await
+                                  _ <- started3.await
+                                  res <- started3.poll
+                                  _   <- permit3.succeed(())
+                                } yield res
+                              }
+            } yield assert(thirdStarted)(isSome)
+          } @@ nonFlaky
         ),
         suite("bufferChunks")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -385,29 +385,64 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * Allows a faster producer to progress independently of a slower consumer by
    * buffering up to `capacity` elements in a queue.
    *
+   * Exactly `capacity` elements will be prefetched — the producer cannot advance
+   * beyond `capacity` elements ahead of the consumer. For `capacity == 1` this
+   * means a strict rendezvous-style synchronisation: the producer may only have
+   * one element ready before the consumer asks for it. For `capacity > 1` the
+   * internal bounded queue is sized at `capacity - 1` so that, when combined
+   * with the single element currently held by the consumer, the total number of
+   * in-flight elements is exactly `capacity`.
+   *
    * @note
    *   This combinator destroys the chunking structure.
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    // Helper: drive the consumer loop from any UIO[Exit[Option[E], A]] source.
+    def consumeLoop(take: UIO[Exit[Option[E], A]]): ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = {
+      lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+        ZChannel.fromZIO(take).flatMap { (exit: Exit[Option[E], A]) =>
+          exit.foldExit(
+            Cause
+              .flipCauseOption(_)
+              .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+            value => ZChannel.write(Chunk.single(value)) *> loop
+          )
+        }
+      loop
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
-
-          process
+        ZIO.suspendSucceed {
+          val cap = capacity
+          if (cap <= 1) {
+            // capacity == 1: use a synchronous Handoff so the producer can have
+            // at most 1 element ready before the consumer requests the next one.
+            // A Handoff acts as a one-slot rendezvous: offer() blocks until
+            // take() is called, ensuring no second element is produced until the
+            // first has been handed off.
+            for {
+              handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+              _ <- {
+                lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                  ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                    chunk =>
+                      ZChannel.fromZIO(ZIO.foreachDiscard(chunk)(a => handoff.offer(Exit.succeed(a)))) *> writer,
+                    err =>
+                      ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                    _ =>
+                      ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+                  )
+                (self.channel >>> writer).drain.runScoped
+              }.forkScoped
+            } yield consumeLoop(handoff.take)
+          } else {
+            // capacity > 1: the consumer holds 1 element at a time, so we size
+            // the internal queue at (cap - 1) to keep total in-flight == cap.
+            self.toQueueOfElements(cap - 1).map(queue => consumeLoop(queue.take))
+          }
         }
       }
     )


### PR DESCRIPTION
Fixes #9810 where `ZStream.buffer(1)` was buffering 2 elements.

## Root cause

`buffer(capacity)` called `toQueueOfElements(capacity)`, which creates a `Queue.bounded(capacity)`. Because `Queue.bounded(n)` can hold `n` items, the producer can fill the queue and then the consumer dequeues one element — at which point the producer is unblocked to add another. The result: the consumer holds 1 element **plus** up to `capacity` elements sit in the queue, giving `capacity + 1` total in-flight elements. For `buffer(1)` this means 2 elements are prefetched, not 1.

## Fix

Two cases:

1. **`capacity == 1`**: use `ZStream.Handoff` (the existing synchronous one-slot rendezvous primitive already in ZStream). `Handoff.offer` blocks until `Handoff.take` is called, so the producer is limited to exactly 1 element ahead of the consumer — strict `buffer(1)` semantics.

2. **`capacity > 1`**: use `Queue.bounded(capacity - 1)`. The queue holds `capacity - 1` items; the consumer holds 1; total in-flight = `capacity`.

The change is local to `ZStream.buffer` and does not touch queue internals, `bufferChunks`, `bufferDropping`, or any other variant.

## Regression tests

Added two `nonFlaky` tests:

- **`buffer(1) prefetches exactly 1 element - not 2`**: blocks element-2 production behind a `Promise`, unblocks it, then verifies element-3 has **not** started while element-1 is still being consumed.
- **`buffer(2) can prefetch a third element`**: same setup with `buffer(2)`, verifies element-3 **has** started once element-2 is unblocked (correct prefetch behaviour).

## Validation

```bash
sbt -Dsbt.supershell=false "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t buffer"
```

Closes #9810

/claim #9810