### PR TITLE
fix(scheduler): gate replenish-searcher unpark on work-visibility (#9878)

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -398,7 +398,14 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             if (searching) {
               searching = false
               val currentState = state.decrementAndGet()
-              maybeUnparkWorker(currentState)
+              // Only replenish the searcher when pending work is actually
+              // visible. Otherwise the newly-unparked worker searches, finds
+              // nothing, and parks again — the excessive park/unpark cycling
+              // #9878 describes. Mirrors the work-visibility gate used above
+              // (L380-391) before parking.
+              if (!localQueue.isEmpty() || !globalQueue.isEmpty()) {
+                maybeUnparkWorker(currentState)
+              }
             }
             currentRunnable = runnable
             runnable.run()


### PR DESCRIPTION
/attempt #9878

## Problem

ZScheduler unparks workers too frequently, causing measurable overhead on the hot path (#9878).

## Diagnosis

The callsite of `maybeUnparkWorker` at `ZScheduler.scala:401` (inside the searching→running transition, immediately after `state.decrementAndGet()`) calls it **unconditionally** — even when both the local and global queues are visibly empty. The newly-unparked worker then searches, finds nothing, and parks again. That's exactly the cycling pattern the issue describes.

The other `maybeUnparkWorker` callsites are either already gated (the about-to-park scan at L380-391 performs a work-visibility check first) or genuinely needed (the two submit paths enqueue fresh work). The replenish-searcher path is the asymmetric offender — and the gate belongs there, not inside `maybeUnparkWorker`.

## Why this angle is different from prior attempts

Prior approaches tried to make the callee smarter — rate-limiting (#10271), batching (#10440, #10444). That adds new state (timers, counters), complicates semantics, and risks masking real wake-ups under load. This PR leaves `maybeUnparkWorker` untouched and gates one specific pathological caller.

## Correctness under the JMM

If a submitter `S` races this check:

- If `S`'s enqueue is memory-ordered **before** our `isEmpty` reads → we see non-empty, we unpark. Same behavior as today.
- If `S`'s enqueue is ordered **after** our reads → by program order in `S` (`offer → state.get`) and the volatile ordering on `state`, `S`'s `state.get` is ordered after our `state.decrementAndGet()`. So `S` observes `currentSearching == 0` and its own `maybeUnparkWorker` fires.

Either side wakes an idle worker. No wake-up lost.

Only self's `localQueue` + `globalQueue` are checked (not peers') because we're transitioning to running, not parking — peer local queues only receive work from their own owning worker, which must be active to push.

No new atomic, no new volatile, no change to state packing.

## Benchmarks

Not included in this initial PR — happy to add JMH numbers on request. The `UnparkFrequencyBenchmark` harness from #10440's branch would be a natural fit. Expect 10–40% fewer `unpark` calls at low/medium submission rates; ~0% change at full saturation.

Refs: #9878
