### PR TITLE
perf: Replace ConcurrentLinkedQueue with MPSC lock-free FiberMailbox

### DIFF
--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -96,4 +96,8 @@ private[zio] trait PlatformSpecific {
   final def newConcurrentMap[A, B]()(implicit unsafe: zio.Unsafe): JMap[A, B] = new HashMap[A, B]()
 
   final def newWeakReference[A](value: A)(implicit unsafe: zio.Unsafe): () => A = { () => value }
+
+  final def onSpinWait(): Unit = ()
+
+  final def threadYield(): Unit = ()
 }

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -111,4 +111,8 @@ private[zio] trait PlatformSpecific {
       majorVersion.toInt
     }.toOption
   }
+
+  final def onSpinWait(): Unit = Thread.onSpinWait()
+
+  final def threadYield(): Unit = Thread.`yield`()
 }

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -89,6 +89,10 @@ private[zio] trait PlatformSpecific {
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
     ConcurrentHashMap.newKeySet[A](initialCapacity)
 
+  final def onSpinWait(): Unit = Thread.onSpinWait()
+
+  final def threadYield(): Unit = Thread.`yield`()
+
   private def blackhole(a: Any): Unit = {
     val _ = a
     ()

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -70,7 +70,7 @@ private[zio] final class FiberMailbox[A <: AnyRef](coreCapacityHint: Int = 8) {
 
       if (spinning < SpinLimit) {
         spinning += 1
-        Thread.onSpinWait()
+        Platform.onSpinWait()
       }
     }
 
@@ -86,13 +86,13 @@ private[zio] final class FiberMailbox[A <: AnyRef](coreCapacityHint: Int = 8) {
       var spins = 0
 
       while ((value eq null) && (spins < SpinLimit)) {
-        Thread.onSpinWait()
+        Platform.onSpinWait()
         spins += 1
         value = core.get(slot)
       }
 
       while (value eq null) {
-        Thread.`yield`()
+        Platform.threadYield()
         value = core.get(slot)
       }
 

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.{AtomicLong, AtomicReferenceArray}
+
+private[zio] final class FiberMailbox[A <: AnyRef](coreCapacityHint: Int = 8) {
+  private[this] final val SpinLimit = 16
+
+  private[this] val coreCapacity = {
+    val minCapacity = if (coreCapacityHint < 2) 2 else math.min(coreCapacityHint, 1 << 30)
+    var value       = 1
+    while (value < minCapacity) value <<= 1
+    value
+  }
+
+  private[this] val mask = coreCapacity - 1
+  private[this] val core = new AtomicReferenceArray[A](coreCapacity)
+
+  @volatile private[this] var head = 0L
+  private[this] var headPadding1   = 0L
+  private[this] var headPadding2   = 0L
+  private[this] var headPadding3   = 0L
+  private[this] var headPadding4   = 0L
+  private[this] var headPadding5   = 0L
+  private[this] var headPadding6   = 0L
+  private[this] var headPadding7   = 0L
+
+  private[this] val tail         = new AtomicLong(0L)
+  private[this] var tailPadding1 = 0L
+  private[this] var tailPadding2 = 0L
+  private[this] var tailPadding3 = 0L
+  private[this] var tailPadding4 = 0L
+  private[this] var tailPadding5 = 0L
+  private[this] var tailPadding6 = 0L
+  private[this] var tailPadding7 = 0L
+
+  private[this] val overflow = new ConcurrentLinkedQueue[A]()
+
+  def offer(message: A): Boolean = {
+    var spinning = 0
+    while (true) {
+      val currentTail = tail.get()
+      val currentHead = head
+
+      if ((currentTail - currentHead) >= coreCapacity) {
+        return overflow.offer(message)
+      }
+
+      if (tail.compareAndSet(currentTail, currentTail + 1)) {
+        val slot = (currentTail & mask).toInt
+        core.lazySet(slot, message)
+        return true
+      }
+
+      if (spinning < SpinLimit) {
+        spinning += 1
+        Thread.onSpinWait()
+      }
+    }
+
+    false
+  }
+
+  def poll(): A = {
+    val currentHead = head
+
+    if (currentHead < tail.get()) {
+      val slot  = (currentHead & mask).toInt
+      var value = core.get(slot)
+      var spins = 0
+
+      while ((value eq null) && (spins < SpinLimit)) {
+        Thread.onSpinWait()
+        spins += 1
+        value = core.get(slot)
+      }
+
+      while (value eq null) {
+        Thread.`yield`()
+        value = core.get(slot)
+      }
+
+      core.lazySet(slot, null.asInstanceOf[A])
+      head = currentHead + 1
+      value
+    } else {
+      overflow.poll()
+    }
+  }
+
+  def isEmpty: Boolean =
+    (head >= tail.get()) && overflow.isEmpty
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -22,7 +22,6 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
@@ -42,7 +41,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _blockingOn     = FiberRuntime.notBlockingOn
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
-  private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
+  private val inbox           = new FiberMailbox[FiberMessage]()
   private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
@@ -130,7 +129,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       if (exit ne null) Exit.succeed(exit)
       else {
         val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
-        inbox.add(FiberMessage.InterruptSignal(cause))
+        inbox.offer(FiberMessage.InterruptSignal(cause))
 
         // If the fiber is not running (which means it's suspended), and the current thread is in the same executor as the fiber,
         // then execute the runloop on the current thread, avoiding context switching and suspension
@@ -1097,7 +1096,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     var stackIndex = startStackIndex
 
     if (currentDepth >= FiberRuntime.MaxDepthBeforeTrampoline) {
-      inbox.add(FiberMessage.Resume(effect))
+      inbox.offer(FiberMessage.Resume(effect))
 
       return null
     }
@@ -1113,7 +1112,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
       if (ops > FiberRuntime.MaxOperationsBeforeYield && RuntimeFlags.cooperativeYielding(_runtimeFlags)) {
         updateLastTrace(cur.trace)
-        inbox.add(FiberMessage.Resume(cur))
+        inbox.offer(FiberMessage.Resume(cur))
 
         return null
       } else {
@@ -1299,7 +1298,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
             case yieldNow: ZIO.YieldNow =>
               updateLastTrace(yieldNow.trace)
-              inbox.add(FiberMessage.resumeUnit)
+              inbox.offer(FiberMessage.resumeUnit)
               return null
 
             case failure: Exit.Failure[Any] =>
@@ -1519,7 +1518,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * Adds a message to be processed by the fiber on the fiber.
    */
   private[zio] def tell(message: FiberMessage): Unit = {
-    inbox.add(message)
+    inbox.offer(message)
 
     // Attempt to spin up fiber, if it's not already running:
     if (running.compareAndSet(false, true)) drainQueueLaterOnExecutor(false)


### PR DESCRIPTION
## Summary

Introduce a dedicated **MPSC (multi-producer, single-consumer) lock-free queue** (`FiberMailbox`) for `FiberRuntime` message passing, replacing the generic `ConcurrentLinkedQueue`.

## Problem

`FiberRuntime` uses a `ConcurrentLinkedQueue` for its inbox, but the actual access pattern is strictly MPSC:
- **Producers**: multiple fibers sending `InterruptSignal`, `Resume`, and other `FiberMessage` types
- **Consumer**: single fiber draining via `drainQueueOnCurrentThread`, guarded by the `running` `AtomicBoolean`

`ConcurrentLinkedQueue` is a general-purpose MPMC queue that allocates a `Node` object per message. For the MPSC access pattern of `FiberRuntime`, a specialized array-backed queue can avoid per-message allocation and improve cache locality.

## Design

`FiberMailbox` is a bounded array-backed ring buffer with `ConcurrentLinkedQueue` overflow:

- **Core**: `AtomicReferenceArray[A]` (8 slots, power-of-2) - the fast path
- **Producers**: CAS on `AtomicLong` tail to claim a slot, `lazySet` to publish
- **Consumer**: `@volatile` head, single-writer - no CAS needed on the read side
- **Overflow**: when core is full (`tail - head >= capacity`), falls back to `ConcurrentLinkedQueue`
- **Spin strategy**: `Thread.onSpinWait()` (bounded, 16 iterations) then `Thread.yield()` escalation in `poll()`
- **False sharing prevention**: 7 `Long` padding fields (56 bytes) between `head` and `tail`
- **Capacity guard**: `math.min(hint, 1 << 30)` prevents integer overflow in power-of-2 rounding

## Changes

| File | Change |
|------|--------|
| `FiberMailbox.scala` | New file (109 lines) - MPSC lock-free queue |
| `FiberRuntime.scala` | `inbox` type changed + 5 call sites (`add` to `offer`) + removed unused `ConcurrentLinkedQueue` import |

## Verification

- [x] `coreJVM/compile` - PASS
- [x] `coreJS/compile` - PASS
- [x] `coreNative/compile` - PASS
- [x] `coreTestsJVM/test` - 3 pre-existing failures (`CauseSpec`, `StackTracesSpec`, `MetricsSpec`) confirmed identical on unmodified baseline
- [x] `scalafmt` - zero diff
- [x] Lock-free correctness review (9-point checklist + adversarial attack vectors)

Resolves #8807