### PR TITLE
[Enchancement] Add ExplicitRhsTraces runtime flag

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -52,6 +52,12 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
 
             assertTrue(RuntimeFlags.diff(oneOn, bothOn) == RuntimeFlags.enable(OpLog))
 
+          } +
+          test("ExplicitRhsTraces") {
+            val flags = RuntimeFlags(ExplicitRhsTraces)
+
+            assertTrue(RuntimeFlags.isEnabled(flags)(ExplicitRhsTraces)) &&
+            assertTrue(RuntimeFlags.isDisabled(RuntimeFlags.none)(ExplicitRhsTraces))
           }
       } +
         suite("gen") {

--- a/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/StackTracesSpec.scala
@@ -266,7 +266,44 @@ object StackTracesSpec extends ZIOBaseSpec {
               |""".stripMargin
         })
       }
-    ) @@ jvmOnly
+    ) @@ jvmOnly,
+    suite("ExplicitRhsTraces")(
+      test("RHS of flatMap is missing from trace by default (Tail Call Optimized)") {
+        def f1 = ZIO.unit.flatMap(_ => f2)
+        def f2 = ZIO.unit.flatMap(_ => f3)
+        def f3 = ZIO.fail("The failure")
+
+        for {
+          cause      <- f1.sandbox.flip
+          traceString = cause.prettyPrint
+        } yield {
+          assertTrue(
+            traceString.contains("f3"),
+            !traceString.contains("f2"),
+            !traceString.contains("f1")
+          )
+        }
+      },
+      test("RHS of flatMap is included in trace when ExplicitRhsTraces flag is enabled") {
+        def f1 = ZIO.unit.flatMap(_ => f2)
+        def f2 = ZIO.unit.flatMap(_ => f3)
+        def f3 = ZIO.fail("The failure")
+
+        val explicitTracesPatch = RuntimeFlags.enable(RuntimeFlag.ExplicitRhsTraces)
+
+        for {
+          _          <- ZIO.updateRuntimeFlags(explicitTracesPatch)
+          cause      <- f1.sandbox.flip
+          traceString = cause.prettyPrint
+        } yield {
+          assertTrue(
+            traceString.contains("f3"),
+            traceString.contains("f2"),
+            traceString.contains("f1")
+          )
+        }
+      }
+    )
   ) @@ sequential
 
   // set to true to print traces

--- a/core/shared/src/main/scala/zio/RuntimeFlag.scala
+++ b/core/shared/src/main/scala/zio/RuntimeFlag.scala
@@ -39,7 +39,8 @@ object RuntimeFlag {
       FiberRoots,
       WindDown,
       CooperativeYielding,
-      EagerShiftBack
+      EagerShiftBack,
+      ExplicitRhsTraces
     )
 
   /**
@@ -170,6 +171,18 @@ object RuntimeFlag {
    */
   case object EagerShiftBack extends RuntimeFlag {
     final val index   = 9
+    final val mask    = 1 << index
+    final val notMask = ~mask
+  }
+
+  /**
+   * The explicit RHS traces flag determines whether the ZIO runtime system will
+   * capture stack traces for the right-hand side of flatMap operations.
+   * Enabling this flag will defeat tail-call optimization and negatively impact
+   * performance and memory usage. Only recommended for debugging.
+   */
+  case object ExplicitRhsTraces extends RuntimeFlag {
+    final val index   = 10
     final val mask    = 1 << index
     final val notMask = ~mask
   }

--- a/core/shared/src/main/scala/zio/RuntimeFlags.scala
+++ b/core/shared/src/main/scala/zio/RuntimeFlags.scala
@@ -48,6 +48,9 @@ object RuntimeFlags {
   def enableAll(self: RuntimeFlags)(that: RuntimeFlags): RuntimeFlags =
     self | that
 
+  def explicitRhsTraces(flags: RuntimeFlags): Boolean =
+    isEnabled(flags, RuntimeFlag.ExplicitRhsTraces.mask)
+
   def fiberRoots(flags: RuntimeFlags): Boolean =
     isEnabled(flags, RuntimeFlag.FiberRoots.mask)
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6192,6 +6192,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       extends Continuation
       with ZIO[Any, Nothing, Unit]
 
+  private[zio] final case class RhsTraceNode(trace: Trace) extends Continuation
+
   private[zio] sealed trait UpdateRuntimeFlagsWithin[R, E, A] extends ZIO[R, E, A] {
     def update: RuntimeFlags.Patch
     def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A]

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1134,12 +1134,20 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 continuation match {
                   case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
                     cur = flatMap.successK(value)
+                    if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                      stackIndex = pushStackFrame(ZIO.RhsTraceNode(flatMap.trace), stackIndex)
+                    }
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+                    if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                      stackIndex = pushStackFrame(ZIO.RhsTraceNode(foldZIO.trace), stackIndex)
+                    }
 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
+
+                  case _: ZIO.RhsTraceNode =>
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1172,12 +1180,20 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                 continuation match {
                   case flatMap: ZIO.FlatMap[Any, Any, Any, Any] =>
                     cur = flatMap.successK(value)
+                    if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                      stackIndex = pushStackFrame(ZIO.RhsTraceNode(flatMap.trace), stackIndex)
+                    }
 
                   case foldZIO: ZIO.FoldZIO[Any, Any, Any, Any, Any] =>
                     cur = foldZIO.successK(value)
+                    if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                      stackIndex = pushStackFrame(ZIO.RhsTraceNode(foldZIO.trace), stackIndex)
+                    }
 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
+
+                  case _: ZIO.RhsTraceNode =>
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1196,8 +1212,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               val first = flatmap.first
 
-              if (first eq ZIO.unit) cur = flatmap.successK(())
-              else {
+              if (first eq ZIO.unit) {
+                cur = flatmap.successK(())
+                if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                  stackIndex = pushStackFrame(ZIO.RhsTraceNode(flatmap.trace), stackIndex)
+                }
+              } else {
                 stackIndex = pushStackFrame(flatmap, stackIndex)
                 cur = first
               }
@@ -1320,7 +1340,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                       cause = cause.stripFailures
                     } else {
                       cur = foldZIO.failureK(cause)
+                      if (RuntimeFlags.explicitRhsTraces(_runtimeFlags)) {
+                        stackIndex = pushStackFrame(ZIO.RhsTraceNode(foldZIO.trace), stackIndex)
+                      }
                     }
+
+                  case _: ZIO.RhsTraceNode =>
 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
                     cause = patchRuntimeFlagsCause(updateFlags.update, cause)


### PR DESCRIPTION
Fixes #8747 
/claim #8747 

### Description
This PR introduces a new RuntimeFlag, `RuntimeFlag.ExplicitRhsTraces` (disabled by default), which allows developers to capture the complete logical stack trace of a `flatMap` chain, including the right-hand side (RHS) continuations.

As noted in the original issue, ZIO's runloop naturally optimizes away the LHS of a `flatMap` as a tail call, meaning the RHS does not typically appear in the execution trace. While great for performance, this makes debugging deeply nested effects difficult. 

To solve this without degrading the runloop's performance or introducing memory leaks for standard execution:
1. Added `ExplicitRhsTraces` to `RuntimeFlags`.
2. Modified `FiberRuntime.runLoop` to conditionally push a lightweight `RhsTraceNode` onto the continuation stack when the flag is enabled.
3. Updated `StackTracesSpec` to verify that TCO is preserved by default, but RHS traces are fully captured when the flag is toggled on.

### Testing
Added a new suite `ExplicitRhsTraces` to `StackTracesSpec` to explicitly test this behavior. Both the default (TCO) behavior and the detailed tracing behavior pass successfully:
<img width="702" height="265" alt="image" src="https://github.com/user-attachments/assets/9d3e39a6-0cb6-4091-a3c9-ebc7a82151f9" />

### Benchmarks
To ensure the `RuntimeFlags.explicitRhsTraces` check does not penalize default execution, I ran the `NarrowFlatMapBenchmark` and `BroadFlatMapBenchmark` suites before and after this PR. 

As shown below, ZIO's throughput remains statistically identical (zero-overhead) when the flag is disabled.

Before (series/2.x)
| Benchmark | (depth) | (size) | Mode | Cnt | Score | Error | Units |
|-----------|---------|--------|------|-----|-------|-------|-------|
| BroadFlatMapBenchmark.catsBroadFlatMap | 20 | N/A | thrpt | 5 | 2086.383 | ± 341.752 | ops/s |
| BroadFlatMapBenchmark.completableFutureBroadFlatMap | 20 | N/A | thrpt | 5 | 8374.482 | ± 306.804 | ops/s |
| BroadFlatMapBenchmark.futureBroadFlatMap | 20 | N/A | thrpt | 5 | 3.896 | ± 0.039 | ops/s |
| BroadFlatMapBenchmark.twitterBroadFlatMap | 20 | N/A | thrpt | 5 | 1136.916 | ± 104.839 | ops/s |
| BroadFlatMapBenchmark.zioBroadFlatMap | 20 | N/A | thrpt | 5 | 2876.461 | ± 366.462 | ops/s |
| NarrowFlatMapBenchmark.catsNarrowFlatMap | N/A | 1000 | thrpt | 5 | 21937.770 | ± 2138.195 | ops/s |
| NarrowFlatMapBenchmark.completableFutureNarrowFlatMap | N/A | 1000 | thrpt | 5 | 95030.738 | ± 9713.942 | ops/s |
| NarrowFlatMapBenchmark.futureNarrowFlatMap | N/A | 1000 | thrpt | 5 | 86.726 | ± 3.680 | ops/s |
| NarrowFlatMapBenchmark.monoNarrowFlatMap | N/A | 1000 | thrpt | 5 | 12606.564 | ± 507.709 | ops/s |
| NarrowFlatMapBenchmark.rxSingleNarrowFlatMap | N/A | 1000 | thrpt | 5 | 34429.380 | ± 3928.695 | ops/s |
| NarrowFlatMapBenchmark.twitterNarrowFlatMap | N/A | 1000 | thrpt | 5 | 29016.512 | ± 385.571 | ops/s |
| NarrowFlatMapBenchmark.zioNarrowFlatMap | N/A | 1000 | thrpt | 5 | 100973.791 | ± 2456.349 | ops/s |

After (This PR)
| Benchmark | (depth) | (size) | Mode | Cnt | Score | Error | Units |
|-----------|---------|--------|------|-----|-------|-------|-------|
| BroadFlatMapBenchmark.catsBroadFlatMap | 20 | N/A | thrpt | 5 | 2129.392 | ± 243.908 | ops/s |
| BroadFlatMapBenchmark.completableFutureBroadFlatMap | 20 | N/A | thrpt | 5 | 8531.321 | ± 536.400 | ops/s |
| BroadFlatMapBenchmark.futureBroadFlatMap | 20 | N/A | thrpt | 5 | 3.977 | ± 0.084 | ops/s |
| BroadFlatMapBenchmark.twitterBroadFlatMap | 20 | N/A | thrpt | 5 | 1106.574 | ± 96.701 | ops/s |
| BroadFlatMapBenchmark.zioBroadFlatMap | 20 | N/A | thrpt | 5 | 3015.336 | ± 110.645 | ops/s |
| NarrowFlatMapBenchmark.catsNarrowFlatMap | N/A | 1000 | thrpt | 5 | 21884.589 | ± 374.555 | ops/s |
| NarrowFlatMapBenchmark.completableFutureNarrowFlatMap | N/A | 1000 | thrpt | 5 | 92921.261 | ± 8258.052 | ops/s |
| NarrowFlatMapBenchmark.futureNarrowFlatMap | N/A | 1000 | thrpt | 5 | 85.876 | ± 3.996 | ops/s |
| NarrowFlatMapBenchmark.monoNarrowFlatMap | N/A | 1000 | thrpt | 5 | 12677.550 | ± 644.603 | ops/s |
| NarrowFlatMapBenchmark.rxSingleNarrowFlatMap | N/A | 1000 | thrpt | 5 | 28071.296 | ± 2608.594 | ops/s |
| NarrowFlatMapBenchmark.twitterNarrowFlatMap | N/A | 1000 | thrpt | 5 | 29413.164 | ± 643.038 | ops/s |
| NarrowFlatMapBenchmark.zioNarrowFlatMap | N/A | 1000 | thrpt | 5 | 100471.709 | ± 10017.077 | ops/s |