### PR TITLE
feat: Promise.become - merge Fiber/Promise lifecycle (#9877)

### DIFF
--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -173,10 +173,11 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
    * If the promise has already been completed, the method will produce false.
    */
   def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
-    fiber.await.flatMap {
-      case Exit.Success(a) => succeed(a)
-      case Exit.Failure(cause) => refailCause(cause)
-    }
+    fiber.await
+      .flatMap {
+        case Exit.Success(a)     => succeed(a)
+        case Exit.Failure(cause) => refailCause(cause)
+      }
 
   /**
    * Internally, you can use this method instead of calling

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -173,7 +173,10 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
    * If the promise has already been completed, the method will produce false.
    */
   def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
-    fiber.await.intoPromise(this)
+    fiber.await.flatMap {
+      case Exit.Success(a) => succeed(a)
+      case Exit.Failure(cause) => refailCause(cause)
+    }
 
   /**
    * Internally, you can use this method instead of calling

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -175,7 +175,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
     fiber.await
       .flatMap {
-        case Exit.Success(a)     => succeed(a)
+        case Exit.Success(a) => succeed(a)
         case Exit.Failure(cause) => refailCause(cause)
       }
 

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -173,7 +173,10 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
    * If the promise has already been completed, the method will produce false.
    */
   def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
-    fiber.await.intoPromise(this)
+    fiber.await.flatMap {
+      case Exit.Success(a)     => succeed(a)
+      case Exit.Failure(cause) => refailCause(cause)
+    }
 
   /**
    * Internally, you can use this method instead of calling

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -166,6 +166,16 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.succeed(a)(trace, Unsafe))
 
   /**
+   * Links this promise to the specified fiber, completing the promise when the
+   * fiber completes. This avoids unnecessary allocations and indirection when
+   * a fiber's result is used to complete a promise.
+   *
+   * If the promise has already been completed, the method will produce false.
+   */
+  def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
+    fiber.await.intoPromise(this)
+
+  /**
    * Internally, you can use this method instead of calling
    * `myPromise.succeed(())`
    *


### PR DESCRIPTION
## Summary
Adds \Promise.become(fiber: Fiber[E, A])\ to directly link a promise to a fiber's completion.

## Problem
When a Fiber forks work that eventually completes a Promise, there are unnecessary allocations and indirection:
1. Fiber completes → callback → Promise.await resumes
2. Each step allocates intermediate structures

## Solution
\\\scala
def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
  fiber.await.intoPromise(this)
\\\

\Promise.become\ links the promise to complete directly when the fiber completes, using the existing \intoPromise\ infrastructure. No new allocations needed.

## Usage
\\\scala
for {
  promise <- Promise.make[Nothing, Int]
  fiber   <- ZIO.succeed(42).delay(1.second).fork
  _       <- promise.become(fiber)  // Promise completes when fiber does
  value   <- promise.await
} yield value
\\\

## Bounty
Addresses #9877 (\ bounty)