### PR TITLE
fix: preserve defects in foldZIO/foldTraceZIO for composite Cause (#9874)

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -342,6 +342,16 @@ object ZIOSpec extends ZIOBaseSpec {
             .foldTraceZIO(_ => ZIO.unit, (_: Nothing) => ZIO.unit)
 
         assertZIO(effect.exit)(dies(equalTo(defect)))
+      },
+      test("defects survive even when failure handler fails") {
+        val defect = new RuntimeException("boom-handler-fail")
+        val effect = ZIO.failCause(Cause.Both(Cause.fail("error"), Cause.die(defect)))
+        val handled = effect.catchAll(_ => ZIO.fail("handler-error"))
+
+        assertZIO(handled.exit.map {
+          case Exit.Failure(cause) => cause.defects.contains(defect)
+          case _                   => false
+        })(isTrue)
       }
     ) @@ zioTag(errors),
     suite("catchSomeCause")(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -344,8 +344,8 @@ object ZIOSpec extends ZIOBaseSpec {
         assertZIO(effect.exit)(dies(equalTo(defect)))
       },
       test("defects survive even when failure handler fails") {
-        val defect = new RuntimeException("boom-handler-fail")
-        val effect = ZIO.failCause(Cause.Both(Cause.fail("error"), Cause.die(defect)))
+        val defect  = new RuntimeException("boom-handler-fail")
+        val effect  = ZIO.failCause(Cause.Both(Cause.fail("error"), Cause.die(defect)))
         val handled = effect.catchAll(_ => ZIO.fail("handler-error"))
 
         assertZIO(handled.exit.map {

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -305,6 +305,45 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(result)((equalTo(t)))
       }
     ) @@ zioTag(errors),
+    suite("catchAll")(
+      test("does not swallow defects in Cause.Both(Fail, Die)") {
+        val defect = new RuntimeException("boom-both")
+        val effect = ZIO.failCause(Cause.Both(Cause.fail("error"), Cause.die(defect)))
+
+        assertZIO(effect.catchAll(_ => ZIO.succeed("handled")).exit)(dies(equalTo(defect)))
+      },
+      test("does not swallow defects in Cause.Then(Fail, Die)") {
+        val defect = new RuntimeException("boom-then")
+        val effect = ZIO.failCause(Cause.Then(Cause.fail("error"), Cause.die(defect)))
+
+        assertZIO(effect.catchAll(_ => ZIO.succeed("handled")).exit)(dies(equalTo(defect)))
+      },
+      test("does not swallow defects in nested composite causes") {
+        val defect = new RuntimeException("boom-nested")
+        val effect = ZIO.failCause(
+          Cause.Both(
+            Cause.Then(Cause.fail("error-1"), Cause.die(defect)),
+            Cause.fail("error-2")
+          )
+        )
+
+        assertZIO(effect.catchAll(_ => ZIO.succeed("handled")).exit)(dies(equalTo(defect)))
+      },
+      test("keeps behavior unchanged when no defects are present") {
+        val effect = ZIO.failCause(Cause.Both(Cause.fail("error-1"), Cause.fail("error-2")))
+
+        assertZIO(effect.catchAll(error => ZIO.succeed(error)))(equalTo("error-1"))
+      },
+      test("foldTraceZIO does not swallow residual defects") {
+        val defect = new RuntimeException("boom-trace")
+        val effect =
+          ZIO
+            .failCause(Cause.Then(Cause.fail("error"), Cause.die(defect)))
+            .foldTraceZIO(_ => ZIO.unit, (_: Nothing) => ZIO.unit)
+
+        assertZIO(effect.exit)(dies(equalTo(defect)))
+      }
+    ) @@ zioTag(errors),
     suite("catchSomeCause")(
       test("catches matching cause") {
         ZIO.interrupt.catchSomeCause {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -722,7 +722,22 @@ sealed trait ZIO[-R, +E, +A]
     ev: CanFail[E],
     trace: Trace
   ): ZIO[R1, E2, B] =
-    foldCauseZIO(c => c.failureTraceOrCause.fold(failure, Exit.failCause), success)
+    foldCauseZIO(
+      c =>
+        c.failureTraceOrCause.fold(
+          errorAndTrace =>
+            c.keepDefects match {
+              case Some(defects) =>
+                failure(errorAndTrace).foldCauseZIO(
+                  handlerCause => Exit.failCause(Cause.Then(handlerCause, defects)),
+                  _ => Exit.failCause(defects)
+                )
+              case None => failure(errorAndTrace)
+            },
+          Exit.failCause
+        ),
+      success
+    )
 
   /**
    * Recovers from errors by accepting one effect to execute for the case of an
@@ -739,7 +754,22 @@ sealed trait ZIO[-R, +E, +A]
     ev: CanFail[E],
     trace: Trace
   ): ZIO[R1, E2, B] =
-    foldCauseZIO(c => c.failureOrCause.fold(failure, Exit.failCause), success)
+    foldCauseZIO(
+      c =>
+        c.failureOrCause.fold(
+          error =>
+            c.keepDefects match {
+              case Some(defects) =>
+                failure(error).foldCauseZIO(
+                  handlerCause => Exit.failCause(Cause.Then(handlerCause, defects)),
+                  _ => Exit.failCause(defects)
+                )
+              case None => failure(error)
+            },
+          Exit.failCause
+        ),
+      success
+    )
 
   /**
    * Returns a new effect that will pass the success value of this effect to the


### PR DESCRIPTION
## Problem

When a `Cause` is composite (`Both`/`Then`) with both `Fail` and `Die`, `catchAll` via `foldZIO` routes through `failureOrCause` which returns `Left(error)` and silently discards co-occurring defects.

```scala
val effect = ZIO.failCause(Cause.Both(Cause.fail("error"), Cause.die(new RuntimeException("boom"))))
effect.catchAll(_ => ZIO.succeed("handled")) // Die silently swallowed!
```

## Root Cause

`failureOrCause` (Cause.scala L132) returns `Left(error)` when `failureOption` finds a `Fail`, but the residual `Cause` containing `Die` is discarded. `foldZIO` passes only the error to the failure handler, losing all defects.

## Fix

Uses existing `keepDefects` method to detect residual `Die` causes after extracting the failure:

- **No defects** (`keepDefects = None`): behavior identical to before (backward compatible)
- **Defects present** (`keepDefects = Some(defects)`): runs the failure handler, then:
  - Handler **succeeds**: re-fails with original defects via `Exit.failCause(defects)`
  - Handler **fails**: combines handler cause with original defects via `Cause.Then`

This pattern is consistent with `tryOrElse` (ZIO.scala L2689) which already uses `keepDefects` for the same purpose.

## Changes

- **ZIO.scala**: Modified `foldZIO` and `foldTraceZIO` to detect and preserve residual defects
- **ZIOSpec.scala**: 6 regression tests covering `Both`, `Then`, nested composites, no-defects baseline, `foldTraceZIO`, and handler-failure path

## Scope Note

This fix preserves `Die` defects. `Interrupt` handling in composite causes follows the existing `keepDefects` semantics and is unchanged.

Fixes #9874