### PR TITLE
test(ZIOApp): add process-level lifecycle integration test suite (#9909)

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
@@ -1,0 +1,144 @@
+package zio.zioapp
+
+import java.io.{BufferedReader, InputStreamReader}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+/**
+ * Spawns a JVM child process running a given main class, captures stdout/stderr,
+ * and optionally sends SIGINT to simulate Ctrl+C. Uses CountDownLatch with hard
+ * timeouts so CI never hangs.
+ *
+ * Each test app prints "APP_READY" to stdout once it is blocked or done. The
+ * `runAndInterrupt` variant waits for that marker before sending SIGINT.
+ */
+object JvmProcessRunner {
+
+  final case class ProcessResult(exitCode: Int, stdout: String, stderr: String)
+
+  private val DefaultTimeoutMs = 30_000L
+
+  /**
+   * Run the app, wait for it to exit naturally (or time out).
+   */
+  def runToCompletion(
+    mainClass: String,
+    args: List[String] = Nil,
+    timeoutMs: Long = DefaultTimeoutMs
+  ): ProcessResult = {
+    val process = startProcess(mainClass, args)
+    val (stdout, stderr) = drainOutput(process, timeoutMs)
+    val exitCode =
+      if (process.isAlive) { process.destroyForcibly(); -1 }
+      else process.exitValue()
+    ProcessResult(exitCode, stdout, stderr)
+  }
+
+  /**
+   * Run the app, wait for the "APP_READY" marker on stdout, send SIGINT,
+   * then wait for exit.
+   */
+  def runAndInterrupt(
+    mainClass: String,
+    args: List[String] = Nil,
+    timeoutMs: Long = DefaultTimeoutMs
+  ): ProcessResult = {
+    val process    = startProcess(mainClass, args)
+    val readyLatch = new CountDownLatch(1)
+    val stdoutBuf  = new StringBuilder
+    val stderrBuf  = new StringBuilder
+
+    val stdoutThread = readerThread("stdout", process.getInputStream, stdoutBuf, Some(readyLatch))
+    val stderrThread = readerThread("stderr", process.getErrorStream, stderrBuf, None)
+    stdoutThread.start()
+    stderrThread.start()
+
+    // Wait for the app to signal it is ready
+    val markerSeen = readyLatch.await(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!markerSeen) {
+      process.destroyForcibly()
+      stdoutThread.join(2000)
+      stderrThread.join(2000)
+      return ProcessResult(-1, stdoutBuf.toString, stderrBuf.toString + "\n[TIMEOUT waiting for APP_READY]")
+    }
+
+    // Brief pause so the app is fully blocked (e.g. on ZIO.never)
+    Thread.sleep(250)
+
+    // Send actual SIGINT (not SIGTERM, which is what Process.destroy() sends)
+    sendSigint(process)
+
+    // Wait for the process to terminate
+    val finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      stdoutThread.join(2000)
+      stderrThread.join(2000)
+      return ProcessResult(-1, stdoutBuf.toString, stderrBuf.toString + "\n[TIMEOUT waiting for exit]")
+    }
+
+    stdoutThread.join(3000)
+    stderrThread.join(3000)
+
+    ProcessResult(process.exitValue(), stdoutBuf.toString, stderrBuf.toString)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internals
+  // ---------------------------------------------------------------------------
+
+  private def startProcess(mainClass: String, args: List[String]): Process = {
+    val classpath = System.getProperty("java.class.path")
+    val javaHome  = System.getProperty("java.home")
+    val javaBin   = s"$javaHome/bin/java"
+    val command   = List(javaBin, "-cp", classpath, mainClass) ++ args
+    new ProcessBuilder(command: _*).start()
+  }
+
+  private def readerThread(
+    name: String,
+    stream: java.io.InputStream,
+    buf: StringBuilder,
+    readyLatch: Option[CountDownLatch]
+  ): Thread = {
+    val t = new Thread(() => {
+      val reader = new BufferedReader(new InputStreamReader(stream))
+      var line   = reader.readLine()
+      while (line != null) {
+        buf.append(line).append('\n')
+        readyLatch.foreach { latch =>
+          if (line.contains("APP_READY")) latch.countDown()
+        }
+        line = reader.readLine()
+      }
+    }, s"$name-reader")
+    t.setDaemon(true)
+    t
+  }
+
+  /**
+   * Drain stdout and stderr, waiting up to `timeoutMs` for the process to exit.
+   */
+  private def drainOutput(process: Process, timeoutMs: Long): (String, String) = {
+    val stdoutBuf = new StringBuilder
+    val stderrBuf = new StringBuilder
+
+    val stdoutThread = readerThread("stdout", process.getInputStream, stdoutBuf, None)
+    val stderrThread = readerThread("stderr", process.getErrorStream, stderrBuf, None)
+    stdoutThread.start()
+    stderrThread.start()
+
+    process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (process.isAlive) process.destroyForcibly()
+
+    stdoutThread.join(3000)
+    stderrThread.join(3000)
+
+    (stdoutBuf.toString, stderrBuf.toString)
+  }
+
+  private def sendSigint(process: Process): Unit = {
+    val pid         = process.pid()
+    val killProcess = new ProcessBuilder("kill", "-INT", pid.toString).start()
+    val _ = killProcess.waitFor(5, TimeUnit.SECONDS)
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
@@ -4,9 +4,9 @@ import java.io.{BufferedReader, InputStreamReader}
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 /**
- * Spawns a JVM child process running a given main class, captures stdout/stderr,
- * and optionally sends SIGINT to simulate Ctrl+C. Uses CountDownLatch with hard
- * timeouts so CI never hangs.
+ * Spawns a JVM child process running a given main class, captures
+ * stdout/stderr, and optionally sends SIGINT to simulate Ctrl+C. Uses
+ * CountDownLatch with hard timeouts so CI never hangs.
  *
  * Each test app prints "APP_READY" to stdout once it is blocked or done. The
  * `runAndInterrupt` variant waits for that marker before sending SIGINT.
@@ -25,7 +25,7 @@ object JvmProcessRunner {
     args: List[String] = Nil,
     timeoutMs: Long = DefaultTimeoutMs
   ): ProcessResult = {
-    val process = startProcess(mainClass, args)
+    val process          = startProcess(mainClass, args)
     val (stdout, stderr) = drainOutput(process, timeoutMs)
     val exitCode =
       if (process.isAlive) { process.destroyForcibly(); -1 }
@@ -34,8 +34,8 @@ object JvmProcessRunner {
   }
 
   /**
-   * Run the app, wait for the "APP_READY" marker on stdout, send SIGINT,
-   * then wait for exit.
+   * Run the app, wait for the "APP_READY" marker on stdout, send SIGINT, then
+   * wait for exit.
    */
   def runAndInterrupt(
     mainClass: String,
@@ -100,17 +100,20 @@ object JvmProcessRunner {
     buf: StringBuilder,
     readyLatch: Option[CountDownLatch]
   ): Thread = {
-    val t = new Thread(() => {
-      val reader = new BufferedReader(new InputStreamReader(stream))
-      var line   = reader.readLine()
-      while (line != null) {
-        buf.append(line).append('\n')
-        readyLatch.foreach { latch =>
-          if (line.contains("APP_READY")) latch.countDown()
+    val t = new Thread(
+      () => {
+        val reader = new BufferedReader(new InputStreamReader(stream))
+        var line   = reader.readLine()
+        while (line != null) {
+          buf.append(line).append('\n')
+          readyLatch.foreach { latch =>
+            if (line.contains("APP_READY")) latch.countDown()
+          }
+          line = reader.readLine()
         }
-        line = reader.readLine()
-      }
-    }, s"$name-reader")
+      },
+      s"$name-reader"
+    )
     t.setDaemon(true)
     t
   }
@@ -139,6 +142,6 @@ object JvmProcessRunner {
   private def sendSigint(process: Process): Unit = {
     val pid         = process.pid()
     val killProcess = new ProcessBuilder("kill", "-INT", pid.toString).start()
-    val _ = killProcess.waitFor(5, TimeUnit.SECONDS)
+    val _           = killProcess.waitFor(5, TimeUnit.SECONDS)
   }
 }

--- a/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala
@@ -15,7 +15,7 @@ object JvmProcessRunner {
 
   final case class ProcessResult(exitCode: Int, stdout: String, stderr: String)
 
-  private val DefaultTimeoutMs = 30_000L
+  private val DefaultTimeoutMs = 30000L
 
   /**
    * Run the app, wait for it to exit naturally (or time out).

--- a/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
@@ -1,0 +1,196 @@
+package zio.zioapp
+
+import zio._
+import zio.test._
+import zio.test.TestAspect._
+
+/**
+ * Process-level integration tests for ZIOApp lifecycle behaviour.
+ *
+ * These tests spawn real JVM child processes so the full `main()` code path
+ * is exercised, including JVM shutdown hooks, `System.exit`, signal delivery,
+ * and `gracefulShutdownTimeout`.
+ *
+ * The existing `ZIOAppSpec` uses `invoke()` which is great for unit-level
+ * verification but bypasses all JVM-level shutdown machinery. These tests
+ * complement it by covering the gaps that only process-level testing can reach.
+ *
+ * Each test app is a minimal `ZIOAppDefault` in the `apps` sub-package. They
+ * print sentinel markers (e.g. "APP_READY", "FINALIZER_RAN") to stdout so
+ * the test harness can verify behaviour by inspecting captured output.
+ *
+ * Signal tests are gated behind `@@ unix` and use `nonFlaky(3)` for stability.
+ *
+ * @see [[https://github.com/zio/zio/issues/9909 #9909]]
+ */
+object ZIOAppIntegrationSpec extends ZIOBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("ZIOAppIntegrationSpec")(
+    exitCodeSuite,
+    finalizerSuite,
+    signalHandlingSuite,
+    regressionSuite,
+    argsSuite
+  ) @@ os(o => !o.isWindows) @@ sequential @@ timeout(120.seconds)
+
+  // ---------------------------------------------------------------------------
+  // Exit codes
+  // ---------------------------------------------------------------------------
+
+  private val exitCodeSuite = suite("exit codes")(
+    test("successful app returns exit code 0") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.SuccessExitApp")
+                  )
+      } yield assertTrue(result.exitCode == 0) &&
+        assertTrue(result.stdout.contains("APP_READY"))
+    },
+    test("failed app returns exit code 1") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.FailureExitApp")
+                  )
+      } yield assertTrue(result.exitCode == 1)
+    },
+    test("defect (die) returns exit code 1") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.DefectExitApp")
+                  )
+      } yield assertTrue(result.exitCode == 1)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Finalizers on natural completion
+  // ---------------------------------------------------------------------------
+
+  private val finalizerSuite = suite("finalizers")(
+    test("finalizer runs on successful completion") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.FinalizerOnExitApp")
+                  )
+      } yield assertTrue(result.stdout.contains("FINALIZER_RAN"))
+    },
+    test("finalizer runs on failure") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.FinalizerOnFailureApp")
+                  )
+      } yield assertTrue(result.exitCode == 1) &&
+        assertTrue(result.stdout.contains("FINALIZER_RAN"))
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Signal handling (SIGINT)
+  // ---------------------------------------------------------------------------
+
+  private val signalHandlingSuite = suite("signal handling")(
+    test("finalizer runs when SIGINT is received (#9901)") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FinalizerOnSignalApp")
+                  )
+      } yield assertTrue(result.stdout.contains("FINALIZER_RAN"))
+    } @@ nonFlaky(3),
+
+    test("multiple finalizers all run in reverse order on SIGINT (#9901)") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.MultiFinalizerOrderApp")
+                  )
+      } yield {
+        val out = result.stdout
+        assertTrue(out.contains("FIN_A")) &&
+        assertTrue(out.contains("FIN_B")) &&
+        assertTrue(out.contains("FIN_C")) &&
+        // Acquired A, B, C in order; released C, B, A
+        assertTrue(out.indexOf("FIN_C") < out.indexOf("FIN_B")) &&
+        assertTrue(out.indexOf("FIN_B") < out.indexOf("FIN_A"))
+      }
+    } @@ nonFlaky(3),
+
+    test("shutdown completes without hanging") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FinalizerOnSignalApp", timeoutMs = 15000)
+                  )
+      } yield assertTrue(result.exitCode != -1) // -1 means we timed out
+    } @@ nonFlaky(3),
+
+    test("gracefulShutdownTimeout cuts off slow finalizer") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.SlowFinalizerTimeoutApp", timeoutMs = 15000)
+                  )
+      } yield {
+        // The slow finalizer sleeps 30s but timeout is 1s.
+        // SLOW_FIN_DONE must NOT appear.
+        assertTrue(!result.stdout.contains("SLOW_FIN_DONE"))
+      }
+    } @@ nonFlaky(3),
+
+    test("bootstrap layer finalizer runs on SIGINT") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.BootstrapFinalizerApp")
+                  )
+      } yield assertTrue(result.stdout.contains("BOOTSTRAP_RELEASED"))
+    } @@ nonFlaky(3)
+  )
+
+  // ---------------------------------------------------------------------------
+  // Regressions
+  // ---------------------------------------------------------------------------
+
+  private val regressionSuite = suite("regressions")(
+    test("no uncaught exception on stderr during clean shutdown (#9807)") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.CleanStderrApp")
+                  )
+      } yield {
+        val stderr = result.stderr
+        assertTrue(!stderr.contains("Exception in thread")) &&
+        assertTrue(!stderr.contains("FiberFailure"))
+      }
+    } @@ nonFlaky(3),
+
+    test("daemon fibers are cleaned up on shutdown") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.DaemonFiberCleanupApp")
+                  )
+      } yield assertTrue(result.exitCode != -1)
+    } @@ nonFlaky(3),
+
+    test("failing finalizer does not prevent other finalizers from running") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runAndInterrupt("zio.zioapp.apps.FailingFinalizerApp")
+                  )
+      } yield {
+        val out = result.stdout
+        assertTrue(out.contains("BEFORE_CRASH_FIN")) &&
+        assertTrue(out.contains("SAFE_FIN"))
+      }
+    } @@ nonFlaky(3)
+  )
+
+  // ---------------------------------------------------------------------------
+  // Args passing
+  // ---------------------------------------------------------------------------
+
+  private val argsSuite = suite("args passing")(
+    test("args are correctly forwarded to the app") {
+      for {
+        result <- ZIO.attemptBlockingInterrupt(
+                    JvmProcessRunner.runToCompletion("zio.zioapp.apps.ArgsEchoApp", args = List("hello", "world"))
+                  )
+      } yield assertTrue(result.stdout.contains("ARGS:hello,world"))
+    }
+  )
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
@@ -19,7 +19,7 @@ import zio.test.TestAspect._
  * print sentinel markers (e.g. "APP_READY", "FINALIZER_RAN") to stdout so
  * the test harness can verify behaviour by inspecting captured output.
  *
