### PR TITLE
fix(test): introduce dual generators to fix deterministic/nondeterministic composition

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -856,7 +856,7 @@ object GenSpec extends ZIOBaseSpec {
       },
       test("swapping order in for-comprehension produces similar diversity") {
         val genA = for {
-          i  <- Gen.fromIterable(1 to 100)
+          _  <- Gen.fromIterable(1 to 100)
           id <- Gen.uuid
         } yield id
 

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -776,6 +776,117 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
-    }
+    },
+    test("map of keys with small domain") {
+      check(Gen.mapOfN(2)(Gen.fromIterable(List(1, 2, 3)), Gen.int)) { map =>
+        assertTrue(map.size == 2)
+      }
+    },
+    suite("determinism")(
+      test("fromIterable and then nondeterministic") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 3)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(3)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(3)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(3))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 3))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("nondeterministic and then fromIterable") {
+        val gen = for {
+          id <- Gen.uuid
+          i  <- Gen.fromIterable(1 to 3)
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(3)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(3)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(1))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 3))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("concat and then nondeterministic") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 3) ++ Gen.const(4)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(4)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(4)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3, 4))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(4))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 4))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(4)))
+      },
+      test("nondeterministic and then concat") {
+        val gen = for {
+          id <- Gen.uuid
+          i  <- Gen.fromIterable(1 to 3) ++ Gen.const(4)
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(4)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(4)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3, 4))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(1))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 4))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(4)))
+      },
+      test("const is deterministic") {
+        val gen = for {
+          id <- Gen.const("id")
+          i  <- Gen.fromIterable(1 to 3)
+        } yield (i, id)
+        assertZIO(gen.runCollect)(equalTo(List(1 -> "id", 2 -> "id", 3 -> "id")))
+      },
+      test("swapping order in for-comprehension produces similar diversity") {
+        val genA = for {
+          i  <- Gen.fromIterable(1 to 100)
+          id <- Gen.uuid
+        } yield id
+
+        val genB = for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(1 to 100)
+        } yield id
+
+        for {
+          a <- genA.runCollectN(5).map(_.toSet.size)
+          b <- genB.runCollectN(5).map(_.toSet.size)
+        } yield assertTrue(a >= 3 && b >= 3)
+      },
+      test("option of fromIterable generates None in checkAll") {
+        val gen = Gen.option(Gen.fromIterable(List("a", "b")))
+        assertZIO(gen.runCollect)(equalTo(List(None, Some("a"), Some("b"))))
+      },
+      test("filter with single-value generators works in runCollectN") {
+        val gen = for {
+          first  <- Gen.int(1, 10).filter(_ == 10)
+          second <- Gen.int(1, 10).filter(_ == 1)
+        } yield (first, second)
+        assertZIO(gen.runCollectN(1))(equalTo(List((10, 1))))
+      },
+      test("boolean is exhaustive in deterministic mode") {
+        assertZIO(Gen.boolean.runCollect)(equalTo(List(false, true)))
+      },
+      test("boolean produces both values in nondeterministic mode") {
+        Gen.boolean.runCollectN(20).map(values => assertTrue(values.toSet == Set(false, true)))
+      }
+    )
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -81,10 +81,10 @@ object GenUtils {
   val smallInt: Gen[Any, Int] = Gen.int(-10, 10)
 
   def sample[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).runCollect.map(_.toList)
+    gen.runCollect
 
   def sample100[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).forever.take(size.toLong).runCollect.map(_.toList)
+    gen.runCollectN(size)
 
   def sampleEffect[E, A](
     gen: Gen[Any, ZIO[Any, E, A]],
@@ -93,7 +93,7 @@ object GenUtils {
     provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.exit)))(size)
 
   def shrink[R, A](gen: Gen[R, A]): URIO[R, A] =
-    gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
+    gen.sample.forever.take(1).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
 
   val shrinkable: Gen[Any, Int] =
     Gen.fromRandomSample(_.nextIntBounded(90).map(_ + 10).map(Sample.shrinkIntegral(0)))

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.Random._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{Chunk, NonEmptyChunk, Random, Trace, UIO, URIO, ZIO, Zippable}
+import zio._
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -32,6 +32,10 @@ import scala.math.Numeric.DoubleIsFractional
  * environment `R`. Generators may be random or deterministic.
  */
 final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
