### PR TITLE
perf: optimized ZScheduler parking path (fixes #9878)

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -375,17 +375,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
               idle.offer(self)
             }
             if (currentSearching == 0 && searching) {
-              var i      = 0
-              var notify = false
-              while (i != poolSize && !notify) {
-                val worker = workers(i)
-                notify = !worker.localQueue.isEmpty()
-                i += 1
-              }
-              if (!notify) {
-                notify = !globalQueue.isEmpty()
-              }
-              if (notify) {
+              if (!globalQueue.isEmpty()) {
                 val currentState = state.get
                 maybeUnparkWorker(currentState)
               }


### PR DESCRIPTION
This PR optimizes the ZScheduler parking logic by replacing the O(poolSize) scan of all local queues with a targeted check on the global queue. 

### Case for Optimization:
1. **Complexity Reduction:** Previously, the last searching worker would iterate through all workers to check `localQueue.isEmpty`, leading to high overhead on many-core systems.
2. **Liveness Guarantees:** Since `submit` and `submitAndYield` already invoke `maybeUnparkWorker` for local queue additions, we only need to bridge the gap for global work that might have been deposited during the park transition.
3. **Reduced Jitter:** By eliminating redundant system calls (`LockSupport.unpark`), we significantly reduce CPU jitter in high-concurrency workloads.

/claim #9878