### PR TITLE
fix: Config withDefault should not swallow list element errors (#10442)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -791,6 +791,18 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           exit <- configProvider.load(config).exit
         } yield assert(exit)(failsWithA[Config.Error])
       } +
+      test("withDefault should not swallow list element errors (#10442)") {
+        final case class Person(name: String, age: Int)
+        val configProvider = ConfigProvider.fromMap(
+          Map("values[0].name" -> "John", "values[0].agr" -> "9")
+        )
+        val person = (Config.string("name") ++ Config.int("age")).map(Person.tupled)
+        val people = Config.listOf("values", person).withDefault(Nil)
+
+        for {
+          exit <- configProvider.load(people).exit
+        } yield assert(exit)(failsWithA[Config.Error])
+      } +
       test("indexed sequence of multiple products with optional fields") {
         val configProvider =
           ConfigProvider.fromMap(Map("employees[0].age" -> "1", "employees[0].id" -> "2", "employees[1].id" -> "4"))

--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -796,7 +796,7 @@ object ConfigProviderSpec extends ZIOBaseSpec {
         val configProvider = ConfigProvider.fromMap(
           Map("values[0].name" -> "John", "values[0].agr" -> "9")
         )
-        val person = (Config.string("name") ++ Config.int("age")).map(Person.tupled)
+        val person = (Config.string("name") ++ Config.int("age")).map { case (a, b) => Person(a, b) }
         val people = Config.listOf("values", person).withDefault(Nil)
 
         for {

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -135,7 +135,7 @@ sealed trait Config[+A] { self =>
    * the specified default value in case the information cannot be found.
    */
   def withDefault[A1 >: A](default: => A1): Config[A1] =
-    self.orElseIf(_.isMissingDataOnly)(Config.succeed(default))
+    self.orElseIf(e => e.isMissingDataOnly && !e.hasBracketedIndexSegment)(Config.succeed(default))
 
   /**
    * A named version of `++`.
@@ -426,6 +426,9 @@ object Config {
     final def isMissingDataOnly: Boolean =
       foldContext(())(Folder.IsMissingDataOnly)
 
+    final def hasBracketedIndexSegment: Boolean =
+      foldContext(())(Folder.HasBracketedIndexSegment)
+
     def prefixed(prefix: Chunk[String]): Error
 
     override def getMessage(): String = toString()
@@ -487,6 +490,25 @@ object Config {
           cause: Cause[Throwable]
         ): Boolean = false
         def unsupportedCase(context: Any, path: Chunk[String], message: String): Boolean = false
+      }
+
+      private val BracketedIndexPattern = """\[\d+\]""".r
+
+      case object HasBracketedIndexSegment extends Folder[Any, Boolean] {
+        private def hasIndex(path: Chunk[String]): Boolean =
+          path.exists(segment => BracketedIndexPattern.findFirstIn(segment).isDefined)
+
+        def andCase(context: Any, left: Boolean, right: Boolean): Boolean                = left || right
+        def invalidDataCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
+        def missingDataCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
+        def orCase(context: Any, left: Boolean, right: Boolean): Boolean                 = left || right
+        def sourceUnavailableCase(
+          context: Any,
+          path: Chunk[String],
+          message: String,
+          cause: Cause[Throwable]
+        ): Boolean = hasIndex(path)
+        def unsupportedCase(context: Any, path: Chunk[String], message: String): Boolean = hasIndex(path)
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #10442.

`Config.listOf("values", person).withDefault(Nil)` incorrectly returns `Nil` when a list element has a missing or mistyped field (e.g., `agr` instead of `age`). The default should only apply when the list key itself is entirely absent, not when list elements exist but have errors.

## Changes

- Added `hasBracketedIndexSegment` method to `Config.Error` that detects path segments matching `\[\d+\]` (bracketed index like `[0]`, `[1]`, etc.), following the existing `IsMissingDataOnly` Folder pattern
- Updated `withDefault` predicate from `_.isMissingDataOnly` to `e => e.isMissingDataOnly && !e.hasBracketedIndexSegment` — this distinguishes "list key absent" from "list element has missing field"
- Added regression test reproducing the exact scenario from the issue

## Notes

- `optional` behavior is **not affected** — it uses a separate code path (`Config.Optional`) with its own condition
- Non-list `withDefault` usage is unaffected (no bracketed indices in paths)
- The fix adds a strictly more conservative condition (default is used less often)