### PR TITLE
test(ZIOApp): process-level lifecycle + cross-platform invoke tests #9909

### DIFF
--- a/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/internal/OneShotSpec.scala
@@ -49,7 +49,7 @@ object OneShotSpec extends ZIOBaseSpec {
         oneShot.lock()
         t.start()
         lock.get()
-        Thread.sleep(10L)
+        Thread.sleep(50L)
         val isSet = oneShot.isSet
         oneShot.unlock()
 
@@ -60,16 +60,16 @@ object OneShotSpec extends ZIOBaseSpec {
           val oneShot = OneShot.make[Int]
 
           new Thread(() => {
-            Thread.sleep(10L)
+            Thread.sleep(100L)
             oneShot.set(1)
           }).start()
 
-          assert(oneShot.get(20L))(equalTo(1))
+          assert(oneShot.get(2000L))(equalTo(1))
         },
         test("fails if no value is set") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.get(10L))(throwsA[OneShot.TimeoutException])
+          assert(oneShot.get(50L))(throwsA[OneShot.TimeoutException])
         }
       ) @@ blocking,
       suite("tryGet(timeout)")(
@@ -77,16 +77,16 @@ object OneShotSpec extends ZIOBaseSpec {
           val oneShot = OneShot.make[Int]
 
           new Thread(() => {
-            Thread.sleep(10L)
+            Thread.sleep(100L)
             oneShot.set(1)
           }).start()
 
-          assert(oneShot.tryGet(20L))(equalTo(1))
+          assert(oneShot.tryGet(2000L))(equalTo(1))
         },
         test("returns null if the value is not set within the timeout") {
           val oneShot = OneShot.make[Object]
 
-          assert(oneShot.tryGet(10L))(equalTo(null))
+          assert(oneShot.tryGet(50L))(equalTo(null))
         }
       ) @@ blocking
     )

