### PR TITLE
introduce ZIO#memoizeSuccess

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1542,6 +1542,53 @@ object ZIOSpec extends ZIOBaseSpec {
           assert(c)(equalTo(d))
       }
     ),
+    suiteAll("memoizeSuccess") {
+      val io: IO[Int, Int] = Random.nextInt.flatMap(i =>
+        Random.nextDouble.flatMap(d =>
+          if (d < 0.5) ZIO.fail(i)
+          else ZIO.succeed(i)
+        )
+      )
+      test("non-memoized returns new instances on repeated calls") {
+        for {
+          a <- io.flip
+          b <- io.flip
+          c <- io
+          d <- io.flip
+          e <- io
+        } yield {
+          // Failure -> Failure -> Success -> Failure -> Success -> Failure
+          // List(-1194344215, -2074907587, -1886689338, -1583814084, -793421097)
+          assertTrue(Set(a, b, c, d, e).size == 5)
+        }
+      }
+      test("memoized returns the same instance after first success result") {
+        io.memoizeSuccess.flatMap(call =>
+          for {
+            a <- call.flip
+            b <- call.flip
+            c <- call
+            d <- call
+            e <- call
+          } yield {
+            assertTrue(
+              a != b,
+              b != c,
+              c == d,
+              d == e
+            )
+          }
+        )
+      }
+      test("memoized returns just one success result even calls are concurrent") {
+        io.memoizeSuccess.flatMap(call =>
+          ZIO
+            .collectAllSuccessesPar(Seq.fill(90)(call))
+            .withParallelism(30)
+            .map(res => assertTrue(res.toSet.size == 1))
+        )
+      }
+    } @@ TestAspect.setSeed(101),
     suite("merge")(
       test("on flipped result") {
         val zio: IO[Int, Int] = ZIO.succeed(1)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1025,6 +1025,36 @@ sealed trait ZIO[-R, +E, +A]
     } yield complete *> promise.await.flatMap { case (patch, a) => ZIO.patchFiberRefs(patch).as(a) }
 
   /**
+   * Returns an effect that, if evaluated, will return the lazily computed
+   * successful result of this effect. Unlike [[memoize]], failed or interrupted
+   * attempts are not memoized and will cause this effect to be re-executed on
+   * subsequent evaluations.
+   */
+  final def memoizeSuccess(implicit trace: Trace): URIO[R, IO[E, A]] =
+    Ref.make[Option[Promise[E, (FiberRefs.Patch, A)]]](None).flatMap { ref =>
+      ZIO.environmentWith[R] { r =>
+        ref.modify {
+          case Some(p) =>
+            (p, false) -> Some(p)
+          case _ =>
+            val p = Promise.unsafe.make[E, (FiberRefs.Patch, A)](FiberId.None)(Unsafe)
+            (p, true) -> Some(p)
+        }.flatMap { case (p, executeSelf) =>
+          ZIO.whenDiscard(executeSelf) {
+            ZIO.uninterruptibleMask(restore =>
+              restore(self.diffFiberRefs).exitWith {
+                case Exit.Failure(cause) => ref.set(None) *> p.failCause(cause)
+                case Exit.Success(res)   => p.succeed(res)
+              }.provideEnvironment(r).fork
+            )
+          } *> p.await.flatMap { case (patch, a) =>
+            ZIO.patchFiberRefs(patch).as(a)
+          }
+        }
+      }
+    }
+
+  /**
    * Returns a new effect where the error channel has been merged into the
    * success channel to their common combined type.
    */


### PR DESCRIPTION
Hello everyone!

I was working on optional dependencies problem: when a dependency is optional, my application should start up even if the dependency is unavailable. For example (details omitted for simplicity):

```scala
val makeRedisCommands: RIO[Scope & RedisClient, RedisCommands] = ??? // fails if connection can't be established during initialization

class CacheStorage(redis: RedisCommands) {
  def get(key: String): Task[String] = redis.get(key)
}

object CacheStorage {
  val layer: RLayer[RedisClient, CacheStorage] = // fails if Redis is unavailable => entire application doesn't start
    ZLayer.scoped(makeRedisCommands) >>> ZLayer.fromFunction(new CacheStorage(_))
}
```
I found that it would be useful to have a ZIO#memoizeSuccess method that allows re-executing an effect until the first successful result:
```scala
val makeRedisCommands: RIO[Scope & RedisClient, RedisCommands] = ???
val makeRedisCommandsMemoized: URIO[Scope & RedisClient, Task[RedisCommands]] = makeRedisCommands.memoizeSuccess

class CacheStorage(redis: Task[RedisCommands]) {
  def get(key: String): Task[String] = redis.flatMap(_.get(key))
}

object CacheStorage {
  val layer: URLayer[RedisClient, CacheStorage] = // now doesn't fail, application starts up
    ZLayer.scoped(makeRedisCommandsMemoized) >>> ZLayer.fromFunction(new CacheStorage(_))
}
```
Note: unlike memoize, it's convenient to move R to the outer effect so that the resource scope is bound to the outer layer.

Also took inspiration from [https://github.com/zio/zio/pull/10693 ](https://github.com/zio/zio/pull/10693). In this case there's no interruption issue since interruption is a Failure, and all Failures are not cached. I also think there's no need to implement `ZIO.memoizeSuccess(A => ZIO[R, E, B])` version.

Looking forward to your feedback!