### PR TITLE
test: add ZIOAppLifecycleSpec for ZIOApp shutdown/lifecycle behavior

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/ZIOAppLifecycleSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppLifecycleSpec.scala
@@ -11,18 +11,18 @@ object ZIOAppLifecycleSpec extends ZIOSpecDefault {
     timeoutMs: Long = 15000L,
     sendSigIntAfterMs: Option[Long] = None
   ): Task[(Int, String, String)] = ZIO.attemptBlocking {
-    val javaHome  = java.lang.System.getProperty("java.home")
-    val javaBin   = javaHome + File.separator + "bin" + File.separator + "java"
-    val classpath = java.lang.System.getProperty("java.class.path")
+    val javaHome                    = java.lang.System.getProperty("java.home")
+    val javaBin                     = javaHome + File.separator + "bin" + File.separator + "java"
+    val classpath                   = java.lang.System.getProperty("java.class.path")
     val cmd: java.util.List[String] = java.util.Arrays.asList(javaBin, "-cp", classpath, className)
-    val pb  = new ProcessBuilder(cmd)
+    val pb                          = new ProcessBuilder(cmd)
     pb.redirectErrorStream(false)
     val process = pb.start()
     sendSigIntAfterMs.foreach { delay =>
       val t = new Thread(new Runnable {
         def run(): Unit = {
           Thread.sleep(delay)
-          val pid = process.pid()
+          val pid       = process.pid()
           val isWindows = java.lang.System.getProperty("os.name").toLowerCase.contains("win")
           if (isWindows) {
             java.lang.Runtime.getRuntime.exec(Array("taskkill", "/PID", pid.toString)).waitFor(); ()
@@ -44,20 +44,20 @@ object ZIOAppLifecycleSpec extends ZIOSpecDefault {
 
   def spec = suite("ZIOAppLifecycleSpec")(
     test("app that succeeds exits with code 0") {
-      for { result <- runApp("zio.AppSucceeds") }
-      yield assertTrue(result._1 == 0, result._2.contains("finalizer ran"))
+      for { result <- runApp("zio.AppSucceeds") } yield assertTrue(result._1 == 0, result._2.contains("finalizer ran"))
     },
     test("app that fails exits with non-zero code") {
-      for { result <- runApp("zio.AppFails") }
-      yield assertTrue(result._1 != 0, result._2.contains("finalizer ran"))
+      for { result <- runApp("zio.AppFails") } yield assertTrue(result._1 != 0, result._2.contains("finalizer ran"))
     },
     test("finalizers run on shutdown signal - regression #9901") {
-      for { result <- runApp("zio.AppNeverWithFinalizer", sendSigIntAfterMs = Some(1000L)) }
-      yield assertTrue(result._2.contains("finalizer ran"))
+      for { result <- runApp("zio.AppNeverWithFinalizer", sendSigIntAfterMs = Some(1000L)) } yield assertTrue(
+        result._2.contains("finalizer ran")
+      )
     } @@ TestAspect.unix,
     test("gracefulShutdownTimeout is respected") {
-      for { result <- runApp("zio.AppSlowFinalizer", sendSigIntAfterMs = Some(500L)) }
-      yield assertTrue(!result._2.contains("slow finalizer done"))
+      for { result <- runApp("zio.AppSlowFinalizer", sendSigIntAfterMs = Some(500L)) } yield assertTrue(
+        !result._2.contains("slow finalizer done")
+      )
     } @@ TestAspect.unix
   ) @@ TestAspect.sequential @@ TestAspect.timeout(2.minutes)
 }
@@ -76,5 +76,7 @@ object AppNeverWithFinalizer extends ZIOAppDefault {
 
 object AppSlowFinalizer extends ZIOAppDefault {
   override val gracefulShutdownTimeout: Duration = 1.second
-  def run = ZIO.acquireRelease(ZIO.unit)(_ => ZIO.sleep(30.seconds) *> Console.printLine("slow finalizer done").orDie).flatMap(_ => ZIO.never)
+  def run = ZIO
+    .acquireRelease(ZIO.unit)(_ => ZIO.sleep(30.seconds) *> Console.printLine("slow finalizer done").orDie)
+    .flatMap(_ => ZIO.never)
 }

--- a/core-tests/jvm/src/test/scala/zio/ZIOAppLifecycleSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/ZIOAppLifecycleSpec.scala
@@ -1,0 +1,80 @@
+package zio
+
+import _root_.zio.test._
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+object ZIOAppLifecycleSpec extends ZIOSpecDefault {
+
+  def runApp(
+    className: String,
+    timeoutMs: Long = 15000L,
+    sendSigIntAfterMs: Option[Long] = None
+  ): Task[(Int, String, String)] = ZIO.attemptBlocking {
+    val javaHome  = java.lang.System.getProperty("java.home")
+    val javaBin   = javaHome + File.separator + "bin" + File.separator + "java"
+    val classpath = java.lang.System.getProperty("java.class.path")
+    val cmd: java.util.List[String] = java.util.Arrays.asList(javaBin, "-cp", classpath, className)
+    val pb  = new ProcessBuilder(cmd)
+    pb.redirectErrorStream(false)
+    val process = pb.start()
+    sendSigIntAfterMs.foreach { delay =>
+      val t = new Thread(new Runnable {
+        def run(): Unit = {
+          Thread.sleep(delay)
+          val pid = process.pid()
+          val isWindows = java.lang.System.getProperty("os.name").toLowerCase.contains("win")
+          if (isWindows) {
+            java.lang.Runtime.getRuntime.exec(Array("taskkill", "/PID", pid.toString)).waitFor(); ()
+          } else {
+            java.lang.Runtime.getRuntime.exec(Array("kill", "-2", pid.toString)).waitFor(); ()
+          }
+        }
+      })
+      t.setDaemon(true)
+      t.start()
+    }
+    val finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!finished) process.destroyForcibly()
+    val stdout = new String(process.getInputStream.readAllBytes())
+    val stderr = new String(process.getErrorStream.readAllBytes())
+    val code   = if (finished) process.exitValue() else -1
+    (code, stdout, stderr)
+  }
+
+  def spec = suite("ZIOAppLifecycleSpec")(
+    test("app that succeeds exits with code 0") {
+      for { result <- runApp("zio.AppSucceeds") }
+      yield assertTrue(result._1 == 0, result._2.contains("finalizer ran"))
+    },
+    test("app that fails exits with non-zero code") {
+      for { result <- runApp("zio.AppFails") }
+      yield assertTrue(result._1 != 0, result._2.contains("finalizer ran"))
+    },
+    test("finalizers run on shutdown signal - regression #9901") {
+      for { result <- runApp("zio.AppNeverWithFinalizer", sendSigIntAfterMs = Some(1000L)) }
+      yield assertTrue(result._2.contains("finalizer ran"))
+    } @@ TestAspect.unix,
+    test("gracefulShutdownTimeout is respected") {
+      for { result <- runApp("zio.AppSlowFinalizer", sendSigIntAfterMs = Some(500L)) }
+      yield assertTrue(!result._2.contains("slow finalizer done"))
+    } @@ TestAspect.unix
+  ) @@ TestAspect.sequential @@ TestAspect.timeout(2.minutes)
+}
+
+object AppSucceeds extends ZIOAppDefault {
+  def run = ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("finalizer ran").orDie).flatMap(_ => ZIO.unit)
+}
+
+object AppFails extends ZIOAppDefault {
+  def run = ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("finalizer ran").orDie).flatMap(_ => ZIO.fail("boom"))
+}
+
+object AppNeverWithFinalizer extends ZIOAppDefault {
+  def run = ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("finalizer ran").orDie).flatMap(_ => ZIO.never)
+}
+
+object AppSlowFinalizer extends ZIOAppDefault {
+  override val gracefulShutdownTimeout: Duration = 1.second
+  def run = ZIO.acquireRelease(ZIO.unit)(_ => ZIO.sleep(30.seconds) *> Console.printLine("slow finalizer done").orDie).flatMap(_ => ZIO.never)
+}


### PR DESCRIPTION
## Summary

Adds a test suite for `ZIOApp` lifecycle and shutdown behavior, as requested in #9909.

## Approach

Tests use a subprocess-based strategy — each test app is launched as a real child JVM process so that signal handling, exit codes, and shutdown hooks are tested end-to-end.

## Test Cases

- **App succeeds**: exits with code 0, finalizers run
- **App fails**: exits with non-zero code, finalizers run  
- **SIGINT shutdown** (Unix only): finalizers run on signal, regression test for #9901
- **gracefulShutdownTimeout** (Unix only): slow finalizer is cut off when timeout exceeded, regression test for #9901

Signal-based tests are gated with `TestAspect.unix` since Windows does not support SIGINT the same way — they will run on Linux CI.

Closes #9909