### PR TITLE
feat(zpipeline): add custom channel transformations using ZChannel.readWithCause

### DIFF
--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -61,10 +61,10 @@ def pairwise[A]: ZPipeline[Any, Nothing, A, (A, A)] = {
         }
 
         // Write results and recurse with new state
-        ZChannel.writeAll(pairs: _*) *>
+        ZChannel.writeAll(pairs.toSeq: _*) *>
           pairwiseChannel(previous)
       },
-      err => ZChannel.fail(err),      // Propagate upstream errors
+      err => ZChannel.failCause(err),      // Propagate upstream errors
       done => ZChannel.succeed(done)  // Stream ended
     )
   )
@@ -84,9 +84,9 @@ def pairwiseChannel[A](previous: Option[A]): ZChannel[Any, Nothing, Chunk[A], An
         currentPrev = Some(current)
       }
 
-      ZChannel.writeAll(pairs: _*) *> pairwiseChannel(currentPrev)
+      ZChannel.writeAll(pairs.toSeq: _*) *> pairwiseChannel(currentPrev)
     },
-    err => ZChannel.fail(err),
+    err => ZChannel.failCause(err),
     done => ZChannel.succeed(done)
   )
 }

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -40,54 +40,24 @@ There is also a `ZPipeline.mapZIO` which is an effectful version of this constru
 
 For stateful transformations that can't be expressed with `map` or `mapZIO`, you can build pipelines directly from `ZChannel` using the `ZChannel.readWithCause` pattern. This is the foundation for any complex pipeline:
 
-```scala mdoc:silent:nest
-import zio.stream.ZChannel
-import zio.Chunk
+When building custom pipelines with `ZChannel.readWithCause`, you define how to handle three cases:
 
-// A pipeline that groups consecutive pairs of elements
-def pairwise[A]: ZPipeline[Any, Nothing, A, (A, A)] = {
+```scala
+def customPipeline[In, Out]: ZPipeline[Any, Nothing, In, Out] = {
   ZPipeline.fromChannel(
     ZChannel.readWithCause(
+      // Case 1: Process incoming Chunk[In]
       elem => {
-        // Process a chunk of elements
-        val pairs = scala.collection.mutable.ListBuffer.empty[(A, A)]
-        var previous: Option[A] = None
-
-        elem.foreach { current =>
-          previous.foreach { prev =>
-            pairs += ((prev, current))
-          }
-          previous = Some(current)
-        }
-
-        // Write results and recurse with new state
-        ZChannel.writeAll(pairs.toSeq: _*) *>
-          pairwiseChannel(previous)
+        // Transform elem and emit outputs
+        // Then recursively call to read next chunk
+        val transformedOutput = ??? // : ZChannel[...]
+        transformedOutput
       },
-      err => ZChannel.failCause(err),      // Propagate upstream errors
-      done => ZChannel.succeed(done)  // Stream ended
+      // Case 2: Propagate errors from upstream  
+      err => ZChannel.failCause(err),
+      // Case 3: Handle stream end
+      done => ZChannel.succeed(done)
     )
-  )
-}
-
-// Helper to maintain state across invocations
-def pairwiseChannel[A](previous: Option[A]): ZChannel[Any, Nothing, Chunk[A], Any, Nothing, (A, A), Any] = {
-  ZChannel.readWithCause(
-    elem => {
-      val pairs = scala.collection.mutable.ListBuffer.empty[(A, A)]
-      var currentPrev = previous
-
-      elem.foreach { current =>
-        currentPrev.foreach { prev =>
-          pairs += ((prev, current))
-        }
-        currentPrev = Some(current)
-      }
-
-      ZChannel.writeAll(pairs.toSeq: _*) *> pairwiseChannel(currentPrev)
-    },
-    err => ZChannel.failCause(err),
-    done => ZChannel.succeed(done)
   )
 }
 ```

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -38,34 +38,41 @@ There is also a `ZPipeline.mapZIO` which is an effectful version of this constru
 
 ### From Custom Channels
 
-For stateful transformations that can't be expressed with `map` or `mapZIO`, you can build pipelines directly from `ZChannel` using the `ZChannel.readWithCause` pattern. This is the foundation for any complex pipeline:
+For stateful transformations that can't be expressed with `map` or `mapZIO`, you can build pipelines directly from `ZChannel` using `ZChannel.readWithCause`. Here is a pipeline that pairs each element with its predecessor:
 
-When building custom pipelines with `ZChannel.readWithCause`, you define how to handle three cases:
+```scala mdoc:silent:nest
+import zio.stream.ZChannel
 
-```scala
-def customPipeline[In, Out]: ZPipeline[Any, Nothing, In, Out] = {
-  ZPipeline.fromChannel(
-    ZChannel.readWithCause(
-      // Case 1: Process incoming Chunk[In]
-      elem => {
-        // Transform elem and emit outputs
-        // Then recursively call to read next chunk
-        val transformedOutput = ??? // : ZChannel[...]
-        transformedOutput
-      },
-      // Case 2: Propagate errors from upstream  
-      err => ZChannel.failCause(err),
-      // Case 3: Handle stream end
-      done => ZChannel.succeed(done)
-    )
+def pairwise[A]: ZPipeline[Any, Nothing, A, (A, A)] =
+  ZPipeline.fromChannel(pairwiseGo[A](None))
+
+def pairwiseGo[A](
+  prev: Option[A]
+): ZChannel[Any, ZNothing, Chunk[A], Any, ZNothing, Chunk[(A, A)], Any] =
+  ZChannel.readWithCause(
+    (in: Chunk[A]) => {
+      val buf  = Chunk.newBuilder[(A, A)]
+      var last = prev
+      in.foreach { a =>
+        last.foreach(p => buf += ((p, a)))
+        last = Some(a)
+      }
+      val out = buf.result()
+      (if (out.nonEmpty) ZChannel.write(out) else ZChannel.unit) *> pairwiseGo(last)
+    },
+    (err: Cause[ZNothing]) => ZChannel.refailCause(err),
+    (_: Any) => ZChannel.unit
   )
-}
 ```
 
