### PR TITLE
Implement NIO Least-Loaded scheduler for ZIO

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -151,8 +151,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
   /**
    * NIO: Choose the worker with the least load using Least-Loaded scheduling.
-   * Scans all workers and returns the one with the minimum number of pending tasks.
-   * Returns null if all workers are blocking.
+   * Scans all workers and returns the one with the minimum number of pending
+   * tasks. Returns null if all workers are blocking.
    */
   private def chooseWorker(): ZScheduler.Worker = {
     val n = poolSize

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -488,8 +488,6 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
       // NOTE: Synchronized block in case the supervisor attempts to mark the worker as blocking at the same time
       // as an external call
-      // NOTE: Synchronized block in case the supervisor attempts to mark the worker as blocking at the same time
-      // as an external call
       final def markAsBlocking(): Unit = synchronized {
         if (blocking) ()
         else {
@@ -618,7 +616,7 @@ private object ZScheduler {
    *
    * Padding (pad* fields) separates hot fields by 128 bytes to avoid false
    * sharing when chooseWorker() reads localQueue.size() and nextRunnable from
-   * other workers. See ZSchedulerJOLPaddingSpec.
+   * other workers.
    */
   private sealed abstract class Worker extends Thread with BlockContext {
 

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -19,7 +19,7 @@ package zio.internal
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong, AtomicLongArray}
 import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.{ConcurrentLinkedQueue, ThreadLocalRandom}
 import scala.collection.mutable
@@ -42,12 +42,18 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val state           = new AtomicInteger(poolSize << 16)
   private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
 
+  // NIO: AtomicLongArray with stride 16 (128 bytes per entry) to track per-worker task counts.
+  // This enables the Least-Loaded scheduling strategy: new tasks are assigned to the worker
+  // with the fewest pending tasks, reducing contention under high load.
+  private[this] val taskCounts = new AtomicLongArray(poolSize * 16)
+
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
 
   (0 until poolSize).foreach { workerId =>
     val worker = makeWorker()
     worker.setName(workerId)
     worker.setDaemon(true)
+    worker.workerIndex = workerId
     workers(workerId) = worker
   }
   workers.foreach(_.start())
@@ -143,16 +149,54 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     }
   }
 
+  /**
+   * NIO: Choose the worker with the least load using Least-Loaded scheduling.
+   * Scans all workers and returns the one with the minimum number of pending tasks.
+   * Returns null if all workers are blocking.
+   */
+  private def chooseWorker(): ZScheduler.Worker = {
+    val n = poolSize
+    if (n == 1) {
+      val w = workers(0)
+      if (w.blocking) null else w
+    } else {
+      var best    = null.asInstanceOf[ZScheduler.Worker]
+      var minLoad = Long.MaxValue
+      var i       = 0
+      while (i < n) {
+        val w = workers(i)
+        if (!w.blocking) {
+          val load = math.max(0L, taskCounts.get(i * 16))
+          if (load < minLoad) {
+            minLoad = load
+            best = w
+          }
+        }
+        i += 1
+      }
+      best
+    }
+  }
+
   def submit(runnable: Runnable)(implicit unsafe: Unsafe): Boolean = {
     val worker = workerOrNull()
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        // NIO: Use Least-Loaded scheduling for external submissions
+        val best = chooseWorker()
+        if ((best eq null) || !best.localQueue.offer(runnable)) {
+          globalQueue.offer(runnable)
+        } else {
+          taskCounts.getAndIncrement(best.workerIndex * 16)
+        }
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
-      } else ()
+      } else {
+        // NIO: Track task count for local queue submission
+        taskCounts.getAndIncrement(worker.workerIndex * 16)
+      }
       val currentState = state.get
       maybeUnparkWorker(currentState)
       true
@@ -166,7 +210,13 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     } else {
       var notify = true
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        // NIO: Use Least-Loaded scheduling for external submissions
+        val best = chooseWorker()
+        if ((best eq null) || !best.localQueue.offer(runnable)) {
+          globalQueue.offer(runnable)
+        } else {
+          taskCounts.getAndIncrement(best.workerIndex * 16)
+        }
       }
       // Attempt resumption in the current Thread
       else if ((worker.nextRunnable eq null) && worker.localQueue.isEmpty()) {
@@ -180,11 +230,16 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
           // Less common path, global queue is not empty, so we have to prioritize the runnable from it
           worker.nextRunnable = fromGlobal
           worker.localQueue.offer(runnable)
+          // NIO: Track task count for the local queue addition
+          taskCounts.getAndIncrement(worker.workerIndex * 16)
         }
       }
       // We have to yield, add the runnable to the local / global queue so that it can be scheduled accordingly
       else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
