### PR TITLE
Optimize ZScheduler: throttle excessive worker unparks

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -40,7 +40,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
   private[this] val state           = new AtomicInteger(poolSize << 16)
-  private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
+  private[this] val workers = Array.ofDim[ZScheduler.Worker](poolSize)
+  private[this] val lastUnparkNanos = new AtomicLong(0L)
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
 
@@ -446,13 +447,21 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
   private def maybeUnparkWorker(currentState: Int): Unit = {
     val currentSearching = currentState & 0xffff
-    val currentActive    = (currentState & 0xffff0000) >> 16
+    val currentActive = (currentState & 0xffff0000) >> 16
     if (currentActive != poolSize && currentSearching == 0) {
-      val worker = idle.poll()
-      if (worker ne null) {
-        state.getAndAdd(0x10001)
-        worker.active = true
-        LockSupport.unpark(worker)
+      val now = System.nanoTime()
+      val prev = lastUnparkNanos.get()
+      if (now - prev < 200000L) {
+        ()
+      } else if (lastUnparkNanos.compareAndSet(prev, now)) {
+        val worker = idle.poll()
+        if (worker ne null) {
+          state.getAndAdd(0x10001)
+          worker.active = true
+          LockSupport.unpark(worker)
+        } else {
+          lastUnparkNanos.compareAndSet(now, 0L)
+        }
       }
     }
   }

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -449,7 +449,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     val currentSearching = currentState & 0xffff
     val currentActive = (currentState & 0xffff0000) >> 16
     if (currentActive != poolSize && currentSearching == 0) {
-      val now = System.nanoTime()
+      val now = java.lang.System.nanoTime()
       val prev = lastUnparkNanos.get()
       if (now - prev < 200000L) {
         ()

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -40,7 +40,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
   private[this] val state           = new AtomicInteger(poolSize << 16)
-  private[this] val workers = Array.ofDim[ZScheduler.Worker](poolSize)
+  private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
   private[this] val lastUnparkNanos = new AtomicLong(0L)
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
@@ -447,9 +447,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
   private def maybeUnparkWorker(currentState: Int): Unit = {
     val currentSearching = currentState & 0xffff
-    val currentActive = (currentState & 0xffff0000) >> 16
+    val currentActive    = (currentState & 0xffff0000) >> 16
     if (currentActive != poolSize && currentSearching == 0) {
-      val now = java.lang.System.nanoTime()
+      val now  = java.lang.System.nanoTime()
       val prev = lastUnparkNanos.get()
       if (now - prev < 200000L) {
         ()


### PR DESCRIPTION
## Summary
- Add CAS-based rate limiter (200µs cooldown) to `maybeUnparkWorker` to prevent excessive `LockSupport.unpark()` syscalls on the hot path
- When no idle worker is available after winning the CAS race, reset the timestamp to avoid blocking future unparks

## Problem
`LockSupport.unpark(worker)` is an expensive syscall that was being invoked unconditionally every time `maybeUnparkWorker` was called from `submit`, `submitAndYield`, and the worker loop. In high-throughput scenarios, multiple threads call this method concurrently, resulting in redundant unparks to workers that are already being woken up.

## Solution
Introduce `lastUnparkNanos: AtomicLong` to track the last successful unpark timestamp. Only one thread per 200µs window can proceed to unpark a worker, using `compareAndSet` for lock-free coordination. If no idle worker is available after winning the CAS, the timestamp is reset to avoid blocking future unparks.

This trades minimal fairness (sub-200µs delay in waking additional workers) for significantly reduced syscall overhead, as suggested in the issue: "trade some fairness for aggression to avoid excessive cycling."

Fixes #9878