### PR TITLE
perf(runtime): replace WeakConcurrentBag/_children with lock-free FiberSet

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Compares [[FiberSet]] against the two structures it replaces:
+ *   - [[WeakConcurrentBag]] — used by `Fiber._roots`
+ *   - `synchronizedSet(WeakHashMap)` — used by `FiberRuntime._children`
+ *
+ * Run with:
+ * {{{
+ *   sbt "benchmarks/jmh:run -prof gc zio.internal.FiberSetBenchmark"
+ * }}}
+ */
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(2)
+@Threads(8)
+class FiberSetBenchmark {
+
+  @Param(Array("1024"))
+  var nurserySize: Int = _
+
+  var fiberSet: FiberSet[BenchEntry]         = _
+  var weakBag: WeakConcurrentBag[BenchEntry] = _
+  var syncWeak: java.util.Set[BenchEntry]    = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    fiberSet = FiberSet[BenchEntry](nurserySize, concurrencyLevel = 8, isAlive = _.isAlive())
+    weakBag = WeakConcurrentBag[BenchEntry](nurserySize, _.isAlive())
+    syncWeak = Collections.synchronizedSet(
+      Collections.newSetFromMap(new java.util.WeakHashMap[BenchEntry, java.lang.Boolean]())
+    )
+  }
+
+  // ---- FiberSet -------------------------------------------------------
+
+  @Benchmark
+  def fiberSet_add(): Unit =
+    fiberSet.add(BenchEntry())
+
+  @Benchmark
+  def fiberSet_addRemove(): Unit = {
+    val e = BenchEntry()
+    fiberSet.add(e)
+    fiberSet.remove(e)
+  }
+
+  // ---- WeakConcurrentBag (baseline for _roots) -----------------------
+
+  @Benchmark
+  def weakBag_add(): Unit =
+    weakBag.add(BenchEntry())
+
+  // ---- synchronizedSet(WeakHashMap) (baseline for _children) ---------
+
+  @Benchmark
+  def syncWeak_add(): Unit =
+    syncWeak.add(BenchEntry())
+
+  @Benchmark
+  def syncWeak_addRemove(): Unit = {
+    val e = BenchEntry()
+    syncWeak.add(e)
+    syncWeak.remove(e)
+  }
+}
+
+object FiberSetBenchmark {
+  val alive: AtomicLong = new AtomicLong(0L)
+  val dead: AtomicLong  = new AtomicLong(0L)
+}
+
+final case class BenchEntry(expiration: Long) {
+  import FiberSetBenchmark._
+
+  def isAlive(): Boolean = {
+    val result = System.nanoTime() <= expiration
+    if (result) alive.incrementAndGet() else dead.incrementAndGet()
+    result
+  }
+}
+
+object BenchEntry {
+  import java.util.concurrent.ThreadLocalRandom
+  def apply(): BenchEntry =
+    BenchEntry(System.nanoTime() + ThreadLocalRandom.current().nextInt(100000))
+}

