### PR TITLE
fix(stream): buffer(n) buffers exactly n elements instead of n+1

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,74 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffer(1) does not prefetch a third element") {
+            for {
+              started2 <- Promise.make[Nothing, Unit]
+              gate2    <- Promise.make[Nothing, Unit]
+              started3 <- Promise.make[Nothing, Unit]
+              gate3    <- Promise.make[Nothing, Unit]
+              result <- ZIO.scoped {
+                          for {
+                            pull <- ZStream
+                                      .fromIterable(1 to 3)
+                                      .mapZIO {
+                                        case 1 => ZIO.succeed(1)
+                                        case 2 => started2.succeed(()) *> gate2.await.as(2)
+                                        case n => started3.succeed(()) *> gate3.await.as(n)
+                                      }
+                                      .buffer(1)
+                                      .toPull
+                            // Pull element 1; the producer starts computing element 2
+                            _ <- pull
+                            // Let element 2 complete so it can be offered to the handoff
+                            _ <- started2.await
+                            _ <- gate2.succeed(())
+                            // Do NOT pull element 2 — the handoff is full.
+                            // Give the runtime a chance to schedule the producer.
+                            _ <- ZIO.yieldNow.repeatN(10)
+                            // Element 3 must not have started because the producer
+                            // is blocked offering element 2 into the full handoff.
+                            v <- started3.poll
+                            _ <- gate3.succeed(())
+                          } yield v
+                        }
+            } yield assert(result)(isNone)
+          } @@ nonFlaky,
+          test("buffer(2) allows a third element to start") {
+            for {
+              gate2    <- Promise.make[Nothing, Unit]
+              started3 <- Promise.make[Nothing, Unit]
+              gate3    <- Promise.make[Nothing, Unit]
+              _ <- ZIO.scoped {
+                     for {
+                       pull <- ZStream
+                                 .fromIterable(1 to 3)
+                                 .mapZIO {
+                                   case 1 => ZIO.succeed(1)
+                                   case 2 => gate2.await.as(2)
+                                   case n => started3.succeed(()) *> gate3.await.as(n)
+                                 }
+                                 .buffer(2)
+                                 .toPull
+                       _ <- pull
+                       _ <- gate2.succeed(())
+                       // With buffer(2), the third element should start eagerly
+                       _ <- started3.await
+                       _ <- gate3.succeed(())
+                     } yield ()
+                   }
+            } yield assertCompletes
+          },
+          test("buffer(1) maintains elements and ordering") {
+            check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
+              assertZIO(
+                ZStream
+                  .fromChunks(chunk: _*)
+                  .buffer(1)
+                  .runCollect
+              )(equalTo(chunk.flatten))
+            }
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -394,8 +394,8 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   - `capacity == 1`: uses a synchronous [[ZStream.Handoff]] so the producer
    *     blocks until the consumer takes.
    *   - `capacity >= 2`: uses a bounded queue of size `capacity - 1`, which
-   *     together with the one eagerly computed element yields exactly `capacity`
-   *     elements of look-ahead.
+   *     together with the one eagerly computed element yields exactly
+   *     `capacity` elements of look-ahead.
    *
    * @note
    *   This combinator destroys the chunking structure.

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -385,29 +385,58 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * Allows a faster producer to progress independently of a slower consumer by
    * buffering up to `capacity` elements in a queue.
    *
+   * Because the upstream producer eagerly computes one element before offering
+   * it to the internal queue, `buffer(n)` previously allowed `n + 1` elements
+   * to be in flight. This version corrects the semantics so that at most `n`
+   * elements are buffered ahead of the consumer:
+   *
+   *   - `capacity <= 0`: no buffering (returns the stream unchanged).
+   *   - `capacity == 1`: uses a synchronous [[ZStream.Handoff]] so the producer
+   *     blocks until the consumer takes.
+   *   - `capacity >= 2`: uses a bounded queue of size `capacity - 1`, which
+   *     together with the one eagerly computed element yields exactly `capacity`
+   *     elements of look-ahead.
+   *
    * @note
    *   This combinator destroys the chunking structure.
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def processLoop(take: => UIO[Exit[Option[E], A]]): ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = {
+      lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+        ZChannel.fromZIO(take).flatMap { (exit: Exit[Option[E], A]) =>
+          exit.foldExit(
+            Cause
+              .flipCauseOption(_)
+              .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+            value => ZChannel.write(Chunk.single(value)) *> loop
+          )
+        }
+      loop
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
-
-          process
+        ZIO.suspendSucceed {
+          val cap = capacity
+          if (cap <= 0)
+            ZIO.succeed(self.channel)
+          else if (cap == 1)
+            for {
+              handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+              _ <- {
+                     lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                       ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                         in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))) *> writer,
+                         err => ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                         _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+                       )
+                     (self.channel >>> writer).drain.runScoped
+                   }.forkScoped
+            } yield processLoop(handoff.take)
+          else
+            self.toQueueOfElements(cap - 1).map(queue => processLoop(queue.take))
         }
       }
     )


### PR DESCRIPTION
/claim #9810

## Problem

`ZStream.buffer(n)` was buffering `n + 1` elements instead of `n`. The upstream producer eagerly computes one element *before* offering it to the internal bounded queue, so with a queue of capacity `n`, the total in-flight count was always `n + 1`.

Reproducer (from the issue): `buffer(1)` allows 3 elements to be produced while the consumer is still processing the first one.

## Root cause

As described by @kyri-petrou in the [issue discussion](https://github.com/zio/zio/issues/9810#issuecomment-2831124982), the sequence is:

1. `fakeNetworkCall(1)` — computed eagerly
2. `offer` — accepted, polled immediately downstream
3. `fakeNetworkCall(2)` — computed eagerly
4. `offer` — added to queue (capacity 1), queue full
5. `fakeNetworkCall(3)` — computed eagerly ← this is the extra element
6. `offer` — blocks because queue is full

## Fix

Three cases, following the approach approved by @jdegoes:

| Capacity | Strategy | Why |
|----------|----------|-----|
| `<= 0` | No-op (return stream unchanged) | No buffering requested |
| `== 1` | Synchronous `Handoff` | Can't use `Queue.bounded(0)`. Handoff blocks the producer until the consumer takes, so exactly 1 element is buffered ahead. |
| `>= 2` | `Queue.bounded(capacity - 1)` | Queue capacity `(n-1)` + 1 eagerly computed element = exactly `n` total |

The `processLoop` helper is extracted to avoid duplicating the channel drain logic across the handoff and queue paths.

## Tests added

| Test | What it verifies |
|------|-----------------|
| `buffer(1) does not prefetch a third element` | After pulling element 1, the producer offers element 2 into the handoff and blocks — element 3 does not start. Repeated 100x (`@@ nonFlaky`). |
| `buffer(2) allows a third element to start` | Confirms that `buffer(2)` does allow 3 elements in flight (correct behaviour for capacity 2). |
| `buffer(1) maintains elements and ordering` | Property-based test ensuring correctness is preserved with the new handoff path. |

## Validation

```
sbt "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t buffer"

23 tests passed. 0 tests failed. 0 tests ignored.
```

All existing buffer tests continue to pass.

Update - 
Video recording of the fix:
https://drive.google.com/file/d/1w3NtJsVE2xbn05m9LP0evoVKairaMDKA/view?usp=sharing
 Shows all 23 buffer tests passing, including 3 new regression tests:
- buffer(1) does not prefetch a third element (repeated 100x)
- buffer(2) allows a third element to start
- buffer(1) maintains elements and ordering