### PR TITLE
feat(ZStream): add fromInputStreamInterruptible

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5749,6 +5749,26 @@ object ZStreamSpec extends ZIOBaseSpec {
             }
           }
         ),
+        suite("fromInputStreamInterruptible")(
+          test("reads bytes correctly") {
+            val chunkSize = ZStream.DefaultChunkSize
+            val data      = Array.tabulate[Byte](chunkSize * 5 / 2)(_.toByte)
+            def is        = new ByteArrayInputStream(data)
+            ZStream.fromInputStreamInterruptible(is, chunkSize).runCollect.map { bytes =>
+              assert(bytes.toArray)(equalTo(data))
+            }
+          },
+          test("interrupts when fiber is interrupted") {
+            val pipe = new java.io.PipedInputStream()
+            val out  = new java.io.PipedOutputStream(pipe)
+            for {
+              fiber  <- ZStream.fromInputStreamInterruptible(pipe).runDrain.fork
+              _      <- ZIO.sleep(100.milliseconds)
+              _      <- fiber.interrupt
+              result <- fiber.await
+            } yield assertTrue(result.isInterrupted)
+          } @@ TestAspect.withLiveClock
+        ),
         test("fromIterable")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           def lazyL = l
           assertZIO(ZStream.fromIterable(lazyL).runCollect)(equalTo(l))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4408,6 +4408,39 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     }
 
   /**
+   * Creates a stream from a `java.io.InputStream` using
+   * `ZIO.attemptBlockingCancelable`, which allows the stream to be interrupted
+   * even when blocked on `InputStream.read`. The input stream is closed when
+   * the fiber is interrupted.
+   *
+   * Unlike [[fromInputStream]], this variant is interruptible at the cost of
+   * closing the underlying stream on interruption.
+   */
+  def fromInputStreamInterruptible(
+    is: => InputStream,
+    chunkSize: => Int = ZStream.DefaultChunkSize
+  )(implicit trace: Trace): ZStream[Any, IOException, Byte] =
+    ZStream.succeed((is, chunkSize)).flatMap { case (is, chunkSize) =>
+      ZStream.repeatZIOChunkOption {
+        for {
+          bufArray  <- ZIO.succeed(Array.ofDim[Byte](chunkSize))
+          bytesRead <- ZIO
+                         .attemptBlockingCancelable(is.read(bufArray))(ZIO.attempt(is.close()).ignore)
+                         .refineToOrDie[IOException]
+                         .asSomeError
+          bytes <- if (bytesRead < 0)
+                     Exit.failNone
+                   else if (bytesRead == 0)
+                     Exit.emptyChunk
+                   else if (bytesRead < chunkSize)
+                     ZIO.succeed(Chunk.fromArray(bufArray).take(bytesRead))
+                   else
+                     ZIO.succeed(Chunk.fromArray(bufArray))
+        } yield bytes
+      }.ensuring(ZIO.attempt(is.close()).ignore)
+    }
+
+  /**
    * Creates a stream from a `java.io.InputStream`. Ensures that the input
    * stream is closed after it is exhausted.
    */


### PR DESCRIPTION
Fixes #9084.

Adds `ZStream.fromInputStreamInterruptible` which uses `ZIO.attemptBlockingCancelable` so the fiber can be interrupted while blocked on `InputStream.read`. The input stream is closed on interruption via the cancelable effect.

The existing `ZStream.fromInputStream` is preserved for backward compatibility.

## Changes

- `streams/shared/src/main/scala/zio/stream/ZStream.scala`: adds `fromInputStreamInterruptible` method immediately after `fromInputStream`, mirroring its implementation but replacing `ZIO.attemptBlockingIO` with `ZIO.attemptBlockingCancelable(...)(ZIO.attempt(is.close()).ignore)` and adding a finalizer to ensure the stream is closed.
- `streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala`: adds a test suite for `fromInputStreamInterruptible` covering basic read correctness and fiber interruption behavior.

/claim #9084