### PR TITLE
fix: fromInputStream should not produce defects for non-IOException (#10380)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5747,7 +5747,18 @@ object ZStreamSpec extends ZIOBaseSpec {
               val is = new ByteArrayInputStream(bytes.toArray)
               ZStream.fromInputStream(is, chunkSize).runCollect.map(assert(_)(equalTo(bytes)))
             }
-          }
+          },
+          test("toInputStream + fromInputStream should not produce defects (#10380)") {
+            ZIO
+              .scoped(
+                ZStream
+                  .fail(new RuntimeException("Boom"))
+                  .toInputStream
+                  .flatMap(is => ZStream.fromInputStream(is).runCollect)
+              )
+              .exit
+              .map(exit => assert(exit)(fails(isSubtype[IOException](hasMessage(containsString("Boom"))))))
+          } @@ TestAspect.jvmOnly
         ),
         test("fromIterable")(check(Gen.small(Gen.chunkOfN(_)(Gen.int))) { l =>
           def lazyL = l

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4393,8 +4393,14 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
     ZStream.succeed((is, chunkSize)).flatMap { case (is, chunkSize) =>
       ZStream.repeatZIOChunkOption {
         for {
-          bufArray  <- ZIO.succeed(Array.ofDim[Byte](chunkSize))
-          bytesRead <- ZIO.attemptBlockingIO(is.read(bufArray)).asSomeError
+          bufArray <- ZIO.succeed(Array.ofDim[Byte](chunkSize))
+          bytesRead <- ZIO
+                         .attemptBlocking(is.read(bufArray))
+                         .refineOrDie {
+                           case e: IOException => e
+                           case e: Throwable   => new IOException(e)
+                         }
+                         .asSomeError
           bytes <- if (bytesRead < 0)
                      Exit.failNone
                    else if (bytesRead == 0)


### PR DESCRIPTION
## Summary

Fixes #10380.

`ZStream.fail(RuntimeException("Boom")).toInputStream.flatMap(ZStream.fromInputStream(_).runCollect)` produces `Cause.Die` instead of recoverable `Cause.Fail`. This happens because `fromInputStream` uses `ZIO.attemptBlockingIO` which calls `refineToOrDie[IOException]` — non-`IOException` throwables become defects.

## Changes

- In `ZStream.fromInputStream`, replaced `ZIO.attemptBlockingIO(is.read(bufArray))` with `ZIO.attemptBlocking(is.read(bufArray)).refineOrDie { case e: IOException => e; case e: Throwable => new IOException(e) }`
- Non-`IOException` errors are now wrapped into `IOException` (preserving the original as the cause) instead of becoming defects
- Added regression test verifying the `toInputStream` + `fromInputStream` round-trip produces a `Fail[IOException]`, not a `Die`

## Notes

- Fatal exceptions (`OutOfMemoryError`, etc.) are still properly handled — `ZIO.attemptBlocking` never catches fatal errors
- `IOException` subtypes are passed through unchanged (matched by the first case)
- The method signature (`ZStream[Any, IOException, Byte]`) and binary compatibility are preserved
- `toInputStream` implementation is not modified