### PR TITLE
fix(macros): move `asInstanceOf` from `Expr` level to generated code

### DIFF
--- a/core/shared/src/main/scala-3/zio/ZIOAppVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ZIOAppVersionSpecific.scala
@@ -39,7 +39,7 @@ private[zio] class ZIOAppVersionSpecificMacros(val ctx: Quotes) {
       report.errorAndAbort(message)
     }
 
-    zio.asInstanceOf[Expr[ZIO[Provided, E, A]]]
+    '{ $zio.asInstanceOf[ZIO[Provided, E, A]] }
   }
 
   def flattenAnd(typeRepr: TypeRepr): List[TypeRepr] =

--- a/stacktracer/src/main/scala-3/zio/internal/stacktracer/Macros.scala
+++ b/stacktracer/src/main/scala-3/zio/internal/stacktracer/Macros.scala
@@ -70,5 +70,5 @@ object Macros {
   }
 
   private def traceExpr(trace: String)(using ctx: Quotes): Expr[Tracer.instance.Type] =
-    Expr(trace).asInstanceOf[Expr[Tracer.instance.Type]]
+    '{ ${ Expr(trace) }.asInstanceOf[Tracer.instance.Type] }
 }

--- a/test/shared/src/main/scala-3/zio/test/ZIOSpecAbstractVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/ZIOSpecAbstractVersionSpecific.scala
@@ -39,7 +39,7 @@ private[test] class ZIOSpecAbstractSpecificMacros(val ctx: Quotes) {
       report.errorAndAbort(message)
     }
 
-    spec.asInstanceOf[Expr[Spec[Provided, E]]]
+    '{ $spec.asInstanceOf[Spec[Provided, E]] }
   }
 
   def flattenAnd(typeRepr: TypeRepr): List[TypeRepr] =


### PR DESCRIPTION
The `asInstanceOf` casts were applied at the `Expr[T]` wrapper level, which doesn't change the type of the generated tree. Moving the cast into the quoted code (`'{ $expr.asInstanceOf[T] }`) ensures the generated tree type-checks correctly.

Fixes #10721.