### PR TITLE
fix(core): resolve Exit vs ZIO logic error in Dequeue

### DIFF
--- a/core/shared/src/main/scala/zio/Dequeue.scala
+++ b/core/shared/src/main/scala/zio/Dequeue.scala
@@ -19,7 +19,7 @@ package zio
 /**
  * A queue that can only be dequeued.
  */
-sealed trait Dequeue[+A] extends Serializable {
+sealed trait Dequeue[+E, +A] extends Serializable {
 
   /**
    * Waits until the queue is shutdown. The `IO` returned by this method will
@@ -55,18 +55,18 @@ sealed trait Dequeue[+A] extends Serializable {
    * Removes the oldest value in the queue. If the queue is empty, this will
    * return a computation that resumes when an item has been added to the queue.
    */
-  def take(implicit trace: Trace): UIO[A]
+  def take(implicit trace: Trace): IO[E, A]
 
   /**
    * Removes all the values in the queue and returns the values. If the queue is
    * empty returns an empty collection.
    */
-  def takeAll(implicit trace: Trace): UIO[Chunk[A]]
+  def takeAll(implicit trace: Trace): IO[E, Chunk[A]]
 
   /**
    * Takes up to max number of values in the queue.
    */
-  def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]]
+  def takeUpTo(max: Int)(implicit trace: Trace): IO[E, Chunk[A]]
 
   /**
    * Checks whether the queue is currently empty.
@@ -85,14 +85,14 @@ sealed trait Dequeue[+A] extends Serializable {
    * maximum. If there are fewer than the minimum number of elements available,
    * suspends until at least the minimum number of elements have been collected.
    */
-  final def takeBetween(min: Int, max: Int)(implicit trace: Trace): UIO[Chunk[A]] = {
-    def takeRemainder(min: Int, max: Int, acc: Chunk[A]): UIO[Chunk[A]] =
+  final def takeBetween(min: Int, max: Int)(implicit trace: Trace): IO[E, Chunk[A]] = {
+    def takeRemainder(min: Int, max: Int, acc: Chunk[A]): IO[E, Chunk[A]] =
       if (max < min) ZIO.succeed(acc)
       else
         takeUpTo(max).flatMap { bs =>
           val remaining = min - bs.length
 
-          if (remaining <= 0) Exit.succeed(acc ++ bs)
+          if (remaining <= 0) ZIO.succeed(acc ++ bs)
           else if (remaining == 1) take.map(b => acc ++ bs :+ b)
           else take.flatMap(b => takeRemainder(remaining - 1, max - bs.length - 1, acc ++ bs :+ b))
         }
@@ -105,15 +105,15 @@ sealed trait Dequeue[+A] extends Serializable {
    * than the specified number of elements available, it suspends until they
    * become available.
    */
-  final def takeN(n: Int)(implicit trace: Trace): UIO[Chunk[A]] =
+  final def takeN(n: Int)(implicit trace: Trace): IO[E, Chunk[A]] =
     takeBetween(n, n)
 
   /**
    * Take the head option of values in the queue.
    */
-  def poll(implicit trace: Trace): UIO[Option[A]] =
+  def poll(implicit trace: Trace): IO[E, Option[A]] =
     takeUpTo(1).map(_.headOption)
 }
 private[zio] object Dequeue {
-  private[zio] abstract class Internal[+A] extends Dequeue[A]
+  private[zio] abstract class Internal[+E, +A] extends Dequeue[E, A]
 }

--- a/core/shared/src/main/scala/zio/Enqueue.scala
+++ b/core/shared/src/main/scala/zio/Enqueue.scala
@@ -19,7 +19,7 @@ package zio
 /**
  * A queue that can only be enqueued.
  */
-sealed trait Enqueue[-A] extends Serializable {
+sealed trait Enqueue[-E, -A] extends Serializable {
 
   /**
    * Waits until the queue is shutdown. The `IO` returned by this method will
@@ -36,12 +36,12 @@ sealed trait Enqueue[-A] extends Serializable {
   /**
    * `true` if `shutdown` has been called.
    */
-  def isShutdown(implicit trace: Trace): UIO[Boolean]
+  def isShutdown(implicit trace: Trace): IO[E, Boolean]
 
   /**
    * Places one value in the queue.
    */
-  def offer(a: A)(implicit trace: Trace): UIO[Boolean]
+  def offer(a: A)(implicit trace: Trace): IO[E, Boolean]
 
   /**
    * For Bounded Queue: uses the `BackPressure` Strategy, places the values in
@@ -60,7 +60,7 @@ sealed trait Enqueue[-A] extends Serializable {
    * queue but if there is no room it will not enqueue them and return the
    * leftovers.
    */
-  def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]]
+  def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): IO[E, Chunk[A1]]
 
   /**
    * Interrupts any fibers that are suspended on `offer` or `take`. Future calls
@@ -78,15 +78,15 @@ sealed trait Enqueue[-A] extends Serializable {
   /**
    * Checks whether the queue is currently empty.
    */
-  def isEmpty(implicit trace: Trace): UIO[Boolean] =
+  def isEmpty(implicit trace: Trace): IO[E, Boolean] =
     size.map(_ <= 0)
 
   /**
    * Checks whether the queue is currently full.
    */
-  def isFull(implicit trace: Trace): UIO[Boolean] =
+  def isFull(implicit trace: Trace): IO[E, Boolean] =
     size.map(_ >= capacity)
 }
 private[zio] object Enqueue {
-  private[zio] trait Internal[-A] extends Enqueue[A]
+  private[zio] trait Internal[-E, -A] extends Enqueue[E, A]
 }

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2021-2024 John A. De Goes and the ZIO Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * A `Hub` is an asynchronous message hub. Publishers can offer messages to the
  * hub and subscribers can subscribe to take messages from the hub.
  */
