### PR TITLE
Fix #9101: resample effectful generators on each check iteration

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -776,6 +776,26 @@ object GenSpec extends ZIOBaseSpec {
       check(Gen.setOfN(2)(Gen.fromIterable(List(1, 2, 3)))) { set =>
         assertTrue(set.size == 2)
       }
+    },
+    test("effectful gen before large deterministic gen produces varied samples (issue #9101)") {
+      // Regression test: in the broken case, uuid was sampled once and reused for all samples
+      // because fromIterable produced an infinite-like stream that never restarted.
+      val gen = for {
+        id <- Gen.uuid
+        _  <- Gen.fromIterable(0 to 1000000)
+      } yield id
+      for {
+        samples <- gen.runCollectN(10)
+      } yield assert(samples.distinct)(hasSize(isGreaterThan(1)))
+    },
+    test("effectful gen after deterministic gen also produces varied samples (issue #9101 working case)") {
+      val gen = for {
+        _ <- Gen.fromIterable(0 to 1000000)
+        id <- Gen.uuid
+      } yield id
+      for {
+        samples <- gen.runCollectN(10)
+      } yield assert(samples.distinct)(hasSize(isGreaterThan(1)))
     }
   )
 }

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -154,7 +154,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    sample.map(_.value).take(1).forever.take(n.toLong).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,7 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n => checkStream(rv.sample.take(1).forever.take(n.toLong))(a => checkConstructor(test(a))))
 
   /**
    * A version of `check` that accepts two random variables.
@@ -800,7 +800,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(rv.sample.take(1).forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1009,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.sample.take(1).forever.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
/claim #9101

## Summary

Fixes the bug where `Gen.uuid` (and other effectful generators) produces the same value every time when combined with `Gen.fromIterable(infinite/large-iterable)` via flatMap in certain orderings.

## Root Cause

The sampling paths in `check`, `checkN`, `checkPar`, and `runCollectN` all use:

```scala
rv.sample.forever.take(n)
```

`ZStream.forever` works by **restarting** the stream once it ends. For single-element effectful generators like `Gen.uuid`, `.sample` is a 1-element stream; `.forever` restarts it on each exhaustion, re-executing the effect and producing a fresh value — this is correct.

The bug manifests when `rv.sample` is **already infinite**: `Gen.uuid.flatMap(_ => Gen.fromIterable(LazyList.iterate(0)(_ + 1)))` produces an infinite stream (one UUID value repeated for every element of the infinite iterable). `.forever` never triggers on an infinite stream, so `uuid` is evaluated **exactly once** and the same UUID appears in all `n` test cases.

The reverse order works by accident: `fromIterable.flatMap(i => uuid)` is also infinite but re-evaluates `uuid.sample` for each outer element, yielding varied UUIDs.

## Fix

Change `rv.sample.forever.take(n)` to `rv.sample.take(1).forever.take(n)` at four call sites:

- `Gen.scala` — `runCollectN`
- `package.scala` — `check`, `checkPar`, `checkN`

By taking exactly 1 element before `.forever`, each "restart" begins a fresh evaluation of the full generator expression — re-executing all ZIO effects (fresh UUID per iteration) — while `.forever` provides the restart loop.

```
// Broken order: uuid.flatMap(_ => fromIterable(infinite)).sample.take(1).forever.take(n)
// = (uuid1, 0), restart → (uuid2, 0), ... → n different UUIDs  ✓

// Working order: fromIterable(infinite).flatMap(i => uuid).sample.take(1).forever.take(n)  
// = (0, uuid1), restart → (0, uuid2), ... → n different UUIDs  ✓
```

## Semantic Change

Previously, `check(Gen.fromIterable(List(1, 2, 3)))` cycled through values 1, 2, 3 on successive samples. With this fix, it always uses element 0 (value `1`) because `.take(1)` cuts the stream before `.forever` restarts. For exhaustive coverage of finite iterables, use `checkFinite` / `runCollect` — those code paths are not affected by this change.

## Tests Added

Two regression tests in `GenSpec.scala`:

1. `"effectful gen before large deterministic gen produces varied samples (issue #9101)"` — verifies the broken case now produces varied UUIDs
2. `"effectful gen after deterministic gen also produces varied samples (issue #9101 working case)"` — verifies the working order remains correct

## Existing tests unaffected

- `checkFinite` / `runCollect` — use `gen.sample.runCollect`, not the `.forever.take(n)` path
- `sample100` in GenUtils — separate utility used for monad-law tests, not changed
- `check(setOfN(2)(fromIterable(List(1,2,3))))` — `setOfN` builds its set via internal `flatMap` iteration (not the outer check loop); the outer `.take(1)` gets the first completed set which has `size == 2` ✓
- `runCollectN` test using `Gen.int` — effectful single-element generator, `.take(1)` is a no-op ✓