### PR TITLE
fix(test): make Gen.elements exhaustive and add Gen.randomChoice for random sampling

### DIFF
--- a/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkIntSpec.scala
@@ -14,7 +14,7 @@ object BitChunkIntSpec extends ZIOBaseSpec {
     Gen.small(Gen.const(_))
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(int: Int): String = {
     val endiannessLong =

--- a/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/BitChunkLongSpec.scala
@@ -14,7 +14,7 @@ object BitChunkLongSpec extends ZIOBaseSpec {
     Gen.small(Gen.const(_))
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   def toBinaryString(endianness: Chunk.BitChunk.Endianness)(long: Long): String = {
     val endiannessLong =

--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -139,7 +139,7 @@ object CauseSpec extends ZIOBaseSpec {
             )
             .map(new Throwable(msg1, _))
         }
-        val failOrDie = Gen.elements[Throwable => Cause[Throwable]](Cause.fail(_), Cause.die(_))
+        val failOrDie = Gen.randomChoice[Throwable => Cause[Throwable]](Cause.fail(_), Cause.die(_))
         check(throwable, failOrDie) { (e, makeCause) =>
           val rootCause        = makeCause(e)
           val cause            = rootCause
@@ -365,7 +365,7 @@ object CauseSpec extends ZIOBaseSpec {
 
   val equalCauses: Gen[Any, (Cause[String], Cause[String])] =
     (causes <*> causes <*> causes).flatMap { case (a, b, c) =>
-      Gen.elements(
+      Gen.randomChoice(
         (a, a),
         (Then(Then(a, b), c), Then(a, Then(b, c))),
         (Then(a, Both(b, c)), Both(Then(a, b), Then(a, c))),

--- a/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ChunkPackedBooleanSpec.scala
@@ -6,7 +6,7 @@ import zio.test._
 object ChunkPackedBooleanSpec extends ZIOBaseSpec {
 
   val genEndianness: Gen[Any, Chunk.BitChunk.Endianness] =
-    Gen.elements(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
+    Gen.randomChoice(Chunk.BitChunk.Endianness.BigEndian, Chunk.BitChunk.Endianness.LittleEndian)
 
   val genBoolChunk: Gen[Any, Chunk[Boolean]] =
     for {
@@ -15,7 +15,7 @@ object ChunkPackedBooleanSpec extends ZIOBaseSpec {
       byteChunk    <- Gen.listOf(Gen.byte).map(Chunk.fromIterable).map(x => x.asBitsByte)
       intChunk     <- Gen.listOf(Gen.int).map(Chunk.fromIterable).map(x => x.asBitsInt(endianness))
       longChunk    <- Gen.listOf(Gen.long).map(Chunk.fromIterable).map(x => x.asBitsLong(endianness))
-      oneOf        <- Gen.elements(booleanChunk, byteChunk, intChunk, longChunk)
+      oneOf        <- Gen.randomChoice(booleanChunk, byteChunk, intChunk, longChunk)
     } yield oneOf
 
   val genInt: Gen[Any, Int] =

--- a/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/StackSpec.scala
@@ -88,5 +88,5 @@ object StackSpec extends ZIOBaseSpec {
   case object False extends Boolean
 
   val gen: Gen[Any, List[Boolean]] =
-    Gen.large(n => Gen.listOfN(n)(Gen.elements(True, False)))
+    Gen.large(n => Gen.listOfN(n)(Gen.randomChoice(True, False)))
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -188,6 +188,9 @@ object GenSpec extends ZIOBaseSpec {
       test("boolean generates true and false") {
         checkSample(Gen.boolean)(contains(true) && contains(false))
       },
+      test("randomChoice generates all specified values") {
+        checkSample(Gen.randomChoice(1, 2, 3))(contains(1) && contains(2) && contains(3))
+      },
       test("byte generates values in range") {
         checkSample(Gen.byte(38, 38))(forall(equalTo(38.toByte)))
       },
@@ -513,6 +516,12 @@ object GenSpec extends ZIOBaseSpec {
       test("boolean shrinks to false") {
         checkShrink(Gen.boolean)(false)
       },
+      test("elements shrinks to first value") {
+        checkShrink(Gen.elements("a", "b", "c"))("a")
+      },
+      test("randomChoice shrinks to first value") {
+        checkShrink(Gen.randomChoice("a", "b", "c"))("a")
+      },
       test("byte shrinks to bottom of range") {
         checkShrink(Gen.byte(38, 123))(38)
       },
@@ -776,6 +785,13 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
+    },
+    test("checkAll(Gen.elements) visits every element position exactly once") {
+      for {
+        counter <- Ref.make(0)
+        _       <- checkAll(Gen.elements(1, 1, 1, 2))(_ => counter.update(_ + 1) *> assertCompletes)
+        count   <- counter.get
+      } yield assertTrue(count == 4)
     }
   )
 }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -286,7 +286,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of booleans. Shrinks toward 'false'.
    */
   def boolean(implicit trace: Trace): Gen[Any, Boolean] =
-    elements(false, true)
+    randomChoice(false, true)
 
   /**
    * A generator whose size falls within the specified bounds.
@@ -399,7 +399,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of currency.
    */
   def currency(implicit trace: Trace): Gen[Any, java.util.Currency] =
-    elements(java.util.Currency.getAvailableCurrencies.asScala.toSeq: _*)
+    randomChoice(java.util.Currency.getAvailableCurrencies.asScala.toSeq: _*)
 
   /**
    * A generator of doubles. Shrinks toward '0'.
@@ -425,8 +425,25 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
   ): Gen[R, Either[A, B]] =
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
+  /**
+   * A generator that produces each of the specified values exactly once, in
+   * order. Designed for use with `checkAll` to exhaustively test every provided
+   * value. Shrinks toward the first value. For random sampling use
+   * `Gen.randomChoice`.
+   */
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty
+    else {
+      val indexed = as.toVector
+      fromIterable(
+        indexed,
+        (a: A) => {
+          val idx = indexed.indexOf(a)
+          if (idx <= 0) ZStream.empty
+          else ZStream.fromIterable(indexed.take(idx))
+        }
+      )
+    }
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -706,6 +723,14 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     char(33, 126)
 
   /**
+   * A generator that randomly selects one of the specified values. Shrinks
+   * toward the first value in the argument list. For exhaustive coverage of all
+   * values use `Gen.elements` with `checkAll`.
+   */
+  def randomChoice[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
+    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+
+  /**
    * A sized generator of sets.
    */
   def setOf[R, A](gen: Gen[R, A])(implicit trace: Trace): Gen[R, Set[A]] =
@@ -927,7 +952,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of whitespace characters.
    */
   def whitespaceChars(implicit trace: Trace): Gen[Any, Char] =
-    Gen.elements((Char.MinValue to Char.MaxValue).filter(_.isWhitespace): _*)
+    Gen.randomChoice((Char.MinValue to Char.MaxValue).filter(_.isWhitespace): _*)
 
   /**
    * Restricts an integer to the specified range.

--- a/test/shared/src/main/scala/zio/test/GenZIO.scala
+++ b/test/shared/src/main/scala/zio/test/GenZIO.scala
@@ -27,14 +27,15 @@ trait GenZIO {
   final def causes[R, E](e: Gen[R, E], t: Gen[R, Throwable])(implicit
     trace: Trace
   ): Gen[R, Cause[E]] = {
-    val fiberId           = (Gen.int zip Gen.int zip Gen.const(Trace.empty)).map { case (a, b, c) => FiberId(a, b, c) }
-    val zTraceElement     = Gen.string.map(_.asInstanceOf[Trace])
-    val zTrace            = fiberId.zipWith(Gen.chunkOf(zTraceElement))(StackTrace(_, _))
-    val failure           = e.zipWith(zTrace)(Cause.fail(_, _))
-    val die               = t.zipWith(zTrace)(Cause.die(_, _))
-    val empty             = Gen.const(Cause.empty)
-    val interrupt         = fiberId.zipWith(zTrace)(Cause.interrupt(_, _))
-    def stackless(n: Int) = Gen.suspend(causesN(n - 1).flatMap(c => Gen.elements(Cause.stack(c), Cause.stackless(c))))
+    val fiberId       = (Gen.int zip Gen.int zip Gen.const(Trace.empty)).map { case (a, b, c) => FiberId(a, b, c) }
+    val zTraceElement = Gen.string.map(_.asInstanceOf[Trace])
+    val zTrace        = fiberId.zipWith(Gen.chunkOf(zTraceElement))(StackTrace(_, _))
+    val failure       = e.zipWith(zTrace)(Cause.fail(_, _))
+    val die           = t.zipWith(zTrace)(Cause.die(_, _))
+    val empty         = Gen.const(Cause.empty)
+    val interrupt     = fiberId.zipWith(zTrace)(Cause.interrupt(_, _))
+    def stackless(n: Int) =
+      Gen.suspend(causesN(n - 1).flatMap(c => Gen.randomChoice(Cause.stack(c), Cause.stackless(c))))
 
     def sequential(n: Int) = Gen.suspend {
       for {

--- a/test/shared/src/main/scala/zio/test/TimeVariants.scala
+++ b/test/shared/src/main/scala/zio/test/TimeVariants.scala
@@ -28,7 +28,7 @@ trait TimeVariants {
    * `DayOfWeek.MONDAY`.
    */
   final def dayOfWeek(implicit trace: Trace): Gen[Any, DayOfWeek] =
-    Gen.elements(
+    Gen.randomChoice(
       DayOfWeek.MONDAY,
       DayOfWeek.TUESDAY,
       DayOfWeek.WEDNESDAY,
@@ -127,7 +127,7 @@ trait TimeVariants {
    * A generator of `java.time.Month` values. Shrinks toward `Month.JANUARY`.
    */
   final def month(implicit trace: Trace): Gen[Any, Month] =
-    Gen.elements(
+    Gen.randomChoice(
       Month.JANUARY,
       Month.FEBRUARY,
       Month.MARCH,
@@ -287,7 +287,7 @@ trait TimeVariants {
    * A generator of `java.time.ZoneId` values. Doesn't have any shrinking.
    */
   final def zoneId(implicit trace: Trace): Gen[Any, ZoneId] =
-    Gen.elements(ZoneId.getAvailableZoneIds.asScala.map(ZoneId.of).toList: _*).noShrink
+    Gen.randomChoice(ZoneId.getAvailableZoneIds.asScala.map(ZoneId.of).toList: _*).noShrink
 
   /**
    * A generator of `java.time.ZoneOffset` values. Shrinks toward

--- a/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenFractionalPoly.scala
@@ -60,5 +60,5 @@ object GenFractionalPoly {
    * instance.
    */
   def genFractionalPoly(implicit trace: Trace): Gen[Any, GenFractionalPoly] =
-    Gen.elements(double, float)
+    Gen.randomChoice(double, float)
 }

--- a/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenIntegralPoly.scala
@@ -59,7 +59,7 @@ object GenIntegralPoly {
    * instance.
    */
   def genIntegralPoly(implicit trace: Trace): Gen[Any, GenIntegralPoly] =
-    Gen.elements(byte, char, int, long, short)
+    Gen.randomChoice(byte, char, int, long, short)
 
   /**
    * Provides evidence that instances of `Gen` and `Integral` exist for

--- a/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenNumericPoly.scala
@@ -72,7 +72,7 @@ object GenNumericPoly {
    * instance.
    */
   def genNumericPoly(implicit trace: Trace): Gen[Any, GenNumericPoly] =
-    Gen.elements(
+    Gen.randomChoice(
       byte,
       char,
       double,

--- a/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
+++ b/test/shared/src/main/scala/zio/test/poly/GenOrderingPoly.scala
@@ -76,7 +76,7 @@ object GenOrderingPoly {
     GenNumericPoly.float
 
   def genOrderingPoly(implicit trace: Trace): Gen[Any, GenOrderingPoly] = {
-    val primitives = Gen.elements(
+    val primitives = Gen.randomChoice(
       boolean,
       byte,
       char,
@@ -88,7 +88,7 @@ object GenOrderingPoly {
       string,
       unit
     )
-    val constructors = Gen.elements(list _, option _, vector _)
+    val constructors = Gen.randomChoice(list _, option _, vector _)
     val collections = for {
       constructor <- constructors
       primitive   <- primitives


### PR DESCRIPTION
Fixes #10187

## Problem

`Gen.elements` was implemented as `int(0, as.length - 1).map(as)` — a random index generator. When used with `checkAll`, which expects to visit every value from a finite deterministic generator, it would only draw random samples and could miss values. With `elements(1, 1, 1, 2)` the probability of never drawing the last index is `(3/4)^n`, which is nonzero at the default sample count.

The reporter also noted that `Gen.fromIterable` already behaves correctly — this fix aligns `elements` with that expectation.

## Fix

`Gen.elements` now delegates to `fromIterable` with a position-based shrinker that shrinks toward the first element (preserving the existing shrink-toward-false behavior of `Gen.boolean`). A new `Gen.randomChoice` carries the old random-sampling semantics for callers that need it.

All call sites in the repo that used `Gen.elements` for random sampling in `check` contexts were migrated to `randomChoice`: `Gen.boolean`, `Gen.currency`, the poly generators, `TimeVariants`, and several core-test specs.

## Tradeoff

This changes the public semantics of `Gen.elements` from random sampling to exhaustive enumeration. The migration to `randomChoice` at all existing call sites ensures existing tests continue to behave the same way, but downstream users calling `check(Gen.elements(...))` will now get deterministic cycling instead of random draws.

## Verification

```
sbt "testTestsJVM/testOnly zio.test.GenSpec"
# 183 tests passed, 0 failed
```

New tests added:
- `checkAll(Gen.elements) visits every element position exactly once` — asserts visit count == 4 for `elements(1,1,1,2)`, which a random sampler producing ~100 samples would fail
- `elements shrinks to first value`
- `randomChoice generates all specified values`
- `randomChoice shrinks to first value`