### PR TITLE
fix(ci): checkout PR's head commit for pull_request_target events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v6.0.2
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
     - name: Setup Java
       uses: actions/setup-java@v5.2.0
       with:
@@ -55,6 +57,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -87,6 +90,7 @@ jobs:
       - name: Checkout Current Branch
         uses: actions/checkout@v6.0.2
         with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
@@ -165,6 +169,8 @@ jobs:
     steps:
     - name: Checkout current branch
       uses: actions/checkout@v6.0.2
+      with:
+        ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
     - name: Setup Java
       uses: actions/setup-java@v5.2.0
       with:
@@ -226,6 +232,8 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
       - name: Setup Java
         uses: actions/setup-java@v5.2.0
         with:
@@ -258,6 +266,8 @@ jobs:
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
       - name: Install Boehm GC
         if: ${{ startsWith(matrix.platform, 'Native') }}
         run: sudo apt-get update && sudo apt-get install -y libgc-dev


### PR DESCRIPTION
## Problem

`pull_request_target` by default checks out the **base branch code**, not the PR's changes.

This caused Netlify previews to show the old website without PR modifications. For example:
- PR #10697 deleted `docs/resources/cookbooks.md` and updated sidebars
- Preview showed the old version with cookbooks still present ❌

## Root Cause

GitHub Actions default behavior for `pull_request_target`:
- Checks out base branch code (without PR changes)
- Workflow runs against outdated code
- Preview built from: old code

## Solution

Explicitly checkout PR's head commit for `pull_request_target`:

```yaml
ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
```

This uses:
- Fork PRs: PR's head commit SHA
- Push events: the pushed `github.ref`

## Changes

Updated checkout in all PR-running jobs:
- lint, publishLocal, build-website, test, testJvms, testPlatforms

Now Netlify previews correctly reflect all PR changes!

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)