### PR TITLE
Optimize Semaphore performance (#9093)

### DIFF
--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -155,53 +155,70 @@ object Semaphore {
           else if (n == 0L)
             ZIO.succeed(Reservation.zero)
           else
-            Promise.make[Nothing, Unit].flatMap { promise =>
-              ref.modify {
-                case Right(permits) if permits >= n =>
-                  Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
-                case Right(permits) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
-                case Left(queue) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
-              }
+            ref.modify {
+              case Right(permits) if permits >= n =>
+                Some(Reservation(ZIO.unit, releaseN(n))) -> Right(permits - n)
+              case state =>
+                None -> state
+            }.flatMap {
+              case Some(reservation) => ZIO.succeed(reservation)
+              case None              => Promise.make[Nothing, Unit].flatMap(slowReserve(n, _))
             }
+
+        private def slowReserve(n: Long, promise: Promise[Nothing, Unit])(implicit trace: Trace): UIO[Reservation] =
+          ref.modify {
+            case Right(permits) if permits >= n =>
+              Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
+            case Right(permits) =>
+              Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
+            case Left(queue) =>
+              Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
+          }
 
         def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =
           ref.modify {
             case Left(queue) =>
-              queue
-                .find(_._1 == promise)
-                .fold(releaseN(n) -> Left(queue)) { case (_, permits) =>
-                  releaseN(n - permits) -> Left(queue.filter(_._1 != promise))
-                }
+              val (before, from) = queue.span(_._1 ne promise)
+              if (from.isEmpty)
+                releaseN(n) -> Left(queue)
+              else {
+                val (_, needed) = from.head
+                releaseN(n - needed) -> Left(before ++ from.tail)
+              }
             case Right(permits) => ZIO.unit -> Right(permits + n)
           }.flatten
 
-        def releaseN(n: Long)(implicit trace: Trace): UIO[Any] = {
+        def releaseN(n: Long)(implicit trace: Trace): UIO[Any] =
+          if (n <= 0L) ZIO.unit
+          else {
 
-          @tailrec
-          def loop(
-            n: Long,
-            state: Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long],
-            acc: UIO[Any]
-          ): (UIO[Any], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
-            state match {
-              case Right(permits) => acc -> Right(permits + n)
-              case Left(queue) =>
-                queue.dequeueOption match {
-                  case None => acc -> Right(n)
-                  case Some(((promise, permits), queue)) =>
-                    if (n > permits)
-                      loop(n - permits, Left(queue), acc *> promise.succeedUnit)
-                    else if (n == permits)
-                      (acc *> promise.succeedUnit) -> Left(queue)
-                    else
-                      acc -> Left((promise -> (permits - n)) +: queue)
-                }
+            @tailrec
+            def loop(
+              remaining: Long,
+              state: Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long],
+              acc: List[Promise[Nothing, Unit]]
+            ): (List[Promise[Nothing, Unit]], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
+              state match {
+                case Right(permits) => acc -> Right(permits + remaining)
+                case Left(queue) =>
+                  queue.dequeueOption match {
+                    case None => acc -> Right(remaining)
+                    case Some(((promise, permits), queue)) =>
+                      if (remaining > permits)
+                        loop(remaining - permits, Left(queue), promise :: acc)
+                      else if (remaining == permits)
+                        (promise :: acc) -> Left(queue)
+                      else
+                        acc -> Left((promise -> (permits - remaining)) +: queue)
+                  }
+              }
+
+            ref.modify(loop(n, _, Nil)).flatMap {
+              case Nil            => ZIO.unit
+              case promise :: Nil => promise.succeedUnit
+              case promises       => ZIO.foreachDiscard(promises.reverse)(_.succeedUnit)
             }
-
-          ref.modify(loop(n, _, ZIO.unit)).flatten
-        }
+          }
       }
   }
 }


### PR DESCRIPTION
/claim #9093

## Summary

Optimizes ZIO's `Semaphore` implementation to address the performance gap reported in #9093, where ZIO's Semaphore was 5-6x slower than Java's in the uncontended case (`threads < permits`).

## Changes

### 1. Fast path: eliminate Promise allocation when permits available

The previous `reserve` method **always** allocated a `Promise[Nothing, Unit]` via `Promise.make`, even when permits were immediately available (the uncontended fast path). The Promise was created, the lambda executed, and then the Promise was discarded — pure waste.

**Fix:** Split `reserve` into a fast path (single `ref.modify` returning `Option[Reservation]`) and a slow path (`slowReserve`) that only creates a Promise when actually needed. In the uncontended case, this eliminates:
- 1 Promise object allocation (~3 objects: Promise + internal Ref + AtomicReference)
- 1 `flatMap` ZIO node
- 1 `Promise.make` effect evaluation

This is the **dominant bottleneck** identified in the issue.

### 2. O(k) cancellation instead of O(n)

The previous `restore` method used `queue.find(...)` + `queue.filter(...)` — two separate O(n) traversals of the immutable Queue on every fiber cancellation.

**Fix:** Replace with a single `queue.span(_._1 ne promise)` traversal that splits the queue at the target element in O(k) time (where k is the target's position). Uses reference equality (`ne`) for Promise identity comparison. For the common case (cancelling the head waiter), this is O(1) instead of O(n).

### 3. Batched promise completion in releaseN

The previous `releaseN` accumulated promise completions via `acc *> promise.succeedUnit`, creating deeply nested `ZIO.FlatMap` chains. The runtime had to traverse these chains one by one.

**Fix:** Use a `List[Promise]` accumulator and batch-complete all promises via `ZIO.foreachDiscard`. Special-case 0 promises (return `ZIO.unit` directly) and 1 promise (avoid `foreachDiscard` overhead). Preserves FIFO wake-up order via `.reverse`.

### 4. Minor: early return for releaseN(n <= 0)

Avoids a no-op CAS when releasing 0 or negative permits (can happen in `restore` edge cases).

## Why not the approach from PR #10378?

The competing PR (#10378, stalled 3+ months) has several issues this PR avoids:

| Concern | PR #10378 | This PR |
|---------|-----------|---------|
| Scope creep | Adds `stats` API | No new public APIs |
| Referential transparency | Uses `ref.unsafe.modify` inside `Exit.succeed` | Uses pure `ref.modify` throughout |
| FIFO reversal bug | Reverses wake-up order in `releaseN` | Preserves FIFO via `.reverse` |
| Unused code | Introduces unused `ScalaQueueCompat` | No dead code |
| Complexity | Custom `JobQueue` with tombstones | Minimal change to existing Queue |

## Testing

All 10 existing `SemaphoreSpec` tests pass:
- withPermit automatically releases on interruption
- withPermit acquire is interruptible  
- withPermitsScoped releases same number of permits
- tryWithPermits variants
- awaiting returns correct count

## Performance Analysis

**Uncontended case (threads < permits):** The Promise elimination removes ~3 object allocations + 1 flatMap per acquire, which is the primary overhead vs Java's raw `AtomicInteger.compareAndSet`. The remaining gap is due to ZIO's effect system overhead (the `acquireReleaseWith` wrapper creates ~5-7 ZIO effect nodes vs Java's single `ZIO.succeed` wrapper).

**Contended case:** The batched `releaseN` reduces ZIO node allocations from O(k) FlatMap nodes to O(1) `foreachDiscard`. The O(k) `restore` improves cancellation under load.