+      } else {
+        // NIO: Track task count for local queue submission
+        taskCounts.getAndIncrement(worker.workerIndex * 16)
       }
 
       if (notify) {
@@ -198,9 +253,14 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private def handleFullWorkerQueue(worker: ZScheduler.Worker, runnable: Runnable): Unit = {
     val rnd    = ThreadLocalRandom.current
     val polled = worker.localQueue.pollUpTo(128)
+    // NIO: Decrement task counts for polled runnables
+    taskCounts.getAndAdd(worker.workerIndex * 16, -polled.size.toLong)
     globalQueue.offerAll(polled, rnd)
     val accepted = worker.localQueue.offer(runnable)
-    if (!accepted) {
+    if (accepted) {
+      // NIO: Increment task count for the newly accepted runnable
+      taskCounts.getAndIncrement(worker.workerIndex * 16)
+    } else {
       // We should never ever need to come here, this is just a precaution in the case we've introduced a bug
       globalQueue.offer(runnable, rnd)
     }
@@ -291,6 +351,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         val cache       = parent.cache
         val idle        = parent.idle
         val poolSize    = ZScheduler.poolSize
+        val taskCounts  = parent.taskCounts
 
         var currentBlocking = false
         var currentOpCount  = 0L
@@ -299,6 +360,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         var searching       = false
 
         while (!isInterrupted) {
+          // NIO: Cache the worker's slot index in taskCounts for efficient updates
+          val selfSlot = workerIndex * 16
           currentBlocking = blocking
           val currentNextRunnable = nextRunnable
           if (currentBlocking) ()
@@ -310,10 +373,15 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
               runnable = globalQueue.poll(random)
               if (runnable eq null) {
                 runnable = localQueue.poll(null)
+                // NIO: Decrement task count when polling from local queue
+                if (runnable ne null) taskCounts.getAndDecrement(selfSlot)
               }
             } else {
               runnable = localQueue.poll(null)
-              if (runnable eq null) {
+              // NIO: Decrement task count when polling from local queue
+              if (runnable ne null) {
+                taskCounts.getAndDecrement(selfSlot)
+              } else {
                 runnable = globalQueue.poll(random)
               }
             }
@@ -339,13 +407,21 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
                       val runnables  = worker.localQueue.pollUpTo(size - size / 2)
                       val nRunnables = runnables.size
                       if (nRunnables > 0) {
+                        // NIO: Decrement source worker's task count for stolen tasks
+                        taskCounts.getAndAdd(worker.workerIndex * 16, -nRunnables.toLong)
                         val iter = runnables.iterator
                         runnable = iter.next()
-                        if (nRunnables > 1) localQueue.offerAll(iter, nRunnables - 1)
+                        if (nRunnables > 1) {
+                          localQueue.offerAll(iter, nRunnables - 1)
+                          // NIO: Increment own task count for runnables added to local queue
+                          taskCounts.getAndAdd(selfSlot, (nRunnables - 1).toLong)
+                        }
                         currentBlocking = blocking
                         if (currentBlocking) {
                           val runnables = localQueue.pollUpTo(256)
                           if (!runnables.isEmpty) {
+                            // NIO: Decrement own task count for runnables moved to global
+                            taskCounts.getAndAdd(selfSlot, -runnables.size.toLong)
                             globalQueue.offerAll(runnables, random)
                           }
                         }
@@ -412,6 +488,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
       // NOTE: Synchronized block in case the supervisor attempts to mark the worker as blocking at the same time
       // as an external call
+      // NOTE: Synchronized block in case the supervisor attempts to mark the worker as blocking at the same time
+      // as an external call
       final def markAsBlocking(): Unit = synchronized {
         if (blocking) ()
         else {
@@ -424,16 +502,20 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
               nextRunnable = null
             }
             globalQueue.offerAll(runnables)
+            // NIO: Reset task count for this worker since it's now blocking
+            parent.taskCounts.set(idx * 16, 0L)
             val worker = cache.poll()
             if (worker eq null) {
               val worker = makeWorker()
               worker.setName(idx)
               worker.setDaemon(true)
+              worker.workerIndex = idx
               workers(idx) = worker
               worker.start()
             } else {
               state.getAndIncrement()
               worker.setName(idx)
+              worker.workerIndex = idx
               workers(idx) = worker
               worker.blocking = false
               worker.active = true
@@ -533,6 +615,10 @@ private object ZScheduler {
   /**
    * A `Worker` is a `Thread` that is responsible for executing actions
    * submitted to the scheduler.
+   *
+   * Padding (pad* fields) separates hot fields by 128 bytes to avoid false
+   * sharing when chooseWorker() reads localQueue.size() and nextRunnable from
+   * other workers. See ZSchedulerJOLPaddingSpec.
    */
   private sealed abstract class Worker extends Thread with BlockContext {
 
@@ -559,11 +645,19 @@ private object ZScheduler {
     var currentRunnable: Runnable =
       null
 
+    // NIO padding fields to prevent false sharing
+    private var pad1_00, pad1_01, pad1_02, pad1_03, pad1_04, pad1_05, pad1_06, pad1_07 = 0L
+    private var pad1_08, pad1_09, pad1_10, pad1_11, pad1_12, pad1_13, pad1_14, pad1_15 = 0L
+
     /**
      * The local work queue for this worker.
      */
     val localQueue: RingBufferPow2[Runnable] =
       RingBufferPow2[Runnable](256)
+
+    // NIO padding fields
+    private var pad2_00, pad2_01, pad2_02, pad2_03, pad2_04, pad2_05, pad2_06, pad2_07 = 0L
+    private var pad2_08, pad2_09, pad2_10, pad2_11, pad2_12, pad2_13, pad2_14, pad2_15 = 0L
 
     /**
      * An optional field providing fast access to the next task to be executed
@@ -572,12 +666,22 @@ private object ZScheduler {
     var nextRunnable: Runnable =
       null
 
+    // NIO padding fields
+    private var pad3_00, pad3_01, pad3_02, pad3_03, pad3_04, pad3_05, pad3_06, pad3_07 = 0L
+    private var pad3_08, pad3_09, pad3_10, pad3_11, pad3_12, pad3_13, pad3_14, pad3_15 = 0L
+
     /**
      * The number of tasks that have been executed by this worker.
      */
     @volatile
     var opCount: Long =
       0L
+
+    // NIO: Index of this worker in the workers array and taskCounts AtomicLongArray.
+    // This is set once when the worker is created and used for O(1) task count updates.
+    @volatile
+    var workerIndex: Int =
+      -1
 
     def markAsBlocking(): Unit
 


### PR DESCRIPTION
## Summary

Implements a Least-Loaded (LL) scheduling strategy for ZScheduler, inspired by "Making the Tokio Scheduler 10X Faster" by Carl Lerche.

### Key Changes

1. **AtomicLongArray with cache-line stride**: Added `taskCounts` field using `AtomicLongArray(poolSize * 16)` - the 16-element stride (128 bytes) ensures each worker count occupies its own cache line, eliminating false sharing when `chooseWorker()` scans all workers.

2. **chooseWorker()**: New private method that scans all workers and returns the one with the minimum number of pending tasks. Returns null if all workers are blocking.

3. **Least-Loaded scheduling in submit/submitAndYield**: When the current thread is not a ZIO worker (external submissions), tasks are routed to the least-loaded worker instead of going directly to the global queue. This distributes external work more evenly from the start, reducing global queue contention under high concurrency.

4. **Task count tracking**: Increment on local queue submission, decrement on poll, update on steal and queue flush. Reset to 0 when worker enters blocking mode.

5. **Worker index and cache-line padding**: Added `workerIndex` field for O(1) task count updates. Added cache-line padding between hot fields in the Worker class to prevent false sharing between adjacent workers during scheduling decisions.

### Performance Motivation

The current ZScheduler uses work-stealing to balance load, but under high concurrency, tasks submitted from external threads (e.g., thread pools outside ZIO) all go to the global queue, creating a bottleneck. The Least-Loaded strategy assigns these tasks directly to the least-loaded worker, reducing contention.

### Testing

- `sbt fmt` applied - code style compliant
- `coreJVM/compile` successful
- `RuntimeSpecJVM` tests passed (4 tests)
- `BlockingSpec` tests passed (25 tests)
- `RuntimeFlagsSpec` tests passed (12 tests)
- `ExecutorSpec` tests passed (10 tests)
- `ZIOSpec` all 568 tests passed

### Reference

- Original issue: https://github.com/zio/zio/issues/9356
- Inspired by: https://tokio.rs/blog/2019-10-scheduler

/claim #9356
