### PR TITLE
Fix #9810 - make ZStream.buffer(n) enforce exact capacity semantics

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,51 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffer(1) buffers exactly 1 element") {
+            for {
+              ref         <- Ref.make(List[Int]())
+              latch       <- Promise.make[Nothing, Unit]
+              gate        <- Promise.make[Nothing, Unit]
+              producedTwo <- Promise.make[Nothing, Unit]
+              s = ZStream
+                    .fromIterable(1 to 5)
+                    .mapZIO { i =>
+                      (ref.update(i :: _) *> producedTwo.succeed(()).when(i == 2)).as(i)
+                    }
+                    .buffer(1)
+              _ <- s
+                     .runForeach(i => latch.succeed(()).when(i == 1) *> gate.await)
+                     .fork
+              _        <- latch.await
+              _        <- producedTwo.await
+              produced <- ref.get
+            } yield assert(produced.reverse)(equalTo(List(1, 2)))
+          } @@ TestAspect.timeout(5.seconds),
+          test("buffer(2) buffers exactly 2 elements") {
+            for {
+              ref           <- Ref.make(List[Int]())
+              latch         <- Promise.make[Nothing, Unit]
+              gate          <- Promise.make[Nothing, Unit]
+              producedThree <- Promise.make[Nothing, Unit]
+              s = ZStream
+                    .fromIterable(1 to 5)
+                    .mapZIO { i =>
+                      (ref.update(i :: _) *> producedThree.succeed(()).when(i == 3)).as(i)
+                    }
+                    .buffer(2)
+              _ <- s
+                     .runForeach(i => latch.succeed(()).when(i == 1) *> gate.await)
+                     .fork
+              _        <- latch.await
+              _        <- producedThree.await
+              produced <- ref.get
+            } yield assert(produced.reverse)(equalTo(List(1, 2, 3)))
+          } @@ TestAspect.timeout(5.seconds),
+          test("buffer(0) is a no-op") {
+            assertZIO(
+              ZStream(1, 2, 3).buffer(0).runCollect
+            )(equalTo(Chunk(1, 2, 3)))
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -385,33 +385,77 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * Allows a faster producer to progress independently of a slower consumer by
    * buffering up to `capacity` elements in a queue.
    *
+   * A value of `capacity` greater than zero bounds the number of elements that
+   * can be produced ahead of the consumer by approximately `capacity`. If
+   * `capacity <= 0` this operator is a no-op and the resulting stream is equal
+   * to the source stream. When `capacity == 1` a synchronous handoff is used so
+   * that exactly one element is buffered. For `capacity >= 2`, a queue of size
+   * `capacity - 1` is used along with the in-flight element to achieve exactly
+   * `capacity` buffered elements.
+   *
    * @note
    *   This combinator destroys the chunking structure.
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
-    new ZStream(
-      ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
+    ZStream.unwrap {
+      ZIO.succeed {
+        val cap = capacity
+        if (cap <= 0) self
+        else if (cap == 1) {
+          new ZStream(
+            ZChannel.unwrapScoped[R] {
+              ZIO.acquireRelease(ZStream.Handoff.make[Exit[Option[E], A]])(_.offer(Exit.fail(None))).flatMap {
+                handoff =>
+                  val producer = {
+                    lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                      ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                        in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))) *> writer,
+                        err => ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                        _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+                      )
+                    (self.channel >>> writer).drain.runScoped
+                  }.forkScoped
 
-          process
+                  lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                    ZChannel.fromZIO(handoff.take).flatMap { (exit: Exit[Option[E], A]) =>
+                      exit.foldExit(
+                        Cause
+                          .flipCauseOption(_)
+                          .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                        value => ZChannel.write(Chunk.single(value)) *> process
+                      )
+                    }
+
+                  producer *> ZIO.succeed(process)
+              }
+            }
+          )
+        } else {
+          val queue = self.toQueueOfElements(cap - 1)
+          new ZStream(
+            ZChannel.unwrapScoped[R] {
+              queue.map { queue =>
+                lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+                  ZChannel.fromZIO {
+                    queue.take
+                  }.flatMap { (exit: Exit[Option[E], A]) =>
+                    exit.foldExit(
+                      Cause
+                        .flipCauseOption(_)
+                        .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                      value => ZChannel.write(Chunk.single(value)) *> process
+                    )
+                  }
+
+                process
+              }
+            }
+          )
         }
       }
-    )
-  }
+    }
 
   /**
    * Allows a faster producer to progress independently of a slower consumer by


### PR DESCRIPTION
/claim #9810

## Proposed changes

Fixes #9810.

This PR fixes an off by one behavior in `ZStream.buffer(capacity)` where `buffer(n)` allowed `n + 1` elements in flight.

1. `capacity <= 0`  
No-op. Returns the original stream unchanged.

2. `capacity == 1`  
Uses a synchronous `ZStream.Handoff` path so exactly one element is buffered ahead.

3. `capacity >= 2`  
Uses internal queue size `capacity - 1` so queue capacity plus one in-flight element equals exactly `capacity`.

## Tests added

1. `buffer(1) buffers exactly 1 element`
2. `buffer(2) buffers exactly 2 elements`
3. `buffer(0) is a no-op`

These tests use `Promise` coordination to make assertions deterministic.

## Validation

- `sbt "-Dsbt.supershell=false" "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t buffer"`
- `sbt "-Dsbt.supershell=false" "streamsTestsJS/testOnly zio.stream.ZStreamSpec -- -t buffer"`
- Native run with Windows toolchain env setup, then:
  - `sbt "-Dsbt.supershell=false" "streamsTestsNative/testOnly zio.stream.ZStreamSpec -- -t buffer"`

Result:  
23 tests passed, 0 failed, 0 ignored on each platform run.

## Proof


https://github.com/user-attachments/assets/d789aecb-7644-4812-851d-1b1975bc0125




Demo video attached showing:

1. git diff for the two changed files
2. realtime JVM, JS, and Native buffer test runs
3. passing test summaries