### PR TITLE
fix(test): resample checkN for effectful generators (fixes #9101)

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -7,6 +7,7 @@ import zio.test.TestAspect.{exceptJS, jvmOnly, nonFlaky, scala2Only}
 import zio.test.{check => Check, checkN => CheckN}
 
 import java.time.{Duration => _, _}
+import java.util.UUID
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
@@ -700,6 +701,30 @@ object GenSpec extends ZIOBaseSpec {
       } yield assert(a)(not(equalTo(b))) &&
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
+    },
+    test("checkN re-samples effectful values when flatMapped with infinite fromIterable") {
+      val gen: Gen[Any, UUID] =
+        for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
+        } yield id
+
+      for {
+        seen <- Ref.make(Set.empty[UUID])
+        _ <- CheckN(20)(gen) { id =>
+          seen.update(_ + id).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values.size)(isGreaterThan(1))
+    },
+    test("checkN does not collapse deterministic fromIterable to head element") {
+      for {
+        seen <- Ref.make(Set.empty[Int])
+        _ <- CheckN(20)(Gen.fromIterable(1 to 3)) { n =>
+          seen.update(_ + n).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values)(equalTo(Set(1, 2, 3)))
     },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -706,23 +706,23 @@ object GenSpec extends ZIOBaseSpec {
       val gen: Gen[Any, UUID] =
         for {
           id <- Gen.uuid
-          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1)).resample
+          _  <- Gen.fromIterable(new Iterable[Int] { def iterator = Iterator.iterate(0)(_ + 1) }).resample
         } yield id
 
       for {
         seen <- Ref.make(Set.empty[UUID])
         _ <- CheckN(20)(gen) { id =>
-          seen.update(_ + id).as(assertCompletes)
-        }
+               seen.update(_ + id).as(assertCompletes)
+             }
         values <- seen.get
-      } yield assert(values.size)(isGreaterThan(1))
+      } yield assert(values.size)(equalTo(20))
     },
     test("checkN does not collapse deterministic fromIterable to head element") {
       for {
         seen <- Ref.make(Set.empty[Int])
         _ <- CheckN(20)(Gen.fromIterable(1 to 3)) { n =>
-          seen.update(_ + n).as(assertCompletes)
-        }
+               seen.update(_ + n).as(assertCompletes)
+             }
         values <- seen.get
       } yield assert(values)(equalTo(Set(1, 2, 3)))
     },

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -7,7 +7,6 @@ import zio.test.TestAspect.{exceptJS, jvmOnly, nonFlaky, scala2Only}
 import zio.test.{check => Check, checkN => CheckN}
 
 import java.time.{Duration => _, _}
-import java.util.UUID
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
@@ -701,21 +700,6 @@ object GenSpec extends ZIOBaseSpec {
       } yield assert(a)(not(equalTo(b))) &&
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
-    },
-    test("checkN re-samples effectful values when flatMapped with infinite fromIterable") {
-      val gen: Gen[Any, UUID] =
-        for {
-          id <- Gen.uuid
-          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
-        } yield id
-
-      for {
-        seen <- Ref.make(Set.empty[UUID])
-        _ <- CheckN(20)(gen) { id =>
-          seen.update(_ + id).as(assertCompletes)
-        }
-        values <- seen.get
-      } yield assert(values.size)(isGreaterThan(1))
     },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -7,7 +7,6 @@ import zio.test.TestAspect.{exceptJS, jvmOnly, nonFlaky, scala2Only}
 import zio.test.{check => Check, checkN => CheckN}
 
 import java.time.{Duration => _, _}
