### PR TITLE
Scala Native  NPE when forking 10K fibers

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
/claim #9681

`ConcurrentHashMap.newKeySet()` isn't implemented in Scala Native's JDK compatibility layer, which caused a NPE when `WeakConcurrentBag` tried to create its internal set during high-fiber-count scenarios. Replaced both overloads with `Collections.newSetFromMap(new ConcurrentHashMap(...))`, which achieves the same concurrent set semantics using APIs that Scala Native actually supports. I verified that the equivalent `newWeakSet` already used `Collections.newSetFromMap` pattern, so this is consistent with existing practice in the file.

Fixes #9681