### PR TITLE
Fix ZIOAppSpec compilation errors

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/ZIOAppSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/ZIOAppSpecJVM.scala
@@ -21,12 +21,11 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
     test("ZIOApp can be created with custom runtime") {
       for {
         ref <- Ref.make(0)
-        runtime = Runtime.default
-        app = ZIOApp(ZIO.succeed(ref.update(_ + 1)), runtime)
+        app = ZIOApp(ZIO.succeed(ref.update(_ + 1)), ZLayer.environment)
         _   <- app.invoke(Chunk.empty)
         v   <- ref.get
       } yield assertTrue(v == 1)
-    } @@ jvm,
+    } @@ jvm(),
     test("shuttingDown flag is set during shutdown") {
       for {
         ref <- Ref.make(false)
@@ -37,14 +36,14 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         _     <- app.invoke(Chunk.empty)
         value <- ref.get
       } yield assertTrue(!value) // Should be false after app completes
-    } @@ jvm,
+    } @@ jvm(),
     test("installSignalHandlers is called during workflow") {
       // This test verifies that signal handlers are installed
       // by checking that the app runs without errors on JVM
       for {
         code <- ZIOAppDefault.fromZIO(ZIO.unit).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
       } yield assertTrue(code == ExitCode.success)
-    } @@ jvm,
+    } @@ jvm(),
     test("shutdown timeout can be set to zero for immediate exit") {
       for {
         ref  <- Ref.make(false)
@@ -60,7 +59,7 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         // With Duration.Zero, shutdown should be immediate
         value <- ref.get
       } yield assertTrue(value) // Finalizer should still run on interrupt
-    } @@ jvm,
+    } @@ jvm(),
     test("shutdown timeout can be set to infinite") {
       for {
         ref  <- Ref.make(false)
@@ -74,7 +73,7 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         _     <- fiber.interrupt
         value <- ref.get
       } yield assertTrue(value)
-    } @@ jvm,
+    } @@ jvm(),
     test("exit with specific code via exit method") {
       for {
         code <- ZIOAppDefault
@@ -82,7 +81,7 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
                  .invoke(Chunk.empty)
                  .exitCode: @nowarn("cat=deprecation")
       } yield assertTrue(code == ExitCode(123))
-    } @@ jvm,
+    } @@ jvm(),
     test("exit method stops the app immediately") {
       for {
         ref       <- Ref.make(false)
@@ -98,7 +97,7 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         neverDone <- neverRun.isDone
         _         <- fiber.await
       } yield assertTrue(!neverDone) // The second effect should never run
-    } @@ jvm,
+    } @@ jvm(),
     test("finalizer timeout is respected") {
       // Test that a slow finalizer doesn't block forever when timeout is set
       for {
@@ -117,7 +116,7 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         _     <- ZIO.sleep(200.millis)
         value <- ref.get
       } yield assertTrue(value) // Finalizer should still have been attempted
-    } @@ jvm,
+    } @@ jvm(),
     test("run method can access args via getArgs") {
       for {
         ref <- Ref.make(Chunk.empty[String])
@@ -128,6 +127,6 @@ object ZIOAppSpecJVM extends ZIOBaseSpec {
         _     <- app.invoke(Chunk("test", "args"))
         value <- ref.get
       } yield assertTrue(value == Chunk("test", "args"))
-    } @@ jvm
-  ) @@ jvm
+    } @@ jvm()
+  ) @@ jvm()
 }

