### PR TITLE
Optimize timeoutTo fast path

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,31 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TimeoutBenchmark {
+  import BenchmarkUtil.unsafeRun
+
+  @Param(Array("0", "100", "10000"))
+  var n: Int = _
+
+  private var effect: UIO[Int] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    effect = ZIO.foldLeft(0 until n)(0) { case (sum, value) =>
+      ZIO.succeed(sum + value)
+    }
+
+  @Benchmark
+  def zioBaseline(): Int =
+    unsafeRun(effect)
+
+  @Benchmark
+  def zioTimeout(): Int =
+    unsafeRun(effect.timeoutTo(-1)(identity)(1.hour))
+}

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5647,21 +5647,52 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       trace: Trace
     ): ZIO[R, E, B1] =
       ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
-            },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+        ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
+          val graft    = ZIO.Grafter(parentFiber)
+          val leftEff  = graft.applyOnExit(self)
+          val rightEff = graft.applyOnExit(ZIO.sleep(duration).interruptible)
+          val flags    = parentStatus.runtimeFlags
+
+          val leftFiber = ZIO.unsafe.makeChildFiber(trace, leftEff, parentFiber, flags, null)(Unsafe)
+          val startLeft = leftFiber.startSuspended()(Unsafe)
+
+          startLeft(leftEff)
+
+          leftFiber.unsafe.poll(Unsafe) match {
+            case Some(exit) =>
+              leftFiber.inheritAll *> exit.mapExit(f)
+            case None =>
+              val rightFiber = ZIO.unsafe.makeChildFiber(trace, rightEff, parentFiber, flags, FiberScope.global)(Unsafe)
+              val startRight = rightFiber.startSuspended()(Unsafe)
+
+              ZIO.async[R, E, B1](
+                { cb =>
+                  val raceIndicator = new java.util.concurrent.atomic.AtomicBoolean()
+
+                  leftFiber.unsafe.addObserver { exit =>
+                    if (raceIndicator.compareAndSet(false, true)) {
+                      cb(rightFiber.interruptAs(parentFiberId) *> leftFiber.inheritAll *> exit.mapExit(f))
+                    }
+                  }(Unsafe)
+
+                  rightFiber.addObserver { exit =>
+                    if (raceIndicator.compareAndSet(false, true)) {
+                      exit match {
+                        case e: Exit.Failure[Nothing] =>
+                          cb(leftFiber.interruptAs(parentFiberId) *> leftFiber.inheritAll *> e)
+                        case _ =>
+                          cb(leftFiber.interruptAs(parentFiberId) *> leftFiber.inheritAll.as(b()))
+                      }
+                    }
+                  }(Unsafe)
+
+                  startRight(rightEff)
+                  ()
+                },
+                leftFiber.id <> rightFiber.id
+              )
+          }
+        }
       }
   }
 


### PR DESCRIPTION
/claim #9211

## Summary

- Adds a `timeoutTo` fast path that starts the primary fiber first and polls it once before creating the timeout sleep fiber.
- Keeps the existing race-with-sleep behavior for effects that do not complete immediately, preserving the current timeout / interruption semantics for the slow path.
- Adds a JMH `TimeoutBenchmark` that compares a baseline effect with the same effect wrapped in a large `timeoutTo`.

## Benchmark

Short same-machine JMH run on Windows / JDK 21:

```text
sbt "benchmarks/jmh:run -i 3 -wi 3 -r 1s -w 1s -f 1 -t 1 zio.TimeoutBenchmark.zioTimeout"
```

Current `series/2.x` with the benchmark added:

```text
n=0      24488.665 ops/s
n=100    22332.523 ops/s
n=10000   3785.747 ops/s
```

This PR:

```text
n=0      35869.946 ops/s
n=100    35484.138 ops/s
n=10000   5412.701 ops/s
```

## Validation

- `sbt "coreTestsJVM/testOnly zio.ZIOSpec -- -t timeout;benchmarks/compile"`
- `sbt "streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t timeout"`
- `sbt "coreTestsJVM/testOnly zio.FiberRefSpec -- -t timeout"`
- `sbt fmt`
