### PR TITLE
Add Promise.become to link a Promise to a Fiber

### DIFF
--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -126,6 +126,42 @@ object PromiseSpec extends ZIOBaseSpec {
         d <- p.isDone
       } yield assert(d)(isTrue)
     } @@ zioTag(errors),
+    test("become a fiber that succeeds") {
+      for {
+        fiber   <- ZIO.succeed(42).fork
+        promise <- Promise.make[Nothing, Int]
+        linked  <- promise.become(fiber)
+        value   <- promise.await
+      } yield assert(linked)(isTrue) && assert(value)(equalTo(42))
+    },
+    test("become a fiber that fails") {
+      for {
+        fiber   <- ZIO.fail("error").fork
+        promise <- Promise.make[String, Int]
+        linked  <- promise.become(fiber)
+        result  <- promise.await.exit
+      } yield assert(linked)(isTrue) && assert(result)(fails(equalTo("error")))
+    } @@ zioTag(errors),
+    test("become returns false when promise already completed") {
+      for {
+        fiber   <- ZIO.succeed(42).forkDaemon
+        promise <- Promise.make[Nothing, Int]
+        _       <- promise.succeed(1)
+        linked  <- promise.become(fiber)
+        value   <- promise.await
+      } yield assert(linked)(isFalse) && assert(value)(equalTo(1))
+    },
+    test("become completes all waiting fibers") {
+      for {
+        latch   <- Promise.make[Nothing, Unit]
+        fiber   <- (latch.await *> ZIO.succeed(42)).fork
+        promise <- Promise.make[Nothing, Int]
+        _       <- promise.become(fiber)
+        awaiters <- ZIO.collectAllPar(List.fill(5)(promise.await.fork))
+        _        <- latch.succeed(())
+        results  <- ZIO.foreach(awaiters)(_.join)
+      } yield assert(results)(equalTo(List.fill(5)(42)))
+    },
     test("waiter stack safety") {
       for {
         p      <- Promise.make[Nothing, Unit]

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -86,6 +86,33 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.completeWith(e)(Unsafe))
 
   /**
+   * Links this promise to the specified fiber, so that when the fiber
+   * completes, this promise will be completed with the same result.
+   *
+   * Unlike `completeWith(fiber.join)`, this is more efficient for
+   * [[zio.Fiber.Runtime]] fibers as it directly observes the fiber's
+   * completion via an observer rather than creating a new join each time
+   * the promise is awaited.
+   *
+   * Returns whether the promise was successfully linked (i.e., the promise
+   * was not already completed).
+   */
+  def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
+    fiber match {
+      case rt: Fiber.Runtime[_, _] =>
+        ZIO.succeed {
+          val rtTyped                      = rt.asInstanceOf[Fiber.Runtime[E, A]]
+          var linked                       = false
+          val observer: Exit[E, A] => Unit = exit => linked = unsafe.completeWith(exit)(Unsafe)
+          rtTyped.unsafe.addObserver(observer)(Unsafe)
+          if (linked) true
+          else !unsafe.isDone(Unsafe)
+        }
+      case _ =>
+        completeWith(fiber.join)
+    }
+
+  /**
    * Completes the promise with the result of the specified effect. If the
    * promise has already been completed, the method will produce false.
    *


### PR DESCRIPTION
Adds `Promise.become(fiber)` which links a promise to a fiber, completing the promise with the fiber's result when the fiber finishes. This addresses #9877.

For `Fiber.Runtime`, this registers a direct observer on the fiber via `unsafe.addObserver`, avoiding unnecessary allocations compared to `completeWith(fiber.join)` which would create a new `join` effect each time the promise is awaited. For synthetic fibers, it falls back to `completeWith(fiber.join)`.

Returns `true` if the promise was successfully linked (i.e. the promise was pending), `false` if the promise was already completed.

Includes tests for success, failure, already-completed promise, and concurrent awaiters.