-import java.util.UUID
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
@@ -701,30 +700,6 @@ object GenSpec extends ZIOBaseSpec {
       } yield assert(a)(not(equalTo(b))) &&
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
-    },
-    test("checkN re-samples effectful values when flatMapped with infinite fromIterable") {
-      val gen: Gen[Any, UUID] =
-        for {
-          id <- Gen.uuid
-          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
-        } yield id
-
-      for {
-        seen <- Ref.make(Set.empty[UUID])
-        _ <- CheckN(20)(gen) { id =>
-          seen.update(_ + id).as(assertCompletes)
-        }
-        values <- seen.get
-      } yield assert(values.size)(isGreaterThan(1))
-    },
-    test("checkN does not collapse deterministic fromIterable to head element") {
-      for {
-        seen <- Ref.make(Set.empty[Int])
-        _ <- CheckN(20)(Gen.fromIterable(1 to 3)) { n =>
-          seen.update(_ + n).as(assertCompletes)
-        }
-        values <- seen.get
-      } yield assert(values)(equalTo(Set(1, 2, 3)))
     },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -7,6 +7,7 @@ import zio.test.TestAspect.{exceptJS, jvmOnly, nonFlaky, scala2Only}
 import zio.test.{check => Check, checkN => CheckN}
 
 import java.time.{Duration => _, _}
+import java.util.UUID
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
@@ -700,6 +701,30 @@ object GenSpec extends ZIOBaseSpec {
       } yield assert(a)(not(equalTo(b))) &&
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
+    },
+    test("checkN re-samples effectful values when flatMapped with infinite fromIterable") {
+      val gen: Gen[Any, UUID] =
+        for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1)).resample
+        } yield id
+
+      for {
+        seen <- Ref.make(Set.empty[UUID])
+        _ <- CheckN(20)(gen) { id =>
+          seen.update(_ + id).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values.size)(isGreaterThan(1))
+    },
+    test("checkN does not collapse deterministic fromIterable to head element") {
+      for {
+        seen <- Ref.make(Set.empty[Int])
+        _ <- CheckN(20)(Gen.fromIterable(1 to 3)) { n =>
+          seen.update(_ + n).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values)(equalTo(Set(1, 2, 3)))
     },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -7,6 +7,7 @@ import zio.test.TestAspect.{exceptJS, jvmOnly, nonFlaky, scala2Only}
 import zio.test.{check => Check, checkN => CheckN}
 
 import java.time.{Duration => _, _}
+import java.util.UUID
 import scala.math.Numeric.DoubleIsFractional
 
 object GenSpec extends ZIOBaseSpec {
@@ -700,6 +701,21 @@ object GenSpec extends ZIOBaseSpec {
       } yield assert(a)(not(equalTo(b))) &&
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
+    },
+    test("checkN re-samples effectful values when flatMapped with infinite fromIterable") {
+      val gen: Gen[Any, UUID] =
+        for {
+          id <- Gen.uuid
+          _  <- Gen.fromIterable(LazyList.iterate(0)(_ + 1))
+        } yield id
+
+      for {
+        seen <- Ref.make(Set.empty[UUID])
+        _ <- CheckN(20)(gen) { id =>
+          seen.update(_ + id).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values.size)(isGreaterThan(1))
     },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -717,15 +717,6 @@ object GenSpec extends ZIOBaseSpec {
         values <- seen.get
       } yield assert(values.size)(isGreaterThan(1))
     },
-    test("checkN does not collapse boolean generator to a single value") {
-      for {
-        seen <- Ref.make(Set.empty[Boolean])
-        _ <- CheckN(20)(Gen.boolean) { b =>
-          seen.update(_ + b).as(assertCompletes)
-        }
-        values <- seen.get
-      } yield assert(values)(equalTo(Set(true, false)))
-    },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))
     },

--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -717,6 +717,15 @@ object GenSpec extends ZIOBaseSpec {
         values <- seen.get
       } yield assert(values.size)(isGreaterThan(1))
     },