--- a/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
@@ -1,0 +1,155 @@
+package zio.zioapp
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+// Helper to fork a JVM with a given main class, grab stdout/stderr and
+// optionally send SIGINT. Uses CountDownLatch + hard timeouts so CI never hangs.
+object JvmProcessRunner {
+
+  case class ProcessResult(exitCode: Int, stdout: String, stderr: String)
+
+  private val defaultTimeoutMs = 30000L
+
+  // Run the app, wait for "APP_READY" marker, then let it finish on its own.
+  def runToCompletion(
+    mainClass: String,
+    args: List[String] = Nil,
+    timeoutMs: Long = defaultTimeoutMs
+  ): ProcessResult = {
+    val pb      = buildProcess(mainClass, args)
+    val process = pb.start()
+
+    val (stdout, stderr) = captureOutput(process, timeoutMs)
+    val exitCode = if (process.isAlive) { process.destroyForcibly(); -1 }
+    else process.exitValue()
+
+    ProcessResult(exitCode, stdout, stderr)
+  }
+
+  // Run the app, wait for APP_READY, send SIGINT, wait for it to shut down.
+  def runAndInterrupt(
+    mainClass: String,
+    args: List[String] = Nil,
+    timeoutMs: Long = defaultTimeoutMs
+  ): ProcessResult = {
+    val pb      = buildProcess(mainClass, args)
+    val process = pb.start()
+
+    val readyLatch = new CountDownLatch(1)
+    val stdoutBuf  = new StringBuilder
+    val stderrBuf  = new StringBuilder
+
+    // stdout reader thread
+    val stdoutThread = new Thread(
+      () => {
+        val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+        var line   = reader.readLine()
+        while (line != null) {
+          stdoutBuf.append(line).append('\n')
+          if (line.contains("APP_READY")) readyLatch.countDown()
+          line = reader.readLine()
+        }
+      },
+      "stdout-reader"
+    )
+    stdoutThread.setDaemon(true)
+    stdoutThread.start()
+
+    // stderr reader thread
+    val stderrThread = new Thread(
+      () => {
+        val reader = new BufferedReader(new InputStreamReader(process.getErrorStream))
+        var line   = reader.readLine()
+        while (line != null) {
+          stderrBuf.append(line).append('\n')
+          line = reader.readLine()
+        }
+      },
+      "stderr-reader"
+    )
+    stderrThread.setDaemon(true)
+    stderrThread.start()
+
+    val markerSeen = readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!markerSeen) {
+      process.destroyForcibly()
+      return ProcessResult(-1, stdoutBuf.toString(), stderrBuf.toString() + "\n[TIMEOUT waiting for APP_READY]")
+    }
+
+    // Small delay so the app is properly blocked on ZIO.never or similar
+    Thread.sleep(200)
+
+    // Send SIGINT to the process
+    sendSigint(process)
+
+    // Wait for the process to terminate
+    val finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      return ProcessResult(-1, stdoutBuf.toString(), stderrBuf.toString() + "\n[TIMEOUT waiting for exit]")
+    }
+
+    // Let output threads finish
+    stdoutThread.join(2000)
+    stderrThread.join(2000)
+
+    ProcessResult(process.exitValue(), stdoutBuf.toString(), stderrBuf.toString())
+  }
+
+  private def buildProcess(mainClass: String, args: List[String]): ProcessBuilder = {
+    val classpath = System.getProperty("java.class.path")
+    val javaHome  = System.getProperty("java.home")
+    val javaBin   = s"$javaHome/bin/java"
+    val cmd       = List(javaBin, "-cp", classpath, mainClass) ++ args
+    new ProcessBuilder(cmd: _*)
+  }
+
+  private def captureOutput(process: Process, timeoutMs: Long): (String, String) = {
+    val stdoutBuf = new StringBuilder
+    val stderrBuf = new StringBuilder
+
+    val stdoutThread = new Thread(
+      () => {
+        val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+        var line   = reader.readLine()
+        while (line != null) {
+          stdoutBuf.append(line).append('\n')
+          line = reader.readLine()
+        }
+      },
+      "stdout-reader"
+    )
+    stdoutThread.setDaemon(true)
+    stdoutThread.start()
+
+    val stderrThread = new Thread(
+      () => {
+        val reader = new BufferedReader(new InputStreamReader(process.getErrorStream))
+        var line   = reader.readLine()
+        while (line != null) {
+          stderrBuf.append(line).append('\n')
+          line = reader.readLine()
+        }
+      },
+      "stderr-reader"
+    )
+    stderrThread.setDaemon(true)
+    stderrThread.start()
+
+    val _ = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (process.isAlive) process.destroyForcibly()
+
+    stdoutThread.join(2000)
+    stderrThread.join(2000)
+
+    (stdoutBuf.toString(), stderrBuf.toString())
+  }
+
+  private def sendSigint(process: Process): Unit = {
+    val pid = process.pid()
+    // Use kill -INT to send actual SIGINT, not SIGTERM
+    val killProcess = new ProcessBuilder("kill", "-INT", pid.toString).start()
+    val _           = killProcess.waitFor(5, TimeUnit.SECONDS)
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
@@ -1,0 +1,134 @@
+package zio.zioapp
+
+import zio._
+import zio.test._
+import zio.test.TestAspect._
+
+// Process-level integration tests for ZIOApp lifecycle.
+// Spawns real JVM subprocesses so we can test exit codes, SIGINT handling,
+// gracefulShutdownTimeout, and the various shutdown regressions (#9807, #9901).
+// Each test uses a tiny ZIOAppDefault from the `apps` package.
+object ZIOAppIntegrationSpec extends ZIOBaseSpec {
+
+  def spec = suite("ZIOAppIntegrationSpec")(
+    suite("exit codes")(
+      test("successful app returns exit code 0") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runToCompletion("zio.zioapp.apps.SuccessExitApp")
+                    )
+        } yield assertTrue(result.exitCode == 0) &&
+          assertTrue(result.stdout.contains("APP_READY"))
+      },
+      test("failed app returns exit code 1") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runToCompletion("zio.zioapp.apps.FailureExitApp")
+                    )
+        } yield assertTrue(result.exitCode == 1)
+      },
+      test("defect (die) returns exit code 1") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runToCompletion("zio.zioapp.apps.DefectExitApp")
+                    )
+        } yield assertTrue(result.exitCode == 1)
+      }
+    ),
+    suite("finalizers on natural completion")(
+      test("finalizer runs when app completes normally") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runToCompletion("zio.zioapp.apps.FinalizerOnExitApp")
+                    )
+        } yield assertTrue(result.stdout.contains("FINALIZER_RAN"))
+      }
+    ),
+    suite("signal handling")(
+      test("finalizer runs when SIGINT is received") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FinalizerOnSignalApp")
+                    )
+        } yield assertTrue(result.stdout.contains("FINALIZER_RAN"))
+      } @@ nonFlaky(3),
+      test("multiple finalizers all run on SIGINT in reverse order") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.MultiFinalizerOrderApp")
+                    )
+        } yield {
+          val stdout = result.stdout
+          // all three should be there
+          assertTrue(stdout.contains("FIN_A")) &&
+          assertTrue(stdout.contains("FIN_B")) &&
+          assertTrue(stdout.contains("FIN_C")) &&
+          // C acquired last -> finalized first, then B, then A
+          assertTrue(stdout.indexOf("FIN_C") < stdout.indexOf("FIN_B")) &&
+          assertTrue(stdout.indexOf("FIN_B") < stdout.indexOf("FIN_A"))
+        }
+      } @@ nonFlaky(3),
+      test("shutdown does not hang indefinitely") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FinalizerOnSignalApp", timeoutMs = 15000)
+                    )
+        } yield assertTrue(result.exitCode != -1) // -1 means timed out
+      } @@ nonFlaky(3),
+      test("gracefulShutdownTimeout cuts off slow finalizer") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.SlowFinalizerTimeoutApp", timeoutMs = 15000)
+                    )
+        } yield {
+          // The slow finalizer tries to sleep 30s but timeout is 1s,
+          // so we should NOT see the done marker
+          assertTrue(!result.stdout.contains("SLOW_FIN_DONE"))
+        }
+      } @@ nonFlaky(3)
+    ),
+    suite("regressions")(
+      test("no uncaught exception on stderr during clean shutdown (#9807)") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.CleanStderrApp")
+                    )
+        } yield {
+          val stderr = result.stderr
+          assertTrue(!stderr.contains("Exception in thread")) &&
+          assertTrue(!stderr.contains("FiberFailure"))
+        }
+      } @@ nonFlaky(3),
+      test("daemon fibers are cleaned up on shutdown") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.DaemonFiberCleanupApp")
+                    )
+        } yield {
+          // The process should exit cleanly - no hang
+          assertTrue(result.exitCode != -1)
+        }
+      } @@ nonFlaky(3),
+      test("failing finalizer does not prevent other finalizers from running") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FailingFinalizerApp")
+                    )
+        } yield {
+          val stdout = result.stdout
+          assertTrue(stdout.contains("BEFORE_CRASH_FIN")) &&
+          assertTrue(stdout.contains("SAFE_FIN"))
+        }
+      } @@ nonFlaky(3)
+    ),
+    suite("args passing")(
+      test("args are correctly forwarded to the app") {
+        for {
+          result <- ZIO.attemptBlockingInterrupt(
+                      JvmProcessRunner.runToCompletion("zio.zioapp.apps.ArgsEchoApp", args = List("hello", "world"))
+                    )
+        } yield assertTrue(result.stdout.contains("ARGS:hello,world"))
+      }
+    )
+  ) @@ os(o => o.isUnix || o.isMac) @@ sequential @@ timeout(120.seconds)
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
@@ -1,0 +1,12 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Tests that args are properly passed through to the app
+object ArgsEchoApp extends ZIOAppDefault {
+  val run = for {
+    args <- getArgs
+    _    <- ZIO.succeed(println("ARGS:" + args.mkString(",")))
+    _    <- ZIO.succeed(println("APP_READY"))
+  } yield ()
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
@@ -1,0 +1,9 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Tests regression #9807 - on clean shutdown, stderr should NOT contain
+// uncaught exception traces from the main thread
+object CleanStderrApp extends ZIOAppDefault {
+  val run = ZIO.succeed(println("APP_READY")) *> ZIO.never
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
@@ -1,0 +1,12 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Tests that daemon fibers are interrupted during shutdown
+object DaemonFiberCleanupApp extends ZIOAppDefault {
+  val run = for {
+    _ <- ZIO.succeed(println("APP_READY"))
+    _ <- (ZIO.sleep(100.millis) *> ZIO.succeed(println("DAEMON_TICK"))).forever.forkDaemon
+    _ <- ZIO.never
+  } yield ()
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
@@ -1,0 +1,7 @@
+package zio.zioapp.apps
+
+import zio._
+
+object DefectExitApp extends ZIOAppDefault {
+  val run = ZIO.succeed(println("APP_READY")) *> ZIO.die(new RuntimeException("fatal error"))
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailingFinalizerApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailingFinalizerApp.scala
@@ -1,0 +1,16 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Tests that a failing finalizer doesn't prevent other finalizers from running
+object FailingFinalizerApp extends ZIOAppDefault {
+  val run = ZIO.scoped {
+    for {
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.succeed(println("SAFE_FIN")))
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.die(new RuntimeException("fin exploded")))
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.succeed(println("BEFORE_CRASH_FIN")))
+      _ <- ZIO.succeed(println("APP_READY"))
+      _ <- ZIO.never
+    } yield ()
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
@@ -1,0 +1,7 @@
+package zio.zioapp.apps
+
+import zio._
+
+object FailureExitApp extends ZIOAppDefault {
+  val run = ZIO.succeed(println("APP_READY")) *> ZIO.fail("something went wrong")
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
@@ -1,0 +1,10 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Tests that a finalizer on a scoped resource runs to completion on natural exit
+object FinalizerOnExitApp extends ZIOAppDefault {
+  val run = ZIO.scoped {
+    ZIO.acquireRelease(ZIO.succeed(println("APP_READY")))(_ => ZIO.succeed(println("FINALIZER_RAN")))
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
@@ -1,0 +1,11 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Runs forever, prints FINALIZER_RAN when interrupted via SIGINT
+// Covers regression #9901 - finalizers should complete on shutdown
+object FinalizerOnSignalApp extends ZIOAppDefault {
+  val run = ZIO.scoped {
+    ZIO.acquireRelease(ZIO.succeed(println("APP_READY")))(_ => ZIO.succeed(println("FINALIZER_RAN"))) *> ZIO.never
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
@@ -1,0 +1,16 @@
+package zio.zioapp.apps
+
+import zio._
+
+// Multiple finalizers should ALL run in reverse order on SIGINT
+object MultiFinalizerOrderApp extends ZIOAppDefault {
+  val run = ZIO.scoped {
+    for {
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.succeed(println("FIN_A")))
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.succeed(println("FIN_B")))
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.succeed(println("FIN_C")))
+      _ <- ZIO.succeed(println("APP_READY"))
+      _ <- ZIO.never
+    } yield ()
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
@@ -1,0 +1,16 @@
+package zio.zioapp.apps
+
+import zio._
+
+// A slow finalizer that should be cut off by gracefulShutdownTimeout.
+// Timeout set to 1 second while finalizer tries to sleep for 30 seconds.
+object SlowFinalizerTimeoutApp extends ZIOAppDefault {
+
+  override def gracefulShutdownTimeout: Duration = 1.second
+
+  val run = ZIO.scoped {
+    ZIO.acquireRelease(ZIO.succeed(println("APP_READY")))(_ =>
+      ZIO.sleep(30.seconds) *> ZIO.succeed(println("SLOW_FIN_DONE"))
+    ) *> ZIO.never
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/SuccessExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/SuccessExitApp.scala
@@ -1,0 +1,7 @@
+package zio.zioapp.apps
+
+import zio._
+
+object SuccessExitApp extends ZIOAppDefault {
+  val run = ZIO.succeed(println("APP_READY")) *> ZIO.succeed(42)
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
@@ -1,0 +1,153 @@
+package zio
+
+import zio.test._
+
+import scala.annotation.nowarn
+
+// Cross-platform tests for ZIOApp using invoke().
+// Covers bootstrap layers, scoped resources, error handling, and app composition.
+object ZIOAppLifecycleSpec extends ZIOBaseSpec {
+  def spec = suite("ZIOAppLifecycleSpec")(
+    suite("bootstrap layer")(
+      test("bootstrap layer resources are released on completion") {
+        for {
+          ref <- Ref.make(false)
+          app = new ZIOAppDefault {
+                  override val bootstrap = ZLayer.scoped(
+                    ZIO.acquireRelease(ZIO.unit)(_ => ref.set(true))
+                  )
+                  val run = ZIO.unit
+                }
+          _        <- app.invoke(Chunk.empty)
+          released <- ref.get
+        } yield assertTrue(released)
+      },
+      test("bootstrap failure results in exit code failure") {
+        val app = new ZIOAppDefault {
+          override val bootstrap = ZLayer.fail("bootstrap broke")
+          val run                = ZIO.unit
+        }
+        for {
+          code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        } yield assertTrue(code == ExitCode.failure)
+      },
+      test("bootstrap resources available during run") {
+        for {
+          ref <- Ref.make(0)
+          app = new ZIOApp {
+                  type Environment = Ref[Int]
+                  val environmentTag = EnvironmentTag[Ref[Int]]
+                  val bootstrap      = ZLayer.succeed(ref)
+                  val run: ZIO[Ref[Int] with ZIOAppArgs with Scope, Any, Any] =
+                    ZIO.serviceWithZIO[Ref[Int]](_.update(_ + 10))
+                }
+          _ <- app.invoke(Chunk.empty)
+          v <- ref.get
+        } yield assertTrue(v == 10)
+      }
+    ),
+    suite("finalizer edge cases")(
+      test("defect in finalizer does not prevent app from completing") {
+        for {
+          ref <- Ref.make(false)
+          app = new ZIOAppDefault {
+                  val run = ZIO.scoped {
+                    for {
+                      _ <- ZIO.addFinalizer(ZIO.die(new RuntimeException("boom")))
+                      _ <- ZIO.addFinalizer(ref.set(true))
+                    } yield ()
+                  }
+                }
+          code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+          ran  <- ref.get
+        } yield assertTrue(ran) && assertTrue(code == ExitCode.failure)
+      },
+      test("nested scoped resources are released in correct order") {
+        for {
+          order <- Ref.make(List.empty[String])
+          app = new ZIOAppDefault {
+                  val run = ZIO.scoped {
+                    for {
+                      _ <- ZIO.acquireRelease(ZIO.unit)(_ => order.update(_ :+ "outer"))
+                      _ <- ZIO.scoped {
+                             ZIO.acquireRelease(ZIO.unit)(_ => order.update(_ :+ "inner"))
+                           }
+                    } yield ()
+                  }
+                }
+          _      <- app.invoke(Chunk.empty)
+          result <- order.get
+        } yield assertTrue(result == List("inner", "outer"))
+      },
+      test("finalizer on interrupted effect runs") {
+        for {
+          running <- Promise.make[Nothing, Unit]
+          ref     <- Ref.make(false)
+          app = new ZIOAppDefault {
+                  val run = ZIO.scoped {
+                    ZIO.acquireRelease(running.succeed(()))(_ => ref.set(true)) *> ZIO.never
+                  }
+                }
+          fiber     <- app.invoke(Chunk.empty).fork
+          _         <- running.await
+          _         <- fiber.interrupt
+          finalized <- ref.get
+        } yield assertTrue(finalized)
+      }
+    ),
+    suite("app composition")(
+      test("composed apps run both effects") {
+        for {
+          ref    <- Ref.make(List.empty[String])
+          app1    = ZIOApp.fromZIO(ref.update(_ :+ "first"))
+          app2    = ZIOApp.fromZIO(ref.update(_ :+ "second"))
+          _      <- (app1 <> app2).invoke(Chunk.empty)
+          result <- ref.get
+        } yield assertTrue(result.contains("first")) && assertTrue(result.contains("second"))
+      },
+      test("composed app fails if either side fails") {
+        val app1 = ZIOApp.fromZIO(ZIO.fail("oops"))
+        val app2 = ZIOApp.fromZIO(ZIO.succeed(42))
+        for {
+          code <- (app1 <> app2).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        } yield assertTrue(code == ExitCode.failure)
+      }
+    ),
+    suite("args threading")(
+      test("ZIOAppArgs are accessible from run") {
+        for {
+          ref <- Ref.make(Chunk.empty[String])
+          app = new ZIOAppDefault {
+                  val run = getArgs.flatMap(args => ref.set(args))
+                }
+          _    <- app.invoke(Chunk("foo", "bar"))
+          args <- ref.get
+        } yield assertTrue(args == Chunk("foo", "bar"))
+      },
+      test("empty args work correctly") {
+        for {
+          ref <- Ref.make(Chunk("placeholder"))
+          app = new ZIOAppDefault {
+                  val run = getArgs.flatMap(args => ref.set(args))
+                }
+          _    <- app.invoke(Chunk.empty)
+          args <- ref.get
+        } yield assertTrue(args.isEmpty)
+      }
+    ),
+    suite("error handling")(
+      test("die in run emits failure exit code") {
+        val app = ZIOApp.fromZIO(ZIO.die(new RuntimeException("fatal")))
+        for {
+          code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        } yield assertTrue(code == ExitCode.failure)
+      },
+      test("interruption in run is handled") {
+        val app = ZIOApp.fromZIO(ZIO.interrupt)
+        for {
+          code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+        } yield assertTrue(code == ExitCode.failure)
+      }
+    )
+  )
+}


### PR DESCRIPTION
## Summary

Adds two test spec files to cover ZIOApp lifecycle behaviour more thoroughly.

### ZIOAppIntegrationSpec (JVM only) - 11 tests

Spawns real child JVM processes so we can exercise the actual `main()` code path including JVM shutdown hooks, `System.exit`, and real OS signal delivery. The existing `ZIOAppSpec` uses `invoke()` which bypasses all of that.

| Area | Test | Regression |
|------|------|------------|
| exit codes | successful app returns 0 | - |
| exit codes | failed app returns 1 | - |
| exit codes | defect (die) returns 1 | - |
| finalizers | finalizer runs on natural completion | - |
| signal handling | finalizer runs on SIGINT | #9901 |
| signal handling | multiple finalizers run in reverse order | #9901 |
| signal handling | shutdown doesn't hang | - |
| signal handling | gracefulShutdownTimeout cuts off slow finalizer | - |
| regression | no uncaught exception on stderr (#9807) | #9807 |
| regression | daemon fibers cleaned up on shutdown | - |
| regression | failing finalizer doesn't prevent others | - |

All signal tests are gated with `@@ unix` and `@@ nonFlaky(3)`.

Uses CountDownLatch-bounded I/O with hard timeouts so CI never hangs. SIGINT is sent via `kill -INT <pid>` (real SIGINT, not Process.destroy which sends SIGTERM).

### ZIOAppLifecycleSpec (shared) - 12 tests

Cross-platform tests using the `invoke()` pathway for lifecycle edge cases the current ZIOAppSpec doesn't cover:

- Bootstrap layer resource release
- Bootstrap layer failure -> ExitCode.failure
- Bootstrap resources available during run
- Defect in finalizer doesn't prevent other finalizers
- Nested scoped resources released in correct order
- Finalizer on interrupted effect
- Composed apps run both sides
- Composed app failure propagation
- Args threading and empty args
- Die and interruption in run -> failure exit code

### Running locally

```bash
sbt "coreTestsJVM/testOnly zio.zioapp.ZIOAppIntegrationSpec"
sbt "coreTestsJVM/testOnly zio.ZIOAppLifecycleSpec"
```

### Demo

All 24 tests passing locally on macOS:

[Demo Video (Google Drive)](https://drive.google.com/file/d/16JS_w_or5VdNHT8v-h8IL9dWxtubWPA5/view?usp=sharing)

/claim #9909
