### PR TITLE
fix: Gen.fromIterable produces same value when flatMapped (fixes #9101)

### DIFF
--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -800,7 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Changes

Fixes #9101

### Problem

When `Gen.fromIterable` is used with an infinite lazy iterable (e.g. `LazyList.iterate(0)(_ + 1)`) and combined with other generators via flatMap, the resulting Gen always produces the same value.

```scala
// Different UUIDs each time ✓
for {
  i <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
  id <- Gen.uuid
} yield id

// Same UUID every time ✗ (BUG)
for {
  id <- Gen.uuid
  _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
} yield id
```

### Root Cause

`check()` used `rv.sample.forever.take(n)` to get n samples from a pre-computed ZStream. When the sample stream is infinite (which happens when `fromIterable` with an infinite iterable is flatMapped with a single-value generator), `take(n)` takes the first n elements — all having the same value because the outer generator's value was captured once by flatMap.

### Fix

Changed `check()`, `checkPar()`, and `CheckN.apply()` to re-evaluate the Gen for each sample using:

```scala
ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n)
```

Instead of:

```scala
rv.sample.forever.take(n)
```

This ensures each sample gets independent values from the generator, matching the expected property-based testing behavior where each sample should be independently generated.

### Files Changed

- `test/shared/src/main/scala/zio/test/package.scala` — 3 lines changed in `check()`, `checkPar()`, and `CheckN.apply()`

Closes #9101