### PR TITLE
fix(test): introduce dual generators to fix deterministic/nondeterministic composition

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -776,6 +776,101 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
-    }
+    },
+    suite("determinism")(
+      test("fromIterable and then nondeterministic") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 3)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(3)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(3)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(3))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 3))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("nondeterministic and then fromIterable") {
+        val gen = for {
+          id <- Gen.uuid
+          i  <- Gen.fromIterable(1 to 3)
+        } yield (i, id)
+
+        val deterministic1    = gen.samples(None).map(_.value._1).runCollect
+        val deterministic2    = gen.samples(None).map(_.value._2).runCollect
+        val nondeterministic1 = gen.samples(Some(3)).map(_.value._1).runCollect
+        val nondeterministic2 = gen.samples(Some(3)).map(_.value._2).runCollect
+
+        assertZIO(deterministic1)(equalTo(Chunk(1, 2, 3))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(1))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 3))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("concat and then nondeterministic") {
+        val gen = for {
+          i  <- Gen.fromIterable(1 to 3) ++ Gen.const(4)
+          id <- Gen.uuid
+        } yield (i, id)
+
+        val deterministic1    = gen.map(_._1).runCollect
+        val deterministic2    = gen.map(_._2).runCollect
+        val nondeterministic1 = gen.map(_._1).runCollectN(4)
+        val nondeterministic2 = gen.map(_._2).runCollectN(4)
+
+        assertZIO(deterministic1)(equalTo(List(1, 2, 3, 4))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(4))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 4))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(4)))
+      },
+      test("nondeterministic and then concat") {
+        val gen = for {
+          id <- Gen.uuid
+          i  <- Gen.fromIterable(1 to 3) ++ Gen.const(4)
+        } yield (i, id)
+
+        val deterministic1    = gen.map(_._1).runCollect
+        val deterministic2    = gen.map(_._2).runCollect
+        val nondeterministic1 = gen.map(_._1).runCollectN(4)
+        val nondeterministic2 = gen.map(_._2).runCollectN(4)
+
+        assertZIO(deterministic1)(equalTo(List(1, 2, 3, 4))) &&
+        assertZIO(deterministic2.map(_.toSet))(hasSize(equalTo(1))) &&
+        assertZIO(nondeterministic1)(forall(isOneOf(1 to 4))) &&
+        assertZIO(nondeterministic2.map(_.toSet))(hasSize(equalTo(4)))
+      },
+      test("const is deterministic") {
+        val gen = for {
+          id <- Gen.const("id")
+          i  <- Gen.fromIterable(1 to 3)
+        } yield (i, id)
+        assertZIO(gen.runCollect)(equalTo(List(1 -> "id", 2 -> "id", 3 -> "id")))
+      },
+      test("boolean can be deterministic") {
+        assertZIO(Gen.boolean.runCollect)(equalTo(List(false, true)))
+      },
+      test("boolean can be nondeterministic") {
+        val gen = Gen.uuid.flatMap(id => Gen.boolean.map(_ => id))
+        assertZIO(gen.runCollectN(3).map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("option can be deterministic") {
+        assertZIO(Gen.option(Gen.boolean).runCollect)(equalTo(List(None, Some(false), Some(true))))
+      },
+      test("option can be nondeterministic") {
+        val gen = Gen.option(Gen.uuid).filter(_.isDefined)
+        assertZIO(gen.runCollectN(3).map(_.toSet))(hasSize(equalTo(3)))
+      },
+      test("gen filter doesn't backtrack") {
+        val filteredGen = for {
+          first  <- Gen.int(1, 10).filter(_ == 10)
+          second <- Gen.int(1, 10).filter(_ == 1)
+          third  <- Gen.int(1, 10).filter(_ == 5)
+        } yield s"$first.$second.$third"
+        assertZIO(filteredGen.runHead)(isSome(equalTo("10.1.5")))
+      } @@ TestAspect.repeats(10)
+    )
   )
 }

