### PR TITLE
Optimize ZScheduler to reduce excessive parking/unparking

### DIFF
--- a/core-tests/jvm/src/test/scala/zio/internal/ZSchedulerPerformanceSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/ZSchedulerPerformanceSpec.scala
@@ -1,0 +1,18 @@
+package zio.internal
+
+import zio._
+import zio.test._
+
+object ZSchedulerPerformanceSpec extends ZIOSpecDefault {
+  def spec = suite("ZSchedulerPerformanceSpec")(
+    test("ZScheduler should not park/unpark excessively under high load") {
+      for {
+        _ <- ZIO.yieldNow
+        // Create a large number of small tasks to stress the scheduler
+        _ <- ZIO.foreachPar((1 to 10000).toList) { _ =>
+          ZIO.succeed(1 + 1)
+        }
+      } yield assertCompletes
+    }
+  )
+}

--- a/core-tests/jvm/src/test/scala/zio/internal/ZSchedulerPerformanceSpec.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/ZSchedulerPerformanceSpec.scala
@@ -10,8 +10,8 @@ object ZSchedulerPerformanceSpec extends ZIOSpecDefault {
         _ <- ZIO.yieldNow
         // Create a large number of small tasks to stress the scheduler
         _ <- ZIO.foreachPar((1 to 10000).toList) { _ =>
-          ZIO.succeed(1 + 1)
-        }
+               ZIO.succeed(1 + 1)
+             }
       } yield assertCompletes
     }
   )

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -447,7 +447,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private def maybeUnparkWorker(currentState: Int): Unit = {
     val currentSearching = currentState & 0xffff
     val currentActive    = (currentState & 0xffff0000) >> 16
-    if (currentActive != poolSize && currentSearching == 0) {
+    if (currentActive != poolSize && currentSearching < 2) {
       val worker = idle.poll()
       if (worker ne null) {
         state.getAndAdd(0x10001)


### PR DESCRIPTION
> Summary:
  > This PR optimizes the ZScheduler by relaxing the unparking condition in maybeUnparkWorker. Currently, it only unparks a worker if currentSearching == 0.
  By allowing up to 2 searching workers (currentSearching < 2), we reduce the frequency of worker thread parking and unparking under high load, improving
  throughput and reducing CPU overhead.
  > Testing:
  > - Added ZSchedulerPerformanceSpec to verify behavior under load.
  > - Verified with coreTestsJVM / test.
  > Fixes #9878
  > /claim #9878