### PR TITLE
feat: Improve ZStream.fromIterable responsiveness with yieldNow (#9356)

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4541,11 +4541,13 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
   def fromIteratorSucceed[A](iterator: => Iterator[A], maxChunkSize: => Int = DefaultChunkSize)(implicit
     trace: Trace
   ): ZStream[Any, Nothing, A] = {
-    def writeOneByOne(iterator: Iterator[A]): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
-      if (iterator.hasNext)
-        ZChannel.write(Chunk.single(iterator.next())) *> writeOneByOne(iterator)
-      else
-        ZChannel.unit
+  def writeOneByOne(iterator: Iterator[A]): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
+    if (iterator.hasNext)
+      ZChannel.write(Chunk.single(iterator.next())) *> 
+      ZChannel.fromZIO(ZIO.yieldNow) *> // Mana shu qator qo'shilishi kerak
+      writeOneByOne(iterator)
+    else
+      ZChannel.unit
 
     def writeChunks(iterator: Iterator[A], maxChunkSize0: Int): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] = {
       val builder = ChunkBuilder.make[A](maxChunkSize0)

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -4539,15 +4539,23 @@ object ZStream extends ZStreamPlatformSpecificConstructors {
    * Creates a stream from an iterator
    */
   def fromIteratorSucceed[A](iterator: => Iterator[A], maxChunkSize: => Int = DefaultChunkSize)(implicit
-    trace: Trace
-  ): ZStream[Any, Nothing, A] = {
-  def writeOneByOne(iterator: Iterator[A]): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
-    if (iterator.hasNext)
-      ZChannel.write(Chunk.single(iterator.next())) *> 
-      ZChannel.fromZIO(ZIO.yieldNow) *> // Mana shu qator qo'shilishi kerak
-      writeOneByOne(iterator)
-    else
-      ZChannel.unit
+      trace: Trace
+    ): ZStream[Any, Nothing, A] = {
+      def loop(iterator: Iterator[A]): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] =
+        if (iterator.hasNext) {
+          val builder = ChunkBuilder.make[A]()
+          var i       = 0
+          while (i < maxChunkSize && iterator.hasNext) {
+            builder += iterator.next()
+            i += 1
+          }
+          ZChannel.write(builder.result()) *> ZChannel.fromZIO(ZIO.yieldNow) *> loop(iterator)
+        } else {
+          ZChannel.unit
+        }
+  
+      ZStream.fromChannel(loop(iterator))
+    }
 
     def writeChunks(iterator: Iterator[A], maxChunkSize0: Int): ZChannel[Any, Any, Any, Any, Nothing, Chunk[A], Any] = {
       val builder = ChunkBuilder.make[A](maxChunkSize0)


### PR DESCRIPTION
/claim #9356

## Description
This PR addresses the issue where `ZStream.fromIterable` (and `fromIteratorSucceed`) could potentially block the ZIO executor when processing very large or infinite iterables. 

## Changes
- Refactored `writeOneByOne` into a more efficient `loop` that uses `ChunkBuilder`.
- Introduced a chunking mechanism based on `maxChunkSize`.
- Added `ZIO.yieldNow` after each chunk emission to ensure the fiber yields control back to the executor.
- This prevents CPU starvation and allows other fibers to run concurrently during large iterable processing.

## Why this approach?
Instead of yielding on every single element (which would be too slow), I implemented chunking. This maintains high throughput while providing the necessary asynchronous boundaries for cooperative multitasking.

## Checklist
- [x] Code follows ZIO contribution guidelines
- [x] Implemented yielding with chunking for performance
- [x] Linked to issue #9356