### PR TITLE
fix: mapZIOPar(1) should not prefetch upstream elements (#9999)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2889,6 +2889,23 @@ object ZStreamSpec extends ZIOBaseSpec {
               result <- queue.takeAll
             } yield assert(result)(equalTo(result.sorted))
           },
+          test("mapZIOPar(1) should not prefetch upstream elements (#9999)") {
+            for {
+              ref     <- Ref.make(0)
+              started <- Promise.make[Nothing, Unit]
+              blocked <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .repeatZIO(ref.updateAndGet(_ + 1))
+                         .mapZIOPar(1)(i => ZIO.when(i == 1)(started.succeed(()) *> blocked.await).as(i))
+                         .take(2)
+                         .runDrain
+                         .fork
+              _     <- started.await
+              count <- ref.get
+              _     <- blocked.succeed(())
+              _     <- fiber.join
+            } yield assertTrue(count == 1)
+          },
           test("interruption propagation") {
             for {
               interrupted <- Ref.make(false)

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -1996,14 +1996,18 @@ object ZPipeline extends ZPipelinePlatformSpecificConstructors {
    */
   def mapZIOPar[Env, Err, In, Out](n: => Int, bufferSize: => Int = 16)(f: In => ZIO[Env, Err, Out])(implicit
     trace: Trace
-  ): ZPipeline[Env, Err, In, Out] =
-    new ZPipeline(
-      ZChannel
-        .identity[Nothing, Chunk[In], Any]
-        .concatMap(ZChannel.writeChunk(_))
-        .mapOutZIOPar(n, bufferSize)(f)
-        .mapOut(Chunk.single)
-    )
+  ): ZPipeline[Env, Err, In, Out] = {
+    val n0 = n
+    if (n0 <= 1) mapZIO(f)
+    else
+      new ZPipeline(
+        ZChannel
+          .identity[Nothing, Chunk[In], Any]
+          .concatMap(ZChannel.writeChunk(_))
+          .mapOutZIOPar(n0, bufferSize)(f)
+          .mapOut(Chunk.single)
+      )
+  }
 
   /**
    * Maps over elements of the stream with the specified effectful function,


### PR DESCRIPTION
## Summary

Fixes #9999.

`mapZIOPar(1)` prefetches extra elements from upstream compared to `mapZIO`, which processes strictly one-at-a-time. The parallel machinery (`mapOutZIOPar`) pulls from upstream before acquiring a permit, causing an extra element to be pulled even with parallelism of 1.

## Changes

- In `ZPipeline.mapZIOPar`, eagerly evaluate the lazy `n` parameter and delegate to sequential `mapZIO(f)` when `n <= 1`
- `ZStream.mapZIOPar` already delegates to `ZPipeline.mapZIOPar`, so it gets the fix transitively
- Added regression test using `Ref` + `Promise` synchronization to verify only 1 upstream element is pulled while the first element is being processed

## Notes

- No change to `mapOutZIOPar` behavior for `n > 1`
- The lazy `n` parameter is evaluated exactly once before the check
- `mapZIOParUnordered` is not addressed here (separate concern)