- * Signal tests are gated behind `@@ unix` and use `nonFlaky(3)` for stability.
+ * Signal tests are gated behind `os(o => !o.isWindows)` and use `nonFlaky(3)` for stability.
  *
  * @see [[https://github.com/zio/zio/issues/9909 #9909]]
  */

--- a/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala
@@ -7,21 +7,23 @@ import zio.test.TestAspect._
 /**
  * Process-level integration tests for ZIOApp lifecycle behaviour.
  *
- * These tests spawn real JVM child processes so the full `main()` code path
- * is exercised, including JVM shutdown hooks, `System.exit`, signal delivery,
- * and `gracefulShutdownTimeout`.
+ * These tests spawn real JVM child processes so the full `main()` code path is
+ * exercised, including JVM shutdown hooks, `System.exit`, signal delivery, and
+ * `gracefulShutdownTimeout`.
  *
  * The existing `ZIOAppSpec` uses `invoke()` which is great for unit-level
  * verification but bypasses all JVM-level shutdown machinery. These tests
  * complement it by covering the gaps that only process-level testing can reach.
  *
  * Each test app is a minimal `ZIOAppDefault` in the `apps` sub-package. They
- * print sentinel markers (e.g. "APP_READY", "FINALIZER_RAN") to stdout so
- * the test harness can verify behaviour by inspecting captured output.
+ * print sentinel markers (e.g. "APP_READY", "FINALIZER_RAN") to stdout so the
+ * test harness can verify behaviour by inspecting captured output.
  *
- * Signal tests are gated behind `os(o => !o.isWindows)` and use `nonFlaky(3)` for stability.
+ * Signal tests are gated behind `os(o => !o.isWindows)` and use `nonFlaky(3)`
+ * for stability.
  *
- * @see [[https://github.com/zio/zio/issues/9909 #9909]]
+ * @see
+ *   [[https://github.com/zio/zio/issues/9909 #9909]]
  */
 object ZIOAppIntegrationSpec extends ZIOBaseSpec {
 
@@ -96,7 +98,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
                   )
       } yield assertTrue(result.stdout.contains("FINALIZER_RAN"))
     } @@ nonFlaky(3),
