### PR TITLE
perf: optimize ZIO.timeoutTo by eliminating second fiber

### DIFF
--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5673,8 +5673,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
                         fiber.unsafe.addObserver { exit =>
                           if (won.compareAndSet(false, true)) {
-                            cancelTimeout()
-                            cb(fiber.inheritAll *> exit.mapExit(f))
+                            cb(ZIO.succeed(cancelTimeout()) *> fiber.inheritAll *> exit.mapExit(f))
                           }
                         }(Unsafe.unsafe)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5646,22 +5646,47 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
-            },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+      ZIO.suspendSucceed {
+        val d = duration
+        d match {
+          case Duration.Infinity =>
+            self.map(f)
+          case d if d <= Duration.Zero =>
+            Exit.succeed(b())
+          case d =>
+            ZIO.uninterruptibleMask { restore =>
+              ZIO.fiberIdWith { parentFiberId =>
+                Clock.scheduler.flatMap { scheduler =>
+                  restore(self).fork.flatMap { fiber =>
+                    ZIO.asyncInterrupt[R, E, B1](
+                      { cb =>
+                        val won = new java.util.concurrent.atomic.AtomicBoolean(false)
+
+                        val cancelTimeout = scheduler.schedule(
+                          () => {
+                            if (won.compareAndSet(false, true)) {
+                              cb(fiber.interruptAs(parentFiberId) *> fiber.inheritAll.as(b()))
+                            }
+                          },
+                          d
+                        )(Unsafe.unsafe)
+
+                        fiber.unsafe.addObserver { exit =>
+                          if (won.compareAndSet(false, true)) {
+                            cancelTimeout()
+                            cb(fiber.inheritAll *> exit.mapExit(f))
+                          }
+                        }(Unsafe.unsafe)
+
+                        Left(ZIO.succeed(cancelTimeout()) *> fiber.interruptAs(parentFiberId))
+                      },
+                      fiber.id
+                    )
+                  }
+                }
+              }
+            }
+        }
       }
   }
 


### PR DESCRIPTION
## Summary

Fixes #9211
/claim #9211

The current `timeoutTo` implementation uses `raceFibersWith` to race the effect against `ZIO.sleep(duration)`, which forks **two fibers**. This causes ~187x overhead compared to running the effect without a timeout.

This PR replaces that approach with a single-fiber design:
- Fork only the effect (no second fiber for sleep)
- Use `Clock.scheduler.schedule` directly for the timeout callback
- Coordinate via `AtomicBoolean` (same pattern as `raceFibersWith`)
- Use `fiber.unsafe.addObserver` to detect effect completion
- `uninterruptibleMask` prevents fiber leaks between fork and observer registration

Also short-circuits for `Duration.Infinity` (skip timeout machinery) and `Duration.Zero` (immediate timeout).

### TestClock compatibility
Uses `Clock.scheduler` (not `globalScheduler` directly), so TestClock's scheduler  which internally wraps `sleep()`  continues to work correctly with `TestClock.adjust`.

### Semantics preserved
- `fiber.inheritAll` is called in both success and timeout paths (matching original behavior)
- Interruption cleanup cancels the scheduled timeout and interrupts the child fiber
- Uninterruptibility semantics are maintained via `uninterruptibleMask`/`restore`

## Test plan
- [ ] Existing `ZIOSpec` timeout tests pass (`timeout`, `timeoutFail`, `timeoutFailCause`, `timeoutTo`)
- [ ] `FiberRefSpec` "`locally` restores parent's value after timeout" passes
- [ ] `ZStreamSpec` timeout tests pass
- [ ] CI green on all platforms (JVM, JS, Native)
