### PR TITLE
fix(renovate): enable pre-release updates for @zio.dev packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   ],
   "packageRules": [
     {
-      "description": "Update Official ZIO Ecosystem Docs",
+      "description": "Update Official ZIO Ecosystem Docs - including pre-releases",
       "matchBaseBranches": [
         "series/2.x"
       ],
@@ -27,14 +27,15 @@
         "documentation"
       ],
       "matchPackageNames": [
-        "^@zio\.dev\/.*"
+        "^@zio\\.dev\\/.*"
       ],
+      "ignoreUnstable": false,
       "enabled": true
     },
     {
       "description": "Disable patch updates for non-ZIO npm packages",
       "matchPackageNames": [
-        "^(?!@zio\.dev\/)"
+        "^(?!@zio\\.dev\\/)"
       ],
       "matchUpdateTypes": [
         "patch"


### PR DESCRIPTION
## Summary

Fixed Renovate configuration to detect pre-release versions (RC, alpha, beta) for `@zio.dev` ecosystem packages. Previously, the recommended preset's `ignoreUnstable: true` was filtering out these updates, causing packages like `@zio.dev/zio-prelude` to miss RC updates.

## Changes

- Added `ignoreUnstable: false` to the `@zio.dev/*` package rule
- Fixed regex escaping for JSON compliance
- Updated rule description for clarity

## Why This Matters

The documentation site uses pre-release versions of ZIO ecosystem packages actively. Without this fix, Renovate silently skipped these updates, leaving the site out-of-date with the latest ZIO library releases.

## Testing

✅ JSON syntax validation passed
✅ Configuration structure verified
✅ Regex patterns tested:
  - `@zio.dev/zio-prelude` ✅ matches (will now get RC47)
  - `@zio.dev/zio-blocks` ✅ matches  
  - Non-ZIO packages correctly excluded

🤖 Generated with Claude Code