-The three-case `readWithCause` pattern is essential:
-- **Case 1 (elem):** Process incoming chunk of elements and decide what to emit
-- **Case 2 (err):** Handle errors from upstream (usually propagate unchanged)
+The three-case `readWithCause` pattern handles:
+- **Case 1 (in):** Process incoming chunk, emit outputs, recurse to read next chunk
+- **Case 2 (err):** Handle errors from upstream (usually propagate with `refailCause`)
 - **Case 3 (done):** Handle stream completion (finalize any pending state)
+
+:::note
+Use `ZNothing` (not `Nothing`) as the error type in channel signatures. `ZNothing` is ZIO's abstract bottom type that avoids Scala type inference issues when composing channels with `readWithCause`.
+:::
 
 :::info
 **Why channels instead of functions?** Pipelines are channels because they need to compose seamlessly with sinks and other pipelines. A function-based pipeline couldn't be composed with a sink—the channel abstraction provides a unified interface for all streaming components.

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -36,6 +36,71 @@ val chars =
 
 There is also a `ZPipeline.mapZIO` which is an effectful version of this constructor.
 
+### From Custom Channels
+
+For stateful transformations that can't be expressed with `map` or `mapZIO`, you can build pipelines directly from `ZChannel` using the `ZChannel.readWithCause` pattern. This is the foundation for any complex pipeline:
+
+```scala mdoc:silent:nest
+import zio.stream.ZChannel
+import zio.Chunk
+
+// A pipeline that groups consecutive pairs of elements
+def pairwise[A]: ZPipeline[Any, Nothing, A, (A, A)] = {
+  ZPipeline.fromChannel(
+    ZChannel.readWithCause(
+      elem => {
+        // Process a chunk of elements
+        val pairs = scala.collection.mutable.ListBuffer.empty[(A, A)]
+        var previous: Option[A] = None
+
+        elem.foreach { current =>
+          previous.foreach { prev =>
+            pairs += ((prev, current))
+          }
+          previous = Some(current)
+        }
+
+        // Write results and recurse with new state
+        ZChannel.writeAll(pairs: _*) *>
+          pairwiseChannel(previous)
+      },
+      err => ZChannel.fail(err),      // Propagate upstream errors
+      done => ZChannel.succeed(done)  // Stream ended
+    )
+  )
+}
+
+// Helper to maintain state across invocations
+def pairwiseChannel[A](previous: Option[A]): ZChannel[Any, Nothing, Chunk[A], Any, Nothing, (A, A), Any] = {
+  ZChannel.readWithCause(
+    elem => {
+      val pairs = scala.collection.mutable.ListBuffer.empty[(A, A)]
+      var currentPrev = previous
+
+      elem.foreach { current =>
+        currentPrev.foreach { prev =>
+          pairs += ((prev, current))
+        }
+        currentPrev = Some(current)
+      }
+
+      ZChannel.writeAll(pairs: _*) *> pairwiseChannel(currentPrev)
+    },
+    err => ZChannel.fail(err),
+    done => ZChannel.succeed(done)
+  )
+}
+```
+
+The three-case `readWithCause` pattern is essential:
+- **Case 1 (elem):** Process incoming chunk of elements and decide what to emit
+- **Case 2 (err):** Handle errors from upstream (usually propagate unchanged)
+- **Case 3 (done):** Handle stream completion (finalize any pending state)
+
+:::info
+**Why channels instead of functions?** Pipelines are channels because they need to compose seamlessly with sinks and other pipelines. A function-based pipeline couldn't be composed with a sink—the channel abstraction provides a unified interface for all streaming components.
+:::
+
 ## Built-in Pipelines
 
 ### Identity

--- a/docs/reference/stream/zpipeline.md
+++ b/docs/reference/stream/zpipeline.md
@@ -41,6 +41,7 @@ There is also a `ZPipeline.mapZIO` which is an effectful version of this constru
 For stateful transformations that can't be expressed with `map` or `mapZIO`, you can build pipelines directly from `ZChannel` using `ZChannel.readWithCause`. Here is a pipeline that pairs each element with its predecessor:
 
 ```scala mdoc:silent:nest
+import zio.{ZNothing, Cause}
 import zio.stream.ZChannel
 
 def pairwise[A]: ZPipeline[Any, Nothing, A, (A, A)] =


### PR DESCRIPTION
## Summary
- Add documentation for creating ZPipeline from custom ZChannel using readWithCause pattern
- Demonstrates stateful pipeline transformations that can't be expressed with map/mapZIO
- Includes pairwise example showing state management across chunk processing

## Test Plan
- [x] Verify mdoc compilation for zpipeline.md
- [x] Manual review of code examples

## Related
ZPipeline documentation enhancements for stream transformations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)