+
+  private[test] def samples(n: Option[Int])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
+    ZStream.scoped[R](Gen.deterministic.locallyScoped(n.isEmpty)) *>
+      n.fold(sample)(sample.forever.take(_))
 
   /**
    * A symbolic alias for `concat`.
@@ -48,21 +52,25 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
     self.zip(that)
 
   /**
-   * Concatenates the specified deterministic generator with this determinstic
-   * generator, resulting in a deterministic generator that generates the values
-   * from this generator and then the values from the specified generator.
+   * A dual generator that concatenates this generator with the provided one:
+   *   - In deterministic mode, combines this deterministic generator with the
+   *     provided one to return a new deterministic generator that generates the
+   *     values from this generator and then the values from the other one.
+   *   - In nondeterministic mode, equivalent to [[Gen.oneOf]].
    */
-  def concat[R1 <: R, A1 >: A](that: Gen[R1, A1])(implicit trace: Trace): Gen[R1, A1] =
-    Gen(self.sample ++ that.sample)
+  def concat[R1 <: R, A1 >: A](that: Gen[R1, A1])(implicit trace: Trace): Gen[R1, A1] = Gen.dual(
+    Gen(self.sample ++ that.sample),
+    Gen.oneOf(self, that)
+  )
 
   /**
    * Maps the values produced by this generator with the specified partial
    * function, discarding any values the partial function is not defined at.
    */
-  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): Gen[R, B] =
-    self.flatMap { a =>
-      pf.andThen(Gen.const(_)).applyOrElse[A, Gen[Any, B]](a, _ => Gen.empty)
-    }
+  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): Gen[R, B] = Gen.dual(
+    Gen(sample.flatMap(_.collect(pf))),
+    Gen(sample.map(_.value).forever.collect(pf).take(1).map(Sample.noShrink))
+  )
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -76,7 +84,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * }}}
    */
   def filter(f: A => Boolean)(implicit trace: Trace): Gen[R, A] =
-    self.flatMap(a => if (f(a)) Gen.const(a) else Gen.empty)
+    filterZIO(a => Exit.succeed(f(a)))
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -89,17 +97,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * val evens: Gen[Any, Int] = Gen.int.map(_ * 2)
    * }}}
    */
-  def filterZIO[R1 <: R](f: A => ZIO[R1, Nothing, Boolean])(implicit trace: Trace): Gen[R1, A] =
-    self.flatMap(a => Gen.fromZIO(f(a)).flatMap(p => if (p) Gen.const(a) else Gen.empty))
+  def filterZIO[R1 <: R](f: A => ZIO[R1, Nothing, Boolean])(implicit trace: Trace): Gen[R1, A] = Gen.dual(
+    Gen(sample.flatMap(_.filterZIO(f))),
+    Gen(sample.map(_.value).forever.filterZIO(f).take(1).map(Sample.noShrink))
+  )
 
   /**
    * Filters the values produced by this generator, discarding any values that
    * meet the specified predicate.
    */
   def filterNot(f: A => Boolean)(implicit trace: Trace): Gen[R, A] =
-    filter(a => !f(a))
+    filter(!f(_))
 
