### PR TITLE
fix: prioritize Die over Fail in Cause#failureOrCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -246,6 +246,44 @@ object CauseSpec extends ZIOBaseSpec {
         }
       }
     ),
+    // Regression tests for https://github.com/zio/zio/issues/9874
+    suite("failureOrCause")(
+      test("returns Left for a pure Fail") {
+        assert(Cause.fail("e").failureOrCause)(isLeft(equalTo("e")))
+      },
+      test("returns Right for a pure Die") {
+        val t = new RuntimeException("boom")
+        assert(Cause.die(t).failureOrCause)(isRight(equalTo(Cause.die(t))))
+      },
+      test("returns Right when Both(Die, Fail) — defect takes priority") {
+        val t    = new RuntimeException("boom")
+        val both = Cause.die(t) && Cause.fail("typed")
+        both.failureOrCause match {
+          case Right(c) => assert(c.isDie)(isTrue)
+          case Left(_)  => assert(false)(isTrue ?? "expected Right but got Left")
+        }
+      },
+      test("returns Right when Then(Die, Fail) — defect takes priority") {
+        val t     = new RuntimeException("boom")
+        val then_ = Cause.die(t) ++ Cause.fail("typed")
+        then_.failureOrCause match {
+          case Right(c) => assert(c.isDie)(isTrue)
+          case Left(_)  => assert(false)(isTrue ?? "expected Right but got Left")
+        }
+      },
+      test("Right result from Both(Die, Fail) contains no typed failures") {
+        val t    = new RuntimeException("boom")
+        val both = Cause.die(t) && Cause.fail("typed")
+        both.failureOrCause match {
+          case Right(c) => assert(c.isFailure)(isFalse)
+          case Left(_)  => assert(false)(isTrue ?? "expected Right but got Left")
+        }
+      },
+      test("returns Right for a pure Interrupt — unchanged behaviour") {
+        val interrupt = Cause.interrupt(FiberId.None)
+        assert(interrupt.failureOrCause)(isRight(equalTo(interrupt)))
+      }
+    ),
     suite("filter")(
       test("fail.filter(false)") {
         val f1 = Cause.fail(())

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -4923,6 +4923,56 @@ object ZIOSpec extends ZIOBaseSpec {
         val exit = Exit.succeed(1).unit
         assertTrue(exit == Exit.unit)
       }
+    ),
+    // Regression tests for https://github.com/zio/zio/issues/9874
+    // Defects (Die) must never be silently dropped by typed error recovery combinators.
+    suite("issue-9874: Die is not swallowed by typed error recovery")(
+      test("catchAll does not swallow a defect when Cause contains Both(Die, Fail)") {
+        val t     = new RuntimeException("defect")
+        val cause = Cause.die(t) && Cause.fail("typed")
+        for {
+          exit <- ZIO.failCause(cause).catchAll(_ => ZIO.succeed("handled")).exit
+        } yield assert(exit)(dies(equalTo(t)))
+      } @@ zioTag(errors),
+      test("catchAll does not swallow a defect when Cause contains Then(Die, Fail)") {
+        val t     = new RuntimeException("defect")
+        val cause = Cause.die(t) ++ Cause.fail("typed")
+        for {
+          exit <- ZIO.failCause(cause).catchAll(_ => ZIO.succeed("handled")).exit
+        } yield assert(exit)(dies(equalTo(t)))
+      } @@ zioTag(errors),
+      test("foldZIO does not swallow a defect when Cause contains Both(Die, Fail)") {
+        val t     = new RuntimeException("defect")
+        val cause = Cause.die(t) && Cause.fail("typed")
+        for {
+          exit <- ZIO
+                    .failCause(cause)
+                    .foldZIO(_ => ZIO.succeed("failure-handled"), _ => ZIO.succeed("success"))
+                    .exit
+        } yield assert(exit)(dies(equalTo(t)))
+      } @@ zioTag(errors),
+      test("retry does not retry when Cause contains Both(Die, Fail)") {
+        val t     = new RuntimeException("defect")
+        val cause = Cause.die(t) && Cause.fail("typed")
+        for {
+          count <- Ref.make(0)
+          exit  <- (count.update(_ + 1) *> ZIO.failCause(cause)).retry(Schedule.recurs(3)).exit
+          n     <- count.get
+        } yield assert(exit)(dies(equalTo(t))) && assert(n)(equalTo(1))
+      } @@ zioTag(errors),
+      test("catchAll on pure Fail still recovers (sanity check)") {
+        for {
+          result <- ZIO.fail("typed").catchAll(_ => ZIO.succeed("handled")).exit
+        } yield assert(result)(succeeds(equalTo("handled")))
+      } @@ zioTag(errors),
+      test("foreachPar typed error recovery is unaffected (regression guard)") {
+        for {
+          result <- ZIO
+                      .foreachPar(List(1, 2, 3))(i => if (i == 2) ZIO.fail(s"err-$i") else ZIO.succeed(i))
+                      .catchAll(e => ZIO.succeed(s"recovered: $e"))
+                      .exit
+        } yield assert(result)(succeeds(anything))
+      }
     )
   )
 

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -128,21 +128,37 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * Retrieve the first checked error on the `Left` if available, if there are
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
+   *
+   * If the `Cause` contains both a defect (`Die`) and a typed failure (`Fail`),
+   * the defect takes priority and this method returns `Right` with the defects
+   * and interruptions stripped of any typed failures. Defects are
+   * non-recoverable and must not be silently dropped by typed error recovery
+   * combinators.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureOrCause: Either[E, Cause[Nothing]] =
+    if (isDie) Right(stripFailures)
+    else
+      failureOption match {
+        case Some(error) => Left(error)
+        case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
 
   /**
    * Retrieve the first checked error and its trace on the `Left` if available,
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
+   *
+   * If the `Cause` contains both a defect (`Die`) and a typed failure (`Fail`),
+   * the defect takes priority and this method returns `Right` with the defects
+   * and interruptions stripped of any typed failures.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
-  }
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] =
+    if (isDie) Right(stripFailures)
+    else
+      failureTraceOption match {
+        case Some(errorAndTrace) => Left(errorAndTrace)
+        case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
 
   /**
    * Produces a list of all recoverable errors `E` in the `Cause`.


### PR DESCRIPTION
/claim #9874

## Problem

When a `Cause` contains both a defect (`Die`) and a typed failure (`Fail`), typed error recovery combinators — `catchAll`, `foldZIO`, `retry`, `.either` — silently swallow the defect.

```scala
val cause = Cause.die(new RuntimeException("defect")) && Cause.fail("typed")
ZIO.failCause(cause).catchAll(_ => ZIO.succeed("handled"))  // BUG: returns "handled"
ZIO.failCause(cause).retry(Schedule.recurs(3))              // BUG: retries 3 times

// Real-world scenario:
ZIO.fail("error")
  .ensuring(ZIO.die(new RuntimeException("defect")))
  .catchAll(_ => ZIO.succeed("recovered"))                  // BUG: Die swallowed


Root Cause
Cause#failureOrCause returned Left(error) even when a Die node coexisted in the same Cause tree. The existing docstring already stated the correct contract — the Right case should be a Cause "known to contain only Die or Interrupt causes" — the implementation simply did not honour it.

Fix
final def failureOrCause: Either[E, Cause[Nothing]] =
  if (isDie) Right(stripFailures)
  else
    failureOption match {
      case Some(error) => Left(error)
      case None        => Right(self.asInstanceOf[Cause[Nothing]])
    }
Same change applied to failureTraceOrCause.

Design decisions
Why isDie only — not isInterrupted: The FiberRuntime already guards against interruption at the FoldZIO level via shouldInterrupt(), before failureK is ever called. Adding isInterrupted here conflicts with the runtime's own interrupt guard and was correctly rejected in PR #10438.

Why stripFailures — not keepDefects: keepDefects strips both Fail and Interrupt nodes. The docstring says the Right case contains "Die or Interrupt causes" — we must preserve both. stripFailures maps Fail → Empty, keeps Die and Interrupt intact.

Not affected
orElse — already used keepDefects (correct before this fix)
foreachPar + catchAll — foreachPar calls cause.stripFailures internally before the outer catchAll sees it
ZChannel parallel internals — Right(cause) branch already routes Die to failureRef correctly
Pure Fail — isDie = false, behaviour unchanged
Pure Die — already returned Right; behaviour unchanged
Tests added
CauseSpec: unit tests on failureOrCause for all Cause shapes (pure Fail, pure Die, Both(Die,Fail), Then(Die,Fail), pure Interrupt)
ZIOSpec: end-to-end regression tests for catchAll, foldZIO, retry, foreachPar regression guard
coreTestsJVM: 2878 passed, 0 failed. streamsTestsJVM: 1137 passed, 0 failed.