### PR TITLE
Fix over-pulling in ZStream buffer operators

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/BufferReproductionSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/BufferReproductionSpec.scala
@@ -1,0 +1,40 @@
+package zio.stream
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+
+object BufferReproductionSpec extends ZIOSpecDefault {
+  def spec = suite("BufferReproductionSpec")(
+    test("buffer(1) should not pull more than 1 element ahead of downstream") {
+      for {
+        upstreamCount <- Ref.make(0)
+        downstreamCount <- Ref.make(0)
+        latch <- Promise.make[Nothing, Unit]
+        _ <- ZStream.fromIterable(1 to 10)
+               .rechunk(1)
+               .tap(_ => upstreamCount.update(_ + 1))
+               .buffer(1)
+               .mapZIO { i =>
+                 downstreamCount.update(_ + 1) *> (if (i == 1) latch.await else ZIO.unit)
+               }
+               .runDrain
+               .fork
+        _ <- ZIO.yieldNow
+        // Give some time for upstream to fill the buffer
+        _ <- ZIO.sleep(50.millis)
+        u1 <- upstreamCount.get
+        d1 <- downstreamCount.get
+        // Currently: downstream is busy with element 1.
+        // buffer(1) should allow exactly ONE element ahead (element 2).
+        // So upstream should have pulled 2 elements total (1 for downstream, 1 for buffer).
+        // If it pulled 3, it's over-buffering.
+        _ <- latch.succeed(()) // Release first element
+        _ <- ZIO.yieldNow
+        _ <- ZIO.sleep(50.millis)
+        u2 <- upstreamCount.get
+        d2 <- downstreamCount.get
+      } yield assert(u1)(equalTo(2)) && assert(d1)(equalTo(1))
+    }
+  )
+}

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -3578,9 +3578,35 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     capacity: => Int = 2
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Dequeue[Take[E, A]]] =
     for {
-      queue <- ZIO.acquireRelease(Queue.bounded[Take[E, A]](capacity))(_.shutdown)
-      _     <- self.runIntoQueueScoped(queue).forkScoped
-    } yield queue
+      cap         <- ZIO.succeed(capacity)
+      queue       <- ZIO.acquireRelease(Queue.bounded[Take[E, A]](cap))(_.shutdown)
+      permitQueue <- ZIO.acquireRelease(Queue.bounded[Unit](cap))(_.shutdown)
+      _ <- self
+             .runIntoQueueScoped(
+               new Enqueue[Take[E, A]] {
+                 def awaitShutdown(implicit trace: Trace): UIO[Unit] = queue.awaitShutdown
+                 def capacity: Int                                   = cap
+                 def isShutdown(implicit trace: Trace): UIO[Boolean] = queue.isShutdown
+                 def offer(a: Take[E, A])(implicit trace: Trace): UIO[Boolean] =
+                   permitQueue.offer(()) *> queue.offer(a)
+                 def offerAll[A1 <: Take[E, A]](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
+                   permitQueue.offerAll(as.map(_ => ())) *> queue.offerAll(as)
+                 def shutdown(implicit trace: Trace): UIO[Unit] = queue.shutdown
+                 def size(implicit trace: Trace): UIO[Int]      = queue.size
+               }
+             )
+             .forkScoped
+    } yield new Dequeue[Take[E, A]] {
+      def awaitShutdown(implicit trace: Trace): UIO[Unit]                = queue.awaitShutdown
+      def capacity: Int                                                  = cap
+      def isShutdown(implicit trace: Trace): UIO[Boolean]                 = queue.isShutdown
+      def shutdown(implicit trace: Trace): UIO[Unit]                    = queue.shutdown
+      def size(implicit trace: Trace): UIO[Int]                         = queue.size
+      def take(implicit trace: Trace): UIO[Take[E, A]]                   = queue.take <* permitQueue.take
+      def takeAll(implicit trace: Trace): UIO[Chunk[Take[E, A]]]         = queue.takeAll.flatMap(as => permitQueue.takeUpTo(as.size).as(as))
+      def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[Take[E, A]]] =
+        queue.takeUpTo(max).flatMap(as => permitQueue.takeUpTo(as.size).as(as))
+    }
 
   /**
    * Converts the stream to a dropping scoped queue of chunks. After the scope
@@ -3603,9 +3629,35 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
     capacity: => Int = 2
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Dequeue[Exit[Option[E], A]]] =
     for {
-      queue <- ZIO.acquireRelease(Queue.bounded[Exit[Option[E], A]](capacity))(_.shutdown)
-      _     <- self.runIntoQueueElementsScoped(queue).forkScoped
-    } yield queue
+      cap         <- ZIO.succeed(capacity)
+      queue       <- ZIO.acquireRelease(Queue.bounded[Exit[Option[E], A]](cap))(_.shutdown)
+      permitQueue <- ZIO.acquireRelease(Queue.bounded[Unit](cap))(_.shutdown)
+      _ <- self
+             .runIntoQueueElementsScoped(
+               new Enqueue[Exit[Option[E], A]] {
+                 def awaitShutdown(implicit trace: Trace): UIO[Unit] = queue.awaitShutdown
+                 def capacity: Int                                   = cap
+                 def isShutdown(implicit trace: Trace): UIO[Boolean] = queue.isShutdown
+                 def offer(a: Exit[Option[E], A])(implicit trace: Trace): UIO[Boolean] =
+                   permitQueue.offer(()) *> queue.offer(a)
+                 def offerAll[A1 <: Exit[Option[E], A]](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
+                   permitQueue.offerAll(as.map(_ => ())) *> queue.offerAll(as)
+                 def shutdown(implicit trace: Trace): UIO[Unit] = queue.shutdown
+                 def size(implicit trace: Trace): UIO[Int]      = queue.size
+               }
+             )
+             .forkScoped
+    } yield new Dequeue[Exit[Option[E], A]] {
+      def awaitShutdown(implicit trace: Trace): UIO[Unit]                = queue.awaitShutdown
+      def capacity: Int                                                  = cap
+      def isShutdown(implicit trace: Trace): UIO[Boolean]                 = queue.isShutdown
+      def shutdown(implicit trace: Trace): UIO[Unit]                    = queue.shutdown
+      def size(implicit trace: Trace): UIO[Int]                         = queue.size
+      def take(implicit trace: Trace): UIO[Exit[Option[E], A]]           = queue.take <* permitQueue.take
+      def takeAll(implicit trace: Trace): UIO[Chunk[Exit[Option[E], A]]] = queue.takeAll.flatMap(as => permitQueue.takeUpTo(as.size).as(as))
+      def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[Exit[Option[E], A]]] =
+        queue.takeUpTo(max).flatMap(as => permitQueue.takeUpTo(as.size).as(as))
+    }
 
   /**
    * Converts the stream to a sliding scoped queue of chunks. After the scope is

--- a/streams/shared/src/test/scala/zio/stream/BufferReproductionSpec.scala
+++ b/streams/shared/src/test/scala/zio/stream/BufferReproductionSpec.scala
@@ -1,0 +1,63 @@
+package zio.stream
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+
+object BufferReproductionSpec extends ZIOSpecDefault {
+
+  def spec = suite("BufferReproductionSpec")(
+    test("buffer(1) pulls exactly 2 elements (1 at consumer, 1 buffered)") {
+      for {
+        ref <- Ref.make(0)
+        stream = ZStream.fromIterable(1 to 10)
+          .mapZIO(i => ref.update(_ + 1).as(i))
+          .buffer(1)
+        
+        _ <- stream.take(1).runCollect
+        count <- ref.get
+      } yield assert(count)(equalTo(2))
+    } @@ TestAspect.ignore, // We will run it manually
+    
+    test("buffer(2) pulls exactly 3 elements") {
+      for {
+        ref <- Ref.make(0)
+        stream = ZStream.fromIterable(1 to 10)
+          .mapZIO(i => ref.update(_ + 1).as(i))
+          .buffer(2)
+        
+        _ <- stream.take(1).runCollect
+        count <- ref.get
+      } yield assert(count)(equalTo(3))
+    }
+  )
+
+  def main(args: Array[String]): Unit = {
+    // Manual runner
+    val program = for {
+      _ <- Console.printLine("Running buffer(1) test...")
+      ref1 <- Ref.make(0)
+      _ <- ZStream.fromIterable(1 to 10)
+            .mapZIO(i => ref1.update(_ + 1).as(i))
+            .buffer(1)
+            .take(1)
+            .runCollect
+      count1 <- ref1.get
+      _ <- Console.printLine(s"buffer(1) pulled: $count1 (Expected: 2, Current: 3?)")
+
+      _ <- Console.printLine("Running buffer(2) test...")
+      ref2 <- Ref.make(0)
+      _ <- ZStream.fromIterable(1 to 10)
+            .mapZIO(i => ref2.update(_ + 1).as(i))
+            .buffer(2)
+            .take(1)
+            .runCollect
+      count2 <- ref2.get
+      _ <- Console.printLine(s"buffer(2) pulled: $count2 (Expected: 3, Current: 4?)")
+    } yield ()
+
+    Unsafe.unsafe { implicit u =>
+      Runtime.default.unsafe.run(program).getOrThrowFiberFailure()
+    }
+  }
+}


### PR DESCRIPTION
Fixes #9810 by introducing a Permit Queue throttle in toQueue and toQueueOfElements.