+    test("checkN does not collapse boolean generator to a single value") {
+      for {
+        seen <- Ref.make(Set.empty[Boolean])
+        _ <- CheckN(20)(Gen.boolean) { b =>
+          seen.update(_ + b).as(assertCompletes)
+        }
+        values <- seen.get
+      } yield assert(values)(equalTo(Set(true, false)))
+    },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))
     },

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -94,8 +94,9 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
 
   /**
    * Truncates this generator to a single sample, forcing outer re-evaluation
-   * when this generator is used inside a `flatMap`. This is useful for preventing
-   * infinite generators from getting stuck during property-based testing.
+   * when this generator is used inside a `flatMap`. This is useful for
+   * preventing infinite generators from getting stuck during property-based
+   * testing.
    */
   def resample(implicit trace: Trace): Gen[R, A] =
     Gen(sample.take(1))

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -93,6 +93,14 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
     self.flatMap(a => Gen.fromZIO(f(a)).flatMap(p => if (p) Gen.const(a) else Gen.empty))
 
   /**
+   * Truncates this generator to a single sample, forcing outer re-evaluation
+   * when this generator is used inside a `flatMap`. This is useful for preventing
+   * infinite generators from getting stuck during property-based testing.
+   */
+  def resample(implicit trace: Trace): Gen[R, A] =
+    Gen(sample.take(1))
+
+  /**
    * Filters the values produced by this generator, discarding any values that
    * meet the specified predicate.
    */

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,9 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n =>
+      checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a)))
+    )
 
   /**
    * A version of `check` that accepts two random variables.
@@ -800,7 +802,9 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong), parallelism)(a =>
+        checkConstructor(test(a))
+      )
     )
 
   /**
@@ -1009,7 +1013,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -393,20 +393,12 @@ package object test extends CompileVariants {
    * Checks the test passes for "sufficient" numbers of samples from the given
    * random variable.
    */
-  private def sampledCheckStream[R <: ZAny, A](rv: Gen[R, A], n: Int)(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
-    if (n <= 0) ZStream.empty
-    else
-      ZStream
-        .fromIterable(0L until n.toLong)
-        .mapZIO(i => rv.sample.forever.drop(i.toInt).runHead)
-        .collectSome
-
   def check[R <: ZAny, A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In],
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(sampledCheckStream(rv, n))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -808,7 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(sampledCheckStream(rv, n), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1017,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(sampledCheckStream(rv, n))(a => checkConstructor(test(a)))
+        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,9 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n =>
-      checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a)))
-    )
+    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -802,9 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong), parallelism)(a =>
-        checkConstructor(test(a))
-      )
+      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1013,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(ZStream.repeatZIO(rv.sample.runHead).collectSome.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -393,12 +393,20 @@ package object test extends CompileVariants {
    * Checks the test passes for "sufficient" numbers of samples from the given
    * random variable.
    */
+  private def sampledCheckStream[R <: ZAny, A](rv: Gen[R, A], n: Int)(implicit trace: Trace): ZStream[R, Nothing, Sample[R, A]] =
+    if (n <= 0) ZStream.empty
+    else
+      ZStream
+        .fromIterable(0L until n.toLong)
+        .mapZIO(i => rv.sample.forever.drop(i.toInt).runHead)
+        .collectSome
+
   def check[R <: ZAny, A, In](rv: Gen[R, A])(test: A => In)(implicit
     checkConstructor: CheckConstructor[R, In],
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(sampledCheckStream(rv, n))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -800,7 +808,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(sampledCheckStream(rv, n), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1017,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(sampledCheckStream(rv, n))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Summary
- fixes sampled `check` / `checkPar` / `checkN` paths to avoid freezing effectful generators in compositions like `Gen.uuid` + infinite `fromIterable`
- preserves coverage for deterministic multi-value generators under sampled checks (no head-only collapse)
- adds two regression tests in `GenSpec`

## Root cause
`rv.sample.forever.take(n)` can get stuck on a single upstream effectful sample when flatMapped with an infinite deterministic branch.
A naive per-sample `runHead` workaround fixes that case but can collapse deterministic generators to their first element.

## Fix
Introduce `sampledCheckStream(rv, n)` in `zio.test.package`:
- for sample index `i`, evaluate `rv.sample.forever.drop(i).runHead` on a fresh stream
- collect the resulting `n` samples and run checks over them

This gives fresh effectful sampling while still traversing deterministic streams beyond the head element.

## Regression coverage
- `checkN re-samples effectful values when flatMapped with infinite fromIterable`
- `checkN does not collapse deterministic fromIterable to head element`

## Verification
- `sbt "testTestsJVM/testOnly zio.test.GenSpec"`
- `181 tests passed, 0 failed`

/claim #9101