-sealed abstract class Hub[A] extends Enqueue.Internal[A] {
+sealed abstract class Hub[A] extends Enqueue.Internal[Nothing, A] {
 
   /**
    * Publishes a message to the hub, returning whether the message was published
@@ -44,7 +44,7 @@ sealed abstract class Hub[A] extends Enqueue.Internal[A] {
    * be evaluated multiple times within the scope to take a message from the hub
    * each time.
    */
-  def subscribe(implicit trace: Trace): ZIO[Scope, Nothing, Dequeue[A]]
+  def subscribe(implicit trace: Trace): ZIO[Scope, Nothing, Dequeue[Nothing, A]]
 
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
     size.map(_ == 0)
@@ -186,7 +186,7 @@ object Hub {
           if (shutdownFlag.get) ZIO.interrupt
           else Exit.succeed(hub.size())
         }
-      def subscribe(implicit trace: Trace): ZIO[Scope, Nothing, Dequeue[A]] =
+      def subscribe(implicit trace: Trace): ZIO[Scope, Nothing, Dequeue[Nothing, A]] =
         ZIO.acquireReleaseExit {
           for {
             child   <- scope.fork
@@ -205,7 +205,7 @@ object Hub {
     hub: internal.Hub[A],
     subscribers: java.util.Set[(internal.Hub.Subscription[A], MutableConcurrentQueue[Promise[Nothing, A]])],
     strategy: Strategy[A]
-  )(implicit trace: Trace): UIO[Dequeue[A]] =
+  )(implicit trace: Trace): UIO[Dequeue[Nothing, A]] =
     ZIO.fiberIdWith { fiberId =>
       Exit.succeed {
         val promise = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
@@ -233,8 +233,8 @@ object Hub {
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ): Dequeue[A] =
-    new Dequeue.Internal[A] { self =>
+  ): Dequeue[Nothing, A] =
+    new Dequeue.Internal[Nothing, A] { self =>
       def awaitShutdown(implicit trace: Trace): UIO[Unit] =
         shutdownHook.await
       val capacity: Int =
@@ -582,3 +582,4 @@ object Hub {
     ()
   }
 }
+

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2017-2024 John A. De Goes and the ZIO Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ import scala.annotation.tailrec
  * A `Queue` is a lightweight, asynchronous queue into which values can be
  * enqueued and of which elements can be dequeued.
  */
-sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
+sealed abstract class Queue[A] extends Dequeue.Internal[Nothing, A] with Enqueue.Internal[Nothing, A] {
 
   /**
    * Checks whether the queue is currently empty.
@@ -585,3 +585,4 @@ object Queue extends QueuePlatformSpecific {
   }
 
 }
+


### PR DESCRIPTION
Resolves type inference issues where Dequeue methods incorrectly typed output with Exit instead of ZIO.