### PR TITLE
Use ConcurrentLinkedDeque on Scala Native

### DIFF
--- a/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
 private[zio] trait QueuePlatformSpecific {
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS or Scala Native, so we use an ArrayDeque instead
+  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS, so we use an ArrayDeque instead
   type ConcurrentDeque[A] = java.util.ArrayDeque[A]
 }

--- a/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,27 +1,5 @@
 package zio
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.mutable
-
 private[zio] trait QueuePlatformSpecific {
-
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in Scala Native, so we need to createa custom `addFirst` method
-  private[zio] final class ConcurrentDeque[A <: AnyRef] extends ConcurrentLinkedQueue[A] {
-
-    def addFirst(a: A): Unit = {
-      var popped = poll()
-      if (popped eq null) {
-        offer(a)
-      } else {
-        val buf = new mutable.ArrayBuffer[A]
-        while (popped ne null) {
-          buf += popped
-          popped = poll()
-        }
-        offer(a)
-        buf.foreach(offer)
-      }
-    }
-
-  }
+  type ConcurrentDeque[A] = java.util.concurrent.ConcurrentLinkedDeque[A]
 }


### PR DESCRIPTION
## Summary

Scala Native 0.5.10 includes `java.util.concurrent.ConcurrentLinkedDeque`, so this removes the native workaround and aligns the native queue alias with the JVM implementation.

It also updates the Scala.js comment so it only mentions the remaining platform that still lacks `ConcurrentLinkedDeque`.

## Testing

- I was not able to rerun local `sbt`/Java checks in this workspace because a JDK and `sbt` are not installed in this environment.
- The same patch previously passed all ZIO CI checks in #10426 except for a flaky `testPlatforms (25, Native1)` timeout, so this fresh PR is intended to rerun the full CI suite on current `series/2.x`.

## Notes

- Demo video required by Algora will be attached in a follow-up comment.

/claim #9189