### PR TITLE
fix(stream): buffer(n) was buffering n+1 elements

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -390,24 +390,60 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
+    if (capacity <= 0) self
+    else if (capacity == 1) bufferOne
+    else {
+      val queue = self.toQueueOfElements(capacity - 1)
+      new ZStream(
+        ZChannel.unwrapScoped[R] {
+          queue.map { queue =>
+            lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+              ZChannel.fromZIO {
+                queue.take
+              }.flatMap { (exit: Exit[Option[E], A]) =>
+                exit.foldExit(
+                  Cause
+                    .flipCauseOption(_)
+                    .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+                  value => ZChannel.write(Chunk.single(value)) *> process
+                )
+              }
+
+            process
+          }
+        }
+      )
+    }
+
+  private def bufferOne(implicit trace: Trace): ZStream[R, E, A] = {
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
+        for {
+          handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+          _       <- {
+            lazy val producer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+              ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                in =>
+                  ZChannel.fromZIO(
+                    ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))
+                  ) *> producer,
+                err => ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+              )
+            (self.channel >>> producer).drain.runScoped.forkScoped
+          }
+        } yield {
+          lazy val consumer: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+            ZChannel.fromZIO(handoff.take).flatMap { (exit: Exit[Option[E], A]) =>
               exit.foldExit(
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.write(Chunk.single(value)) *> consumer
               )
             }
-
-          process
+          consumer
         }
       }
     )


### PR DESCRIPTION
## Summary

Fixes #9810

`ZStream.buffer(n)` was effectively buffering `n+1` elements due to one additional element always being in-flight between the upstream producer fiber and the internal queue.

## Root Cause

`buffer(n)` called `toQueueOfElements(n)` which created `Queue.bounded(n)`. The upstream producer runs in a forked fiber: it pulls an element, processes it (e.g., via `mapZIO`), then offers it to the queue. By the time the queue is full and the producer blocks, one additional element has already been pulled and is being processed — resulting in `n` items in queue + 1 in-flight = `n+1` total.

## Fix

- **`capacity > 1`**: Use `Queue.bounded(capacity - 1)` to account for the in-flight element, yielding exactly `capacity` total buffered elements.
- **`capacity == 1`**: Use `ZStream.Handoff` for synchronous 1-element exchange (rendezvous semantics), ensuring only 1 element is ever in transit.
- **`capacity <= 0`**: Identity (no buffering, same as before).

## Testing

All existing buffer tests pass (20 tests). The fix preserves backward compatibility for ordering and error propagation.

/claim #9810