### PR TITLE
ZScheduler: implement least-loaded routing to reduce global queue con…

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -143,13 +143,34 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     }
   }
 
+  private def leastLoadedWorker(): ZScheduler.Worker = {
+    var i       = 0
+    var best    = null.asInstanceOf[ZScheduler.Worker]
+    var minLoad = Int.MaxValue
+    while (i < poolSize) {
+      val w = workers(i)
+      if (!w.blocking) {
+        val load = w.localQueue.size() + (if (w.nextRunnable ne null) 1 else 0)
+        if (load < minLoad) {
+          minLoad = load
+          best = w
+        }
+      }
+      i += 1
+    }
+    best
+  }
+
   def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
     val worker = workerOrNull()
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        val best = leastLoadedWorker()
+        if ((best eq null) || !best.localQueue.offer(runnable)) {
+          globalQueue.offer(runnable)
+        }
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
       } else ()
@@ -166,7 +187,10 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     } else {
       var notify = true
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        val best = leastLoadedWorker()
+        if ((best eq null) || !best.localQueue.offer(runnable)) {
+          globalQueue.offer(runnable)
+        }
       }
       // Attempt resumption in the current Thread
       else if ((worker.nextRunnable eq null) && worker.localQueue.isEmpty()) {


### PR DESCRIPTION
Closes #9356
/claim #9356

This PR implements the least-loaded routing strategy for `ZScheduler` to address performance bottlenecks when fibers are spawned from non-worker or blocking threads.

### Design

A single private method `leastLoadedWorker()` scans the workers array and returns the non-blocking worker with the smallest `localQueue.size() + nextRunnable` load. All wakeups remain delegated to `maybeUnparkWorker` — the idle-queue state machine is untouched.

- **Hot path unchanged**: The fiber-to-fiber fork branch in both `submit` and `submitAndYield` is unmodified.
- **Zero configuration**: No new flags, no new scheduler class.
- **Minimalist**: 28-line surgical diff.

### Performance (JMH, series/2.x baseline)

| Benchmark | Baseline | This PR | Delta |
| :--- | :--- | :--- | :--- |
| ForkMany | 258 ± 45 ops/s | 289 ± 11 ops/s | **+12%** |
| ChainedFork | 2127 ± 285 ops/s | 2254 ± 24 ops/s | **+6%** |
| PingPong | 1435 ± 71 ops/s | 1522 ± 113 ops/s | **+6%** |
| YieldMany | 398 ± 25 ops/s | 400 ± 49 ops/s | **~flat** |

### Verification

All 33 `ZSchedulerSpec`, `ExecutorSpec`, and `RuntimeSpec` tests pass.