### PR TITLE
fix(native): replace ConcurrentHashMap.newKeySet to fix NPE in WeakConcurrentBag

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
## Summary

Fixes #9681 — NPE in `WeakConcurrentBag.addToLongTermStorage` when forking 10K fibers on Scala Native.

### Root Cause

Scala Native's `ConcurrentHashMap.newKeySet()` returns a `KeySetView` that has a race condition in `treeifyBin()` under extreme concurrency. When thousands of fibers are forked simultaneously, concurrent inserts trigger the treeification path which NPEs due to Scala Native's incomplete implementation.

### Fix

Replace `ConcurrentHashMap.newKeySet[A]()` with `Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())` in the Scala Native `PlatformSpecific`. This wraps a regular `ConcurrentHashMap` as a `Set`, avoiding the buggy `KeySetView` code path entirely while maintaining identical concurrent set semantics.

### Files Changed

- `core/native/src/main/scala/zio/internal/PlatformSpecific.scala` — Both `newConcurrentSet` overloads

/claim #9681