### PR TITLE
Fix withDefault silently swallowing parse errors in indexed sequences

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala
@@ -724,6 +724,18 @@ object ConfigProviderSpec extends ZIOBaseSpec {
           exit <- configProvider.load(config).exit
         } yield assert(exit)(failsWithA[Config.Error])
       } +
+      test("indexed sequence with missing field does not trigger withDefault") {
+        // A typo in a field name (e.g. "idd" instead of "id") produces a
+        // MissingData error for the wrong key.  withDefault on the surrounding
+        // listOf must NOT swallow that error and return Nil; it should fail.
+        val configProvider = ConfigProvider.fromMap(Map("employees[0].age" -> "1", "employees[0].idd" -> "2"))
+        val product        = Config.int("age").zip(Config.int("id"))
+        val config         = Config.listOf("employees", product).withDefault(Nil)
+
+        for {
+          exit <- configProvider.load(config).exit
+        } yield assert(exit)(failsWithA[Config.Error])
+      } +
       test("indexed sequence of multiple products") {
         val configProvider = ConfigProvider.fromMap(
           Map(

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -722,6 +722,19 @@ object ConfigProvider {
                   ZIO
                     .foreach(Chunk.fromIterable(indices)) { index =>
                       loop(prefix :+ BracketedIndex(index), config, split = true)
+                        .mapError { e =>
+                          // The sequence key is present (indices were found), so a
+                          // MissingData error from within an element must not satisfy
+                          // isMissingDataOnly at the outer level; otherwise withDefault
+                          // or optional on the sequence would silently swallow a
+                          // structural parse error (e.g. a typo in a field name).
+                          if (e.isMissingDataOnly)
+                            e && Config.Error.InvalidData(
+                              prefix :+ BracketedIndex(index),
+                              s"A required field is missing in sequence element at index $index"
+                            )
+                          else e
+                        }
                     }
                     .map { chunkChunk =>
                       val flattened = chunkChunk.flatten

--- a/core/shared/src/main/scala/zio/ConfigProvider.scala
+++ b/core/shared/src/main/scala/zio/ConfigProvider.scala
@@ -721,20 +721,19 @@ object ConfigProvider {
                 } else
                   ZIO
                     .foreach(Chunk.fromIterable(indices)) { index =>
-                      loop(prefix :+ BracketedIndex(index), config, split = true)
-                        .mapError { e =>
-                          // The sequence key is present (indices were found), so a
-                          // MissingData error from within an element must not satisfy
-                          // isMissingDataOnly at the outer level; otherwise withDefault
-                          // or optional on the sequence would silently swallow a
-                          // structural parse error (e.g. a typo in a field name).
-                          if (e.isMissingDataOnly)
-                            e && Config.Error.InvalidData(
-                              prefix :+ BracketedIndex(index),
-                              s"A required field is missing in sequence element at index $index"
-                            )
-                          else e
-                        }
+                      loop(prefix :+ BracketedIndex(index), config, split = true).mapError { e =>
+                        // The sequence key is present (indices were found), so a
+                        // MissingData error from within an element must not satisfy
+                        // isMissingDataOnly at the outer level; otherwise withDefault
+                        // or optional on the sequence would silently swallow a
+                        // structural parse error (e.g. a typo in a field name).
+                        if (e.isMissingDataOnly)
+                          e && Config.Error.InvalidData(
+                            prefix :+ BracketedIndex(index),
+                            s"A required field is missing in sequence element at index $index"
+                          )
+                        else e
+                      }
                     }
                     .map { chunkChunk =>
                       val flattened = chunkChunk.flatten


### PR DESCRIPTION
## Problem

`Config.withDefault` uses `orElseIf(_.isMissingDataOnly)` as its fallback condition. When a `listOf` config is used with `withDefault`, a typo in a field name inside a list element produces a `MissingData` error (the mistyped key is absent), which satisfies `isMissingDataOnly`. This causes `withDefault` to substitute the default value instead of propagating the error.

Example:

```scala
final case class Person(name: String, age: Int)
val person = (Config.string("name") ++ Config.int("age")).map(Person.tupled)
val config = Config.listOf("values", person).withDefault(Nil)

// Map has "agr" instead of "age" — a typo
ConfigProvider.fromMap(Map("values[0].name" -> "John", "values[0].agr" -> "9"))
  .load(config)
// Before fix: succeeds with Nil  (silently swallows the error)
// After fix:  fails with Config.Error
```

## Root cause

In `ConfigProvider`, the `Sequence` case iterates over enumerated indices and calls `loop` for each element. When indices are non-empty, the sequence key is known to exist. An element-level `MissingData` (e.g. a missing field inside the element) propagated to an outer `Fallback` incorrectly appears as "purely missing data", satisfying the `withDefault` / `optional` condition.

## Fix

In the `Sequence` handler, when indices are non-empty (the list key is present), any element error that is `isMissingDataOnly` is combined with an `InvalidData` at the element prefix. This makes `isMissingDataOnly` return `false` for the combined error, so outer `withDefault` and `optional` see it as a structural parse failure rather than an absent key.

The fix does not affect inner `withDefault`/`optional` applied to individual element fields — those are evaluated inside the `loop` call and resolve before the error would reach the outer handler.

## Changes

- `core/shared/src/main/scala/zio/ConfigProvider.scala` — promote element-level missing-only errors to `And(e, InvalidData)` when the sequence key is present
- `core-tests/shared/src/test/scala/zio/ConfigProviderSpec.scala` — new test covering the case: field typo in a list element with `withDefault` on the list must fail, not return the default

## Testing

```
sbt "coreTestsJVM/testOnly zio.ConfigProviderSpec"
# 88 tests passed. 0 tests failed. 0 tests ignored.
```

Closes #10442