### PR TITLE
fix(streams): uncap mapZIOPar parallelism from bufferSize

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -673,7 +673,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         val input       = SingleProducerAsyncInput.unsafe.make[InErr, InElem, InDone](fiberId)(Unsafe)
         val queueReader = ZChannel.fromInput(input)
         val n0          = n.toLong
-        val bufferSize0 = bufferSize
+        val bufferSize0 = math.max(bufferSize, n)
         val outgoing    = Queue.unsafe.bounded[Fiber[Either[Unit, OutDone], OutElem2]](bufferSize0, fiberId)(Unsafe)
         val errorSignal = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
         val permits     = Semaphore.unsafe.make(n0)(Unsafe)


### PR DESCRIPTION
## Summary

Fixes #9339 — Parallelism level in `ZStream#mapZIOPar` is no longer bounded by the `bufferSize` parameter.

### Root Cause

In `ZChannel.mapOutZIOPar`, the `outgoing` queue was created with `bufferSize` capacity. The producer loop offers fibers to this queue after they start (`latch.await *> outgoing.offer(fiber)`). When the queue is full, `offer` suspends, blocking the producer from pulling more elements and acquiring new permits. This effectively caps parallelism at `min(n, bufferSize)` — with the default `bufferSize = 16`, a `mapZIOPar(100, f)` would only ever run 16 concurrent tasks.

### Fix

Use `math.max(bufferSize, n)` as the actual queue capacity, ensuring the buffer never limits the configured parallelism. Explicit `bufferSize` values larger than `n` are preserved, while users relying on the default get a correctly sized buffer.

### Files Changed

- `streams/shared/src/main/scala/zio/stream/ZChannel.scala` — `mapOutZIOPar` method (1 line)

/claim #9339