### PR TITLE
Avoid storing interruption in memoize functions

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.Cause._
 import zio.LatchOps._
+import zio.Random.RandomLive
 import zio.internal.{FiberRuntime, Platform}
 import zio.test.Assertion._
 import zio.test.TestAspect.{exceptJS, flaky, forked, jvmOnly, nonFlaky, scala2Only, timeout, withLiveClock}
@@ -1525,14 +1526,14 @@ object ZIOSpec extends ZIOBaseSpec {
           .map(tuple => assert(tuple._1)(not(equalTo(tuple._2))))
       },
       test("memoized returns the same instance on repeated calls") {
-        val ioMemo = Random.nextString(10).memoize
+        val ioMemo = RandomLive.nextString(10).memoize
         ioMemo
           .flatMap(io => io <*> io)
           .map(tuple => assert(tuple._1)(equalTo(tuple._2)))
       },
       test("memoized function returns the same instance on repeated calls") {
         for {
-          memoized <- ZIO.memoize((n: Int) => Random.nextString(n))
+          memoized <- ZIO.memoize((n: Int) => RandomLive.nextString(n))
           a        <- memoized(10)
           b        <- memoized(10)
           c        <- memoized(11)
@@ -1540,6 +1541,60 @@ object ZIOSpec extends ZIOBaseSpec {
         } yield assert(a)(equalTo(b)) &&
           assert(b)(not(equalTo(c))) &&
           assert(c)(equalTo(d))
+      },
+      test("memoized function does not memoize interruption") {
+        for {
+          p1 <- Promise.make[Nothing, Unit]
+          p2 <- Promise.make[Nothing, Unit]
+
+          memo <-
+            (p1.succeedUnit *> p2.await *> RandomLive.nextString(10)).memoize
+
+          first <- memo.fork
+          _     <- p1.await
+          calls <- memo.fork.replicateZIO(50)
+          res1  <- first.interrupt
+          _     <- p2.succeed(())
+          res2  <- ZIO.foreach(calls)(_.join)
+          res3  <- memo
+        } yield assertTrue(
+          res1.isInterrupted,
+          res2.forall(_ == res3)
+        )
+      },
+      test("ZIO.memoize returns the same error on repeated calls") {
+        for {
+          memoized <- ZIO.memoize((n: Int) => RandomLive.nextString(n).flip)
+          a        <- memoized(10).either
+          b        <- memoized(10).either
+          c        <- memoized(11).either
+          d        <- memoized(11).either
+        } yield {
+          assertTrue(a.isLeft) &&
+          assert(a)(equalTo(b)) &&
+          assert(b)(not(equalTo(c))) &&
+          assert(c)(equalTo(d))
+        }
+      },
+      test("ZIO.memoize does not memoize interruption") {
+        for {
+          p1 <- Promise.make[Nothing, Unit]
+          p2 <- Promise.make[Nothing, Unit]
+
+          memo <-
+            ZIO.memoize((_: Any) => p1.succeedUnit *> p2.await *> RandomLive.nextString(10))
+
+          first <- memo("call").fork
+          _     <- p1.await
+          calls <- memo("call").fork.replicateZIO(50)
+          res1  <- first.interrupt
+          _     <- p2.succeed(())
+          res2  <- ZIO.foreach(calls)(_.join)
+          res3  <- memo("call")
+        } yield assertTrue(
+          res1.isInterrupted,
+          res2.forall(_ == res3)
+        )
       }
     ),
     suite("merge")(

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1542,6 +1542,12 @@ object ZIOSpec extends ZIOBaseSpec {
           assert(b)(not(equalTo(c))) &&
           assert(c)(equalTo(d))
       },
+      test("memoized function returns the same instance on repeated calls under contention") {
+        for {
+          memoized <- ZIO.memoize((n: Int) => RandomLive.nextString(n))
+          a        <- ZIO.foreachPar(1 to 4)(_ => memoized(10))
+        } yield assertTrue(a.distinct.size == 1)
+      } @@ nonFlaky(10000) @@ jvmOnly,
       test("memoized function does not memoize interruption") {
         for {
           p1 <- Promise.make[Nothing, Unit]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4392,7 +4392,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                        }
             b <- promise.await.exitWith {
                    case Exit.Success((patch, b))                      => ZIO.patchFiberRefs(patch).as(b)
-                   case ex if !isSetter.get() && ex.isInterruptedOnly => ZIO.yieldNow *> loop(a)
+                   case ex if !isSetter.get() && ex.isInterruptedOnly => loop(a)
                    case ex                                            => ex.asInstanceOf[Exit[E, Nothing]]
                  }
           } yield b

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -23,6 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
 import scala.collection.mutable.ListBuffer
@@ -1019,10 +1020,7 @@ sealed trait ZIO[-R, +E, +A]
    * result of this effect.
    */
   final def memoize(implicit trace: Trace): UIO[ZIO[R, E, A]] =
-    for {
-      promise  <- Promise.make[E, (FiberRefs.Patch, A)]
-      complete <- self.diffFiberRefs.intoPromise(promise).once
-    } yield complete *> promise.await.flatMap { case (patch, a) => ZIO.patchFiberRefs(patch).as(a) }
+    ZIO.memoize((_: Unit) => self).map(_.apply(()))
 
   /**
    * Returns a new effect where the error channel has been merged into the
@@ -1052,9 +1050,9 @@ sealed trait ZIO[-R, +E, +A]
    */
   final def once(implicit trace: Trace): UIO[ZIO[R, E, Unit]] =
     ZIO.succeed {
-      val ref = Ref.unsafe.make(true)(Unsafe)
+      val ref = new AtomicBoolean(false)
 
-      ZIO.whenDiscard(ref.unsafe.getAndSet(false)(Unsafe))(self)
+      ZIO.whenDiscard(ref.compareAndSet(false, true))(self)
     }
 
   /**
@@ -4371,20 +4369,36 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Returns a memoized version of the specified effectual function.
    */
   def memoize[R, E, A, B](f: A => ZIO[R, E, B])(implicit trace: Trace): UIO[A => ZIO[R, E, B]] =
-    Ref.Synchronized.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]]).map { ref => a =>
-      for {
-        promise <- ref.modifyZIO { map =>
-                     map.get(a) match {
-                       case Some(promise) => Exit.succeed((promise, map))
-                       case _ =>
-                         for {
-                           promise <- Promise.make[E, (FiberRefs.Patch, B)]
-                           _       <- f(a).diffFiberRefs.intoPromise(promise).fork
-                         } yield (promise, map.updated(a, promise))
-                     }
-                   }
-        b <- promise.await.flatMap { case (patch, b) => ZIO.patchFiberRefs(patch).as(b) }
-      } yield b
+    Ref.Synchronized.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]]).map { ref =>
+      def loop(a: A): ZIO[R, E, B] =
+        ZIO.suspendSucceed {
+          val isSetter = new AtomicBoolean()
+          for {
+            promise <- ref.modifyZIO { map =>
+                         map.getOrElse(a, null) match {
+                           case null =>
+                             for {
+                               p <- Promise.make[E, (FiberRefs.Patch, B)]
+                               _ <- ZIO.uninterruptibleMask { restore =>
+                                      isSetter.set(true)
+                                      restore(f(a).diffFiberRefs).exitWith {
+                                        case ex if ex.isInterruptedOnly => ref.update(_.removed(a)) *> p.done(ex)
+                                        case ex                         => p.done(ex)
+                                      }.fork
+                                    }
+                             } yield (p, map.updated(a, p))
+                           case p => Exit.succeed((p, map))
+                         }
+                       }
+            b <- promise.await.exitWith {
+                   case Exit.Success((patch, b))                      => ZIO.patchFiberRefs(patch).as(b)
+                   case ex if !isSetter.get() && ex.isInterruptedOnly => ZIO.yieldNow *> loop(a)
+                   case ex                                            => ex.asInstanceOf[Exit[E, Nothing]]
+                 }
+          } yield b
+        }
+
+      loop
     }
 
   /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4385,7 +4385,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                                isSetter.set(true)
                                restore(f(a).diffFiberRefs).exitWith {
                                  case ex if ex.isInterruptedOnly =>
-                                   ref.unsafe.update(_.removed(a))
+                                   ref.unsafe.update(_ - a)
                                    p.unsafe.done(ex)
                                    Exit.unit
                                  case ex =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -4369,27 +4369,34 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
    * Returns a memoized version of the specified effectual function.
    */
   def memoize[R, E, A, B](f: A => ZIO[R, E, B])(implicit trace: Trace): UIO[A => ZIO[R, E, B]] =
-    Ref.Synchronized.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]]).map { ref =>
+    ZIO.succeed {
+      @inline implicit def u: Unsafe = Unsafe
+
+      val ref = Ref.unsafe.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]])
       def loop(a: A): ZIO[R, E, B] =
