### PR TITLE
perf: reduce excessive worker unparking in ZScheduler

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -443,11 +443,16 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         }
       }
     }
-
   private def maybeUnparkWorker(currentState: Int): Unit = {
     val currentSearching = currentState & 0xffff
     val currentActive    = (currentState & 0xffff0000) >> 16
-    if (currentActive != poolSize && currentSearching == 0) {
+
+    val shouldUnpark =
+      currentActive != poolSize &&
+        currentSearching == 0 &&
+        !globalQueue.isEmpty()
+
+    if (shouldUnpark) {
       val worker = idle.poll()
       if (worker ne null) {
         state.getAndAdd(0x10001)


### PR DESCRIPTION
### Summary

Reduces aggressive worker unparking in `ZScheduler.maybeUnparkWorker`, which is currently invoked frequently in the hot path.

### Problem

`LockSupport.unpark(worker)` is relatively expensive and is triggered too often, leading to excessive park/unpark cycles and unnecessary overhead.

### Solution

Adds a lightweight guard before unparking:

- Only unpark when:
  - Not all workers are active
  - No workers are currently searching
  - There is pending work in the global queue (`!globalQueue.isEmpty()`)

This reduces redundant wake-ups while preserving scheduler behavior.

### Impact

- Fewer unnecessary `unpark` calls
- Reduced thread wake-up overhead
- Minimal behavioral change

### Notes

This is a conservative optimization. Further improvements could include more advanced heuristics or benchmarking-based tuning.

/claim #9878