--- a/core-tests/jvm-native/src/test/scala/zio/ZIOAppSpecJVM.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/ZIOAppSpecJVM.scala
@@ -1,0 +1,133 @@
+package zio
+
+import zio.test._
+import zio.test.TestAspect.{jvm, nonFlaky}
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * JVM-specific tests for ZIOApp signal handling and shutdown behavior.
+ * These tests cover the behavior when the app completes due to external signals (SIGINT, SIGTERM),
+ * graceful shutdown timeout, and finalizer execution during shutdown.
+ * 
+ * Related issues:
+ * - #9901: Finalizers not running on termination
+ * - #9807: Race between shutdown hooks
+ * - #9240: Signal handler compatibility (covered by platform)
+ */
+object ZIOAppSpecJVM extends ZIOBaseSpec {
+
+  def spec = suite("ZIOAppSpecJVM")(
+    test("ZIOApp can be created with custom runtime") {
+      for {
+        ref <- Ref.make(0)
+        runtime = Runtime.default
+        app = ZIOApp(ZIO.succeed(ref.update(_ + 1)), runtime)
+        _   <- app.invoke(Chunk.empty)
+        v   <- ref.get
+      } yield assertTrue(v == 1)
+    } @@ jvm,
+    test("shuttingDown flag is set during shutdown") {
+      for {
+        ref <- Ref.make(false)
+        app = new ZIOAppDefault {
+                override def run: ZIO[ZIOAppArgs with Scope, Any, Any] =
+                  ZIO.succeed(shuttingDown.get()).flatMap(ref.set)
+              }
+        _     <- app.invoke(Chunk.empty)
+        value <- ref.get
+      } yield assertTrue(!value) // Should be false after app completes
+    } @@ jvm,
+    test("installSignalHandlers is called during workflow") {
+      // This test verifies that signal handlers are installed
+      // by checking that the app runs without errors on JVM
+      for {
+        code <- ZIOAppDefault.fromZIO(ZIO.unit).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.success)
+    } @@ jvm,
+    test("shutdown timeout can be set to zero for immediate exit") {
+      for {
+        ref  <- Ref.make(false)
+        app   = new ZIOAppDefault {
+                 override val gracefulShutdownTimeout: Duration = Duration.Zero
+                 override def run: ZIO[ZIOAppArgs with Scope, Any, Any] =
+                   ZIO.never.ensuring(ref.set(true))
+               }
+        fiber <- app.invoke(Chunk.empty).fork
+        _     <- ZIO.sleep(50.millis) // Give some time for the app to start
+        // Interrupt should cause finalizer to attempt to run
+        _     <- fiber.interrupt
+        // With Duration.Zero, shutdown should be immediate
+        value <- ref.get
+      } yield assertTrue(value) // Finalizer should still run on interrupt
+    } @@ jvm,
+    test("shutdown timeout can be set to infinite") {
+      for {
+        ref  <- Ref.make(false)
+        app   = new ZIOAppDefault {
+                 override val gracefulShutdownTimeout: Duration = Duration.Infinity
+                 override def run: ZIO[ZIOAppArgs with Scope, Any, Any] =
+                   ZIO.never.ensuring(ref.set(true))
+               }
+        fiber <- app.invoke(Chunk.empty).fork
+        _     <- ZIO.sleep(50.millis)
+        _     <- fiber.interrupt
+        value <- ref.get
+      } yield assertTrue(value)
+    } @@ jvm,
+    test("exit with specific code via exit method") {
+      for {
+        code <- ZIOAppDefault
+                 .fromZIO(ZIO.unit *> ZIO.succeed(ExitCode(123)))
+                 .invoke(Chunk.empty)
+                 .exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode(123))
+    } @@ jvm,
+    test("exit method stops the app immediately") {
+      for {
+        ref       <- Ref.make(false)
+        started   <- Promise.make[Nothing, Unit]
+        neverRun  <- Promise.make[Nothing, Unit]
+        // Using exit should stop the app before the second effect runs
+        app        = ZIOAppDefault.fromZIO(
+                      started.succeed(()) *> ZIO.exit(ExitCode.success) *> neverRun.succeed(()).as(false)
+                    )
+        fiber     <- app.invoke(Chunk.empty).fork
+        _         <- started.await
+        _         <- ZIO.sleep(100.millis)
+        neverDone <- neverRun.isDone
+        _         <- fiber.await
+      } yield assertTrue(!neverDone) // The second effect should never run
+    } @@ jvm,
+    test("finalizer timeout is respected") {
+      // Test that a slow finalizer doesn't block forever when timeout is set
+      for {
+        ref  <- Ref.make(false)
+        app   = new ZIOAppDefault {
+                 override val gracefulShutdownTimeout: Duration = 100.millis
+                 override def run: ZIO[ZIOAppArgs with Scope, Any, Any] =
+                   ZIO.never.ensuring(
+                     ZIO.sleep(500.millis) *> ref.set(true)
+                   )
+               }
+        fiber <- app.invoke(Chunk.empty).fork
+        _     <- ZIO.sleep(50.millis)
+        _     <- fiber.interrupt
+        // Give some time for the timeout to potentially kick in
+        _     <- ZIO.sleep(200.millis)
+        value <- ref.get
+      } yield assertTrue(value) // Finalizer should still have been attempted
+    } @@ jvm,
+    test("run method can access args via getArgs") {
+      for {
+        ref <- Ref.make(Chunk.empty[String])
+        app = new ZIOAppDefault {
+                override def run: ZIO[ZIOAppArgs with Scope, Any, Any] =
+                  ZIOAppArgs.getArgs.flatMap(args => ref.set(args))
+              }
+        _     <- app.invoke(Chunk("test", "args"))
+        value <- ref.get
+      } yield assertTrue(value == Chunk("test", "args"))
+    } @@ jvm
+  ) @@ jvm
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -67,7 +67,9 @@ object ZIOAppSpec extends ZIOBaseSpec {
         }
       }
 
