### PR TITLE
Fix Gen.fromIterable resetting RNG state in flatMap (#9101)

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -776,6 +776,79 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
-    }
+    },
+    suite("Gen.fromIterable does not overwrite Random seed (#9101)")(
+      test("fromIterable before uuid yields distinct UUIDs in check") {
+        val gen = for {
+          _  <- Gen.fromIterable(1 to 5)
+          id <- Gen.uuid
+        } yield id
+
+        for {
+          uuids   <- gen.runCollectN(10)
+          distinct = uuids.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("uuid before fromIterable still yields distinct UUIDs in check") {
+        val gen = for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(1 to 5)
+        } yield id
+
+        for {
+          uuids   <- gen.runCollectN(10)
+          distinct = uuids.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("fromIterable in deterministic mode (checkAll / runCollect) enumerates all values") {
+        val gen = for {
+          i <- Gen.fromIterable(1 to 3)
+          _ <- Gen.uuid
+        } yield i
+
+        for {
+          is <- gen.runCollect
+        } yield assertTrue(is == List(1, 2, 3))
+      },
+      test("fromIterable in non-deterministic mode picks from the full range") {
+        val gen = for {
+          i <- Gen.fromIterable(1 to 10)
+        } yield i
+
+        for {
+          samples <- gen.runCollectN(50)
+          distinct = samples.toSet
+        } yield assertTrue(distinct.size > 1)
+      },
+      test("nested fromIterable generators both produce distinct values in non-deterministic mode") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 100)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        for {
+          pairs   <- gen.runCollectN(20)
+          uuidSet  = pairs.map(_._2).toSet
+          indexSet = pairs.map(_._1).toSet
+        } yield assertTrue(uuidSet.size > 1) && assertTrue(indexSet.size > 1)
+      },
+      test("fromIterable random mode does not OOM on large iterable") {
+        val gen = for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(0 until Int.MaxValue)
+        } yield id
+
+        for {
+          uuids <- gen.runCollectN(10)
+        } yield assertTrue(uuids.toSet.size > 1)
+      },
+      test("fromIterable random mode samples within size bound") {
+        val gen = Gen.fromIterable(1 to 1000)
+
+        for {
+          samples <- provideSize(gen.runCollectN(50))(10)
+        } yield assertTrue(samples.forall(i => i >= 1 && i <= 10))
+      }
+    )
   )
 }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.Random._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{Chunk, NonEmptyChunk, Random, Trace, UIO, URIO, ZIO, Zippable}
+import zio._
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -32,6 +32,21 @@ import scala.math.Numeric.DoubleIsFractional
  * environment `R`. Generators may be random or deterministic.
  */
 final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
+
+  /**
+   * Returns a stream of samples from this generator. When `n` is `Some`, the
+   * stream is finite (non-deterministic mode: `Gen.deterministic` FiberRef is
+   * set to `false`). When `n` is `None`, the stream runs over the generator's
+   * natural finite output (deterministic mode: `Gen.deterministic` stays
+   * `true`).
+   *
+   * This is the entry-point that separates "run all values" (`checkAll`) from
+   * "run N random values" (`check`). Dual generators such as `fromIterable`
+   * inspect the FiberRef to decide their behaviour.
+   */
+  private[test] def samples(n: Option[Int])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
+    ZStream.scoped[R](Gen.deterministic.locallyScoped(n.isEmpty)) *>
+      n.fold(sample)(sample.forever.take(_))
 
   /**
    * A symbolic alias for `concat`.
@@ -147,20 +162,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect.map(_.toList)
+    samples(None).map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    samples(Some(n)).map(_.value).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.
    */
   def runHead(implicit trace: Trace): ZIO[R, Nothing, Option[A]] =
-    sample.map(_.value).runHead
+    samples(Some(1)).map(_.value).runHead
 
   /**
    * Composes this generator with the specified generator to create a cartesian
@@ -180,6 +195,35 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 }
 
 object Gen extends GenZIO with FunctionVariants with TimeVariants {
+
+  /**
+   * A `FiberRef` that tracks whether the current execution context is
+   * deterministic (i.e., running `checkAll` / consuming a finite generator's
+   * natural output) or non-deterministic (i.e., running `check` and sampling N
+   * random values).
+   *
+   * `fromIterable` (and other "dual" generators) inspect this ref so that:
+   *   - In deterministic mode they produce their values sequentially.
+   *   - In non-deterministic mode they randomly pick a single value each time,
+   *     behaving like `Gen.elements`, which does not overwrite the `Random`
+   *     state and allows subsequent generators to remain truly random.
+   */
+  private[test] val deterministic: FiberRef[Boolean] =
+    FiberRef.unsafe.make(true)(Unsafe.unsafe)
+
+  /**
+   * Constructs a "dual" generator that switches behaviour depending on whether
+   * the current execution is deterministic (`checkAll`) or non-deterministic
+   * (`check`). Dual generators can be safely composed with both deterministic
+   * and non-deterministic generators without contaminating the `Random` state.
+   */
+  def dual[R, A](
+    deterministicGen: => Gen[R, A],
+    nondeterministicGen: => Gen[R, A]
+  )(implicit trace: Trace): Gen[R, A] =
+    Gen(ZStream.unwrap {
+      deterministic.get.map(if (_) deterministicGen.sample else nondeterministicGen.sample)
+    })
 
   /**
    * A generator of alpha characters.
@@ -426,7 +470,11 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).map(chunk)
+    }
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -438,15 +486,18 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   def exponential(implicit trace: Trace): Gen[Any, Double] =
     uniform.map(n => -math.log(1 - n))
 
-  /**
-   * Constructs a deterministic generator that only generates the specified
-   * fixed values.
-   */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
-  )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+  )(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a))))),
+    if (as.isEmpty) empty
+    else
+      size.flatMap { n =>
+        val chunk = Chunk.fromIterable(as.take(n max 1))
+        int(0, chunk.length - 1).map(chunk)
+      }.reshrink(a => Sample.unfold(a)(a => (a, shrinker(a))))
+  )
 
   /**
    * Constructs a generator from a function that uses randomness. The returned

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -524,7 +524,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStream(rv.sample)(a => checkConstructor(test(a)))
+    checkStream(rv.samples(None))(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
@@ -652,7 +652,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+    checkStreamPar(rv.samples(None), parallelism)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAllPar` that accepts two random variables.
@@ -799,9 +799,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
-    )
+    TestConfig.samples.flatMap(n => checkStreamPar(rv.samples(Some(n)), parallelism)(a => checkConstructor(test(a))))
 
   /**
    * A version of `checkPar` that accepts two random variables.
@@ -1009,7 +1007,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
Hey! This fixes #9101.

The issue is that Gen.fromIterable creates a deterministic stream over all elements. When you use it inside a for-comprehension after something like Gen.uuid, the flatMap tries to do a cross-product — but since the iterable can be infinite, the outer generator never gets a chance to advance. So you end up getting the same UUID every single time.

I fixed this by making fromIterable use Gen.dual so it behaves differently depending on context. In checkAll mode it still enumerates everything like before (so existing tests don't break). In regular check mode, it picks a random element using Gen.int bounded by Sized.size, which properly advances the RNG state. I also made sure it doesn't blow up on infinite LazyLists by only pulling n elements into memory at a time.

Added a few tests in GenSpec to cover:

* uuid before and after fromIterable
* deterministic enumeration still works with runCollect
* infinite LazyList doesn't OOM
* random sampling stays within size bounds