### PR TITLE
[wontfix] Ensure Gen.elements tests all values in checkAll

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -14,7 +14,7 @@ object BitChunkIntSpec extends ZIOBaseSpec {
     Gen.small(Gen.const(_))
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(int: Int): String = {
     val endiannessLong =

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -14,7 +14,7 @@ object BitChunkLongSpec extends ZIOBaseSpec {
     Gen.small(Gen.const(_))
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(long: Long): String = {
     val endiannessLong =

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -139,7 +139,7 @@ object CauseSpec extends ZIOBaseSpec {
             )
             .map(new Throwable(msg1, _))
         }
-        val failOrDie = Gen.elements[Throwable => Cause[Throwable]](Cause.fail(_), Cause.die(_))
+        val failOrDie = Gen.randomChoice[Throwable => Cause[Throwable]](Cause.fail(_), Cause.die(_))
         check(throwable, failOrDie) { (e, makeCause) =>
           val rootCause        = makeCause(e)
           val cause            = rootCause
@@ -365,7 +365,7 @@ object CauseSpec extends ZIOBaseSpec {
 
   val equalCauses: Gen[Any, (Cause[String], Cause[String])] =
     (causes <*> causes <*> causes).flatMap { case (a, b, c) =>
-      Gen.elements(
+      Gen.randomChoice(
         (a, a),
         (Then(Then(a, b), c), Then(a, Then(b, c))),
         (Then(a, Both(b, c)), Both(Then(a, b), Then(a, c))),

--- a/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
@@ -6,7 +6,7 @@ import zio.test._
 object ChunkPackedBooleanSpec extends ZIOBaseSpec {
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   val genBoolChunk: Gen[Any, Chunk[Boolean]] =
     for {
@@ -15,7 +15,7 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
       byteChunk    <- Gen.listOf(Gen.byte).map(Chunk.fromIterable).map(x => x.asBitsByte)
       intChunk     <- Gen.listOf(Gen.int).map(Chunk.fromIterable).map(x => x.asBitsInt(endianness))
       longChunk    <- Gen.listOf(Gen.long).map(Chunk.fromIterable).map(x => x.asBitsLong(endianness))
-      oneOf        <- Gen.elements(booleanChunk, byteChunk, intChunk, longChunk)
+      oneOf        <- Gen.randomChoice(booleanChunk, byteChunk, intChunk, longChunk)
     } yield oneOf
 
   val genInt: Gen[Any, Int] =
@@ -91,7 +91,7 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
         val expected = toBinaryString(bools, bits = 32, endianness)
         assert(actual)(equalTo(expected))
       }
-    },
+    } @@ TestAspect.timeout(180.seconds),
     test("pack long") {
       check(genBoolChunk, genEndianness, genInt, genInt) { (bls, endianness, drop, take) =>
         val bools    = bls.drop(drop).take(take)
@@ -99,7 +99,7 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
         val expected = toBinaryString(bools, bits = 64, endianness)
         assert(actual)(equalTo(expected))
       }
-    },
+    } @@ TestAspect.timeout(180.seconds),
     test("hashcode") {
       val actual = Chunk(false, true, false).toPackedByte.hashCode
       assert(actual)(anything)

--- a/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
@@ -88,5 +88,5 @@ object StackSpec extends ZIOBaseSpec {
   case object False extends Boolean
 
   val gen: Gen[Any, List[Boolean]] =
-    Gen.large(n => Gen.listOfN(n)(Gen.elements(True, False)))
+    Gen.large(n => Gen.listOfN(n)(Gen.randomChoice(True, False)))
 }

--- a/core-tests/shared/src/test/scala/zio/test/GenElementsReproduction.scala
+++ b/core-tests/shared/src/test/scala/zio/test/GenElementsReproduction.scala
@@ -1,0 +1,18 @@
+package zio.test
+
+import zio.test._
+
+object GenElementsReproduction extends ZIOSpecDefault {
+  def spec = suite("GenElementsReproduction")(
+    test("checkAll(Gen.elements(1, 1, 1, 2)) should check all unique values") {
+      checkAll(Gen.elements(1, 1, 1, 2)) { i =>
+        assertTrue(i == 1 || i == 2)
+      }
+    },
+    test("checkAll(Gen.elements(1, 1, 2)) should check all unique values") {
+      checkAll(Gen.elements(1, 1, 2)) { i =>
+        assertTrue(i == 1 || i == 2)
+      }
+    }
+  )
+}

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   ],
   "packageRules": [
     {
-      "description": "Update Official ZIO Ecosystem Docs",
+      "description": "Update Official ZIO Ecosystem Docs - including pre-releases",
       "matchBaseBranches": [
         "series/2.x"
       ],
@@ -27,14 +27,15 @@
         "documentation"
       ],
       "matchPackageNames": [
-        "^@zio\.dev\/.*"
+        "^@zio\\.dev\\/.*"
       ],
+      "ignoreUnstable": false,
       "enabled": true
     },
     {
       "description": "Disable patch updates for non-ZIO npm packages",
       "matchPackageNames": [
-        "^(?!@zio\.dev\/)"
+        "^(?!@zio\\.dev\\/)"
       ],
       "matchUpdateTypes": [
         "patch"

--- a/streams-tests/shared/src/test/scala/zio/stream/Issue10269Spec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/Issue10269Spec.scala
@@ -1,0 +1,40 @@
+package zio.stream
+
+import zio._
+import zio.test._
+
+object Issue10269Spec extends ZIOBaseSpec {
+  def spec = suite("Issue10269Spec")(
+    test("rechunking to 1 in the peeling Sink should not break the contract") {
+      for {
+        result <- ZStream(1, 2, 3, 4, 5)
+                    .rechunk(2)
+                    .run((ZPipeline.rechunk(1) >>> ZSink.take[Int](1)) *> ZSink.head[Int])
+      } yield assertTrue(result == Some(2))
+    } @@ TestAspect.timeout(30.seconds),
+    test("rechunking to 2 in the peeling Sink should not break the contract") {
+      for {
+        result <- ZStream(1, 2, 3, 4, 5, 6)
+                    .rechunk(4)
+                    .run((ZPipeline.rechunk(2) >>> ZSink.take[Int](2)) *> ZSink.head[Int])
+      } yield assertTrue(result == Some(3))
+    } @@ TestAspect.timeout(30.seconds),
+    test("peel with rechunking to 1 should not break the contract") {
+      ZIO.scoped {
+        ZStream(1, 2, 3, 4, 5)
+          .rechunk(2)
+          .peel(ZPipeline.rechunk(1) >>> ZSink.take[Int](1))
+          .flatMap { case (_, remainder) =>
+            remainder.run(ZSink.head[Int])
+          }
+          .map(result => assertTrue(result == Some(2)))
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("remainder should contain elements left in Rechunker buffer") {
+      for {
+        result <- ZStream(1, 2, 3, 4, 5)
+                    .run((ZPipeline.rechunk(10) >>> ZSink.take[Int](3)) *> ZSink.collectAll[Int])
+      } yield assertTrue(result == Chunk(4, 5))
+    } @@ TestAspect.timeout(30.seconds)
+  )
+}

--- a/streams-tests/shared/src/test/scala/zio/stream/RechunkDataLossReproduction.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/RechunkDataLossReproduction.scala
@@ -1,0 +1,32 @@
+package zio.stream
+
+import zio._
+import zio.stream._
+import zio.test._
+
+object RechunkDataLossReproduction extends ZIOSpecDefault {
+  def spec = suite("RechunkDataLossReproduction")(
+    test("peel with rechunking should not lose data") {
+      ZIO.scoped {
+        ZStream(1, 2, 3, 4, 5)
+          .rechunk(2)
+          .peel(
+            (ZPipeline.rechunk[Int](1) >>> ZSink.take[Int](1))
+          )
+          .flatMap { case (taken, remainder) =>
+            remainder.run(ZSink.head).map { head =>
+              assertTrue(taken == Chunk(1) && head == Some(2))
+            }
+          }
+      }
+    } @@ TestAspect.timeout(30.seconds),
+    test("ZStream(1, 2, 3, 4, 5).rechunk(2).run((ZPipeline.rechunk(1) >>> ZSink.take(1)) *> ZSink.head)") {
+      ZStream(1, 2, 3, 4, 5)
+        .rechunk(2)
+        .run(
+          (ZPipeline.rechunk[Int](1) >>> ZSink.take[Int](1)) *> ZSink.head
+        )
+        .map(result => assertTrue(result == Some(2)))
+    } @@ TestAspect.timeout(30.seconds)
+  )
+}

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -426,7 +426,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty else fromIterable(as.distinct)
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -447,6 +447,12 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
   )(implicit trace: Trace): Gen[R, A] =
     Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+
+  /**
+   * Constructs a generator that randomly chooses one of the specified values.
+   */
+  def randomChoice[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
+    if (as.isEmpty) empty else int(0, as.length - 1).map(i => as(i))
 
   /**
    * Constructs a generator from a function that uses randomness. The returned

--- a/test/shared/src/main/scala/zio/test/GenZIO.scala
+++ b/test/shared/src/main/scala/zio/test/GenZIO.scala
@@ -27,14 +27,15 @@ trait GenZIO {
   final def causes[R, E](e: Gen[R, E], t: Gen[R, Throwable])(implicit
     trace: Trace
   ): Gen[R, Cause[E]] = {
-    val fiberId           = (Gen.int zip Gen.int zip Gen.const(Trace.empty)).map { case (a, b, c) => FiberId(a, b, c) }
-    val zTraceElement     = Gen.string.map(_.asInstanceOf[Trace])
-    val zTrace            = fiberId.zipWith(Gen.chunkOf(zTraceElement))(StackTrace(_, _))
-    val failure           = e.zipWith(zTrace)(Cause.fail(_, _))
-    val die               = t.zipWith(zTrace)(Cause.die(_, _))
-    val empty             = Gen.const(Cause.empty)
-    val interrupt         = fiberId.zipWith(zTrace)(Cause.interrupt(_, _))
-    def stackless(n: Int) = Gen.suspend(causesN(n - 1).flatMap(c => Gen.elements(Cause.stack(c), Cause.stackless(c))))
+    val fiberId       = (Gen.int zip Gen.int zip Gen.const(Trace.empty)).map { case (a, b, c) => FiberId(a, b, c) }
+    val zTraceElement = Gen.string.map(_.asInstanceOf[Trace])
+    val zTrace        = fiberId.zipWith(Gen.chunkOf(zTraceElement))(StackTrace(_, _))
+    val failure       = e.zipWith(zTrace)(Cause.fail(_, _))
+    val die           = t.zipWith(zTrace)(Cause.die(_, _))
+    val empty         = Gen.const(Cause.empty)
+    val interrupt     = fiberId.zipWith(zTrace)(Cause.interrupt(_, _))
+    def stackless(n: Int) =
+      Gen.suspend(causesN(n - 1).flatMap(c => Gen.randomChoice(Cause.stack(c), Cause.stackless(c))))
 
     def sequential(n: Int) = Gen.suspend {
       for {

--- a/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
@@ -60,5 +60,5 @@ object GenFractionalPoly {
    * instance.
    */
   def genFractionalPoly(implicit trace: Trace): Gen[Any, GenFractionalPoly] =
-    Gen.elements(double, float)
+    Gen.randomChoice(double, float)
 }

--- a/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
@@ -59,7 +59,7 @@ object GenIntegralPoly {
    * instance.
    */
   def genIntegralPoly(implicit trace: Trace): Gen[Any, GenIntegralPoly] =
-    Gen.elements(byte, char, int, long, short)
+    Gen.randomChoice(byte, char, int, long, short)
 
   /**
    * Provides evidence that instances of `Gen` and `Integral` exist for

--- a/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
@@ -72,7 +72,7 @@ object GenNumericPoly {
    * instance.
    */
   def genNumericPoly(implicit trace: Trace): Gen[Any, GenNumericPoly] =
-    Gen.elements(
+    Gen.randomChoice(
       byte,
       char,
       double,

--- a/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
@@ -76,7 +76,7 @@ object GenOrderingPoly {
     GenNumericPoly.float
 
   def genOrderingPoly(implicit trace: Trace): Gen[Any, GenOrderingPoly] = {
-    val primitives = Gen.elements(
+    val primitives = Gen.randomChoice(
       boolean,
       byte,
       char,
@@ -88,7 +88,7 @@ object GenOrderingPoly {
       string,
       unit
     )
-    val constructors = Gen.elements(list _, option _, vector _)
+    val constructors = Gen.randomChoice(list _, option _, vector _)
     val collections = for {
       constructor <- constructors
       primitive   <- primitives

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -4,6 +4,7 @@ const path = require('path');
 
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/vsDark');
+const { getEditUrl } = require('./editUrl')
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -241,7 +242,7 @@ const config = {
               },
             ],
           ],
-          editUrl: 'https://github.com/zio/zio/edit/series/2.x',
+          editUrl: getEditUrl,
         },
         blog: {
           blogTitle: 'ZIO Blog',

--- a/website/editUrl.js
+++ b/website/editUrl.js
@@ -1,0 +1,52 @@
+const ecosystemRepos = {
+  'izumi-reflect': { repo: 'https://github.com/zio/izumi-reflect', branch: 'develop' },
+  'zio2-interop-cats2': { repo: 'https://github.com/zio/interop-cats', branch: 'main' },
+  'zio-amqp': { repo: 'https://github.com/zio/zio-amqp', branch: 'master' },
+  'zio-aws': { repo: 'https://github.com/zio/zio-aws', branch: 'master' },
+  'zio-blocks': { repo: 'https://github.com/zio/zio-blocks', branch: 'main' },
+  'zio-bson': { repo: 'https://github.com/zio/zio-bson', branch: 'main' },
+  'zio-cache': { repo: 'https://github.com/zio/zio-cache', branch: 'series/2.x' },
+  'zio-cli': { repo: 'https://github.com/zio/zio-cli', branch: 'master' },
+  'zio-config': { repo: 'https://github.com/zio/zio-config', branch: 'series/4.x' },
+  'zio-direct': { repo: 'https://github.com/zio/zio-direct', branch: 'main' },
+  'zio-dynamodb': { repo: 'https://github.com/zio/zio-dynamodb', branch: 'series/2.x' },
+  'zio-ftp': { repo: 'https://github.com/zio/zio-ftp', branch: 'series/2.x' },
+  'zio-json': { repo: 'https://github.com/zio/zio-json', branch: 'series/2.x' },
+  'zio-kafka': { repo: 'https://github.com/zio/zio-kafka', branch: 'master' },
+  'zio-lambda': { repo: 'https://github.com/zio/zio-lambda', branch: 'master' },
+  'zio-logging': { repo: 'https://github.com/zio/zio-logging', branch: 'master' },
+  'zio-metrics-connectors': { repo: 'https://github.com/zio/zio-metrics-connectors', branch: 'series/2.x' },
+  'zio-parser': { repo: 'https://github.com/zio/zio-parser', branch: 'master' },
+  'zio-prelude': { repo: 'https://github.com/zio/zio-prelude', branch: 'series/2.x' },
+  'zio-process': { repo: 'https://github.com/zio/zio-process', branch: 'series/2.x' },
+  'zio-profiling': { repo: 'https://github.com/zio/zio-profiling', branch: 'master' },
+  'zio-query': { repo: 'https://github.com/zio/zio-query', branch: 'series/2.x' },
+  'zio-quill': { repo: 'https://github.com/zio/zio-quill', branch: 'master' },
+  'zio-redis': { repo: 'https://github.com/zio/zio-redis', branch: 'main' },
+  'zio-rocksdb': { repo: 'https://github.com/zio/zio-rocksdb', branch: 'master' },
+  'zio-s3': { repo: 'https://github.com/zio/zio-s3', branch: 'series/2.x' },
+  'zio-sbt': { repo: 'https://github.com/zio/zio-sbt', branch: 'main' },
+  'zio-schema': { repo: 'https://github.com/zio/zio-schema', branch: 'main' },
+  'zio-sqs': { repo: 'https://github.com/zio/zio-sqs', branch: 'series/2.x' },
+  'zio-streams-compress': { repo: 'https://github.com/zio/zio-streams-compress', branch: 'main' },
+  'zio-telemetry': { repo: 'https://github.com/zio/zio-telemetry', branch: 'series/2.x' },
+
+}
+
+function getEditUrl({ docPath, versionDocsDirPath }) {
+  const parts = docPath.split('/')
+  const project = parts[0]
+  const ecosystem = ecosystemRepos[project]
+
+  if (versionDocsDirPath === 'docs' && ecosystem) {
+    const relativePath = parts.slice(1).join('/')
+    return `${ecosystem.repo}/edit/${ecosystem.branch}/docs/${relativePath}`
+  }
+
+  return `https://github.com/zio/zio/edit/series/2.x/${versionDocsDirPath}/${docPath}`
+}
+
+module.exports = {
+  ecosystemRepos,
+  getEditUrl,
+}


### PR DESCRIPTION
Resolves #10187

### Problem
Gen.elements was implemented using Gen.int, which produces a random stream of indices. When used with checkAll, which expects to test all possible values of a generator, it would only test a limited number of random samples, potentially missing some values (especially if there are many elements).

### Solution
Modified Gen.elements to use Gen.fromIterable, which creates a deterministic stream containing all elements. This ensures that checkAll will test every element provided to Gen.elements.

### Changes
- Updated Gen.elements in Gen.scala to delegate to Gen.fromIterable
- Added Gen.randomChoice as a utility for generators that need random selection (not exhaustive testing)
- Updated test generators that previously relied on Gen.elements for random sampling to use Gen.randomChoice instead:
  - StackSpec: Boolean selection in property tests
  - ChunkPackedBooleanSpec: Endianness and chunk type selection
  - BitChunkIntSpec/BitChunkLongSpec: Endianness selection
  - CauseSpec: Function and cause pair selection
- Applied formatting fixes to test files
- Updated poly generators to use randomChoice

### Fix for CI Failures
The initial implementation caused timeout failures in property tests due to exponential growth in test combinations when Gen.elements was used for random sampling. This follow-up commit replaces all such usages with the new Gen.randomChoice function, resolving the timeouts while maintaining the correct exhaustive behavior of Gen.elements where needed.
