### PR TITLE
Fix #9874: don't let typed error recovery drop defects/interruption

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2529,6 +2529,16 @@ object ZIOSpec extends ZIOBaseSpec {
 
         assertZIO(io.catchAllCause(ZIO.succeed(_)))(equalTo(Cause.fail("Uh oh!")))
       } @@ zioTag(errors),
+      test("catchAll does not recover from defects in combined Fail+Die cause (issue 9874)") {
+        val cause = Cause.die(new RuntimeException("defect")) && Cause.fail("typed error")
+        val io    = ZIO.failCause(cause).catchAll(_ => ZIO.succeed("recovered"))
+        assertZIO(io.exit)(dies(isSubtype[RuntimeException](hasMessage(equalTo("defect")))))
+      } @@ zioTag(errors),
+      test("catchAll does not recover from interruption in combined Fail+Interrupt cause (issue 9874)") {
+        val cause = Cause.interrupt(FiberId.None) && Cause.fail("typed error")
+        val io    = ZIO.failCause(cause).catchAll(_ => ZIO.succeed("recovered"))
+        assertZIO(io.exit)(isInterrupted)
+      } @@ zioTag(errors),
       test("exception in fromFuture does not kill fiber") {
         val io = ZIO.fromFuture(_ => throw ExampleError).either
         assertZIO(io)(isLeft(equalTo(ExampleError)))

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -130,8 +130,11 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * only `Die` or `Interrupt` causes.
    */
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(error) =>
+      val stripped = stripFailures
+      if (stripped eq Empty) Left(error)
+      else Right(stripped)
+    case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
   /**
@@ -140,8 +143,11 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * to contain only `Die` or `Interrupt` causes.
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(errorAndTrace) =>
+      val stripped = stripFailures
+      if (stripped eq Empty) Left(errorAndTrace)
+      else Right(stripped)
+    case None => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
   }
 
   /**


### PR DESCRIPTION
claim #9874

## Problem

When a `Cause` contains both a typed failure (`Fail`) and a defect (`Die`) or interruption (`Interrupt`), error handlers like `catchAll` silently swallow the defect/interruption and only recover the typed failure.

Repro from the issue:

val dieCause = Cause.die(new RuntimeException("boom"))
val combinedCause = dieCause && Cause.fail("boom")

ZIO.failCause(combinedCause).catchAll { e =>
  ZIO.debug(e)
} *> ZIO.debug("Success")
// prints: "handled: boom" then "Success" — defect silently dropped

## Solution

Modified `Cause.failureOrCause` and `Cause.failureTraceOrCause` to check for non-recoverable causes (defects/interruption) before returning a typed failure. When a failure is found, `stripFailures` is called — if the result is non-empty (contains `Die` or `Interrupt`), the stripped cause is returned on the `Right`, preventing typed error handlers from recovering.

## Changes

- `core/shared/src/main/scala/zio/Cause.scala` — Modified `failureOrCause` and `failureTraceOrCause`
- `core-tests/shared/src/test/scala/zio/ZIOSpec.scala` — Added 2 regression tests

## Testing

sbt "coreTestsJVM/testOnly zio.ZIOSpec -- -t 9874"

2 tests passed. 0 tests failed.