### PR TITLE
fix: classic assertion equalTo now uses Diff rendering when a Diff instance is available

### DIFF
--- a/core-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -1,0 +1,43 @@
+package zio.test
+
+object AssertionSpec extends ZIOSpecDefault {
+
+  private def renderFailure(result: TestResult): String = {
+    def renderMessage(message: ErrorMessage): String =
+      message.render(isSuccess = false).lines.map(_.fragments.map(_.text).mkString).mkString("\n")
+
+    def loop(trace: TestTrace[Boolean]): String =
+      trace match {
+        case node: TestTrace.Node[Boolean] => renderMessage(node.message)
+        case TestTrace.AndThen(_, right)   => loop(right)
+        case TestTrace.And(left, right)    => s"${loop(left)}\n${loop(right)}"
+        case TestTrace.Or(left, right)     => s"${loop(left)}\n${loop(right)}"
+        case TestTrace.Not(inner)          => loop(inner)
+      }
+
+    loop(result.failures.get)
+  }
+
+  def spec = suite("AssertionSpec")(
+    test("classic equalTo uses Diff rendering for strings") {
+      val expected = "hello brave new world from the zio assertion diff renderer"
+      val actual   = "hello bold new world from the zio assertion diff renderer"
+      val failure  = renderFailure(Assertion.equalTo(expected).run(actual))
+
+      assertTrue(
+        failure.contains("There was a difference"),
+        failure.contains("Expected"),
+        failure.contains("Diff"),
+        failure.contains("-expected"),
+        failure.contains("+obtained")
+      )
+    },
+    test("classic equalTo falls back to product diff when no Diff instance resolves") {
+      final case class Example(left: Int, right: Int)
+
+      val failure = renderFailure(Assertion.equalTo(Example(1, 2)).run(Example(1, 3)))
+
+      assertTrue(failure.contains(".right : expected '2' got '3'"))
+    }
+  )
+}

--- a/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
@@ -17,7 +17,10 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.internal.ansi.AnsiStringOps
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.diff.{Diff, DiffResult}
+import zio.test.internal.OptionalImplicit
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants extends FieldExtractorPlatformSpecific {
@@ -66,7 +69,7 @@ trait AssertionVariants extends FieldExtractorPlatformSpecific {
     }
   }
 
-  def equalTo[A, B](expected: A)(implicit eql: Eql[A, B]): Assertion[B] =
+  def equalTo[A, B](expected: A)(implicit eql: Eql[A, B], diff: OptionalImplicit[Diff[A]]): Assertion[B] =
     Assertion[B](
       TestArrow
         .make[B, Boolean] { actual =>
@@ -76,10 +79,27 @@ trait AssertionVariants extends FieldExtractorPlatformSpecific {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            diff.value match {
+              case Some(d) if !d.isLowPriority && !result && expected != null && actual != null && expected.getClass
+                    .isInstance(actual) =>
+                val diffResult = d.diff(expected, actual.asInstanceOf[A])
+                diffResult match {
+                  case DiffResult.Different(_, _, None) =>
+                    M.pretty(actual) + M.equals + M.pretty(expected)
+                  case diffResult =>
+                    M.choice("There was no difference", "There was a difference") ++
+                      M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(expected)) ++
+                      M.custom(
+                        ConsoleUtils.underlined(
+                          "Diff"
+                        ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
+                      ) ++
+                      M.custom(scala.Console.RESET + diffResult.render)
+                }
+              case _ if expected.isInstanceOf[Product] =>
+                M.text(diffProduct(actual, expected))
+              case _ =>
+                M.pretty(actual) + M.equals + M.pretty(expected)
             }
           }
         }

--- a/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
@@ -17,7 +17,10 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.internal.ansi.AnsiStringOps
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.diff.{Diff, DiffResult}
+import zio.test.internal.OptionalImplicit
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
@@ -65,7 +68,7 @@ trait AssertionVariants {
     }
   }
 
