### PR TITLE
perf: reduce redundant LockSupport.unpark() calls in ZScheduler

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -19,7 +19,7 @@ package zio.internal
 import zio._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicLong}
 import java.util.concurrent.locks.LockSupport
 import java.util.concurrent.{ConcurrentLinkedQueue, ThreadLocalRandom}
 import scala.collection.mutable
@@ -40,6 +40,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
   private[this] val state           = new AtomicInteger(poolSize << 16)
+  private[this] val notifyPending   = new AtomicBoolean(false)
   private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
@@ -393,6 +394,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             while (!active && !isInterrupted) {
               LockSupport.park()
             }
+            notifyPending.set(false)
             searching = true
           } else {
             if (searching) {
@@ -450,9 +452,13 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (currentActive != poolSize && currentSearching == 0) {
       val worker = idle.poll()
       if (worker ne null) {
-        state.getAndAdd(0x10001)
-        worker.active = true
-        LockSupport.unpark(worker)
+        if (notifyPending.compareAndSet(false, true)) {
+          state.getAndAdd(0x10001)
+          worker.active = true
+          LockSupport.unpark(worker)
+        } else {
+          idle.offer(worker)
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a CAS-based notification gate (`AtomicBoolean notifyPending`) to `maybeUnparkWorker()` to prevent redundant `LockSupport.unpark()` syscalls under burst load.

## Problem

`maybeUnparkWorker()` is called on every `submit()` and `submitAndYield()`. `LockSupport.unpark()` is an expensive JVM syscall, and under burst load, multiple threads can issue unparks to wake workers that are already in the process of waking up — wasting CPU on redundant kernel transitions.

## Solution

- Added an `AtomicBoolean notifyPending` field to `ZScheduler`
- In `maybeUnparkWorker`, gate the unpark behind `notifyPending.compareAndSet(false, true)` — if another unpark is already in-flight, return the worker to the idle queue instead
- After a worker wakes from `LockSupport.park()`, clear `notifyPending` to reopen the gate for the next notification cycle

This ensures at most one in-flight unpark at a time, eliminating redundant syscalls while preserving correctness — a waking worker will pick up any newly submitted tasks.

This follows the same notification pattern used by the Tokio scheduler, which is cited as inspiration in the source file.

## Test plan

- [ ] Existing ZIO test suite passes (no behavioral change, only performance)
- [ ] Benchmark `submit()`/`submitAndYield()` under burst load to verify reduced unpark syscall count

> **Note:** A wakeup latency regression test is recommended to verify that the CAS gate does not introduce measurable delay under normal (non-burst) workloads.

Fixes #9878