### PR TITLE
feat(ci): implement safe two-workflow pattern for fork PR previews

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,35 +122,20 @@ jobs:
           path: ./website/build
           overwrite: true
 
+      - name: Save PR Metadata
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR Metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-metadata
+          path: pr-number.txt
+          overwrite: true
+
       - name: Print All Generated Files
         run: find ./website/build -print
-
-  deploy-preview:
-    needs: [build-website]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: website-artifact
-          path: website-artifact
-
-      - name: Deploy preview to Netlify
-        uses: nwtgck/actions-netlify@v3.0
-        with:
-          publish-dir: ./website-artifact
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
-          alias: pr-${{ github.event.pull_request.number }}
-          enable-pull-request-comment: true
-          overwrites-pull-request-comment: true
-          enable-commit-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 5
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,18 +122,6 @@ jobs:
           path: ./website/build
           overwrite: true
 
-      - name: Save PR Metadata
-        if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
-      - name: Upload PR Metadata
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-metadata
-          path: pr-number.txt
-          overwrite: true
-
       - name: Print All Generated Files
         run: find ./website/build -print
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -24,17 +25,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download PR Metadata
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-metadata
-          path: pr-metadata
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Read PR Number
         id: pr
-        run: echo "number=$(cat pr-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+        run: echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Preview to Netlify
         uses: nwtgck/actions-netlify@v3.0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,52 @@
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Website Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: website-artifact
+          path: website-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR Metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR Number
+        id: pr
+        run: echo "number=$(cat pr-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+
+      - name: Deploy Preview to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: ./website-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "PR #${{ steps.pr.outputs.number }}"
+          alias: pr-${{ steps.pr.outputs.number }}
+          enable-pull-request-comment: true
+          overwrites-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 5


### PR DESCRIPTION
## Summary

Implements the official GitHub-recommended **two-workflow split pattern** for securely deploying Netlify previews on ALL pull requests, including forks.

## Problem

Previous attempts to support fork PR previews either:
- ❌ **`pull_request_target` + checkout PR head** = runs untrusted fork code with secrets (GHSL-2021-004 supply-chain attack)
- ❌ **`pull_request` only** = forks get no secrets, deploy fails silently

## Solution: Two-Workflow Split

**Workflow 1: CI (pull_request event)** 
- Runs with NO secrets (safe for forks)
- Builds website, uploads `website-artifact` and `pr-metadata`

**Workflow 2: Deploy Preview (workflow_run event)**
- Triggered after Workflow 1 completes 
- Runs on base branch with secrets available
- Downloads pre-built artifact, deploys to Netlify

## Changes

**ci.yml:**
- Add PR number artifact upload to `build-website`
- Remove `deploy-preview` job

**deploy-preview.yml:** (new file)
- Uses `workflow_run` trigger (safe for secrets)
- Downloads artifacts, deploys to Netlify

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)