### PR TITLE
fix: include RHS flatMap call sites in stacktraces (#8747)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -25,6 +25,25 @@ object StackTracesSpec extends ZIOBaseSpec {
       }
     ),
     suite("captureMultiMethod")(
+      test("captures right-hand side flatMap frames") {
+        def c = ZIO.fail("Oh no!")
+        def b = ZIO.unit.flatMap(_ => c)
+        def a = ZIO.unit.flatMap(_ => b)
+
+        for {
+          cause <- a.cause
+          trace  = cause.prettyPrint
+          iC     = trace.indexOf("at zio.StackTracesSpec.spec.c")
+          iB     = trace.indexOf("at zio.StackTracesSpec.spec.b")
+          iA     = trace.indexOf("at zio.StackTracesSpec.spec.a")
+        } yield assertTrue(
+          iC >= 0,
+          iB >= 0,
+          iA >= 0,
+          iC < iB,
+          iB < iA
+        )
+      },
       test("captures a deep embedded failure") {
         val deepUnderlyingFailure =
           for {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6167,6 +6167,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   ) extends Continuation
       with ZIO[R, E, A2]
 
+  private[zio] final case class TracePoint(trace: Trace) extends Continuation
+
   private[zio] sealed abstract class Continuation {
     def trace: Trace
   }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1134,12 +1134,16 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 continuation match {
                   case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
                     cur = flatMap.successK(value)
+                    if (cur ne null) stackIndex = pushStackFrame(ZIO.TracePoint(flatMap.trace), stackIndex)
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+                    if (cur ne null) stackIndex = pushStackFrame(ZIO.TracePoint(foldZIO.trace), stackIndex)
 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
+
+                  case _: ZIO.TracePoint => ()
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1172,12 +1176,16 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 continuation match {
                   case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
                     cur = flatMap.successK(value)
+                    if (cur ne null) stackIndex = pushStackFrame(ZIO.TracePoint(flatMap.trace), stackIndex)
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+                    if (cur ne null) stackIndex = pushStackFrame(ZIO.TracePoint(foldZIO.trace), stackIndex)
 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
+
+                  case _: ZIO.TracePoint => ()
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1196,8 +1204,10 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               val first = flatmap.first
 
-              if (first eq ZIO.unit) cur = flatmap.successK(())
-              else {
+              if (first eq ZIO.unit) {
+                cur = flatmap.successK(())
+                if (cur ne null) stackIndex = pushStackFrame(ZIO.TracePoint(flatmap.trace), stackIndex)
+              } else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
                 cur = first
               }
@@ -1321,6 +1331,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                     } else {
                       cur = foldZIO.failureK(cause)
                     }
+
+                  case _: ZIO.TracePoint => ()
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
                     cause = patchRuntimeFlagsCause(updateFlags.update, cause)


### PR DESCRIPTION
## Problem

When failure occurs in the **right-hand side** (continuation) of a `flatMap` chain, ZIO stacktraces only show the failure site. Intermediate call sites — the functions that constructed the `flatMap` — are invisible:

```scala
def a = ZIO.unit.flatMap(_ => b)
def b = ZIO.unit.flatMap(_ => c)
def c = ZIO.fail("error")
// before: stacktrace shows only 'c'
// after:  stacktrace shows c → b → a  ✓
```

Left-side traces (where `first != ZIO.unit`) already worked correctly. This PR fixes the right-side case.

## Root Cause

When the run-loop pops a `FlatMap` or `FoldZIO` continuation from the internal stack and invokes `successK`, the continuation's `Trace` is discarded along with the stack frame. The produced effect then runs with an empty stack, so `generateStackTrace()` can only see `_lastTrace` (the failure site).

The same issue applies to the `ZIO.unit` fast-path: `if (first eq ZIO.unit) cur = flatmap.successK(())` skips pushing anything to the stack, so the calling `flatMap`'s trace is immediately lost when the next effect sets `_lastTrace`.

## Fix

Introduce `ZIO.TracePoint`: a zero-weight `Continuation` that carries only a `Trace` value. After calling `successK`, push a `TracePoint` with the calling continuation's `Trace` onto the stack. This keeps the call-site visible to `generateStackTrace()` for the lifetime of the produced effect.

`TracePoint` is a **pure no-op** in both success and failure unwind paths (handled by `case _: ZIO.TracePoint => ()`).

## Changes

| File | Change |
|---|---|
| `ZIO.scala` | Add `private[zio] final case class TracePoint(trace: Trace) extends Continuation` |
| `FiberRuntime.scala` | Push `TracePoint` after each `successK` call (success paths × 2 + `ZIO.unit` fast-path); skip `TracePoint` in failure path |
| `StackTracesSpec.scala` | New regression test: RHS flatMap chain of depth 3 asserts `c < b < a` in trace |

## Performance

- **`NarrowFlatMapBenchmark`** — unaffected. Uses `ZIO.succeed[Int](i+1).flatMap(loop)`; `first != ZIO.unit` so the fast-path branch is not taken.
- **`BroadFlatMapBenchmark`** — unaffected for the same reason.
- **`ZIO.unit.flatMap` / `*>` chains** — one extra stack push+pop per continuation transition (array write + array null-write). Minimal overhead; no allocation on the hot path since `TracePoint` is a case class on a short-lived stack frame.

/claim #8747