-  def withFilter(f: A => Boolean)(implicit trace: Trace): Gen[R, A] = filter(f)
+  def withFilter(f: A => Boolean)(implicit trace: Trace): Gen[R, A] =
+    filter(f)
 
   def flatMap[R1 <: R, B](f: A => Gen[R1, B])(implicit trace: Trace): Gen[R1, B] =
     Gen {
@@ -147,20 +158,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect.map(_.toList)
+    samples(None).map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    samples(Some(n)).map(_.value).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.
    */
   def runHead(implicit trace: Trace): ZIO[R, Nothing, Option[A]] =
-    sample.map(_.value).runHead
+    samples(Some(1)).map(_.value).runHead
 
   /**
    * Composes this generator with the specified generator to create a cartesian
@@ -180,6 +191,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 }
 
 object Gen extends GenZIO with FunctionVariants with TimeVariants {
+
+  private[test] val deterministic = FiberRef.unsafe.make(true)(Unsafe.unsafe)
+
+  /**
+   * Constructs a dual generator that switches behavior based on whether it is
+   * being used in deterministic mode (checkAll/runCollect) or nondeterministic
+   * mode (check/runCollectN).
+   */
+  def dual[R, A](
+    deterministic: => Gen[R, A],
+    nondeterministic: => Gen[R, A]
+  )(implicit trace: Trace): Gen[R, A] = Gen(ZStream.unwrap {
+    Gen.deterministic.get.map(if (_) deterministic.sample else nondeterministic.sample)
+  })
 
   /**
    * A generator of alpha characters.
@@ -286,7 +311,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of booleans. Shrinks toward 'false'.
    */
   def boolean(implicit trace: Trace): Gen[Any, Boolean] =
-    elements(false, true)
+    fromIterable(Chunk(false, true))
 
   /**
    * A generator whose size falls within the specified bounds.
@@ -380,8 +405,10 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * deterministic generator that generates all of the values generated by the
    * specified generators.
    */
-  def concatAll[R, A](gens: => Iterable[Gen[R, A]])(implicit trace: Trace): Gen[R, A] =
-    Gen.suspend(gens.foldLeft[Gen[R, A]](Gen.empty)(_ ++ _))
+  def concatAll[R, A](gens: => Iterable[Gen[R, A]])(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(gens).flatMap(_.sample)),
+    Gen.oneOf(Chunk.fromIterable(gens): _*)
+  )
 
   /**
    * A constant generator of the specified value.
@@ -426,7 +453,11 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).map(chunk)
+    }
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -439,14 +470,23 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     uniform.map(n => -math.log(1 - n))
 
   /**
-   * Constructs a deterministic generator that only generates the specified
-   * fixed values.
+   * A dual generator from the specified list of fixed values:
+   *   - In deterministic mode, generates all of the specified values in order.
+   *   - In nondeterministic mode, equivalent to [[Gen.elements]], picking one
+   *     value at random per sample.
+   *
+   * Note: The iterable must be finite when used in nondeterministic mode (via
+   * `check` or `runCollectN`), since random element selection requires
+   * materializing the collection. Infinite iterables work only in deterministic
+   * mode (via `checkAll` or `runCollect`).
    */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
-  )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+  )(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(as).map(Sample.unfold(_)(a => (a, shrinker(a))))),
+    Gen.suspend(elements(Chunk.fromIterable(as): _*))
+  )
 
   /**
    * Constructs a generator from a function that uses randomness. The returned
@@ -670,10 +710,14 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of optional values. Shrinks toward `None`.
    */
   def option[R, A](gen: Gen[R, A])(implicit trace: Trace): Gen[R, Option[A]] =
-    oneOf(none, gen.map(Some(_)))
+    none.concat(gen.map(Some(_)))
 
   def oneOf[R, A](as: Gen[R, A]*)(implicit trace: Trace): Gen[R, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).flatMap(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).flatMap(chunk)
+    }
 
   /**
    * Constructs a generator of partial functions from `A` to `B` given a
@@ -821,7 +865,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * when creating generators that refer to themselves.
    */
   def suspend[R, A](gen: => Gen[R, A])(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.suspend(gen.sample))
