### PR TITLE
fix(native): avoid NPE in WeakConcurrentBag on Scala Native

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagNativeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagNativeSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.test._
+import zio.test.TestAspect.nativeOnly
+import zio.{ZIO, ZIOBaseSpec}
+
+/**
+ * Regression test for https://github.com/zio/zio/issues/9681
+ *
+ * `WeakConcurrentBag.addToLongTermStorage` triggered an NPE in Scala Native
+ * when forking many fibers because `ConcurrentHashMap.newKeySet()` has a race
+ * condition in `treeifyBin()` under high concurrency.  The fix switches the
+ * Scala Native `Platform.newConcurrentSet` implementation to
+ * `Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())`
+ * which avoids the buggy `KeySetView` / `treeifyBin` code path.
+ */
+object WeakConcurrentBagNativeSpec extends ZIOBaseSpec {
+
+  def spec =
+    suite("WeakConcurrentBagNativeSpec")(
+      test("does not NPE when forking 10K fibers (regression: #9681)") {
+        // Each fork exercises WeakConcurrentBag.addToLongTermStorage via the
+        // scheduler's internal bookkeeping.  Prior to the fix this would
+        // throw a NullPointerException on Scala Native.
+        ZIO.foreachPar(1 to 10000)(_ => ZIO.unit).as(assertCompletes)
+      }
+    ) @@ nativeOnly
+}

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
Fixes #9681 where `WeakConcurrentBag.addToLongTermStorage` caused NPE in Scala Native when forking 10K fibers.

## Root Cause

`ConcurrentHashMap.newKeySet()` in Scala Native has a race condition in `treeifyBin()` when under high concurrency. This is a known upstream Scala Native issue (https://github.com/scala-native/scala-native/issues/4388).

When many fibers are forked simultaneously, `WeakConcurrentBag.addToLongTermStorage` calls `Platform.newConcurrentSet` which previously used `ConcurrentHashMap.newKeySet()` — triggering the buggy `KeySetView` / `treeifyBin` code path.

## Fix

Replace both `newConcurrentSet` overloads in Scala Native's `PlatformSpecific` with:

```scala
Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
```

This avoids the `KeySetView` / `treeifyBin` code path entirely. The approach is consistent with the existing `newWeakSet` implementation which already uses `Collections.newSetFromMap`. The JVM implementation is **unchanged**.

## Test

Added `WeakConcurrentBagNativeSpec` — a `nativeOnly` stress test that forks 10,000 fibers in parallel, directly exercising the `addToLongTermStorage` path that previously caused the NPE.

Closes #9681

/claim #9681