### PR TITLE
fix(ci): add PR comment posting for Netlify preview deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,18 @@ jobs:
           path: ./website/build
           overwrite: true
 
+      - name: Save PR Metadata
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR Metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-metadata
+          path: pr-number.txt
+          overwrite: true
+
       - name: Print All Generated Files
         run: find ./website/build -print
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,35 +122,20 @@ jobs:
           path: ./website/build
           overwrite: true
 
+      - name: Save PR Metadata
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR Metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-metadata
+          path: pr-number.txt
+          overwrite: true
+
       - name: Print All Generated Files
         run: find ./website/build -print
-
-  deploy-preview:
-    needs: [build-website]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          name: website-artifact
-          path: website-artifact
-
-      - name: Deploy preview to Netlify
-        uses: nwtgck/actions-netlify@v3.0
-        with:
-          publish-dir: ./website-artifact
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "PR #${{ github.event.pull_request.number }} — ${{ github.event.pull_request.title }}"
-          alias: pr-${{ github.event.pull_request.number }}
-          enable-pull-request-comment: true
-          overwrites-pull-request-comment: true
-          enable-commit-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 5
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,18 +122,6 @@ jobs:
           path: ./website/build
           overwrite: true
 
-      - name: Save PR Metadata
-        if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
-      - name: Upload PR Metadata
-        if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
-        with:
-          name: pr-metadata
-          path: pr-number.txt
-          overwrite: true
-
       - name: Print All Generated Files
         run: find ./website/build -print
 

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -40,16 +40,24 @@ jobs:
         run: echo "number=$(cat pr-metadata/pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Preview to Netlify
+        id: netlify-deploy
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: ./website-artifact
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "PR #${{ steps.pr.outputs.number }}"
           alias: pr-${{ steps.pr.outputs.number }}
-          enable-pull-request-comment: true
-          overwrites-pull-request-comment: true
+          enable-pull-request-comment: false
           enable-commit-comment: false
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         timeout-minutes: 5
+
+      - name: Post Preview URL Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.number }}
+          header: netlify-preview
+          message: |
+            🚀 Preview deployed to Netlify: ${{ steps.netlify-deploy.outputs.deploy-url }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -8,7 +8,9 @@ on:
 permissions:
   actions: read
   contents: read
+  deployments: write
   pull-requests: write
+  statuses: write
 
 jobs:
   deploy-preview:
@@ -25,9 +27,17 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Download PR Metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Read PR Number
         id: pr
-        run: echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
+        run: echo "number=$(cat pr-metadata/pr-number.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Preview to Netlify
         uses: nwtgck/actions-netlify@v3.0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -6,6 +6,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -24,17 +25,9 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download PR Metadata
-        uses: actions/download-artifact@v4
-        with:
-          name: pr-metadata
-          path: pr-metadata
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Read PR Number
         id: pr
-        run: echo "number=$(cat pr-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+        run: echo "number=${{ github.event.workflow_run.pull_requests[0].number }}" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Preview to Netlify
         uses: nwtgck/actions-netlify@v3.0

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,52 @@
+name: Deploy Preview
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download Website Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: website-artifact
+          path: website-artifact
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download PR Metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR Number
+        id: pr
+        run: echo "number=$(cat pr-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+
+      - name: Deploy Preview to Netlify
+        uses: nwtgck/actions-netlify@v3.0
+        with:
+          publish-dir: ./website-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "PR #${{ steps.pr.outputs.number }}"
+          alias: pr-${{ steps.pr.outputs.number }}
+          enable-pull-request-comment: true
+          overwrites-pull-request-comment: true
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 5


### PR DESCRIPTION
## Summary
- Disable `enable-pull-request-comment` in `nwtgck/actions-netlify` (it doesn't work in `workflow_run` context — unfixed upstream bug #545)
- Remove `overwrites-pull-request-comment` (no longer needed)
- Add `id: netlify-deploy` to capture the deploy URL output
- Add `marocchino/sticky-pull-request-comment@v2` step to post preview URL as PR comment
- Uses `header: netlify-preview` to deduplicate — re-runs update the existing comment instead of creating new ones

## Why the fix works
`nwtgck/actions-netlify`'s `enable-pull-request-comment` option internally relies on `context.payload.pull_request` to find which PR to comment on. In `workflow_run` context, GitHub always leaves this payload empty—especially for fork PRs. This is a confirmed limitation ([nwtgck/actions-netlify#545](https://github.com/nwtgck/actions-netlify/issues/545)) that was closed without a fix.

The workaround uses `marocchino/sticky-pull-request-comment@v2` which has an explicit `number:` input for non-`pull_request` event contexts, and a `header:` key that prevents comment duplication on re-runs.

## Test plan
- Open a PR (from fork or same repo)
- Verify CI builds website and uploads artifacts
- Verify Deploy Preview workflow triggers and deploys to Netlify
- Verify a comment appears on the PR page: `🚀 Preview deployed to Netlify: https://pr-XXXX--zio-dev-preview.netlify.app`
- On a subsequent push to the same PR, verify the comment is **updated** (not duplicated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)