--- a/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenUtils.scala
@@ -81,10 +81,10 @@ object GenUtils {
   val smallInt: Gen[Any, Int] = Gen.int(-10, 10)
 
   def sample[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).runCollect.map(_.toList)
+    gen.runCollect
 
   def sample100[R, A](gen: Gen[R, A]): ZIO[R, Nothing, List[A]] =
-    gen.sample.map(_.value).forever.take(size.toLong).runCollect.map(_.toList)
+    gen.runCollectN(size)
 
   def sampleEffect[E, A](
     gen: Gen[Any, ZIO[Any, E, A]],
@@ -93,13 +93,13 @@ object GenUtils {
     provideSize(sample100(gen).flatMap(effects => ZIO.foreach(effects)(_.exit)))(size)
 
   def shrink[R, A](gen: Gen[R, A]): URIO[R, A] =
-    gen.sample.take(1).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
+    gen.samples(Some(1)).flatMap(_.shrinkSearch(_ => true)).take(size * 10L).runLast.map(_.get)
 
   val shrinkable: Gen[Any, Int] =
     Gen.fromRandomSample(_.nextIntBounded(90).map(_ + 10).map(Sample.shrinkIntegral(0)))
 
   def shrinkWith[R, A](gen: Gen[R, A])(f: A => Boolean): ZIO[R, Nothing, List[A]] =
-    gen.sample.take(1).flatMap(_.shrinkSearch(!f(_))).take(size * 10L).filter(!f(_)).runCollect.map(_.toList)
+    gen.samples(Some(1)).flatMap(_.shrinkSearch(!f(_))).take(size * 10L).filter(!f(_)).runCollect.map(_.toList)
 
   val three: Gen[Any, Int] = Gen(ZStream(Sample.unfold[Any, Int, Int](3) { n =>
     if (n == 0) (n, ZStream.empty)

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -19,7 +19,7 @@ package zio.test
 import zio.Random._
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{Chunk, NonEmptyChunk, Random, Trace, UIO, URIO, ZIO, Zippable}
+import zio._
 
 import java.nio.charset.StandardCharsets
 import java.util.UUID
@@ -32,6 +32,9 @@ import scala.math.Numeric.DoubleIsFractional
  * environment `R`. Generators may be random or deterministic.
  */
 final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =>
+  private[test] def samples(n: Option[Int])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
+    ZStream.scoped[R](Gen.deterministic.locallyScoped(n.isEmpty)) *>
+      n.fold(sample)(sample.forever.take(_))
 
   /**
    * A symbolic alias for `concat`.
@@ -48,21 +51,25 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
     self.zip(that)
 
   /**
-   * Concatenates the specified deterministic generator with this determinstic
-   * generator, resulting in a deterministic generator that generates the values
-   * from this generator and then the values from the specified generator.
+   * A dual generator that concatenates this generator with the provided one:
+   *   - In deterministic mode, combines this deterministic generator with the
+   *     provided one to return a new deterministic generator that generates the
+   *     values from this generator and then the values from the other one.
+   *   - In nondeterministic mode, equivalent to [[Gen.oneOf]].
    */
-  def concat[R1 <: R, A1 >: A](that: Gen[R1, A1])(implicit trace: Trace): Gen[R1, A1] =
-    Gen(self.sample ++ that.sample)
+  def concat[R1 <: R, A1 >: A](that: Gen[R1, A1])(implicit trace: Trace): Gen[R1, A1] = Gen.dual(
+    Gen(self.sample ++ that.sample),
+    Gen.oneOf(self, that)
+  )
 
   /**
    * Maps the values produced by this generator with the specified partial
    * function, discarding any values the partial function is not defined at.
    */
-  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): Gen[R, B] =
-    self.flatMap { a =>
-      pf.andThen(Gen.const(_)).applyOrElse[A, Gen[Any, B]](a, _ => Gen.empty)
-    }
+  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): Gen[R, B] = Gen.dual(
+    Gen(sample.flatMap(_.collect(pf))),
+    Gen(sample.map(_.value).forever.collect(pf).take(1).map(Sample.noShrink))
+  )
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -76,7 +83,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * }}}
    */
   def filter(f: A => Boolean)(implicit trace: Trace): Gen[R, A] =
-    self.flatMap(a => if (f(a)) Gen.const(a) else Gen.empty)
+    filterZIO(a => Exit.succeed(f(a)))
 
   /**
    * Filters the values produced by this generator, discarding any values that
@@ -89,26 +96,26 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * val evens: Gen[Any, Int] = Gen.int.map(_ * 2)
    * }}}
    */
-  def filterZIO[R1 <: R](f: A => ZIO[R1, Nothing, Boolean])(implicit trace: Trace): Gen[R1, A] =
-    self.flatMap(a => Gen.fromZIO(f(a)).flatMap(p => if (p) Gen.const(a) else Gen.empty))
+  def filterZIO[R1 <: R](f: A => ZIO[R1, Nothing, Boolean])(implicit trace: Trace): Gen[R1, A] = Gen.dual(
+    Gen(sample.flatMap(_.filterZIO(f))),
+    Gen(sample.map(_.value).forever.filterZIO(f).take(1).map(Sample.noShrink))
+  )
 
   /**
    * Filters the values produced by this generator, discarding any values that
    * meet the specified predicate.
    */
   def filterNot(f: A => Boolean)(implicit trace: Trace): Gen[R, A] =
-    filter(a => !f(a))
+    filter(!f(_))
 
   def withFilter(f: A => Boolean)(implicit trace: Trace): Gen[R, A] = filter(f)
 
   def flatMap[R1 <: R, B](f: A => Gen[R1, B])(implicit trace: Trace): Gen[R1, B] =
-    Gen {
-      self.sample.flatMap { sample =>
-        val values  = f(sample.value).sample
-        val shrinks = Gen(sample.shrink).flatMap(f).sample
-        values.map(_.flatMap(Sample(_, shrinks)))
-      }
-    }
+    Gen(self.sample.flatMap { sample =>
+      val values  = f(sample.value).sample
+      val shrinks = Gen(sample.shrink).flatMap(f).sample
+      values.map(_.flatMap(Sample(_, shrinks)))
+    })
 
   def flatten[R1 <: R, B](implicit ev: A <:< Gen[R1, B], trace: Trace): Gen[R1, B] =
     flatMap(ev)
@@ -147,20 +154,20 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * Runs the generator and collects all of its values in a list.
    */
   def runCollect(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).runCollect.map(_.toList)
+    samples(None).map(_.value).runCollect.map(_.toList)
 
   /**
    * Repeatedly runs the generator and collects the specified number of values
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    samples(Some(n)).map(_.value).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.
    */
   def runHead(implicit trace: Trace): ZIO[R, Nothing, Option[A]] =
-    sample.map(_.value).runHead
+    samples(Some(1)).map(_.value).runHead
 
   /**
    * Composes this generator with the specified generator to create a cartesian
@@ -180,6 +187,18 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 }
 
 object Gen extends GenZIO with FunctionVariants with TimeVariants {
+  private val deterministic: FiberRef[Boolean] = FiberRef.unsafe.make(true)(Unsafe.unsafe)
+
+  /**
+   * Constructs a new dual generator that can be composed correctly with both
+   * deterministic and with nondeterministic generators.
+   */
+  def dual[R, A](
+    deterministic: => Gen[R, A],
+    nondeterministic: => Gen[R, A]
+  )(implicit trace: Trace): Gen[R, A] = Gen(ZStream.unwrap {
+    Gen.deterministic.get.map(if (_) deterministic.sample else nondeterministic.sample)
+  })
 
   /**
    * A generator of alpha characters.
@@ -286,7 +305,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of booleans. Shrinks toward 'false'.
    */
   def boolean(implicit trace: Trace): Gen[Any, Boolean] =
-    elements(false, true)
+    fromIterable(Chunk(false, true))
 
   /**
    * A generator whose size falls within the specified bounds.
@@ -376,12 +395,16 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     }
 
   /**
-   * Combines the specified deterministic generators to return a new
-   * deterministic generator that generates all of the values generated by the
-   * specified generators.
+   * A dual generator that concatenates all provided generators:
+   *   - In deterministic mode, combines the specified deterministic generators
+   *     to return a new deterministic generator that generates all the values
+   *     generated by the specified generators.
+   *   - In nondeterministic mode, equivalent to [[Gen.oneOf]].
    */
-  def concatAll[R, A](gens: => Iterable[Gen[R, A]])(implicit trace: Trace): Gen[R, A] =
-    Gen.suspend(gens.foldLeft[Gen[R, A]](Gen.empty)(_ ++ _))
+  def concatAll[R, A](gens: => Iterable[Gen[R, A]])(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(gens).flatMap(_.sample)),
+    Gen.oneOf(Chunk.fromIterable(gens): _*)
+  )
 
   /**
    * A constant generator of the specified value.
@@ -426,7 +449,11 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     oneOf(left.map(Left(_)), right.map(Right(_)))
 
   def elements[A](as: A*)(implicit trace: Trace): Gen[Any, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).map(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).map(chunk)
+    }
 
   def empty(implicit trace: Trace): Gen[Any, Nothing] =
     emptyGen
@@ -439,14 +466,17 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
     uniform.map(n => -math.log(1 - n))
 
   /**
-   * Constructs a deterministic generator that only generates the specified
-   * fixed values.
+   * A dual generator from the specified list of fixed values:
+   *   - In deterministic mode, generates only the specified values.
+   *   - In nondeterministic mode, equivalent to [[Gen.elements]].
    */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
