### PR TITLE
fix: zio-test: classic assertion `equalto` using `diff`

### DIFF
--- a/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
@@ -78,7 +78,7 @@ trait AssertionVariants {
             if (expected.isInstanceOf[Product]) {
               M.text(diffProduct(actual, expected))
             } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+              M.text(diffProduct(actual, expected, rootClassName = Some(expected.getClass.getSimpleName)))
             }
           }
         }


### PR DESCRIPTION
Fixes #8664