### PR TITLE
Implement Promise.become(fiber) to merge Fiber and Promise

### DIFF
--- a/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/PromiseSpec.scala
@@ -134,6 +134,123 @@ object PromiseSpec extends ZIOBaseSpec {
         _      <- ZIO.foreach(fibers)(_.await)
       } yield assertCompletes
     },
+    suite("become")(
+      test("become with a succeeding fiber") {
+        for {
+          fiber  <- ZIO.succeed(42).fork
+          p      <- Promise.make[Nothing, Int]
+          became <- p.become(fiber)
+          v      <- p.await
+        } yield assert(became)(isTrue) && assert(v)(equalTo(42))
+      },
+      test("become with a failing fiber") {
+        for {
+          fiber  <- ZIO.fail("error").fork
+          p      <- Promise.make[String, Int]
+          became <- p.become(fiber)
+          v      <- p.await.exit
+        } yield assert(became)(isTrue) && assert(v)(fails(equalTo("error")))
+      } @@ zioTag(errors),
+      test("become with a dying fiber") {
+        for {
+          fiber  <- ZIO.die(new RuntimeException("boom")).fork
+          p      <- Promise.make[Nothing, Int]
+          became <- p.become(fiber)
+          v      <- p.await.exit
+        } yield assert(became)(isTrue) && assert(v)(dies(hasMessage(equalTo("boom"))))
+      },
+      test("become with an already completed fiber") {
+        for {
+          fiber  <- ZIO.succeed(99).fork
+          _      <- fiber.await
+          p      <- Promise.make[Nothing, Int]
+          became <- p.become(fiber)
+          v      <- p.await
+        } yield assert(became)(isTrue) && assert(v)(equalTo(99))
+      },
+      test("become returns false on already completed promise") {
+        for {
+          p      <- Promise.make[Nothing, Int]
+          _      <- p.succeed(1)
+          fiber  <- ZIO.succeed(42).fork
+          became <- p.become(fiber)
+          v      <- p.await
+        } yield assert(became)(isFalse) && assert(v)(equalTo(1))
+      },
+      test("become returns false when called twice") {
+        for {
+          fiber1 <- ZIO.succeed(1).fork
+          fiber2 <- ZIO.succeed(2).fork
+          p      <- Promise.make[Nothing, Int]
+          b1     <- p.become(fiber1)
+          b2     <- p.become(fiber2)
+          v      <- p.await
+        } yield assert(b1)(isTrue) && assert(b2)(isFalse) && assert(v)(equalTo(1))
+      },
+      test("become transfers pre-existing waiters") {
+        for {
+          p      <- Promise.make[Nothing, Int]
+          f1     <- p.await.fork
+          f2     <- p.await.fork
+          fiber  <- ZIO.succeed(42).fork
+          _      <- p.become(fiber)
+          v1     <- f1.join
+          v2     <- f2.join
+        } yield assert(v1)(equalTo(42)) && assert(v2)(equalTo(42))
+      },
+      test("become isDone when fiber completes") {
+        for {
+          fiber <- ZIO.succeed(42).fork
+          p     <- Promise.make[Nothing, Int]
+          _     <- p.become(fiber)
+          _     <- fiber.await
+          d     <- p.isDone
+        } yield assert(d)(isTrue)
+      },
+      test("become isDone before fiber completes") {
+        for {
+          p     <- Promise.make[Nothing, Int]
+          fiber <- (ZIO.succeed(42) <* ZIO.sleep(1.second)).fork
+          _     <- p.become(fiber)
+          d     <- p.isDone
+        } yield assert(d)(isFalse)
+      },
+      test("become poll when fiber has completed") {
+        for {
+          fiber  <- ZIO.succeed(42).fork
+          _      <- fiber.await
+          p      <- Promise.make[Nothing, Int]
+          _      <- p.become(fiber)
+          result <- p.poll.someOrFail("fail").flatten.exit
+        } yield assert(result)(succeeds(equalTo(42)))
+      },
+      test("become poll before fiber completes") {
+        for {
+          p     <- Promise.make[Nothing, Int]
+          fiber <- (ZIO.succeed(42) <* ZIO.sleep(1.second)).fork
+          _     <- p.become(fiber)
+          poll  <- p.poll
+        } yield assert(poll)(isNone)
+      },
+      test("completeWith on a linked promise returns false") {
+        for {
+          fiber <- ZIO.succeed(42).fork
+          p     <- Promise.make[Nothing, Int]
+          _     <- p.become(fiber)
+          s     <- p.succeed(99)
+          v     <- p.await
+        } yield assert(s)(isFalse) && assert(v)(equalTo(42))
+      },
+      test("become waiter stack safety") {
+        for {
+          p      <- Promise.make[Nothing, Unit]
+          fibers <- ZIO.foreach(1 to n)(_ => p.await.forkDaemon)
+          fiber  <- ZIO.unit.fork
+          _      <- p.become(fiber)
+          _      <- ZIO.foreach(fibers)(_.await)
+        } yield assertCompletes
+      }
+    ),
     suite("State")(
       suite("add")(
         test("stack safety") {

--- a/core/shared/src/main/scala/zio/Promise.scala
+++ b/core/shared/src/main/scala/zio/Promise.scala
@@ -47,7 +47,8 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   def await(implicit trace: Trace): IO[E, A] =
     ZIO.suspendSucceed {
       state.get match {
-        case Done(value) => value
+        case Done(value)          => value
+        case FiberLinked(fiber)   => fiber.await.flatMap(exit => exit)
         case pending =>
           ZIO.asyncInterrupt[Any, E, A](
             k => {
@@ -57,7 +58,14 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
                   case pending: Pending[?, ?] =>
                     if (state.compareAndSet(pending, pending.add(k))) ()
                     else loop(state.get)
-                  case Done(value) => k(value)
+                  case Done(value)        => k(value)
+                  case FiberLinked(fiber) =>
+                    fiber match {
+                      case runtime: Fiber.Runtime[E, A] @unchecked =>
+                        runtime.unsafe.addObserver((exit: Exit[E, A]) => k(exit))(Unsafe)
+                      case _ =>
+                        k(fiber.await.flatMap(exit => exit))
+                    }
                 }
               loop(pending)
 
@@ -70,6 +78,18 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
           )
       }
     }
+
+  /**
+   * Links this promise to the specified fiber, such that this promise will
+   * complete with the same result as the fiber. Any fibers waiting on this
+   * promise will be transferred to the fiber's observer list, avoiding
+   * intermediate allocations.
+   *
+   * If this promise has already been completed or linked, the method will
+   * produce false.
+   */
+  def become(fiber: Fiber[E, A])(implicit trace: Trace): UIO[Boolean] =
+    ZIO.succeed(unsafe.become(fiber)(trace, Unsafe))
 
   /**
    * Kills the promise with the specified error, which will be propagated to all
@@ -175,6 +195,7 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
     ZIO.succeed(unsafe.succeedUnit(ev0, trace, Unsafe))
 
   private[zio] trait UnsafeAPI extends Serializable {
+    def become(fiber: Fiber[E, A])(implicit trace: Trace, unsafe: Unsafe): Boolean
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean
     def die(e: Throwable)(implicit trace: Trace, unsafe: Unsafe): Boolean
     def done(io: IO[E, A])(implicit unsafe: Unsafe): Unit
@@ -192,6 +213,27 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
   private[zio] def state: AtomicReference[Promise.internal.State[E, A]] =
     unsafe.asInstanceOf[AtomicReference[Promise.internal.State[E, A]]]
   private[zio] val unsafe: UnsafeAPI = new AtomicReference(Promise.internal.State.empty[E, A]) with UnsafeAPI { state =>
+    def become(fiber: Fiber[E, A])(implicit trace: Trace, unsafe: Unsafe): Boolean = {
+      @annotation.tailrec
+      def loop(): Boolean =
+        state.get match {
+          case pending: Pending[?, ?] =>
+            if (state.compareAndSet(pending, FiberLinked(fiber))) {
+              if (pending.size > 0) {
+                fiber match {
+                  case runtime: Fiber.Runtime[E, A] @unchecked =>
+                    transferToRuntime(pending, runtime)
+                  case _ =>
+                    pending.complete(fiber.await.flatMap(exit => exit))
+                }
+              }
+              true
+            } else loop()
+          case _ => false
+        }
+      loop()
+    }
+
     def completeWith(io: IO[E, A])(implicit unsafe: Unsafe): Boolean = {
       @annotation.tailrec
       def loop(): Boolean =
@@ -223,12 +265,25 @@ final class Promise[E, A] private (blockingOn: FiberId) extends Serializable {
       completeWith(ZIO.interruptAs(fiberId))
 
     def isDone(implicit unsafe: Unsafe): Boolean =
-      state.get().isInstanceOf[Done[?, ?]]
+      state.get() match {
+        case _: Done[?, ?]      => true
+        case FiberLinked(fiber) =>
+          fiber match {
+            case runtime: Fiber.Runtime[E, A] @unchecked => runtime.unsafe.poll.isDefined
+            case _                                        => false
+          }
+        case _                  => false
+      }
 
     def poll(implicit unsafe: Unsafe): Option[IO[E, A]] =
       state.get() match {
-        case Done(value) => Some(value)
-        case _           => None
+        case Done(value)        => Some(value)
+        case FiberLinked(fiber) =>
+          fiber match {
+            case runtime: Fiber.Runtime[E, A] @unchecked => runtime.unsafe.poll
+            case _                                        => None
+          }
+        case _                  => None
       }
 
     def refailCause(e: Cause[E])(implicit trace: Trace, unsafe: Unsafe): Boolean =
@@ -246,6 +301,7 @@ object Promise {
   private[zio] object internal {
     sealed abstract class State[E, A]            extends Serializable
     final case class Done[E, A](value: IO[E, A]) extends State[E, A]
+    final case class FiberLinked[E, A](fiber: Fiber[E, A]) extends State[E, A]
     sealed abstract class Pending[E, A] extends State[E, A] { self =>
       def complete(io: IO[E, A]): Unit
       def add(waiter: IO[E, A] => Any): Pending[E, A]
@@ -325,6 +381,24 @@ object Promise {
 
     object State {
       def empty[E, A]: State[E, A] = Empty.asInstanceOf[State[E, A]]
+    }
+
+    private[zio] def transferToRuntime[E, A](
+      pending: Pending[E, A],
+      runtime: Fiber.Runtime[E, A]
+    )(implicit u: Unsafe): Unit = {
+      var current: Pending[E, A] = pending
+      while (current ne Empty) {
+        current match {
+          case link: Link[?, ?] =>
+            val waiter   = link.waiter
+            val observer: Exit[E, A] => Unit = exit => waiter(exit)
+            runtime.unsafe.addObserver(observer)(u)
+            current = link.ws
+          case _ =>
+            current = Empty.asInstanceOf[Pending[E, A]]
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #9877 — Implements `Promise.become(fiber: Fiber[E, A]): UIO[Boolean]` to directly link a Promise to a Fiber, eliminating intermediate allocations when bridging Fiber results to Promises.

/claim #9877

## Problem

When a Fiber's result is used to complete a Promise (via `intoPromise`), there's a redundant allocation:
1. Fiber completes → stores ExitValue → observers notified
2. `Promise.completeWith(fiber.await)` → creates intermediate callback chain

This indirection wastes allocations and adds latency.

## Solution

Add `Promise.become(fiber)` which atomically links the promise to a fiber:

- **New `FiberLinked` state** in Promise's State ADT — a terminal state (like `Done`) that references a fiber
- **Waiter transfer**: Pre-existing waiters in the Pending state are directly transferred to the FiberRuntime's observer list (zero-copy for runtime fibers)
- **Delegation**: `await` on a linked promise delegates to `fiber.await`, `poll`/`isDone` delegate to the fiber
- **One-shot**: Like `complete`, `become` is one-shot — subsequent calls return `false`
- **Fallback**: For non-runtime (synthetic) fibers, falls back to completing waiters with `fiber.await`

## Files Changed

- `core/shared/src/main/scala/zio/Promise.scala` — Core implementation
- `core-tests/shared/src/test/scala/zio/PromiseSpec.scala` — 12 new tests

## Key Implementation Decisions

1. **FiberLinked as terminal state**: The promise never transitions from FiberLinked back to Pending/Done. This avoids complex state transitions and race conditions.

2. **Direct observer transfer for FiberRuntime**: Waiters are registered as observers on the FiberRuntime, using `Exit[E, A] => Unit` wrappers. Since `Exit[E, A] <: IO[E, A]`, no allocation is needed for the adaptation.

3. **Cleanup safety**: When a transferred waiter is cancelled (via asyncInterrupt), the cleanup is a no-op on the FiberLinked state. The fiber observer remains but calling `k(exit)` on a cancelled async is a no-op — no resource leak.

4. **`transferToRuntime` in `Promise.internal`**: The waiter iteration accesses `private` Link/Empty types, so the transfer logic lives inside the `internal` object where they're visible.

## Usage

```scala
for {
  fiber  <- effect.fork
  promise <- Promise.make[E, A]
  _      <- promise.become(fiber)  // Zero-copy link
  result <- promise.await          // Delegates to fiber.await
} yield result
```

## Test Plan

12 new tests covering:
- Succeeding/failing/dying fibers
- Already-completed fibers
- Already-completed promises (returns false)
- Double-become (second returns false)
- Pre-existing waiter transfer
- isDone before/after fiber completion
- Poll before/after fiber completion
- completeWith on linked promise (returns false)
- Waiter stack safety (10k waiters)