-  )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+  )(implicit trace: Trace): Gen[R, A] = Gen.dual(
+    Gen(ZStream.fromIterable(as).map(Sample.unfold(_)(a => (a, shrinker(a))))),
+    Gen.elements(Chunk.fromIterable(as): _*)
+  )
 
   /**
    * Constructs a generator from a function that uses randomness. The returned
@@ -670,10 +700,14 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * A generator of optional values. Shrinks toward `None`.
    */
   def option[R, A](gen: Gen[R, A])(implicit trace: Trace): Gen[R, Option[A]] =
-    oneOf(none, gen.map(Some(_)))
+    none.concat(gen.map(Some.apply))
 
   def oneOf[R, A](as: Gen[R, A]*)(implicit trace: Trace): Gen[R, A] =
-    if (as.isEmpty) empty else int(0, as.length - 1).flatMap(as)
+    if (as.isEmpty) empty
+    else {
+      val chunk = Chunk.fromIterable(as)
+      int(0, chunk.length - 1).flatMap(chunk)
+    }
 
   /**
    * Constructs a generator of partial functions from `A` to `B` given a
@@ -821,7 +855,7 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
    * when creating generators that refer to themselves.
    */
   def suspend[R, A](gen: => Gen[R, A])(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.suspend(gen.sample))
