### PR TITLE
Add tests and logic for error handling and defect recovery

### DIFF
--- a/src/features/error_handling/DefectsTest.scala
+++ b/src/features/error_handling/DefectsTest.scala
@@ -1,0 +1,25 @@
+package features.error_handling
+
+import zio.test._
+import zio.{UIO, ZIO, Task}
+
+object DefectsTest extends ZIOSpecDefault {
+
+  def spec = suite("Defects Handling")(
+    test("catchAll should handle defects properly") {
+      val faultyEffect: ZIO[Any, Nothing, String] = ZIO.fail(new RuntimeException("Test error"))
+
+      val result: ZIO[Any, Nothing, String] = faultyEffect.catchAll(_ => UIO.succeed("Recovered"))
+
+      assertZIO(result)(equalTo("Recovered"))
+    },
+
+    test("fold should handle defects properly") {
+      val faultyEffect: ZIO[Any, Nothing, String] = ZIO.fail(new RuntimeException("Test error"))
+
+      val result: ZIO[Any, Nothing, String] = faultyEffect.fold(_ => "Recovered", identity)
+
+      assert(result)(equalTo("Recovered"))
+    }
+  )
+}

--- a/src/features/error_handling/ErrorHandling.scala
+++ b/src/features/error_handling/ErrorHandling.scala
@@ -1,0 +1,18 @@
+package features.error_handling
+
+import zio.{UIO, ZIO}
+
+object ErrorHandling {
+
+  def handleDefects(): ZIO[Any, Nothing, String] = {
+    val faultyEffect: ZIO[Any, Nothing, String] = ZIO.fail(new RuntimeException("Test error"))
+
+    faultyEffect.catchAll(_ => UIO.succeed("Recovered"))
+  }
+
+  def foldWithDefects(): String = {
+    val faultyEffect: ZIO[Any, Nothing, String] = ZIO.fail(new RuntimeException("Test error"))
+
+    faultyEffect.fold(_ => "Recovered", identity)
+  }
+}


### PR DESCRIPTION
This pull request adds error handling tests and functionality to improve defect recovery. A new test file, `DefectsTest.scala`, has been created in the `src/features/error_handling/` directory. It includes tests for `catchAll` and `fold` to validate that defects are correctly handled during execution.

In addition, the `ErrorHandling.scala` file was introduced to demonstrate how defect recovery works using the `catchAll` and `fold` methods. This file showcases how defects can be caught and processed, ensuring that the system remains stable even when errors occur.

These changes help make sure that the application can recover gracefully from defects and that our error handling code is thoroughly tested. The goal is to improve the reliability of the system and prevent it from failing unexpectedly.

Closes #9874