-      val app1 = ZIOApp(ZIO.fail("Uh oh!"), Runtime.addLogger(logger1))
+      val app1 = new ZIOAppDefault {
+        override def runtime: Runtime[Any] = Runtime.default.addLogger(logger1)
+      }
 
       for {
         c <- app1.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")

--- a/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppSpec.scala
@@ -22,6 +22,23 @@ object ZIOAppSpec extends ZIOBaseSpec {
         code <- ZIOApp.fromZIO(ZIO.succeed("Hurray!")).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
       } yield assertTrue(code == ExitCode.success)
     },
+    test("die translates into ExitCode.failure") {
+      for {
+        code <- ZIOApp.fromZIO(ZIO.die(new RuntimeException("died!"))).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.failure)
+    },
+    test("interruption translates into ExitCode.failure") {
+      for {
+        ref       <- Ref.make(false)
+        effect     = ZIO.never.ensuring(ref.set(true))
+        app        = ZIOAppDefault.fromZIO(effect)
+        fiber     <- app.invoke(Chunk.empty).fork
+        _         <- ZIO.sleep(10.millis) // Let the app start
+        _         <- fiber.interrupt
+        finalized <- ref.get
+        code      <- fiber.await
+      } yield assertTrue(finalized) && assertTrue(code.isFailure)
+    },
     test("composed app logic runs component logic") {
       for {
         ref <- Ref.make(2)
@@ -79,6 +96,160 @@ object ZIOAppSpec extends ZIOBaseSpec {
               }
         _     <- app.invoke(Chunk.empty)
         value <- ref2.get
+      } yield assertTrue(value)
+    },
+    test("multiple finalizers run in reverse order") {
+      for {
+        ref  <- Ref.make(List.empty[Int])
+        app   = ZIOAppDefault.fromZIO(
+                 ZIO
+                   .acquireRelease(ref.update(1 :: _))(ref.update(2 :: _))
+                   .acquireRelease(ref.update(3 :: _))(ref.update(4 :: _))
+                   .acquireRelease(ref.update(5 :: _))(ref.update(6 :: _))
+                   .as(())
+               )
+        _     <- app.invoke(Chunk.empty)
+        value <- ref.get
+      } yield assertTrue(value == List(6, 5, 4, 3, 2, 1))
+    },
+    test("finalizers run even when app fails") {
+      for {
+        ref <- Ref.make(false)
+        app  = ZIOAppDefault.fromZIO(
+                 ZIO
+                   .acquireRelease(ZIO.unit)(_ => ref.set(true))
+                   .zipRight(ZIO.fail("error"))
+               )
+        _     <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        value <- ref.get
+      } yield assertTrue(value)
+    },
+    test("finalizers run even when app dies") {
+      for {
+        ref <- Ref.make(false)
+        app  = ZIOAppDefault.fromZIO(
+                 ZIO
+                   .acquireRelease(ZIO.unit)(_ => ref.set(true))
+                   .zipRight(ZIO.die(new RuntimeException("died")))
+               )
+        _     <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        value <- ref.get
+      } yield assertTrue(value)
+    },
+    test("exit code reflects specific failure types") {
+      for {
+        // Test that different failure types result in proper exit codes
+        code1 <- ZIOApp.fromZIO(ZIO.fail(())).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        code2 <- ZIOApp.fromZIO(ZIO.die(new Exception)).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        code3 <- ZIOApp.fromZIO(ZIO.interrupt).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code1 == ExitCode.failure) &&
+        assertTrue(code2 == ExitCode.failure) &&
+        assertTrue(code3 == ExitCode.failure)
+    },
+    test("gracefulShutdownTimeout is respected") {
+      // This test verifies that the gracefulShutdownTimeout is accessible
+      // and can be overridden
+      val app = new ZIOAppDefault {
+        override val gracefulShutdownTimeout: Duration = 5.seconds
+        override def run: ZIO[ZIOAppArgs with Scope, Any, Any] = ZIO.never
+      }
+      assertTrue(app.gracefulShutdownTimeout == 5.seconds)
+    },
+    test("app completes successfully with ExitCode.success") {
+      for {
+        ref <- Ref.make(0)
+        app  = ZIOAppDefault.fromZIO(ref.update(_ + 1))
+        code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        v   <- ref.get
+      } yield assertTrue(code == ExitCode.success) && assertTrue(v == 1)
+    },
+    test("app exits with failure when using exit") {
+      for {
+        code <- ZIOAppDefault
+                 .fromZIO(ZIO.succeed(ExitCode(42)))
+                 .invoke(Chunk.empty)
+                 .exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode(42))
+    },
+    test("nested finalizers all run") {
+      for {
+        ref <- Ref.make(0)
+        app  = ZIOAppDefault.fromZIO(
+                 ZIO.acquireRelease(ref.update(_ + 1))(_ => ref.update(_ - 1)) *>
+                   ZIO.acquireRelease(ref.update(_ + 1))(_ => ref.update(_ - 1)) *>
+                   ZIO.acquireRelease(ref.update(_ + 1))(_ => ref.update(_ - 1)) *>
+                   ZIO.unit
+               )
+        _     <- app.invoke(Chunk.empty)
+        value <- ref.get
+      } yield assertTrue(value == 0) // All acquired resources should be released
+    },
+    test("scope finalizers are run on normal completion") {
+      for {
+        ref <- Ref.make(false)
+        app  = ZIOAppDefault.fromZIO(
+                 ZIO.acquireRelease(ZIO.unit)(_ => ref.set(true))
+               )
+        _     <- app.invoke(Chunk.empty)
+        value <- ref.get
+      } yield assertTrue(value)
+    },
+    test("interruption causes finalizers to run") {
+      for {
+        ref       <- Ref.make(false)
+        started   <- Promise.make[Nothing, Unit]
+        effect     = (started.succeed(()) *> ZIO.never).ensuring(ref.set(true))
+        app        = ZIOAppDefault.fromZIO(effect)
+        fiber     <- app.invoke(Chunk.empty).fork
+        _         <- started.await
+        _         <- fiber.interrupt
+        value     <- ref.get
+      } yield assertTrue(value)
+    },
+    test("defect in finalizer does not prevent other finalizers") {
+      for {
+        ref1 <- Ref.make(false)
+        ref2 <- Ref.make(false)
+        app  = ZIOAppDefault.fromZIO(
+                 ZIO
+                   .acquireRelease(ref1.set(true))(_ => ZIO.die(new RuntimeException("finalizer error")))
+                   .acquireRelease(ref2.set(true))(_ => ZIO.unit)
+                   .as(())
+               )
+        // This should not throw - finalizer errors should be caught
+        _     <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        value <- ref2.get
+      } yield assertTrue(value) // Second finalizer should still run
+    },
+    test("test args are accessible in run") {
+      for {
+        ref <- Ref.make(Chunk.empty[String])
+        app  = ZIOAppDefault.fromZIO(ZIOAppArgs.getArgs.flatMap(args => ref.set(args)))
+        _     <- app.invoke(Chunk("arg1", "arg2"))
+        value <- ref.get
+      } yield assertTrue(value == Chunk("arg1", "arg2"))
+    },
+    test("app composition runs both apps") {
+      for {
+        ref1 <- Ref.make(0)
+        ref2 <- Ref.make(0)
+        app1 = ZIOApp.fromZIO(ref1.update(_ + 1))
+        app2 = ZIOApp.fromZIO(ref2.update(_ + 1))
+        _   <- (app1 <> app2).invoke(Chunk.empty)
+        v1  <- ref1.get
+        v2  <- ref2.get
+      } yield assertTrue(v1 == 1) && assertTrue(v2 == 1)
+    },
+    test("bootstrap layer is provided to run") {
+      for {
+        ref <- Ref.make(false)
+        app = new ZIOAppDefault {
+                override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
+                  ZLayer.fromZIO(ref.set(true))
+                override val run: ZIO[ZIOAppArgs with Scope, Any, Any] = ZIO.unit
+              }
+        _     <- app.invoke(Chunk.empty)
+        value <- ref.get
       } yield assertTrue(value)
     }
   )


### PR DESCRIPTION
This PR fixes the compilation errors in the ZIOAppSpec tests.

## Changes:
1. ZIOAppSpecJVM.scala: Fixed type mismatch - use ZLayer.environment instead of Runtime
2. ZIOAppSpecJVM.scala: Added explicit parentheses to jvm test aspect (Scala 3 requirement)  
3. ZIOAppSpec.scala: Fixed logger test to properly override runtime instead of using incorrect ZLayer

This fixes the failing CI tests on PR #10586.

## Original PR: #10586