### PR TITLE
perf: optimize Semaphore with lazy Promise allocation

### DIFF
--- a/benchmarks/src/main/scala/zio/stm/SinglePermitSemaphoreBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/stm/SinglePermitSemaphoreBenchmark.scala
@@ -1,0 +1,61 @@
+package zio.stm
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+import zio.BenchmarkUtil._
+import zio._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Semaphore => JSemaphore}
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(1)
+class SinglePermitSemaphoreBenchmark {
+  @Param(Array("1", "2", "5", "10"))
+  var fibers: Int = _
+
+  @Param(Array("1", "2", "5"))
+  var permits: Int = _
+
+  val ops: Int = 1000
+
+  @Benchmark
+  def zioSemaphore(bh: Blackhole): Unit =
+    unsafeRun(for {
+      sem   <- Semaphore.make(permits.toLong)
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops)(sem.withPermit(Exit.succeed(bh.consume(1))))))
+      _     <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def javaSemaphoreFair(bh: Blackhole): Unit =
+    unsafeRun(for {
+      lock <- ZIO.succeed(new JSemaphore(permits, true))
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops) {
+                 ZIO.succeed {
+                   lock.acquire()
+                   try bh.consume(1)
+                   finally lock.release()
+                 }
+               }))
+      _ <- fiber.join
+    } yield ())
+
+  @Benchmark
+  def javaSemaphoreUnfair(bh: Blackhole): Unit =
+    unsafeRun(for {
+      lock <- ZIO.succeed(new JSemaphore(permits, false))
+      fiber <- ZIO.forkAll(List.fill(fibers)(repeat(ops) {
+                 ZIO.succeed {
+                   lock.acquire()
+                   try bh.consume(1)
+                   finally lock.release()
+                 }
+               }))
+      _ <- fiber.join
+    } yield ())
+}

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -155,15 +155,27 @@ object Semaphore {
           else if (n == 0L)
             ZIO.succeed(Reservation.zero)
           else
-            Promise.make[Nothing, Unit].flatMap { promise =>
-              ref.modify {
-                case Right(permits) if permits >= n =>
-                  Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
-                case Right(permits) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
-                case Left(queue) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
-              }
+            // Fast path: try to acquire without allocating a Promise
+            ref.modify {
+              case Right(permits) if permits >= n =>
+                Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
+              case other =>
+                null.asInstanceOf[Reservation] -> other
+            }.flatMap { reservation =>
+              if (reservation ne null) ZIO.succeed(reservation)
+              else
+                // Slow path: need to wait, allocate Promise now
+                Promise.make[Nothing, Unit].flatMap { promise =>
+                  ref.modify {
+                    case Right(permits) if permits >= n =>
+                      // Permits became available between our first check and now
+                      Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
+                    case Right(permits) =>
+                      Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
+                    case Left(queue) =>
+                      Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
+                  }
+                }
             }
 
         def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =


### PR DESCRIPTION
## Summary

Addresses #9093 — ZIO Semaphore performance not too great.

### Problem

The previous Semaphore.reserve() implementation **always** allocated a Promise before checking if permits were available. This caused unnecessary GC pressure and ~5-6x slower performance vs Java's Semaphore in uncontended scenarios (when 	hreads < permits).

### Solution

**Lazy Promise allocation** — a two-phase acquire strategy:

1. **Fast path**: Try to acquire permits via ef.modify **without** allocating a Promise. If permits are available, return immediately with zero allocation overhead.
2. **Slow path**: Only when permits are insufficient, allocate a Promise and enqueue the waiter.

This eliminates the primary bottleneck in the uncontended case while preserving identical behavior in the contended case.

### Changes

- **core/shared/src/main/scala/zio/Semaphore.scala**: Refactored eserve() to use two-phase acquire with lazy Promise allocation
- **enchmarks/.../SinglePermitSemaphoreBenchmark.scala**: Added JMH benchmark comparing ZIO Semaphore against Java fair/unfair Semaphore across varying fiber counts and permit levels

### Test Results

All existing SemaphoreSpec tests pass (10/10):

\\\
+ SemaphoreSpec
  + withPermitsScoped releases same number of permits
  + withPermit automatically releases the permit if the effect is interrupted
  + tryWithPermits acquires and releases same number of permits
  + withPermit acquire is interruptible
  + tryWithPermits returns None if no permits available
  + tryWithPermit acquires and releases same number of permits
  + tryWithPermits if 0 permits requested
  + tryWithPermits fails if requested permits in negative number
  + awaiting returns the count of waiting fibers
  + tryWithPermits restores permits after failure
10 tests passed. 0 tests failed. 0 tests ignored.
\\\

### Expected Performance Impact

- **Uncontended** (	hreads < permits): Significant improvement — eliminates Promise.make allocation overhead
- **Contended** (	hreads > permits): Identical behavior — Promise is still allocated when waiting is required
- **No behavioral change**: The optimization is purely internal; the public API and semantics are unchanged