### PR TITLE
fix(native): replace ConcurrentHashMap.newKeySet with synchronized HashSet to avoid treeifyBin NPE

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
+    Collections.synchronizedSet(new java.util.HashSet[A]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
+    Collections.synchronizedSet(new java.util.HashSet[A](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
Fixes #9681

On Scala Native, `ConcurrentHashMap.newKeySet()` returns a `KeySetView` that triggers a `NullPointerException` in `treeifyBin` when under high concurrency (e.g., forking 10,000+ fibers). This is a known issue in the Scala Native JDK compatibility layer.

This PR replaces the `newConcurrentSet` implementations in `PlatformSpecific.scala` for the Native platform with `Collections.synchronizedSet(new java.util.HashSet())`. This avoids the buggy `ConcurrentHashMap` path while maintaining $O(1)$ size lookups, which are required for performance in `WeakConcurrentBag`.

This is consistent with the approach discussed in #9681 and avoids the $O(n)$ performance penalty of `ConcurrentLinkedQueue.size()`.