### PR TITLE
error handling fix for ZStream#peel (#10777)

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -3398,6 +3398,16 @@ object ZStreamSpec extends ZIOBaseSpec {
               exit <- stream.peel(sink).exit
             } yield assert(exit)(fails(equalTo("fail")))
           },
+          test("propagates errors 2") {
+            val stream = ZStream.fail("oh noes")
+            stream
+              .peel(ZSink.succeed(()))
+              .flatMap { case (_, tail) =>
+                tail.runDrain
+              }
+              .flip
+              .map(s => assertTrue(s == "oh noes"))
+          },
           test("preserves the scope") {
             for {
               ref     <- Ref.make[Chunk[String]](Chunk.empty)

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -1096,32 +1096,13 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
       } else if (that0 eq ZChannel.identityAny) {
         self.asInstanceOf[ZChannel[Env1, InErr, InElem, InDone, OutErr1, OutElem2, OutDone2]]
       } else {
-        class ChannelFailure(val err: Cause[OutErr1]) extends Throwable(null, null, true, false) {
-          override def getMessage: String = err.unified.headOption.fold("<unknown>")(_.message)
-
-          override def getStackTrace(): Array[StackTraceElement] =
-            err.unified.headOption.fold[Chunk[StackTraceElement]](Chunk.empty)(_.trace).toArray
-
-          override def getCause(): Throwable =
-            err.find { case Cause.Die(throwable, _) => throwable }
-              .orElse(err.find { case Cause.Fail(value: Throwable, _) => value })
-              .orNull
-
-          def fillSuppressed()(implicit unsafe: Unsafe): Unit =
-            if (getSuppressed().length == 0) {
-              err.unified.iterator.drop(1).foreach(unified => addSuppressed(unified.toThrowable))
-            }
-
-          override def toString =
-            err.prettyPrint
-        }
-        var channelFailure: ChannelFailure = null
+        var channelFailure: ZChannel.ChannelFailure[OutErr1] = null
 
         lazy val reader: ZChannel[Env, OutErr, OutElem, OutDone, Nothing, OutElem, OutDone] =
           ZChannel.readWithCause(
             elem => ZChannel.write(elem) *> reader,
             err => {
-              channelFailure = new ChannelFailure(err)
+              channelFailure = new ZChannel.ChannelFailure(err)
               ZChannel.refailCause(Cause.die(channelFailure))
             },
             done => ZChannel.succeedNow(done)
@@ -1140,7 +1121,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
                     (e, st) => Cause.fail(e, st),
                     (t, st) =>
                       t match {
-                        case t: ChannelFailure if t == channelFailure =>
+                        case t: ZChannel.ChannelFailure[OutErr1] if t == channelFailure =>
                           t.err
                         case t => Cause.die(t, st)
                       },
@@ -1580,6 +1561,26 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
 }
 
 object ZChannel {
+  private[stream] final class ChannelFailure[OutErr1](val err: Cause[OutErr1])
+      extends Throwable(null, null, true, false) {
+    override def getMessage: String = err.unified.headOption.fold("<unknown>")(_.message)
+
+    override def getStackTrace(): Array[StackTraceElement] =
+      err.unified.headOption.fold[Chunk[StackTraceElement]](Chunk.empty)(_.trace).toArray
+
+    override def getCause(): Throwable =
+      err.find { case Cause.Die(throwable, _) => throwable }
+        .orElse(err.find { case Cause.Fail(value: Throwable, _) => value })
+        .orNull
+
+    def fillSuppressed()(implicit unsafe: Unsafe): Unit =
+      if (getSuppressed().length == 0) {
+        err.unified.iterator.drop(1).foreach(unified => addSuppressed(unified.toThrowable))
+      }
+
+    override def toString =
+      err.prettyPrint
+  }
   private val failLeftUnit = Exit.fail(Left(()))
   private val failUnit     = Exit.failCause(Cause.unit)
 

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -2458,9 +2458,14 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
 
       lazy val producer: ZChannel[Any, Any, Any, Any, E, Chunk[A1], Unit] = ZChannel.unwrap(
         handoff.take.map {
-          case Signal.Emit(els)   => ZChannel.write(els) *> producer
-          case Signal.Halt(cause) => ZChannel.refailCause(cause)
-          case Signal.End         => ZChannel.unit
+          case Signal.Emit(els) => ZChannel.write(els) *> producer
+          case Signal.Halt(cause) =>
+            val unwrapped = cause match {
+              case Cause.Die(value: ZChannel.ChannelFailure[E], _) => value.err
+              case _                                               => cause
+            }
+            ZChannel.refailCause(unwrapped)
+          case Signal.End => ZChannel.unit
         }
       )
 


### PR DESCRIPTION
Here's my attempt at fixing #10777.

Not particularly happy with the fact that `peel` would concern itself with what ought to be implementation details of `pipeToOrFail`… But unless `ZChannel` can grow a new primitive to get rid of the wrapping of `Cause.Fail` in `ChannelFailure`, I wouldn't know how else to solve this problem. Maybe somebody else has a better idea 🤷🏻‍♂️ 