--- a/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio._
+import zio.test._
+import zio.test.TestAspect.{flaky, jvmOnly}
+import zio.ZIOBaseSpec
+
+object FiberSetSpec extends ZIOBaseSpec {
+
+  // A simple wrapper whose liveness can be toggled for GC-predicate tests.
+  final class Entry(@volatile var alive: Boolean = true)
+
+  def mkSet(nursery: Int = 64, concurrency: Int = 1): FiberSet[Entry] =
+    FiberSet[Entry](nursery, concurrency, _.alive)
+
+  def spec =
+    suite("FiberSetSpec") {
+      test("isEmpty on a freshly created set") {
+        val set = mkSet()
+        assertTrue(set.isEmpty)
+      } +
+        test("add makes isEmpty return false") {
+          val set = mkSet()
+          set.add(new Entry())
+          assertTrue(!set.isEmpty)
+        } +
+        test("added entry appears in iteration") {
+          val set = mkSet()
+          val e   = new Entry()
+          set.add(e)
+          assertTrue(set.iterator.exists(_ eq e))
+        } +
+        test("removed entry does not appear in iteration") {
+          val set = mkSet()
+          val e   = new Entry()
+          set.add(e)
+          set.remove(e)
+          assertTrue(!set.iterator.exists(_ eq e))
+        } +
+        test("removing an entry not in the set is a no-op") {
+          val set = mkSet()
+          val e   = new Entry()
+          set.remove(e) // must not throw
+          assertTrue(set.isEmpty)
+        } +
+        test("dead entries are excluded from iteration") {
+          val set = mkSet()
+          val e   = new Entry()
+          set.add(e)
+          e.alive = false
+          assertTrue(!set.iterator.exists(_ eq e))
+        } +
+        test("dead entries cause isEmpty to return true") {
+          val set = mkSet()
+          val e   = new Entry()
+          set.add(e)
+          e.alive = false
+          assertTrue(set.isEmpty)
+        } +
+        test("entries evicted from a full nursery remain reachable") {
+          // nursery = 4 slots; adding 20 entries forces most into long-term storage
+          val set     = mkSet(nursery = 4)
+          val entries = List.fill(20)(new Entry())
+          entries.foreach(set.add)
+          val found = set.iterator.toSet
+          assertTrue(entries.forall(e => found.contains(e)))
+        } +
+        test("concurrent adds are all represented") {
+          val set     = FiberSet[Entry](1024, concurrencyLevel = 4, isAlive = _.alive)
+          val entries = List.fill(200)(new Entry())
+          ZIO
+            .foreachPar(entries)(e => ZIO.succeed(set.add(e)))
+            .map(_ => assertTrue(entries.forall(e => set.iterator.exists(_ eq e))))
+        } +
+        test("gc reclaims cleared weak references from long-term storage") {
+          val set               = mkSet(nursery = 4)
+          var hard: List[Entry] = (1 to 16).map(_ => new Entry()).toList
+          hard.foreach(set.add)
+          set.iterator.foreach(_ => ()) // flush nursery into long-term storage
+
+          hard = Nil // drop all hard references
+          java.lang.System.gc()
+          set.add(new Entry()) // triggers drainQueue / sweepLongTerm
+
+          assertTrue(set.size < 17)
+        } @@ flaky
+    } @@ jvmOnly
+}

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,12 +16,11 @@
 
 package zio
 
-import zio.internal.{FiberRenderer, FiberScope}
+import zio.internal.{FiberRenderer, FiberScope, FiberSet}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import scala.concurrent.Future
-import zio.internal.WeakConcurrentBag
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a
@@ -1070,7 +1069,10 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
-    WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
-      .withAutoGc(5.seconds)
+  private[zio] val _roots: FiberSet[Fiber.Runtime[_, _]] =
+    FiberSet[Fiber.Runtime[_, _]](
+      nurserySize = 10000,
+      concurrencyLevel = java.lang.Runtime.getRuntime.availableProcessors() * 4,
+      isAlive = _.isAlive()
+    )
 }

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.{FiberRenderer, FiberScope, FiberSet}
+import zio.internal.{FiberRenderer, FiberScope, WeakConcurrentBag}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
@@ -1069,10 +1069,7 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: FiberSet[Fiber.Runtime[_, _]] =
-    FiberSet[Fiber.Runtime[_, _]](
-      nurserySize = 10000,
-      concurrencyLevel = java.lang.Runtime.getRuntime.availableProcessors() * 4,
-      isAlive = _.isAlive()
-    )
+  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
+    WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
+      .withAutoGc(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -24,7 +24,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
@@ -43,7 +42,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
   private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var _children       = null.asInstanceOf[FiberSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
   private var _stack          = null.asInstanceOf[Array[Continuation]]
@@ -84,15 +83,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       )
   }
 
-  private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
+  private[this] def childrenChunk(children: FiberSet[Fiber.Runtime[_, _]]): Chunk[Fiber.Runtime[_, _]] =
     // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
     if (children eq null) Chunk.empty
     else {
       val bldr = Chunk.newBuilder[Fiber.Runtime[_, _]]
-      children.forEach { child =>
-        if ((child ne null) && child.isAlive())
-          bldr.addOne(child)
-      }
+      children.forEach(bldr.addOne)
       bldr.result()
     }
 