-        ZIO.suspendSucceed {
+        ZIO.fiberIdWith { fiberId =>
           val isSetter = new AtomicBoolean()
           for {
-            promise <- ref.modifyZIO { map =>
+            promise <- ref.modify { map =>
                          map.getOrElse(a, null) match {
                            case null =>
-                             for {
-                               p <- Promise.make[E, (FiberRefs.Patch, B)]
-                               _ <- ZIO.uninterruptibleMask { restore =>
-                                      isSetter.set(true)
-                                      restore(f(a).diffFiberRefs).exitWith {
-                                        case ex if ex.isInterruptedOnly => ref.update(_.removed(a)) *> p.done(ex)
-                                        case ex                         => p.done(ex)
-                                      }.fork
-                                    }
-                             } yield (p, map.updated(a, p))
-                           case p => Exit.succeed((p, map))
+                             val p = Promise.unsafe.make[E, (FiberRefs.Patch, B)](fiberId)
+                             val f2 = ZIO.uninterruptibleMask { restore =>
+                               isSetter.set(true)
+                               restore(f(a).diffFiberRefs).exitWith {
+                                 case ex if ex.isInterruptedOnly =>
+                                   ref.unsafe.update(_.removed(a))
+                                   p.unsafe.done(ex)
+                                   Exit.unit
+                                 case ex =>
+                                   p.unsafe.done(ex)
+                                   Exit.unit
+                               }.fork
+                             }
+                             (f2.as(p), map.updated(a, p))
+                           case p => (Exit.succeed(p), map)
                          }
-                       }
+                       }.flatten
             b <- promise.await.exitWith {
                    case Exit.Success((patch, b))                      => ZIO.patchFiberRefs(patch).as(b)
                    case ex if !isSetter.get() && ex.isInterruptedOnly => loop(a)


### PR DESCRIPTION
/fixes #10644

Fixes `ZIO#memoize` and `ZIO.memoize` so that in the case the "main" fiber is interrupted during the computation of the effect we discard the outcome instead of persisting it.

In cases that we have other fibers awaiting for the "main" fiber to complete and the promise if fulfilled with an interruption, we retry the loop