### PR TITLE
Remove Useless Cheatsheet Section

### DIFF
--- a/docs/resources/cheatsheets.md
+++ b/docs/resources/cheatsheets.md
@@ -1,7 +1,0 @@
----
-id: cheatsheets 
-title:  "Cheat Sheets"
----
-
-- [ZIO Cheat Sheet](https://github.com/ghostdogpr/zio-cheatsheet)
-- [Snippets for Future/Scalaz Task](https://gist.github.com/ubourdon/7b7e929117343b2324cde6eab57674a6)

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -576,7 +576,6 @@ module.exports = {
     "resources/articles",
     "resources/videos",
     "resources/cookbooks",
-    "resources/cheatsheets",
     "resources/sampleprojects",
     "resources/poweredbyzio"
   ]


### PR DESCRIPTION
This pull request removes the "Cheat Sheets" section from the documentation. The following key changes were made:

Documentation updates:

* Removed the `cheatsheets.md` file and its links from the documentation, eliminating references to ZIO and Future/Scalaz Task cheat sheets.
* Removed `"resources/cheatsheets"` from the sidebar configuration in `website/sidebars.js` so it no longer appears in the documentation navigation.