### PR TITLE
fix: catchAll properly recovers from defects in combined Cause (#9874)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -371,9 +371,9 @@ object CauseSpec extends ZIOBaseSpec {
         val cause = Cause.die(new RuntimeException("boom")) && Cause.fail("error")
         assert(cause.failureOrCause)(isRight(anything))
       },
-      test("returns Right when cause contains both failure and interruption") {
+      test("returns Left when cause contains failure and interruption but no defect") {
         val cause = Cause.interrupt(FiberId.None) && Cause.fail("error")
-        assert(cause.failureOrCause)(isRight(anything))
+        assert(cause.failureOrCause)(isLeft(equalTo("error")))
       }
     )
   ) @@ samples(10)

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -357,6 +357,24 @@ object CauseSpec extends ZIOBaseSpec {
           }
         }
       }
+    ),
+    suite("failureOrCause - issue 9874")(
+      test("returns Left for pure failure") {
+        val cause = Cause.fail("error")
+        assert(cause.failureOrCause)(isLeft(equalTo("error")))
+      },
+      test("returns Right for pure defect") {
+        val cause = Cause.die(new RuntimeException("boom"))
+        assert(cause.failureOrCause)(isRight(anything))
+      },
+      test("returns Right when cause contains both failure and defect") {
+        val cause = Cause.die(new RuntimeException("boom")) && Cause.fail("error")
+        assert(cause.failureOrCause)(isRight(anything))
+      },
+      test("returns Right when cause contains both failure and interruption") {
+        val cause = Cause.interrupt(FiberId.None) && Cause.fail("error")
+        assert(cause.failureOrCause)(isRight(anything))
+      }
     )
   ) @@ samples(10)
 

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -312,11 +312,11 @@ object ZIOSpec extends ZIOBaseSpec {
           exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
         } yield assert(exit)(dies(hasMessage(equalTo("boom"))))
       },
-      test("catchAll does not recover from interruption in combined Cause") {
+      test("catchAll recovers from failure combined with interruption (no defect)") {
         val combinedCause = Cause.interrupt(FiberId.None) && Cause.fail("fail")
         for {
-          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
-        } yield assert(exit)(isInterrupted)
+          result <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered"))
+        } yield assert(result)(equalTo("recovered"))
       },
       test("catchAll recovers from pure failure Cause") {
         for {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -305,6 +305,25 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
+    suite("catchAll - issue 9874")(
+      test("catchAll does not recover from defects in combined Cause") {
+        val combinedCause = Cause.die(new RuntimeException("boom")) && Cause.fail("fail")
+        for {
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
+        } yield assert(exit)(dies(hasMessage(equalTo("boom"))))
+      },
+      test("catchAll does not recover from interruption in combined Cause") {
+        val combinedCause = Cause.interrupt(FiberId.None) && Cause.fail("fail")
+        for {
+          exit <- ZIO.failCause(combinedCause).catchAll(_ => ZIO.succeed("recovered")).exit
+        } yield assert(exit)(isInterrupted)
+      },
+      test("catchAll recovers from pure failure Cause") {
+        for {
+          result <- ZIO.fail("fail").catchAll(e => ZIO.succeed(e))
+        } yield assert(result)(equalTo("fail"))
+      }
+    ) @@ zioTag(errors),
     suite("catchSomeCause")(
       test("catches matching cause") {
         ZIO.interrupt.catchSomeCause {

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -128,20 +128,34 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * Retrieve the first checked error on the `Left` if available, if there are
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
+   *
+   * If the `Cause` contains both checked errors and defects or interruptions,
+   * the defects/interruptions take priority and the result will be a `Right`
+   * with the failures stripped.
    */
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(error) =>
+      val stripped = stripFailures
+      if (stripped.isEmpty) Left(error)
+      else Right(stripped)
+    case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
   /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
+   *
+   * If the `Cause` contains both checked errors and defects or interruptions,
+   * the defects/interruptions take priority and the result will be a `Right`
+   * with the failures stripped.
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(errorAndTrace) =>
+      val stripped = stripFailures
+      if (stripped.isEmpty) Left(errorAndTrace)
+      else Right(stripped)
+    case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
   /**

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -129,15 +129,14 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
    *
-   * If the `Cause` contains both checked errors and defects or interruptions,
-   * the defects/interruptions take priority and the result will be a `Right`
-   * with the failures stripped.
+   * If the `Cause` contains both checked errors and defects, the defects take
+   * priority and the result will be a `Right` with the failures stripped.
+   * Interruptions alone do not prevent failure recovery.
    */
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
     case Some(error) =>
-      val stripped = stripFailures
-      if (stripped.isEmpty) Left(error)
-      else Right(stripped)
+      if (defects.nonEmpty) Right(stripFailures)
+      else Left(error)
     case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
@@ -146,15 +145,14 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
    *
-   * If the `Cause` contains both checked errors and defects or interruptions,
-   * the defects/interruptions take priority and the result will be a `Right`
-   * with the failures stripped.
+   * If the `Cause` contains both checked errors and defects, the defects take
+   * priority and the result will be a `Right` with the failures stripped.
+   * Interruptions alone do not prevent failure recovery.
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
     case Some(errorAndTrace) =>
-      val stripped = stripFailures
-      if (stripped.isEmpty) Left(errorAndTrace)
-      else Right(stripped)
+      if (defects.nonEmpty) Right(stripFailures)
+      else Left(errorAndTrace)
     case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 


### PR DESCRIPTION
Fixes #9874 - catchAll now properly handles combined Cause containing both failures and defects/interruptions. When Cause contains both Fail and Die (or Interrupt), defects/interruptions take priority instead of being silently swallowed. Added regression tests in ZIOSpec and CauseSpec.