### PR TITLE
fix(deps): override webpackbar to v7 for webpack 5.106.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install NodeJS
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24.14.1
 
       - name: Compile Docs
         run: |

--- a/website/package.json
+++ b/website/package.json
@@ -72,8 +72,12 @@
     "tailwindcss": "4.2.2",
     "tslib": "^2.4.0"
   },
+  "overrides": {
+    "webpackbar": "^7.0.0"
+  },
   "resolutions": {
-    "cytoscape": "3.33.2"
+    "cytoscape": "3.33.2",
+    "webpackbar": "^7.0.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
- Override `webpackbar` to `^7.0.0` (npm `overrides` + yarn `resolutions`) to fix Docusaurus build failure caused by webpack 5.106.0 removing deprecated `ProgressPlugin` options
- Update Node.js version to 24.14.1 in CI configuration

## Context
Webpack 5.106.0 enforces strict schema validation for `ProgressPlugin`, breaking `webpackbar` v6 which still passes removed options (`name`, `color`, `reporter`). This is a known issue tracked in [facebook/docusaurus#11923](https://github.com/facebook/docusaurus/issues/11923).

## Test plan
- [ ] CI website build passes with the new override