+    Gen.unit.flatMap(_ => gen)
 
   /**
    * A generator of throwables.

--- a/test/shared/src/main/scala/zio/test/Sample.scala
+++ b/test/shared/src/main/scala/zio/test/Sample.scala
@@ -18,7 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZStream
-import zio.{ZIO, Zippable, Trace}
+import zio._
 
 /**
  * A sample is a single observation from a random variable, together with a tree
@@ -39,8 +39,25 @@ final case class Sample[-R, +A](value: A, shrink: ZStream[R, Nothing, Sample[R, 
    * not meet the specified predicate and recursively filtering the shrink tree.
    */
   def filter(f: A => Boolean)(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
-    if (f(value)) ZStream(Sample(value, shrink.flatMap(_.filter(f))))
-    else shrink.flatMap(_.filter(f))
+    filterZIO(a => Exit.succeed(f(a)))
+
+  /**
+   * Filters this sample by replacing it with its shrink tree if the value does
+   * not meet the specified effectful predicate and recursively filtering the
+   * shrink tree.
+   */
+  def filterZIO[R1 <: R](
+    f: A => ZIO[R1, Nothing, Boolean]
+  )(implicit trace: Trace): ZStream[R1, Nothing, Sample[R1, A]] =
+    ZStream.fromZIO(f(value)).flatMap { keep =>
+      val shrink = this.shrink.flatMap(_.filterZIO(f))
+      if (keep) ZStream(Sample(value, shrink)) else shrink
+    }
+
+  def collect[B](pf: PartialFunction[A, B])(implicit trace: Trace): ZStream[R, Nothing, Sample[R, B]] = {
+    val shrink = this.shrink.flatMap(_.collect(pf))
+    pf.andThen(b => ZStream(Sample(b, shrink))).applyOrElse(value, (_: A) => shrink)
+  }
 
   def flatMap[R1 <: R, B](f: A => Sample[R1, B])(implicit trace: Trace): Sample[R1, B] = {
     val sample = f(value)

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -524,7 +524,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStream(rv.sample)(a => checkConstructor(test(a)))
+    checkStream(rv.samples(None))(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAll` that accepts two random variables.
@@ -652,7 +652,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    checkStreamPar(rv.sample, parallelism)(a => checkConstructor(test(a)))
+    checkStreamPar(rv.samples(None), parallelism)(a => checkConstructor(test(a)))
 
   /**
    * A version of `checkAllPar` that accepts two random variables.
@@ -800,7 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(rv.samples(Some(n)), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.samples(Some(n)))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Summary

Fixes #9101, #5616, #9146

`Gen.fromIterable` and other deterministic generators now compose correctly with nondeterministic generators (like `Gen.uuid`) regardless of ordering in for-comprehensions.

### Attribution

**This PR implements the same approach designed by @joroKr21 in #9378** (FiberRef-based dual generators). Full credit for the conceptual solution goes to them. I'm submitting this as an alternative implementation with a slightly smaller diff and a few minor differences (listed below). If maintainers prefer to merge #9378 instead, that's perfectly fine — the goal is to get this fix landed.

### The problem

```scala
// Both should produce diverse UUIDs, but the second one repeats the same UUID:
for { i <- Gen.fromIterable(1 to 3); id <- Gen.uuid } yield id  // ✓ 3 different UUIDs
for { id <- Gen.uuid; _ <- Gen.fromIterable(1 to 3) } yield id  // ✗ same UUID 3 times
```

The root cause is that `Gen.flatMap` uses `ZStream.flatMap` internally. When an effect-based generator (`Gen.uuid` → `ZStream.fromZIO`) emits a single element, the flatMap closure captures that one value and pairs it with every element from the inner deterministic generator.

### The fix

Introduces a `FiberRef`-based mode tracking and a `Gen.dual` constructor that switches generator behavior depending on whether it is used in:
- **Deterministic mode** (`checkAll` / `runCollect`): exhaustive enumeration, cartesian product semantics — unchanged from current behavior
- **Nondeterministic mode** (`check` / `runCollectN`): each generator produces one random sample per pass, so `.forever.take(n)` yields `n` independent samples

Key changes:
- **`fromIterable`**: enumerates all values in deterministic mode, picks one randomly (via `elements`) in nondeterministic mode
- **`concat` / `concatAll`**: sequential concatenation in deterministic mode, `oneOf` in nondeterministic mode
- **`filter` / `filterZIO` / `collect`**: use `Sample`-level filtering with shrink tree preservation in deterministic mode, streaming retry in nondeterministic mode
- **`boolean`**: now `fromIterable(Chunk(false, true))` — exhaustive in `checkAll`
- **`option`**: now `none.concat(gen.map(Some(_)))` — generates `None` in `checkAll` (#5616)
- **`Sample`**: added `filterZIO` and `collect` methods
- **`suspend`**: now `Gen.unit.flatMap(_ => gen)` to propagate dual-mode correctly

### Differences from #9378

- Smaller diff — no changes to `flatMap` itself
- Shrink test utilities (`GenUtils`) use `samples()` to preserve shrink trees
- `suspend` propagates dual-mode correctly via `Gen.unit.flatMap` instead of `ZStream.suspend`

### Tradeoffs

- Infinite iterables (e.g. `LazyList.iterate(0)(_ + 1)`) work only in deterministic mode. In nondeterministic mode, `fromIterable` must materialize the collection for random access.
- Binary compatibility is preserved — only new methods are added, no existing signatures are changed.

## Test plan

- [x] All 189 existing `GenSpec` tests pass
- [x] 10 new regression tests in `determinism` suite covering:
  - `fromIterable` + nondeterministic in both orderings
  - `concat` + nondeterministic in both orderings
  - `const` preserves deterministic behavior
  - `boolean` exhaustive in `checkAll`
  - `boolean` nondeterministic in `check`
  - `option` exhaustive in `checkAll`
  - `option` nondeterministic in `check`
  - `filter` doesn't backtrack in nondeterministic mode

/claim #9101