@@ -568,11 +564,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def getChildren(): JavaSet[Fiber.Runtime[_, _]] = {
+  private def getChildren(): FiberSet[Fiber.Runtime[_, _]] = {
     // executed by the fiber itself, no risk of racing with transferChildren
     var children = _children
     if (children eq null) {
-      children = Platform.newConcurrentWeakSet[Fiber.Runtime[_, _]]()(Unsafe)
+      children = FiberSet[Fiber.Runtime[_, _]](256, 1, _.isAlive())
       _children = children
     }
     children
@@ -738,7 +734,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    */
   private def interruptAllChildren(): UIO[Any] =
     if (sendInterruptSignalToAllChildren(_children)) {
-      val iterator = _children.iterator()
+      val iterator = _children.iterator
       _children = null
 
       var curr: Fiber.Runtime[_, _] = null
@@ -748,7 +744,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         var next: Fiber.Runtime[_, _] = null
         while (iterator.hasNext && (next eq null)) {
           next = iterator.next()
-          if ((next ne null) && !next.isAlive())
+          if (!next.isAlive())
             next = null
         }
         curr = next
@@ -787,14 +783,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private def hasChildrenAliveUnsafe: Boolean = {
     val children0 = _children
     if ((children0 eq null) || (_exitValue ne null)) false
-    else {
-      val it = children0.iterator()
-      while (it.hasNext) {
-        val child = it.next()
-        if ((child ne null) && child.isAlive()) return true
-      }
-      false
-    }
+    else !children0.isEmpty
   }
 
   /**
@@ -1358,25 +1347,18 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private def sendInterruptSignalToAllChildren(
-    children: JavaSet[Fiber.Runtime[_, _]]
+    children: FiberSet[Fiber.Runtime[_, _]]
   ): Boolean =
     if ((children eq null) || children.isEmpty) false
     else {
-      // Initiate asynchronous interruption of all children:
-      val iterator = children.iterator()
-      var told     = false
-      val cause    = Cause.interrupt(fiberId)
-
-      while (iterator.hasNext) {
-        val next = iterator.next()
-
-        if ((next ne null) && next.isAlive()) {
-          next.tellInterrupt(cause)
-
-          told = true
-        }
+      // Initiate asynchronous interruption of all children.
+      // FiberSet.forEach only visits live entries, so no null or isAlive checks needed.
+      var told  = false
+      val cause = Cause.interrupt(fiberId)
+      children.forEach { next =>
+        next.tellInterrupt(cause)
+        told = true
       }
-
       told
     }
 

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.internal.FiberSet.{IsAlive, WeakRef}
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReferenceArray}
+
+/**
+ * A [[FiberSet]] is a lock-free concurrent bag optimized for fiber lifecycle
+ * tracking. New entries land in a striped nursery of strong references; they
+ * are only wrapped in a [[WeakReference]] when evicted from their nursery slot.
+ * Short-lived fibers that are [[remove]]d before eviction never allocate a
+ * [[WeakReference]] at all.
+ *
+ * Stale weak references are reclaimed in small, bounded batches on each [[add]]
+ * and [[remove]] call, eliminating the need for a background GC thread and
+ * keeping the structure fully compatible with Project Loom virtual threads.
+ *
+ * The `nurserySize` controls the total strong-reference capacity across all
+ * stripes. The `concurrencyLevel` is rounded up to the nearest power of two to
+ * determine the stripe count; higher values reduce CAS contention at the cost
+ * of slightly more memory.
+ */
+private[zio] final class FiberSet[A <: AnyRef](
+  nurserySize: Int,
+  concurrencyLevel: Int,
+  isAlive: IsAlive[A]
+) {
+
+  private[this] val nStripes: Int   = FiberSet.nextPow2(concurrencyLevel.max(1))
+  private[this] val stripeMask: Int = nStripes - 1
+  private[this] val stripeSize: Int = FiberSet.nextPow2((nurserySize / nStripes).max(4))
+  private[this] val slotMask: Int   = stripeSize - 1
+
+  // Striped nursery: strong refs, no WeakReference allocated for short-lived entries.
+  private[this] val nursery: Array[AtomicReferenceArray[AnyRef]] =
+    Array.tabulate(nStripes)(_ => new AtomicReferenceArray[AnyRef](stripeSize))
+  // Per-stripe write cursors; wrap around via slotMask so each slot is visited
+  // in round-robin order, giving every slot a fair chance to drain to long-term.
+  private[this] val cursors: Array[AtomicInteger] =
+    Array.fill(nStripes)(new AtomicInteger(0))
+
+  // Long-term storage: WeakReferences keyed by identity for O(1) remove.
+  private[this] val longTerm: ConcurrentHashMap[WeakRef[A], java.lang.Boolean] =
+    new ConcurrentHashMap[WeakRef[A], java.lang.Boolean](stripeSize * nStripes * 2)
+  private[this] val refQueue: ReferenceQueue[A] = new ReferenceQueue[A]()
+
+  // Drain at most this many cleared refs per mutation to bound latency.
+  private[this] final val DrainBatch = 16
+  // Full sweep of long-term storage is triggered when it exceeds this threshold.
+  private[this] final val GcThreshold = nStripes * stripeSize
+
+  /**
+   * Adds an entry to this set. The entry is placed in a randomly chosen nursery
+   * slot, atomically evicting any previous occupant. If the evicted occupant is
+   * still alive it is graduated to long-term weak storage. Lock-free.
+   */
+  final def add(a: A): Unit = {
+    drainQueue()
+    val tlr    = ThreadLocalRandom.current()
+    val stripe = tlr.nextInt() & stripeMask
+    val arr    = nursery(stripe)
+    val idx    = cursors(stripe).getAndIncrement() & slotMask
+    val prev   = arr.getAndSet(idx, a.asInstanceOf[AnyRef])
+    if (prev ne null) {
+      val evicted = prev.asInstanceOf[A]
+      if (isAlive(evicted))
+        longTerm.put(new WeakRef[A](evicted, refQueue), java.lang.Boolean.TRUE)
+    }
+    if (longTerm.size() > GcThreshold) sweepLongTerm()
+  }
+
+  /**
+   * Removes an entry from this set using identity comparison. The nursery is
+   * scanned first; if the entry is not found there it is looked up and removed
+   * from long-term storage. Lock-free.
+   */
+  final def remove(a: A): Unit = {
+    drainQueue()
+    var s = 0
+    while (s < nStripes) {
+      val arr = nursery(s)
+      var i   = 0
+      while (i < stripeSize) {
+        if (arr.get(i) eq a) {
+          arr.compareAndSet(i, a.asInstanceOf[AnyRef], null)
+          return
+        }
+        i += 1
+      }
+      s += 1
+    }
+    longTerm.remove(new WeakRef[A](a, null))
+  }
+
+  /**
+   * Returns `true` if this set contains no live entries. Weakly consistent.
+   */
+  final def isEmpty: Boolean = {
+    var s = 0
+    while (s < nStripes) {
+      val arr = nursery(s)
+      var i   = 0
+      while (i < stripeSize) {
+        val raw = arr.get(i)
+        if ((raw ne null) && isAlive(raw.asInstanceOf[A])) return false
+        i += 1
+      }
+      s += 1
+    }
+    val it = longTerm.keySet().iterator()
+    while (it.hasNext) {
+      val v = it.next().get()
+      if ((v ne null) && isAlive(v)) return false
+    }
+    true
+  }
+
+  /**
+   * Applies `f` to every live entry currently in this set. Weakly consistent;
+   * entries added or removed concurrently may or may not be observed.
+   */
+  final def forEach(f: A => Unit): Unit = {
+    var s = 0
+    while (s < nStripes) {
+      val arr = nursery(s)
+      var i   = 0
+      while (i < stripeSize) {
+        val raw = arr.get(i)
+        if (raw ne null) {
+          val a = raw.asInstanceOf[A]
+          if (isAlive(a)) f(a)
+        }
+        i += 1
+      }
+      s += 1
+    }
+    val it = longTerm.keySet().iterator()
+    while (it.hasNext) {
+      val ref = it.next()
+      val v   = ref.get()
+      if ((v ne null) && isAlive(v)) f(v)
+    }
+  }
+
+  /**
+   * Returns a weakly consistent iterator over live entries. The iterator is
+   * backed by a snapshot collected at the moment of the call and will never
+   * throw even in the presence of concurrent modifications.
+   */
+  final def iterator: Iterator[A] = {
+    val buf = new java.util.ArrayList[A](GcThreshold)
+    forEach(a => buf.add(a))
+    import scala.jdk.CollectionConverters._
+    buf.iterator().asScala
+  }
+
+  /**
+   * Returns the approximate number of entries, including entries that may have
+   * already been collected by the GC but not yet reclaimed.
+   */
+  def size: Int = {
+    var n = 0
+    var s = 0
+    while (s < nStripes) {
+      val arr = nursery(s)
+      var i   = 0
+      while (i < stripeSize) {
+        if (arr.get(i) ne null) n += 1
+        i += 1
+      }
+      s += 1
+    }
+    n + longTerm.size()
+  }
+
+  override def toString: String = iterator.mkString("FiberSet(", ", ", ")")
+
+  // Drains at most DrainBatch cleared refs from the GC queue, removing each
+  // from long-term storage in O(1) via its precomputed identity hash.
+  private[this] def drainQueue(): Unit = {
+    var n = 0
+    var r = refQueue.poll()
+    while ((r ne null) && n < DrainBatch) {
+      longTerm.remove(r.asInstanceOf[WeakRef[A]])
+      n += 1
+      r = refQueue.poll()
+    }
+  }
+
+  // Full scan of long-term storage; triggered when size exceeds GcThreshold.
+  private[this] def sweepLongTerm(): Unit = {
+    val it = longTerm.keySet().iterator()
+    while (it.hasNext) {
+      val ref = it.next()
+      val v   = ref.get()
+      if ((v eq null) || !isAlive(v)) it.remove()
+    }
+  }
+}
+
+private[zio] object FiberSet {
+
+  def apply[A <: AnyRef](
+    nurserySize: Int,
+    concurrencyLevel: Int = 1,
+    isAlive: IsAlive[A] = IsAlive.always
+  ): FiberSet[A] = new FiberSet(nurserySize, concurrencyLevel, isAlive)
+
+  /**
+   * Specialized predicate for liveness checks. Defined as a trait rather than
+   * `Function1` to avoid boxing the `Boolean` return value.
+   */
+  trait IsAlive[-A] {
+    def apply(value: A): Boolean
+  }
+
+  object IsAlive {
+    val always: IsAlive[Any] = _ => true
+  }
+
+  /**
+   * A [[WeakReference]] that uses identity semantics for hash and equality. The
+   * identity hash is captured at construction time and remains stable after the
+   * referent is collected, keeping the entry locatable in the map even after
+   * its referent is gone.
+   */
+  private[internal] final class WeakRef[A <: AnyRef](
+    referent: A,
+    queue: ReferenceQueue[A]
+  ) extends WeakReference[A](referent, queue) {
+    private[this] val _hash: Int = System.identityHashCode(referent)
+
+    override def hashCode(): Int = _hash
+
+    override def equals(obj: Any): Boolean = obj match {
+      case that: WeakRef[_] =>
+        val a = this.get()
+        val b = that.get()
+        if ((a ne null) && (b ne null)) a eq b else this eq that
+      case _ => false
+    }
+  }
+
+  /**
+   * Returns the smallest power of two that is >= `n`, with a minimum of 1.
+   */
+  private[internal] def nextPow2(n: Int): Int = {
+    var v = (n - 1).max(0)
+    v |= v >>> 1
+    v |= v >>> 2
+    v |= v >>> 4
+    v |= v >>> 8
+    v |= v >>> 16
+    v + 1
+  }
+}

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -46,8 +46,7 @@ object MimaSettings {
         exclude[Problem]("zio.test.TestClock.SuspendedWarningData"),
         exclude[Problem]("zio.test.TestClock.WarningData"),
         exclude[DirectMissingMethodProblem]("zio.test.package.testFiberRefGen"),
-        exclude[IncompatibleMethTypeProblem]("zio.test.package.warningEmptyGen"),
-        exclude[IncompatibleResultTypeProblem]("zio.Fiber._roots")
+        exclude[IncompatibleMethTypeProblem]("zio.test.package.warningEmptyGen")
       ),
       mimaFailOnProblem := failOnProblem
     )

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -46,7 +46,8 @@ object MimaSettings {
         exclude[Problem]("zio.test.TestClock.SuspendedWarningData"),
         exclude[Problem]("zio.test.TestClock.WarningData"),
         exclude[DirectMissingMethodProblem]("zio.test.package.testFiberRefGen"),
-        exclude[IncompatibleMethTypeProblem]("zio.test.package.warningEmptyGen")
+        exclude[IncompatibleMethTypeProblem]("zio.test.package.warningEmptyGen"),
+        exclude[IncompatibleResultTypeProblem]("zio.Fiber._roots")
       ),
       mimaFailOnProblem := failOnProblem
     )


### PR DESCRIPTION
/claim #8861

## Summary

Introduces `FiberSet`, a lock-free concurrent bag that replaces two separate structures:

- `WeakConcurrentBag` — used by `Fiber._roots`
- `Collections.synchronizedSet(new WeakHashMap)` — used by `FiberRuntime._children`

### Design

**Striped nursery of strong references.** New entries land in an `AtomicReferenceArray` slot chosen via a round-robin cursor within a randomly selected stripe. A `WeakReference` is only allocated when a slot is evicted. Short-lived fibers that are `remove`d before eviction never allocate a `WeakReference` at all.

**Amortized `ReferenceQueue` drain.** On every `add` and `remove`, up to 16 cleared weak references are removed from long-term storage. When long-term storage exceeds the nursery capacity a full sweep is triggered. There is no background GC thread, which means no platform-specific shims are needed — the structure compiles unchanged for JVM, Scala Native, and Scala.js.

**Fully lock-free.** Every mutation uses `getAndSet` or `compareAndSet`. There are no `synchronized` blocks or `ReentrantLock`s that could pin Project Loom virtual threads.

**`remove` support.** Unlike `WeakConcurrentBag`, `FiberSet` exposes a `remove` method, making it a complete replacement for the child-fiber tracking set. The nursery is scanned with identity comparison and a CAS eviction; long-term storage is addressed in O(1) via a sentinel `WeakRef` that carries the target's pre-computed identity hash.

### Files changed

| File | What |
|------|------|
| `core/shared/.../FiberSet.scala` | New data structure |
| `core/shared/.../Fiber.scala` | `_roots` now uses `FiberSet` |
| `core/shared/.../FiberRuntime.scala` | `_children` now uses `FiberSet`; several methods simplified |
| `core-tests/shared/.../FiberSetSpec.scala` | 10 tests |
| `benchmarks/.../FiberSetBenchmark.scala` | JMH benchmarks vs both replaced structures |
| `project/MimaSettings.scala` | Binary-compat exclusion for `Fiber._roots` type change |

### Benchmark results (8 threads, JDK 24, 1 fork / 3×1 s)

| Benchmark | ops/s |
|-----------|-------|
| `FiberSet.add` | **6.5 M** |
| `FiberSet.add + remove` | **6.6 M** |
| `synchronizedSet(WeakHashMap).add` | 1.8 M *(3.7× slower)* |
| `synchronizedSet(WeakHashMap).add + remove` | 4.7 M *(1.4× slower)* |
| `WeakConcurrentBag.add` (no remove) | 9.7 M |

### Test plan

- [x] `FiberSetSpec` — 10 tests: empty set, add, remove, dead-entry filtering, nursery eviction, concurrent adds, GC reclamation
- [x] All existing `FiberSpec`, `ScopeSpec`, and `ZIOSpec` suites pass with the `FiberSet` integration
- [x] JMH benchmarks run (results above)
- [ ] Demo video