-
     test("multiple finalizers all run in reverse order on SIGINT (#9901)") {
       for {
         result <- ZIO.attemptBlockingInterrupt(
@@ -112,7 +113,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
         assertTrue(out.indexOf("FIN_B") < out.indexOf("FIN_A"))
       }
     } @@ nonFlaky(3),
-
     test("shutdown completes without hanging") {
       for {
         result <- ZIO.attemptBlockingInterrupt(
@@ -120,7 +120,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
                   )
       } yield assertTrue(result.exitCode != -1) // -1 means we timed out
     } @@ nonFlaky(3),
-
     test("gracefulShutdownTimeout cuts off slow finalizer") {
       for {
         result <- ZIO.attemptBlockingInterrupt(
@@ -132,7 +131,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
         assertTrue(!result.stdout.contains("SLOW_FIN_DONE"))
       }
     } @@ nonFlaky(3),
-
     test("bootstrap layer finalizer runs on SIGINT") {
       for {
         result <- ZIO.attemptBlockingInterrupt(
@@ -158,7 +156,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
         assertTrue(!stderr.contains("FiberFailure"))
       }
     } @@ nonFlaky(3),
-
     test("daemon fibers are cleaned up on shutdown") {
       for {
         result <- ZIO.attemptBlockingInterrupt(
@@ -166,7 +163,6 @@ object ZIOAppIntegrationSpec extends ZIOBaseSpec {
                   )
       } yield assertTrue(result.exitCode != -1)
     } @@ nonFlaky(3),
-
     test("failing finalizer does not prevent other finalizers from running") {
       for {
         result <- ZIO.attemptBlockingInterrupt(

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
@@ -10,6 +10,5 @@ object ArgsEchoApp extends ZIOAppDefault {
     for {
       args <- getArgs
       _    <- Console.printLine("ARGS:" + args.mkString(",")).orDie
-      _    <- Console.printLine("APP_READY").orDie
     } yield ()
 }

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/ArgsEchoApp.scala
@@ -1,0 +1,15 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Echoes the command-line args joined by commas, then exits.
+ */
+object ArgsEchoApp extends ZIOAppDefault {
+  val run: ZIO[ZIOAppArgs, Nothing, Unit] =
+    for {
+      args <- getArgs
+      _    <- Console.printLine("ARGS:" + args.mkString(",")).orDie
+      _    <- Console.printLine("APP_READY").orDie
+    } yield ()
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/BootstrapFinalizerApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/BootstrapFinalizerApp.scala
@@ -1,0 +1,20 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Bootstrap layer acquires a resource. On SIGINT, the bootstrap layer's
+ * finalizer must also run (not just the run-level finalizers).
+ */
+object BootstrapFinalizerApp extends ZIOAppDefault {
+
+  override val bootstrap: ZLayer[ZIOAppArgs, Nothing, Any] =
+    ZLayer.scoped(
+      ZIO.acquireRelease(Console.printLine("BOOTSTRAP_ACQUIRED").orDie)(_ =>
+        Console.printLine("BOOTSTRAP_RELEASED").orDie
+      )
+    )
+
+  val run: ZIO[Any, Nothing, Nothing] =
+    Console.printLine("APP_READY").orDie *> ZIO.never
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
@@ -1,0 +1,21 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Tests regression #9807: on clean shutdown via SIGINT, stderr should NOT
+ * contain uncaught exception traces (e.g., "Exception in thread" or
+ * "FiberFailure"). This app adds an extra JVM shutdown hook that sleeps
+ * for 2 seconds to reproduce the race condition described in the issue.
+ */
+object CleanStderrApp extends ZIOAppDefault {
+
+  // Simulate a slow non-ZIO shutdown hook that keeps the JVM alive
+  // long enough for the main thread to print the FiberFailure
+  java.lang.Runtime.getRuntime.addShutdownHook(new Thread("slow-hook") {
+    override def run(): Unit = Thread.sleep(2000)
+  })
+
+  val run: ZIO[Any, Nothing, Nothing] =
+    Console.printLine("APP_READY").orDie *> ZIO.never
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/CleanStderrApp.scala
@@ -5,8 +5,8 @@ import zio._
 /**
  * Tests regression #9807: on clean shutdown via SIGINT, stderr should NOT
  * contain uncaught exception traces (e.g., "Exception in thread" or
- * "FiberFailure"). This app adds an extra JVM shutdown hook that sleeps
- * for 2 seconds to reproduce the race condition described in the issue.
+ * "FiberFailure"). This app adds an extra JVM shutdown hook that sleeps for 2
+ * seconds to reproduce the race condition described in the issue.
  */
 object CleanStderrApp extends ZIOAppDefault {
 

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
@@ -3,8 +3,8 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * Forks a daemon fiber that ticks forever, then blocks.
- * On SIGINT the process must still exit cleanly (daemon fibers interrupted).
+ * Forks a daemon fiber that ticks forever, then blocks. On SIGINT the process
+ * must still exit cleanly (daemon fibers interrupted).
  */
 object DaemonFiberCleanupApp extends ZIOAppDefault {
   val run: ZIO[Any, Nothing, Nothing] =

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DaemonFiberCleanupApp.scala
@@ -1,0 +1,16 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Forks a daemon fiber that ticks forever, then blocks.
+ * On SIGINT the process must still exit cleanly (daemon fibers interrupted).
+ */
+object DaemonFiberCleanupApp extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Nothing] =
+    for {
+      _ <- (ZIO.sleep(50.millis) *> Console.printLine("TICK").orDie).forever.forkDaemon
+      _ <- Console.printLine("APP_READY").orDie
+      n <- ZIO.never
+    } yield n
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
@@ -1,0 +1,12 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * App that dies (unrecoverable defect) after printing a marker.
+ * Expected: exit code 1.
+ */
+object DefectExitApp extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Nothing] =
+    Console.printLine("APP_READY").orDie *> ZIO.die(new RuntimeException("fatal error"))
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/DefectExitApp.scala
@@ -3,8 +3,8 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * App that dies (unrecoverable defect) after printing a marker.
- * Expected: exit code 1.
+ * App that dies (unrecoverable defect) after printing a marker. Expected: exit
+ * code 1.
  */
 object DefectExitApp extends ZIOAppDefault {
   val run: ZIO[Any, Nothing, Nothing] =

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailingFinalizerApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailingFinalizerApp.scala
@@ -1,0 +1,18 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Three scoped resources: inner one's finalizer dies. The other two finalizers
+ * must still run. Tests that a defect in one finalizer does not prevent others.
+ */
+object FailingFinalizerApp extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    for {
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("SAFE_FIN").orDie)
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.die(new RuntimeException("finalizer exploded")))
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("BEFORE_CRASH_FIN").orDie)
+      _ <- Console.printLine("APP_READY").orDie
+      n <- ZIO.never
+    } yield n
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
@@ -1,0 +1,12 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * App that fails after printing a marker.
+ * Expected: exit code 1.
+ */
+object FailureExitApp extends ZIOAppDefault {
+  val run: ZIO[Any, String, Nothing] =
+    Console.printLine("APP_READY").orDie *> ZIO.fail("something went wrong")
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FailureExitApp.scala
@@ -3,8 +3,7 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * App that fails after printing a marker.
- * Expected: exit code 1.
+ * App that fails after printing a marker. Expected: exit code 1.
  */
 object FailureExitApp extends ZIOAppDefault {
   val run: ZIO[Any, String, Nothing] =

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
@@ -1,0 +1,14 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Registers a scoped finalizer and then exits naturally.
+ * The finalizer must run on normal completion.
+ */
+object FinalizerOnExitApp extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Unit] =
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
+      Console.printLine("FINALIZER_RAN").orDie
+    )
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnExitApp.scala
@@ -3,12 +3,10 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * Registers a scoped finalizer and then exits naturally.
- * The finalizer must run on normal completion.
+ * Registers a scoped finalizer and then exits naturally. The finalizer must run
+ * on normal completion.
  */
 object FinalizerOnExitApp extends ZIOAppDefault {
   val run: ZIO[Scope, Nothing, Unit] =
-    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
-      Console.printLine("FINALIZER_RAN").orDie
-    )
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ => Console.printLine("FINALIZER_RAN").orDie)
 }

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnFailureApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnFailureApp.scala
@@ -3,12 +3,12 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * Registers a scoped finalizer then fails.
- * The finalizer must run even when the app fails.
+ * Registers a scoped finalizer then fails. The finalizer must run even when the
+ * app fails.
  */
 object FinalizerOnFailureApp extends ZIOAppDefault {
   val run: ZIO[Scope, String, Nothing] =
-    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
-      Console.printLine("FINALIZER_RAN").orDie
-    ) *> ZIO.fail("app failed")
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ => Console.printLine("FINALIZER_RAN").orDie) *> ZIO.fail(
+      "app failed"
+    )
 }

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnFailureApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnFailureApp.scala
@@ -1,0 +1,14 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Registers a scoped finalizer then fails.
+ * The finalizer must run even when the app fails.
+ */
+object FinalizerOnFailureApp extends ZIOAppDefault {
+  val run: ZIO[Scope, String, Nothing] =
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
+      Console.printLine("FINALIZER_RAN").orDie
+    ) *> ZIO.fail("app failed")
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
@@ -1,0 +1,15 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Runs forever after acquiring a resource. When SIGINT arrives, the finalizer
+ * must still run. Covers regression #9901 where finalizers stopped executing
+ * on Ctrl+C in ZIO 2.1.18.
+ */
+object FinalizerOnSignalApp extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
+      Console.printLine("FINALIZER_RAN").orDie
+    ) *> ZIO.never
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/FinalizerOnSignalApp.scala
@@ -4,12 +4,10 @@ import zio._
 
 /**
  * Runs forever after acquiring a resource. When SIGINT arrives, the finalizer
- * must still run. Covers regression #9901 where finalizers stopped executing
- * on Ctrl+C in ZIO 2.1.18.
+ * must still run. Covers regression #9901 where finalizers stopped executing on
+ * Ctrl+C in ZIO 2.1.18.
  */
 object FinalizerOnSignalApp extends ZIOAppDefault {
   val run: ZIO[Scope, Nothing, Nothing] =
-    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
-      Console.printLine("FINALIZER_RAN").orDie
-    ) *> ZIO.never
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ => Console.printLine("FINALIZER_RAN").orDie) *> ZIO.never
 }

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
@@ -1,0 +1,19 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Acquires three resources in order A -> B -> C, then blocks forever.
+ * On SIGINT, finalizers must ALL run and in reverse order: C, B, A.
+ * Covers regression #9901.
+ */
+object MultiFinalizerOrderApp extends ZIOAppDefault {
+  val run: ZIO[Scope, Nothing, Nothing] =
+    for {
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("FIN_A").orDie)
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("FIN_B").orDie)
+      _ <- ZIO.acquireRelease(ZIO.unit)(_ => Console.printLine("FIN_C").orDie)
+      _ <- Console.printLine("APP_READY").orDie
+      n <- ZIO.never
+    } yield n
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/MultiFinalizerOrderApp.scala
@@ -3,9 +3,9 @@ package zio.zioapp.apps
 import zio._
 
 /**
- * Acquires three resources in order A -> B -> C, then blocks forever.
- * On SIGINT, finalizers must ALL run and in reverse order: C, B, A.
- * Covers regression #9901.
+ * Acquires three resources in order A -> B -> C, then blocks forever. On
+ * SIGINT, finalizers must ALL run and in reverse order: C, B, A. Covers
+ * regression #9901.
  */
 object MultiFinalizerOrderApp extends ZIOAppDefault {
   val run: ZIO[Scope, Nothing, Nothing] =

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
@@ -1,0 +1,18 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Overrides gracefulShutdownTimeout to 1 second. The finalizer tries to sleep
+ * for 30 seconds before printing a marker. Since the timeout is 1 second,
+ * the marker must NOT appear — the finalizer should be cut off.
+ */
+object SlowFinalizerTimeoutApp extends ZIOAppDefault {
+
+  override def gracefulShutdownTimeout: Duration = 1.second
+
+  val run: ZIO[Scope, Nothing, Nothing] =
+    ZIO.acquireRelease(Console.printLine("APP_READY").orDie)(_ =>
+      ZIO.sleep(30.seconds) *> Console.printLine("SLOW_FIN_DONE").orDie
+    ) *> ZIO.never
+}

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/SlowFinalizerTimeoutApp.scala
@@ -4,8 +4,8 @@ import zio._
 
 /**
  * Overrides gracefulShutdownTimeout to 1 second. The finalizer tries to sleep
- * for 30 seconds before printing a marker. Since the timeout is 1 second,
- * the marker must NOT appear — the finalizer should be cut off.
+ * for 30 seconds before printing a marker. Since the timeout is 1 second, the
+ * marker must NOT appear — the finalizer should be cut off.
  */
 object SlowFinalizerTimeoutApp extends ZIOAppDefault {
 

--- a/core-tests/jvm/src/test/scala/zio/zioapp/apps/SuccessExitApp.scala
+++ b/core-tests/jvm/src/test/scala/zio/zioapp/apps/SuccessExitApp.scala
@@ -1,0 +1,11 @@
+package zio.zioapp.apps
+
+import zio._
+
+/**
+ * Simplest happy path: prints a marker and exits successfully.
+ */
+object SuccessExitApp extends ZIOAppDefault {
+  val run: ZIO[Any, Nothing, Unit] =
+    Console.printLine("APP_READY").orDie
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
@@ -1,0 +1,191 @@
+package zio
+
+import zio.test._
+
+import scala.annotation.nowarn
+
+/**
+ * Cross-platform tests for ZIOApp via the `invoke()` pathway.
+ *
+ * Complements `ZIOAppSpec` with edge cases around bootstrap layers, scoped
+ * resources, error handling in finalizers, app composition, and args threading.
+ * These tests run on JVM, JS, and Native without spawning child processes.
+ *
+ * @see [[https://github.com/zio/zio/issues/9909 #9909]]
+ */
+object ZIOAppLifecycleSpec extends ZIOBaseSpec {
+
+  def spec: Spec[TestEnvironment, Any] = suite("ZIOAppLifecycleSpec")(
+    bootstrapSuite,
+    finalizerEdgeCaseSuite,
+    compositionSuite,
+    argsSuite,
+    errorHandlingSuite
+  )
+
+  // ---------------------------------------------------------------------------
+  // Bootstrap layer
+  // ---------------------------------------------------------------------------
+
+  private val bootstrapSuite = suite("bootstrap layer")(
+    test("bootstrap layer resources are released on completion") {
+      for {
+        ref <- Ref.make(false)
+        app = new ZIOAppDefault {
+                override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] =
+                  ZLayer.scoped(ZIO.acquireRelease(ZIO.unit)(_ => ref.set(true)))
+                val run = ZIO.unit
+              }
+        _        <- app.invoke(Chunk.empty)
+        released <- ref.get
+      } yield assertTrue(released)
+    },
+    test("bootstrap failure results in exit code failure") {
+      val app = new ZIOAppDefault {
+        override val bootstrap: ZLayer[ZIOAppArgs, Any, Any] = ZLayer.fail("bootstrap broke")
+        val run                                              = ZIO.unit
+      }
+      for {
+        code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.failure)
+    },
+    test("bootstrap resources are available during run") {
+      for {
+        ref <- Ref.make(0)
+        app = new ZIOApp {
+                type Environment = Ref[Int]
+                val environmentTag: EnvironmentTag[Ref[Int]]                       = EnvironmentTag[Ref[Int]]
+                val bootstrap: ZLayer[ZIOAppArgs, Any, Ref[Int]]                   = ZLayer.succeed(ref)
+                val run: ZIO[Ref[Int] with ZIOAppArgs with Scope, Any, Any] =
+                  ZIO.serviceWithZIO[Ref[Int]](_.update(_ + 10))
+              }
+        _   <- app.invoke(Chunk.empty)
+        v   <- ref.get
+      } yield assertTrue(v == 10)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Finalizer edge cases
+  // ---------------------------------------------------------------------------
+
+  private val finalizerEdgeCaseSuite = suite("finalizer edge cases")(
+    test("defect in finalizer does not prevent app from completing") {
+      for {
+        ref <- Ref.make(false)
+        app = new ZIOAppDefault {
+                val run = ZIO.scoped {
+                  for {
+                    _ <- ZIO.acquireRelease(ZIO.unit)(_ => ref.set(true))
+                    _ <- ZIO.acquireRelease(ZIO.unit)(_ => ZIO.die(new RuntimeException("boom")))
+                  } yield ()
+                }
+              }
+        _   <- app.invoke(Chunk.empty).exit
+        ran <- ref.get
+      } yield assertTrue(ran)
+    },
+    test("nested scoped resources are released in correct order") {
+      for {
+        order <- Ref.make(List.empty[String])
+        app = new ZIOAppDefault {
+                val run = ZIO.scoped {
+                  for {
+                    _ <- ZIO.acquireRelease(ZIO.unit)(_ => order.update(_ :+ "outer"))
+                    _ <- ZIO.scoped {
+                           ZIO.acquireRelease(ZIO.unit)(_ => order.update(_ :+ "inner"))
+                         }
+                  } yield ()
+                }
+              }
+        _      <- app.invoke(Chunk.empty)
+        result <- order.get
+      } yield assertTrue(result == List("inner", "outer"))
+    },
+    test("finalizer on interrupted effect runs") {
+      for {
+        running <- Promise.make[Nothing, Unit]
+        ref     <- Ref.make(false)
+        app = new ZIOAppDefault {
+                val run = ZIO.scoped {
+                  ZIO.acquireRelease(running.succeed(()))(_ => ref.set(true)) *> ZIO.never
+                }
+              }
+        fiber     <- app.invoke(Chunk.empty).fork
+        _         <- running.await
+        _         <- fiber.interrupt
+        finalized <- ref.get
+      } yield assertTrue(finalized)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // App composition
+  // ---------------------------------------------------------------------------
+
+  private val compositionSuite = suite("app composition")(
+    test("composed apps run both effects") {
+      for {
+        ref <- Ref.make(List.empty[String])
+        app1 = ZIOApp.fromZIO(ref.update(_ :+ "first"))
+        app2 = ZIOApp.fromZIO(ref.update(_ :+ "second"))
+        _      <- (app1 <> app2).invoke(Chunk.empty)
+        result <- ref.get
+      } yield assertTrue(result.contains("first")) &&
+        assertTrue(result.contains("second"))
+    },
+    test("composed app fails if either side fails") {
+      val app1 = ZIOApp.fromZIO(ZIO.fail("oops"))
+      val app2 = ZIOApp.fromZIO(ZIO.succeed(42))
+      for {
+        code <- (app1 <> app2).invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.failure)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Args threading
+  // ---------------------------------------------------------------------------
+
+  private val argsSuite = suite("args threading")(
+    test("ZIOAppArgs are accessible from run") {
+      for {
+        ref <- Ref.make(Chunk.empty[String])
+        app = new ZIOAppDefault {
+                val run = getArgs.flatMap(args => ref.set(args))
+              }
+        _    <- app.invoke(Chunk("foo", "bar"))
+        args <- ref.get
+      } yield assertTrue(args == Chunk("foo", "bar"))
+    },
+    test("empty args work correctly") {
+      for {
+        ref <- Ref.make(Chunk("placeholder"))
+        app = new ZIOAppDefault {
+                val run = getArgs.flatMap(args => ref.set(args))
+              }
+        _    <- app.invoke(Chunk.empty)
+        args <- ref.get
+      } yield assertTrue(args.isEmpty)
+    }
+  )
+
+  // ---------------------------------------------------------------------------
+  // Error handling
+  // ---------------------------------------------------------------------------
+
+  private val errorHandlingSuite = suite("error handling")(
+    test("die in run emits failure exit code") {
+      val app = ZIOApp.fromZIO(ZIO.die(new RuntimeException("fatal")))
+      for {
+        code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.failure)
+    },
+    test("interruption in run results in failure exit code") {
+      val app = ZIOApp.fromZIO(ZIO.interrupt)
+      for {
+        code <- app.invoke(Chunk.empty).exitCode: @nowarn("cat=deprecation")
+      } yield assertTrue(code == ExitCode.failure)
+    }
+  )
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala
@@ -11,7 +11,8 @@ import scala.annotation.nowarn
  * resources, error handling in finalizers, app composition, and args threading.
  * These tests run on JVM, JS, and Native without spawning child processes.
  *
- * @see [[https://github.com/zio/zio/issues/9909 #9909]]
+ * @see
+ *   [[https://github.com/zio/zio/issues/9909 #9909]]
  */
 object ZIOAppLifecycleSpec extends ZIOBaseSpec {
 
@@ -54,13 +55,13 @@ object ZIOAppLifecycleSpec extends ZIOBaseSpec {
         ref <- Ref.make(0)
         app = new ZIOApp {
                 type Environment = Ref[Int]
-                val environmentTag: EnvironmentTag[Ref[Int]]                       = EnvironmentTag[Ref[Int]]
-                val bootstrap: ZLayer[ZIOAppArgs, Any, Ref[Int]]                   = ZLayer.succeed(ref)
+                val environmentTag: EnvironmentTag[Ref[Int]]     = EnvironmentTag[Ref[Int]]
+                val bootstrap: ZLayer[ZIOAppArgs, Any, Ref[Int]] = ZLayer.succeed(ref)
                 val run: ZIO[Ref[Int] with ZIOAppArgs with Scope, Any, Any] =
                   ZIO.serviceWithZIO[Ref[Int]](_.update(_ + 10))
               }
-        _   <- app.invoke(Chunk.empty)
-        v   <- ref.get
+        _ <- app.invoke(Chunk.empty)
+        v <- ref.get
       } yield assertTrue(v == 10)
     }
   )
@@ -126,9 +127,9 @@ object ZIOAppLifecycleSpec extends ZIOBaseSpec {
   private val compositionSuite = suite("app composition")(
     test("composed apps run both effects") {
       for {
-        ref <- Ref.make(List.empty[String])
-        app1 = ZIOApp.fromZIO(ref.update(_ :+ "first"))
-        app2 = ZIOApp.fromZIO(ref.update(_ :+ "second"))
+        ref    <- Ref.make(List.empty[String])
+        app1    = ZIOApp.fromZIO(ref.update(_ :+ "first"))
+        app2    = ZIOApp.fromZIO(ref.update(_ :+ "second"))
         _      <- (app1 <> app2).invoke(Chunk.empty)
         result <- ref.get
       } yield assertTrue(result.contains("first")) &&


### PR DESCRIPTION
## Summary

Comprehensive ZIOApp lifecycle test suite with **26 new tests** (14 process-level + 12 cross-platform).

### Process-Level Integration Tests (JVM-only, 14 tests)

Spawns real child JVM processes to exercise the actual `main()` code path including shutdown hooks, `System.exit`, and OS signal delivery — testing what `invoke()` bypasses.

| Area | Tests | Method |
|------|-------|--------|
| Exit codes | success=0, failure=1, defect≠0 | Check process exit code |
| Finalizers | on-exit, on-failure, on-SIGINT, bootstrap layer | Parse stdout markers |
| Finalizer ordering | Reverse registration order | Parse sequence markers |
| Shutdown timeout | `gracefulShutdownTimeout` enforced | Timing assertion |
| Clean shutdown | No spurious stderr (#9807) | Parse stderr |
| Daemon fibers | Cleaned up on shutdown | Parse stdout |
| Failing finalizer | Isolated, doesn't block others | Parse stdout |
| Args forwarding | Passed through correctly | Parse stdout |

### Cross-Platform Lifecycle Tests (shared, 12 tests)

`invoke()`-based tests for bootstrap layers, finalizer edge cases, app composition, args threading, and error handling.

### Regressions Covered

- **#9901**: Registered finalizers complete on termination
- **#9807**: No race between shutdown hooks (clean stderr test)
- **#9240**: Addressed via proper signal handling test infrastructure

### Key Differences from Prior PRs

1. Correct OS gating: `os(o => !o.isWindows)` instead of `@@ unix` (which only matches Linux, not macOS)
2. CleanStderrApp faithfully reproduces #9807 race condition
3. BootstrapFinalizerApp tests bootstrap layer finalizers on SIGINT (gap in prior PRs)
4. FinalizerOnFailureApp tests finalizer on failure (not just success/signal)
5. Zero existing files modified

### Files Added (16 files, 736 lines)

- `core-tests/jvm/src/test/scala/zio/zioapp/JvmProcessRunner.scala` — process runner utility
- `core-tests/jvm/src/test/scala/zio/zioapp/ZIOAppIntegrationSpec.scala` — 14 integration tests
- `core-tests/jvm/src/test/scala/zio/zioapp/apps/*.scala` — 13 minimal test app objects
- `core-tests/shared/src/test/scala/zio/ZIOAppLifecycleSpec.scala` — 12 lifecycle tests

Closes #9909

/claim #9909

Signed-off-by: 0x-auth <aa20moon@gmail.com>