+    Gen.unit.flatMap(_ => gen)
 
   /**
    * A generator of throwables.

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{ZIO, Zippable, Trace}
+import zio._
 
 /**
  * A sample is a single observation from a random variable, together with a tree
@@ -39,8 +39,20 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
    * not meet the specified predicate and recursively filtering the shrink tree.
    */
   def filter(f: A => Boolean)(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
-    if (f(value)) ZStream(Sample(value, shrink.flatMap(_.filter(f))))
-    else shrink.flatMap(_.filter(f))
+    filterZIO(a => Exit.succeed(f(a)))
+
+  /**
+   * Filters this sample by replacing it with its shrink tree if the value does
+   * not meet the specified effectful predicate and recursively filtering the
+   * shrink tree.
+   */
+  def filterZIO[R1 <: R](
+    f: A => ZIO[R1, Nothing, Boolean]
+  )(implicit trace: Trace): ZStream[R1, Nothing, Sample[R1, A]] =
+    ZStream.fromZIO(f(value)).flatMap { keep =>
+      val shrink = this.shrink.flatMap(_.filterZIO(f))
+      if (keep) ZStream(Sample(value, shrink)) else shrink
+    }
 
   def flatMap[R1 <: R, B](f: A => Sample[R1, B])(implicit trace: Trace): Sample[R1, B] = {
     val sample = f(value)
@@ -49,6 +61,11 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
 
   def foreach[R1 <: R, B](f: A => ZIO[R1, Nothing, B])(implicit trace: Trace): ZIO[R1, Nothing, Sample[R1, B]] =
     f(value).map(Sample(_, shrink.mapZIO(_.foreach(f))))
+
+  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, B]] = {
+    val shrink = this.shrink.flatMap(_.collect(pf))
+    pf.andThen(b => ZStream(Sample(b, shrink))).applyOrElse(value, (_: A) => shrink)
+  }
 
   def map[B](f: A => B)(implicit trace: Trace): Sample[R, B] =
     Sample(f(value), shrink.map(_.map(f)))

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -524,7 +524,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStream(rv.sample)(a => checkConstructor(test(a)))
+    checkStream(rv.samples(None))(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
@@ -652,7 +652,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+    checkStreamPar(rv.samples(None), parallelism)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAllPar` that accepts two random variables.
@@ -799,9 +799,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
-    )
+    TestConfig.samples.flatMap(n => checkStreamPar(rv.samples(Some(n)), parallelism)(a => checkConstructor(test(a))))
 
   /**
    * A version of `checkPar` that accepts two random variables.
@@ -1009,7 +1007,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Summary

Fixes #9101, #5616, #9146

`Gen.fromIterable` and other deterministic generators now compose correctly with nondeterministic generators (like `Gen.uuid`) regardless of ordering in for-comprehensions.

### The problem

```scala
// Both should produce diverse UUIDs, but the second one repeats the same UUID:
for { i <- Gen.fromIterable(1 to 3); id <- Gen.uuid } yield id  // ✓ 3 different UUIDs
for { id <- Gen.uuid; _ <- Gen.fromIterable(1 to 3) } yield id  // ✗ same UUID 3 times
```

The root cause is that `Gen.flatMap` uses `ZStream.flatMap` internally. When an effect-based generator (`Gen.uuid` → `ZStream.fromZIO`) emits a single element, the flatMap closure captures that one value and pairs it with every element from the inner deterministic generator.

### The fix

Introduces a `FiberRef`-based mode tracking and a `Gen.dual` constructor that switches generator behavior depending on whether it is used in:
- **Deterministic mode** (`checkAll` / `runCollect`): exhaustive enumeration, cartesian product semantics — unchanged from current behavior
- **Nondeterministic mode** (`check` / `runCollectN`): each generator produces one random sample per pass, so `.forever.take(n)` yields `n` independent samples

Key changes:
- **`fromIterable`**: enumerates all values in deterministic mode, picks one randomly (via `elements`) in nondeterministic mode
- **`concat` / `concatAll`**: sequential concatenation in deterministic mode, `oneOf` in nondeterministic mode
- **`filter` / `filterZIO` / `collect`**: use `Sample`-level filtering with shrink tree preservation in deterministic mode, streaming retry in nondeterministic mode
- **`boolean`**: now `fromIterable(Chunk(false, true))` — exhaustive in `checkAll`
- **`option`**: now `none.concat(gen.map(Some(_)))` — generates `None` in `checkAll` (#5616)
- **`Sample`**: added `filterZIO` and `collect` methods

### Tradeoffs

- Infinite iterables (e.g. `LazyList.iterate(0)(_ + 1)`) work only in deterministic mode. In nondeterministic mode, `fromIterable` must materialize the collection for random access. This is documented in the scaladoc.
- Binary compatibility is preserved — only new methods are added, no existing signatures are changed.

### Related

Built on the same conceptual approach as #9378 by @joroKr21. Differences: smaller diff (no `flatMap` changes needed), shrink test utilities use raw `sample` stream to preserve shrink trees, and `suspend` propagates dual-mode correctly via `Gen.unit.flatMap`.

/claim #9101