### PR TITLE
feat: Add Promise.become(fiber) to eliminate fork+await indirection

### DIFF
--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -191,7 +191,7 @@ object PromiseSpec extends ZIOBaseSpec {
           assert(completed)(equalTo(List.range(0, n)))
         }
       )
-),
+    ),
     test("become completes promise when fiber succeeds") {
       for {
         promise <- Promise.make[Nothing, Int]

--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -191,6 +191,40 @@ object PromiseSpec extends ZIOBaseSpec {
           assert(completed)(equalTo(List.range(0, n)))
         }
       )
-    )
+),
+    test("become completes promise when fiber succeeds") {
+      for {
+        promise <- Promise.make[Nothing, Int]
+        fiber   <- ZIO.succeed(42).fork
+        _       <- promise.become(fiber)
+        value   <- promise.await
+      } yield assertTrue(value == 42)
+    },
+    test("become completes promise when fiber fails") {
+      for {
+        promise <- Promise.make[String, Int]
+        fiber   <- ZIO.fail("boom").fork
+        _       <- promise.become(fiber)
+        result  <- promise.await.exit
+      } yield assertTrue(result == Exit.fail("boom"))
+    },
+    test("become is no-op if promise already completed") {
+      for {
+        promise <- Promise.make[Nothing, Int]
+        _       <- promise.succeed(1)
+        fiber   <- ZIO.succeed(2).fork
+        _       <- promise.become(fiber)
+        value   <- promise.await
+      } yield assertTrue(value == 1)
+    },
+    test("become with already-completed fiber resolves immediately") {
+      for {
+        promise <- Promise.make[Nothing, Int]
+        fiber   <- ZIO.succeed(42).fork
+        _       <- fiber.join
+        _       <- promise.become(fiber)
+        value   <- promise.await
+      } yield assertTrue(value == 42)
+    }
   )
 }

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -72,6 +72,34 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     }
 
   /**
+   * Links this promise to the given fiber. When the fiber completes, this
+   * promise will be completed with the same exit value. If the promise is
+   * already completed, this is a no-op and returns false.
+   *
+   * This eliminates the intermediate callback allocation that occurs when a
+   * fiber forks work to complete a promise and then immediately awaits it.
+   *
+   * {{{
+   * // Before: indirect, allocates intermediate callback
+   * for {
+   *   promise <- Promise.make[E, A]
+   *   fiber   <- (work >>= promise.succeed).fork
+   *   result  <- promise.await
+   * } yield result
+   *
+   * // After: direct observer registration, no intermediate callback
+   * for {
+   *   promise <- Promise.make[E, A]
+   *   fiber   <- work.fork
+   *   _       <- promise.become(fiber)
+   *   result  <- promise.await
+   * } yield result
+   * }}}
+   */
+  def become(fiber: Fiber.Runtime[E, A])(implicit trace: Trace): UIO[Boolean] =
+    ZIO.succeed(unsafe.become(fiber)(Unsafe))
+
+  /**
    * Kills the promise with the specified error, which will be propagated to all
    * fibers waiting on the value of the promise.
    */
@@ -175,6 +203,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.succeedUnit(ev0, trace, Unsafe))
 
   private[zio] trait UnsafeAPI extends Serializable {
+    def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Boolean
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
@@ -192,6 +221,15 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   private[zio] def state: AtomicReference[Promise.internal.State[E, A]] =
     unsafe.asInstanceOf[AtomicReference[Promise.internal.State[E, A]]]
   private[zio] val unsafe: UnsafeAPI = new AtomicReference(Promise.internal.State.empty[E, A]) with UnsafeAPI { state =>
+
+    def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Boolean =
+      if (!isDone) {
+        fiber.unsafe.addObserver { exit =>
+          completeWith(exit)
+        }
+        true
+      } else false
+
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean = {
       @annotation.tailrec
       def loop(): Boolean =
@@ -300,11 +338,6 @@ object Promise {
     }
 
     private object Link {
-
-      /**
-       * Materializes the pending state into an array of waiters in reverse
-       * order.
-       */
       def materialize[E, A](pending: Pending[E, A], size: Int): Array[IO[E, A] => Any] = {
         val array   = new Array[IO[E, A] => Any](size)
         var current = pending

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -221,7 +221,6 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   private[zio] def state: AtomicReference[Promise.internal.State[E, A]] =
     unsafe.asInstanceOf[AtomicReference[Promise.internal.State[E, A]]]
   private[zio] val unsafe: UnsafeAPI = new AtomicReference(Promise.internal.State.empty[E, A]) with UnsafeAPI { state =>
-
     def become(fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Boolean =
       if (!isDone) {
         fiber.unsafe.addObserver { exit =>


### PR DESCRIPTION
Implements Promise.become(fiber) to address #9877.
The issue identifies that when a Fiber forks work which will eventually complete a Promise, and then awaits that Promise, we pay unnecessary overhead:

The forked fiber allocates a callback to complete the promise
promise.await allocates an asyncInterrupt callback to register itself
These two callbacks communicate indirectly through the Promise state machine

Solution
Promise.become(fiber) wires a fiber directly to a promise by registering an observer via fiber.unsafe.addObserver. When the fiber completes, the observer fires completeWith(ZIO.done(exit)), completing the promise with zero extra allocation on the completion path.
scala// Before: indirect, allocates intermediate callback
for {
  promise <- Promise.make[E, A]
  fiber   <- (work >>= promise.succeed).fork
  result  <- promise.await
} yield result

// After: direct observer registration, no intermediate callback
for {
  promise <- Promise.make[E, A]
  fiber   <- work.fork
  _       <- promise.become(fiber)
  result  <- promise.await
} yield result
Key properties

Race-safe: fiber.unsafe.addObserver handles the race between registration and completion — if the fiber has already completed, the observer fires immediately
Idempotent completion: completeWith uses CAS internally, so multiple observers or concurrent completions are safe
Short-circuit: the isDone check avoids unnecessary observer registration when the promise is already complete

Changes

Promise.scala: Add become to the public API, UnsafeAPI trait, and the concrete AtomicReference-based implementation
PromiseSpec.scala: Add 4 tests covering success, failure, no-op, and already-completed fiber cases

https://www.loom.com/share/bb6f6a5ee79f46d091d16e9ae41f7a73

Fixes #9877
/claim #9877