### PR TITLE
fix(ZStream): mapZIOPar parallelism no longer bounded by buffer size

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2997,6 +2997,29 @@ object ZStreamSpec extends ZIOBaseSpec {
               )
             )
           } @@ flaky,
+          test("parallelism is not bounded by bufferSize (#9339)") {
+            // Regression test: mapZIOPar(n) with a small bufferSize should still
+            // achieve n-level parallelism.  Previously the effective parallelism
+            // was min(n, bufferSize) because the bounded outgoing queue stalled
+            // the producer loop before n fibers could be in-flight.
+            val parallelism = 8
+            val bufferSize  = 2 // intentionally smaller than parallelism
+            for {
+              latch <- CountdownLatch.make(parallelism + 1)
+              f <- ZStream
+                     .range(0, 1000)
+                     .mapZIOPar(parallelism, bufferSize)(_ => latch.countDown *> latch.await)
+                     .runDrain
+                     .fork
+              // Wait until exactly `parallelism` fibers have counted down, which
+              // can only happen if all `parallelism` slots were actually used at
+              // once regardless of the small bufferSize.
+              _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)
+              _     <- latch.countDown
+              count <- latch.count
+              _     <- f.join
+            } yield assertTrue(count == 0)
+          } @@ TestAspect.jvmOnly @@ TestAspect.nonFlaky @@ TestAspect.timeout(10.seconds),
           test("does not freeze when output is only partially consumed (#10195)") {
             val stream = ZStream.range(0, 100).mapZIOPar(8)(_ => ZIO.unit)
             assertZIO(stream.take(1).runDrain.exit)(succeeds(anything))

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -673,8 +673,11 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         val input       = SingleProducerAsyncInput.unsafe.make[InErr, InElem, InDone](fiberId)(Unsafe)
         val queueReader = ZChannel.fromInput(input)
         val n0          = n.toLong
-        val bufferSize0 = bufferSize
-        val outgoing    = Queue.unsafe.bounded[Fiber[Either[Unit, OutDone], OutElem2]](bufferSize0, fiberId)(Unsafe)
+        // The outgoing queue is unbounded so that the parallelism level `n` is not
+        // inadvertently capped by `bufferSize`.  Actual concurrency is still bounded
+        // by the semaphore below.  `bufferSize` is retained in the signature for
+        // binary compatibility but no longer limits in-flight fibers.
+        val outgoing    = Queue.unsafe.unbounded[Fiber[Either[Unit, OutDone], OutElem2]](fiberId)(Unsafe)
         val errorSignal = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
         val permits     = Semaphore.unsafe.make(n0)(Unsafe)
         val failureRef  = Ref.unsafe.make[Cause[OutErr1]](Cause.empty)(Unsafe)
@@ -705,7 +708,16 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                              )
                              .interruptible
                              .forkIn(childScope)
-                             .flatMap(fiber => latch.await *> outgoing.offer(fiber))
+                             .flatMap { fiber =>
+                               // Offer the fiber into the ordered output queue *before*
+                               // waiting for the permit latch.  The queue is unbounded so
+                               // this never blocks; ordering is preserved because fibers are
+                               // offered in the same order they are pulled from upstream.
+                               // The latch.await afterwards provides backpressure: the main
+                               // loop only pulls the next element once a semaphore permit has
+                               // been acquired (i.e. once one of the n slots is free).
+                               outgoing.offer(fiber) *> latch.await
+                             }
                          }.forever.interruptible
                            .onError(_.failureOrCause match {
                              case Left(x: Left[OutErr, ?]) =>


### PR DESCRIPTION
Fixes #9339 where `ZStream.mapZIOPar(n)` was effectively limited to `min(n, bufferSize)` parallelism.

## Root Cause

The ordered `mapOutZIOPar` implementation used a **bounded queue** (`Queue.unsafe.bounded[Fiber[...]](bufferSize)`) to hold in-flight fibers between the producer loop and the writer. The producer loop would:
1. Fork a fiber (which waits for a semaphore permit, signals a latch, then runs `f`)
2. Wait for `latch.await` (i.e. wait until a permit is acquired)
3. Call `outgoing.offer(fiber)` — **this blocked when the queue was full**

Because the queue capacity was `bufferSize` (default 16), the producer stalled after enqueuing `bufferSize` fibers even when `n > bufferSize` semaphore permits were available. Effective parallelism was thus `min(n, bufferSize)`.

## Fix

Two changes to `ZChannel#mapOutZIOPar`:

1. **Unbounded fiber queue**: Changed `outgoing` from `Queue.unsafe.bounded(...bufferSize...)` to `Queue.unsafe.unbounded`. Fibers are lightweight; actual concurrency is already bounded by the semaphore.

2. **Reordered offer/await**: The producer now calls `outgoing.offer(fiber)` *before* `latch.await`. This means:
   - The queue never blocks the producer loop (no `bufferSize` cap on throughput).
   - Output ordering is preserved: fibers are enqueued in the same order as upstream elements.
   - Input backpressure is maintained: `latch.await` causes the producer to wait for a semaphore permit before pulling the next element, so at most `n` elements are ever in-flight.
   - Memory safety with `Int.MaxValue` parallelism: the number of queued fibers is bounded by `n` because each fiber must acquire (or wait for) a semaphore permit. No large array is pre-allocated.

The `bufferSize` parameter is retained in the public API for binary compatibility.

## Test

Added a regression test `parallelism is not bounded by bufferSize (#9339)` that calls `mapZIOPar(n=8, bufferSize=2)` and verifies that all 8 fibers run concurrently (using a `CountdownLatch`), which would deadlock on the old implementation since only 2 could be in-flight.

/claim #9339