-  def equalTo[A, B](expected: A)(implicit eql: Eql[A, B]): Assertion[B] =
+  def equalTo[A, B](expected: A)(implicit eql: Eql[A, B], diff: OptionalImplicit[Diff[A]]): Assertion[B] =
     Assertion[B](
       TestArrow
         .make[B, Boolean] { actual =>
@@ -75,10 +78,27 @@ trait AssertionVariants {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            diff.value match {
+              case Some(d) if !d.isLowPriority && !result && expected != null && actual != null && expected.getClass
+                    .isInstance(actual) =>
+                val diffResult = d.diff(expected, actual.asInstanceOf[A])
+                diffResult match {
+                  case DiffResult.Different(_, _, None) =>
+                    M.pretty(actual) + M.equals + M.pretty(expected)
+                  case diffResult =>
+                    M.choice("There was no difference", "There was a difference") ++
+                      M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(expected)) ++
+                      M.custom(
+                        ConsoleUtils.underlined(
+                          "Diff"
+                        ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
+                      ) ++
+                      M.custom(scala.Console.RESET + diffResult.render)
+                }
+              case _ if expected.isInstanceOf[Product] =>
+                M.text(diffProduct(actual, expected))
+              case _ =>
+                M.pretty(actual) + M.equals + M.pretty(expected)
             }
           }
         }

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -17,8 +17,11 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.test.{ErrorMessage => M}
+import zio.internal.ansi.AnsiStringOps
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.diff.{Diff, DiffResult}
+import zio.test.internal.OptionalImplicit
+import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
   private def diffProduct[T](
@@ -68,7 +71,7 @@ trait AssertionVariants {
   /**
    * Makes a new assertion that requires a value equal the specified value.
    */
-  final def equalTo[A](expected: A): Assertion[A] =
+  final def equalTo[A](expected: A)(implicit diff: OptionalImplicit[Diff[A]]): Assertion[A] =
     Assertion[A](
       TestArrow
         .make[A, Boolean] { actual =>
@@ -78,10 +81,26 @@ trait AssertionVariants {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            diff.value match {
+              case Some(d) if !d.isLowPriority && !result =>
+                val diffResult = d.diff(expected, actual)
+                diffResult match {
+                  case DiffResult.Different(_, _, None) =>
+                    M.pretty(actual) + M.equals + M.pretty(expected)
+                  case diffResult =>
+                    M.choice("There was no difference", "There was a difference") ++
+                      M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(expected)) ++
+                      M.custom(
+                        ConsoleUtils.underlined(
+                          "Diff"
+                        ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
+                      ) ++
+                      M.custom(scala.Console.RESET + diffResult.render)
+                }
+              case _ if expected.isInstanceOf[Product] =>
+                M.text(diffProduct(actual, expected))
+              case _ =>
+                M.pretty(actual) + M.equals + M.pretty(expected)
             }
           }
         }


### PR DESCRIPTION
Fixes #8664

/claim #8664

## Problem

The classic `Assertion.equalTo` did not use the `Diff` mechanism for error rendering, unlike `SmartAssertions.equalTo`. When an assertion like `assert(actual)(equalTo(expected))` failed, users only saw a basic `actual was equal to expected` message without the rich diff output.

## Solution

Added `OptionalImplicit[Diff[A]]` to the implicit parameter list of the public `equalTo` method in `AssertionVariants` for all Scala versions (2.12, 2.13, and 3). When a `Diff[A]` instance is available in scope (which it is for `String`, `List`, `Map`, `Option`, etc.), the failure message now shows the same rich diff output as smart assertions.

This is a minimal, additive change:
- The `OptionalImplicit` mechanism means the implicit resolves to `None` if no `Diff[A]` is available — no source breakage
- For types without a `Diff` instance (e.g. custom case classes without derivation), falls back to the existing `diffProduct` product rendering
- No new methods added to `Diff` — the rendering logic mirrors what `SmartAssertions.equalTo` already does

## Before

```
✗ equalTo was "hello bold new world..."
  expected: "hello brave new world..."
```

## After

```
✗ There was a difference
  Expected: "hello brave new world from the zio assertion diff renderer"
  Diff -expected +obtained
  hello [brave|bold] new world from the zio assertion diff renderer
```

## Testing

Added `AssertionSpec` with tests covering:
1. Classic `equalTo` uses Diff rendering for `String` comparisons
2. Falls back to product diff when no `Diff` instance resolves (custom case classes)