### PR TITLE
fix(test): assertTrue on Java static method calls (Scala 3)

### DIFF
--- a/test-tests/shared/src/test/scala-3/zio/test/SmartAssertionScala3Spec.scala
+++ b/test-tests/shared/src/test/scala-3/zio/test/SmartAssertionScala3Spec.scala
@@ -4,6 +4,17 @@ object SmartAssertionScala3Spec extends ZIOBaseSpec {
 
   override def spec =
     suite("SmartAssertionScala3Spec")(
+      suite("Java static method calls")(
+        test("on java.lang.Math") {
+          assertTrue(java.lang.Math.abs(-1) == 1)
+        },
+        test("on java.lang.Integer") {
+          assertTrue(java.lang.Integer.parseInt("42") == 42)
+        },
+        test("nested inside boolean operators") {
+          assertTrue(java.lang.Math.abs(-1) == 1 && java.lang.Math.max(1, 2) == 2)
+        }
+      ),
       suite("new instance creation")(
         test("anonymous class (trait) with overload and type args - new instance") {
           trait ClassWithOverload[X] {

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -389,7 +389,13 @@ object SmartAssertMacros {
 
         val tpe = lhs.tpe.widen
 
-        if (tpe.typeSymbol.isPackageDef)
+        val isStaticJavaQualifier =
+          lhs.symbol != Symbol.noSymbol && {
+            val flagsShow = lhs.symbol.flags.show
+            flagsShow.contains("Flags.JavaDefined") && flagsShow.contains("Flags.Module")
+          }
+
+        if (tpe.typeSymbol.isPackageDef || isStaticJavaQualifier)
           '{ TestArrow.succeed($expr).span(${ getSpan(method) }) }
         else
           tpe.asType match {


### PR DESCRIPTION
`assertTrue(java.lang.Math.abs(-1) == 1)` failed at runtime with `NoClassDefFoundError: java/lang/Math$`. For a Java-static qualifier, Scala 3 synthesizes a fake module symbol with no real `MODULE$` field; the SmartAssert macro's default arrow-composition path reified the qualifier as a value, emitting a `getstatic Math$.MODULE$` against a class that does not exist at runtime.

Detect Java-static qualifiers (symbols carrying both `JavaDefined` and `Module` flags) and fold the entire call into a single `TestArrow.succeed`, so the underlying call compiles to `INVOKESTATIC`. Adds Scala 3 regression coverage for `java.lang.Math.abs`, `java.lang.Integer.parseInt`, and the same calls nested inside `&&`.