### PR TITLE
Avoid retaining finalizers in long running flatMap streams

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1665,7 +1665,21 @@ object ZStreamSpec extends ZIOBaseSpec {
                           }
                         }
             } yield assert(result)(equalTo(List(1, 2)))
-          }
+          },
+          test("does not leak memory with long-running flatMap (#10742)") {
+            // Simulates a Kafka consumer pattern: a long stream of records, each flatMapped
+            // into a sub-stream. Without the fix, closeLastSubstream accumulates a chain of
+            // child executor close effects via `prevLastClose *> f`, retaining all child
+            // executors. Each child executor retains its `emitted` field (the last value
+            // the sub-stream produced). With 15k * 1MB this far exceeds a 1GB heap.
+            val n = 15000
+            ZStream
+              .repeatZIO(ZIO.succeed(new Array[Byte](1024 * 1024)))
+              .take(n.toLong)
+              .flatMap(data => ZStream.succeed(data))
+              .runDrain
+              .as(assertCompletes)
+          } @@ TestAspect.jvmOnly
         ),
         suite("flatMapPar")(
           test("guarantee ordering")(check(tinyListOf(Gen.int)) { (m: List[Int]) =>

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -212,13 +212,11 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
                 (f: URIO[Env, Any]) =>
                   if (isNullOrZIOUnit(f)) Exit.unit
                   else
-                    ZIO.succeed {
+                    ZIO.suspendSucceed {
                       val prevLastClose = closeLastSubstream
-                      if (prevLastClose eq null) {
-                        closeLastSubstream = f
-                      } else {
-                        closeLastSubstream = prevLastClose *> f
-                      }
+                      closeLastSubstream = f
+                      if (isNullOrZIOUnit(prevLastClose)) Exit.unit
+                      else prevLastClose
                     }
 
               val exec: ErasedExecutor[Env] = new ChannelExecutor(value, providedEnv, innerExecuteLastClose)
@@ -554,7 +552,7 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
         childExecutor.close
       )
 
-    def finishWithDoneValue(doneValue: Any): Unit = {
+    def finishWithDoneValue(doneValue: Any): ZIO[Env, Nothing, Unit] = {
       val modifiedParent =
         parentSubexecutor.copy(
           lastDone =
@@ -565,13 +563,12 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
 
       val thisClose = childExecutor.close(Exit.succeed(doneValue))
       val lastClose = closeLastSubstream
-      if (isNullOrZIOUnit(lastClose)) {
-        closeLastSubstream = thisClose
-      } else {
-        closeLastSubstream = lastClose *> thisClose
-      }
+      closeLastSubstream = thisClose
 
       replaceSubexecutor(modifiedParent)
+
+      if (isNullOrZIOUnit(lastClose)) null
+      else executeCloseLastSubstream(ZIO.uninterruptible(lastClose)).unit
     }
 
     ChannelState.Read(
@@ -587,7 +584,6 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
             handleSubexecFailure(cause).effectOrNullIgnored // NOTE: assuming finalizers cannot fail
           case Exit.Success(doneValue) =>
             finishWithDoneValue(doneValue)
-            null
         }
       }
     )

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -212,11 +212,13 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
                 (f: URIO[Env, Any]) =>
                   if (isNullOrZIOUnit(f)) Exit.unit
                   else
-                    ZIO.suspendSucceed {
+                    ZIO.succeed {
                       val prevLastClose = closeLastSubstream
-                      closeLastSubstream = f
-                      if (isNullOrZIOUnit(prevLastClose)) Exit.unit
-                      else prevLastClose
+                      if (prevLastClose eq null) {
+                        closeLastSubstream = f
+                      } else {
+                        closeLastSubstream = prevLastClose *> f
+                      }
                     }
 
               val exec: ErasedExecutor[Env] = new ChannelExecutor(value, providedEnv, innerExecuteLastClose)
@@ -498,11 +500,13 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
       self.upstreamExecutor,
       onEffect = (effect: ZIO[Env, Nothing, Unit]) => {
         val close = this.closeLastSubstream
+        this.closeLastSubstream = null
         if (isNullOrZIOUnit(close)) effect
         else executeCloseLastSubstream(ZIO.uninterruptible(close)) *> effect
       },
       onEmit = { (emitted: Any) =>
         val close = this.closeLastSubstream
+        this.closeLastSubstream = null
         if (!isNullOrZIOUnit(close)) {
           val closeLast = ZIO.uninterruptible(close)
 
@@ -552,7 +556,7 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
         childExecutor.close
       )
 
-    def finishWithDoneValue(doneValue: Any): ZIO[Env, Nothing, Unit] = {
+    def finishWithDoneValue(doneValue: Any): Unit = {
       val modifiedParent =
         parentSubexecutor.copy(
           lastDone =
@@ -563,12 +567,13 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
 
       val thisClose = childExecutor.close(Exit.succeed(doneValue))
       val lastClose = closeLastSubstream
-      closeLastSubstream = thisClose
+      if (isNullOrZIOUnit(lastClose)) {
+        closeLastSubstream = thisClose
+      } else {
+        closeLastSubstream = lastClose *> thisClose
+      }
 
       replaceSubexecutor(modifiedParent)
-
-      if (isNullOrZIOUnit(lastClose)) null
-      else executeCloseLastSubstream(ZIO.uninterruptible(lastClose)).unit
     }
 
     ChannelState.Read(
@@ -584,6 +589,7 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
             handleSubexecFailure(cause).effectOrNullIgnored // NOTE: assuming finalizers cannot fail
           case Exit.Success(doneValue) =>
             finishWithDoneValue(doneValue)
+            null
         }
       }
     )

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -500,15 +500,22 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
       self.upstreamExecutor,
       onEffect = (effect: ZIO[Env, Nothing, Unit]) => {
         val close = this.closeLastSubstream
-        this.closeLastSubstream = null
         if (isNullOrZIOUnit(close)) effect
-        else executeCloseLastSubstream(ZIO.uninterruptible(close)) *> effect
+        else {
+          val closeLast = ZIO.uninterruptible {
+            this.closeLastSubstream = null
+            close
+          }
+          executeCloseLastSubstream(closeLast) *> effect
+        }
       },
       onEmit = { (emitted: Any) =>
         val close = this.closeLastSubstream
-        this.closeLastSubstream = null
         if (!isNullOrZIOUnit(close)) {
-          val closeLast = ZIO.uninterruptible(close)
+          val closeLast = ZIO.uninterruptible {
+            this.closeLastSubstream = null
+            close
+          }
 
           executeCloseLastSubstream(closeLast).flatMap { _ =>
             val childExecutor: ErasedExecutor[Env] =


### PR DESCRIPTION
Fixes #10742.

closeLastSubstream accumulated an unbounded chain of child executor close effects via prevLastClose *> f, retaining all previous child executors and their captured data for the lifetime of the stream.

Two sites built this chain:

1. innerExecuteLastClose (ConcatAll): appended new close effects onto the chain. Now stores only the latest and returns the previous for immediate execution.

2. finishWithDoneValue (pullFromChild): chained via *>. Now stores only the latest and returns the previous through executeCloseLastSubstream.

