### PR TITLE
feat(ci): enable Netlify PR preview deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,31 @@ jobs:
       - name: Print All Generated Files
         run: find ./website/build -print
 
+  deploy-preview:
+    needs: [build-website]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: website-artifact
+          path: website-artifact
+
+      - name: Deploy preview to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: ./website-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
+          alias: pr-${{ github.event.pull_request.number }}
+          enable-pull-request-comment: true
+          overwrites-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 5
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,8 +127,11 @@ jobs:
 
   deploy-preview:
     needs: [build-website]
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ env:
 
 on:
   pull_request:
+  pull_request_target:
   push:
     branches:
       - 'series/2.x'
@@ -17,7 +18,7 @@ on:
     types: [update-docs]
 
 concurrency:
-  group: ci-pr-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  group: ci-pr-${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -127,7 +128,7 @@ jobs:
 
   deploy-preview:
     needs: [build-website]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "website/build"
-  ignore  = "exit 1"
+  ignore  = "exit 0"
 
 [build.environment]
   NODE_VERSION            = "20"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  publish = "website/build"
+  ignore  = "exit 1"
+
+[build.environment]
+  NODE_VERSION            = "20"
+  USE_SIMPLE_CSS_MINIFIER = "true"


### PR DESCRIPTION
Add netlify.toml configuration and CI job to automatically deploy website previews to Netlify on each pull request. The deploy-preview job:
- Runs only on PRs (not blocking the main CI gate)
- Downloads the pre-built website artifact from build-website job
- Deploys to Netlify using nwtgck/actions-netlify
- Posts a PR comment with the preview URL using the alias pr-<number>

Netlify configuration disables its own build process since GitHub Actions handles the full sbt + yarn build pipeline which would exceed Netlify's timeout budget.

Repository owner must manually:
1. Create a blank Netlify site (no Git connection)
2. Add NETLIFY_AUTH_TOKEN and NETLIFY_SITE_ID as GitHub secrets