### PR TITLE
fix(Gen): fromIterable should consume random state for reproducibility

### DIFF
--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -446,7 +446,13 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
   )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+    Gen {
+      val size = as.size
+      ZStream.fromEffect(nextInt.map(i => math.abs(i) % size)).map { i =>
+        val a = as.iterator.drop(i).next()
+        Sample.unfold(a)(a => (a, shrinker(a)))
+      }
+    }
 
   /**
    * Constructs a generator from a function that uses randomness. The returned


### PR DESCRIPTION
@@ -445,11 +445,16 @@ object Gen extends GenVersionSpecific with FunctionVariants with TimeVariants {

  /** $fromIterable now consumes a random int on each sample to properly advance the random state. Without this, composing Gen.fromIterable with other generators (e.g. Gen.uuid) in a for-comprehension would cause reproducibility bugs where earlier generators produce the same value on every run.