### PR TITLE
fix(test): force TestResult.result eagerly

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/ScopeAssertEvalSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ScopeAssertEvalSpec.scala
@@ -1,0 +1,38 @@
+package zio.test
+
+import java.util.concurrent.atomic.AtomicBoolean
+import zio._
+
+object ScopeAssertEvalSpec extends ZIOBaseSpec {
+
+  private val aliveResource: ZIO[Scope, Nothing, AtomicBoolean] =
+    ZIO.acquireRelease(
+      ZIO.succeed(new AtomicBoolean(true))
+    )(flag => ZIO.succeed(flag.set(false)))
+
+  def spec = suite("ScopeAssertEvalSpec")(
+    test("assertTrue captures inside ZIO.scoped see live resources") {
+      ZIO.scoped {
+        for {
+          alive <- aliveResource
+        } yield assertTrue(alive.get)
+      }
+    },
+    test("eagerly captured Boolean works") {
+      ZIO.scoped {
+        for {
+          alive  <- aliveResource
+          isAlive = alive.get
+        } yield assertTrue(isAlive)
+      }
+    },
+    test("ZIO.succeed right before yield sees the flag set") {
+      ZIO.scoped {
+        for {
+          alive   <- aliveResource
+          isAlive <- ZIO.succeed(alive.get)
+        } yield assertTrue(isAlive)
+      }
+    }
+  )
+}

--- a/test-tests/shared/src/test/scala/zio/test/ScopeAssertEvalSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/ScopeAssertEvalSpec.scala
@@ -18,7 +18,7 @@ object ScopeAssertEvalSpec extends ZIOBaseSpec {
         } yield assertTrue(alive.get)
       }
     },
-    test("eagerly captured Boolean works") {
+    test("eagerly captured Boolean inside ZIO.scoped works") {
       ZIO.scoped {
         for {
           alive  <- aliveResource

--- a/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
+++ b/test/shared/src/main/scala-2/zio/test/SmartAssertMacros.scala
@@ -252,7 +252,7 @@ class SmartAssertMacros(val c: blackbox.Context) {
 
     q"""
 ..$stats
-$TestResult($ast.withCode($codeString).meta(location = $location))
+$TestResult.cached($ast.withCode($codeString).meta(location = $location))
 """
   }
 

--- a/test/shared/src/main/scala-3/zio/test/Macros.scala
+++ b/test/shared/src/main/scala-3/zio/test/Macros.scala
@@ -422,7 +422,7 @@ object SmartAssertMacros {
     val arrow             = transform(expr).asExprOf[TestArrow[Any, Boolean]]
     val pos               = expr.asTerm.pos
     val location          = Expr(Some(s"${pos.sourceFile.path}:${pos.endLine + 1}"))
-    val result            = '{ TestResult($arrow.withCode($code).meta(location = $location)) }
+    val result            = '{ TestResult.cached($arrow.withCode($code).meta(location = $location)) }
     if stats.isEmpty then result else Block(stats, result.asTerm).asExprOf[TestResult]
   }
 

--- a/test/shared/src/main/scala/zio/test/Assertion.scala
+++ b/test/shared/src/main/scala/zio/test/Assertion.scala
@@ -66,7 +66,7 @@ object Assertion extends AssertionVariants {
             .result()
         }
       )
-    TestResult(
+    TestResult.cached(
       (TestArrow.succeed(expr).withCode(codeString.getOrElse("input")) >>> assertion.arrow).withLocation
         .withCompleteCode(completeString.getOrElse("<CODE>"))
     )

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -12,7 +12,20 @@ import scala.util.control.TailCalls
 
 case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
-  lazy val result: TestTrace[Boolean] = TestArrow.run(arrow, Right(()))
+  /**
+   * Optional pre-computed trace. When set (via `TestResult.cached`), `result`
+   * returns it directly instead of running `arrow`, and composition operators
+   * propagate it so that side-effecting expressions captured at construction
+   * time are not re-executed.
+   *
+   * Default `None` for plain `TestResult(arrow)` construction, preserving the
+   * original lazy-run semantics for any user code that builds `TestResult`
+   * directly from an arrow.
+   */
+  protected def maybeCachedTrace: Option[TestTrace[Boolean]] = None
+
+  lazy val result: TestTrace[Boolean] =
+    maybeCachedTrace.getOrElse(TestArrow.run(arrow, Right(())))
 
   lazy val failures: Option[TestTrace[Boolean]] = TestTrace.prune(result, false)
 
@@ -20,11 +33,20 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
   def isSuccess: Boolean = failures.isEmpty
 
-  def &&(that: TestResult): TestResult = TestResult(arrow && that.arrow)
+  def &&(that: TestResult): TestResult =
+    TestResult.fromTrace(
+      arrow && that.arrow,
+      for { l <- self.maybeCachedTrace; r <- that.maybeCachedTrace } yield l && r
+    )
 
-  def ||(that: TestResult): TestResult = TestResult(arrow || that.arrow)
+  def ||(that: TestResult): TestResult =
+    TestResult.fromTrace(
+      arrow || that.arrow,
+      for { l <- self.maybeCachedTrace; r <- that.maybeCachedTrace } yield l || r
+    )
 
-  def unary_! : TestResult = TestResult(!arrow)
+  def unary_! : TestResult =
+    TestResult.fromTrace(!arrow, self.maybeCachedTrace.map(t => !t))
 
   def implies(that: TestResult): TestResult = !self || that
 
@@ -38,35 +60,62 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
   def ??(message: String): TestResult = self.label(message)
 
-  def label(message: String): TestResult = TestResult(arrow.label(message))
+  def label(message: String): TestResult =
+    TestResult.fromTrace(
+      arrow.label(message),
+      self.maybeCachedTrace.map(_.withCustomLabel(Some(message)))
+    )
 
   def setGenFailureDetails(details: GenFailureDetails): TestResult =
-    TestResult(arrow.setGenFailureDetails(details))
+    TestResult.fromTrace(
+      arrow.setGenFailureDetails(details),
+      self.maybeCachedTrace.map(_.withGenFailureDetails(Some(details)))
+    )
 }
 
 object TestResult {
 
   /**
-   * Build a `TestResult` whose underlying `TestArrow` is run **once, eagerly**,
-   * with the resulting `TestTrace` cached behind a constant arrow. This is used
-   * by every `assertTrue` / `assert(...)(...)` entry point so that:
+   * Build a `TestResult` whose underlying `TestArrow` is run **once, eagerly**.
+   * The resulting `TestTrace` is stashed on the returned `TestResult` so that
+   * `result`/`failures` reuse it instead of running the arrow again. The
+   * original `arrow` is preserved on the returned value (so callers that
+   * inspect `tr.arrow` still see the structured tree built by the macros).
    *
-   *   - Side-effecting expressions inside the assertion (e.g.
-   *     `q.offer(1)`, `alive.get`) are evaluated exactly once, at the call
-   *     site — i.e. *inside* the user's effect chain. That keeps any
-   *     scope-managed resources alive when the captured value is read, and
-   *     prevents `&&`/`||` composition from re-running the side effect on
-   *     every combinator step.
+   * Used by every `assertTrue` / `assert(...)(...)` entry point so that:
    *
-   *   - Subsequent runs of the resulting arrow (driven by `result` /
-   *     `failures` inspection, or by composing into a larger `TestResult`)
-   *     return the cached trace without re-executing the original
-   *     expression.
+   *   - Side-effecting expressions inside the assertion (e.g. `q.offer(1)`,
+   *     `alive.get`) are evaluated exactly once, at the call site — i.e.
+   *     *inside* the user's effect chain. That keeps any scope-managed
+   *     resources alive when the captured value is read.
+   *
+   *   - Composition (`&&`/`||`/`!`/`label`/...) propagates the cached trace, so
+   *     chained assertions never re-run the underlying arrow and the captured
+   *     side effects fire exactly once.
    */
   def cached(arrow: TestArrow[Any, Boolean]): TestResult = {
     val trace = TestArrow.run(arrow, Right(()))
-    TestResult(TestArrow.TestArrowF[Any, Boolean](_ => trace))
+    fromTrace(arrow, Some(trace))
   }
+
+  /**
+   * Internal helper that wraps `arrow` with an optional pre-computed
+   * `cachedTrace`. When `cachedTrace` is `Some`, the returned `TestResult`
+   * short-circuits `result` to it and propagates it through composition. When
+   * `None`, falls back to the plain `TestResult(arrow)` constructor.
+   */
+  private[test] def fromTrace(
+    arrow: TestArrow[Any, Boolean],
+    cachedTrace: Option[TestTrace[Boolean]]
+  ): TestResult =
+    cachedTrace match {
+      case Some(t) =>
+        new TestResult(arrow) {
+          override protected val maybeCachedTrace: Option[TestTrace[Boolean]] = Some(t)
+        }
+      case None =>
+        TestResult(arrow)
+    }
 
   def allSuccesses(assert: TestResult, asserts: TestResult*): TestResult = asserts.foldLeft(assert)(_ && _)
 

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -12,9 +12,9 @@ import scala.util.control.TailCalls
 
 case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
-  lazy val result: TestTrace[Boolean] = TestArrow.run(arrow, Right(()))
+  val result: TestTrace[Boolean] = TestArrow.run(arrow, Right(()))
 
-  lazy val failures: Option[TestTrace[Boolean]] = TestTrace.prune(result, false)
+  val failures: Option[TestTrace[Boolean]] = TestTrace.prune(result, false)
 
   def isFailure: Boolean = failures.isDefined
 

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -12,9 +12,9 @@ import scala.util.control.TailCalls
 
 case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 
-  val result: TestTrace[Boolean] = TestArrow.run(arrow, Right(()))
+  lazy val result: TestTrace[Boolean] = TestArrow.run(arrow, Right(()))
 
-  val failures: Option[TestTrace[Boolean]] = TestTrace.prune(result, false)
+  lazy val failures: Option[TestTrace[Boolean]] = TestTrace.prune(result, false)
 
   def isFailure: Boolean = failures.isDefined
 
@@ -45,6 +45,29 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
 }
 
 object TestResult {
+
+  /**
+   * Build a `TestResult` whose underlying `TestArrow` is run **once, eagerly**,
+   * with the resulting `TestTrace` cached behind a constant arrow. This is used
+   * by every `assertTrue` / `assert(...)(...)` entry point so that:
+   *
+   *   - Side-effecting expressions inside the assertion (e.g.
+   *     `q.offer(1)`, `alive.get`) are evaluated exactly once, at the call
+   *     site — i.e. *inside* the user's effect chain. That keeps any
+   *     scope-managed resources alive when the captured value is read, and
+   *     prevents `&&`/`||` composition from re-running the side effect on
+   *     every combinator step.
+   *
+   *   - Subsequent runs of the resulting arrow (driven by `result` /
+   *     `failures` inspection, or by composing into a larger `TestResult`)
+   *     return the cached trace without re-executing the original
+   *     expression.
+   */
+  def cached(arrow: TestArrow[Any, Boolean]): TestResult = {
+    val trace = TestArrow.run(arrow, Right(()))
+    TestResult(TestArrow.TestArrowF[Any, Boolean](_ => trace))
+  }
+
   def allSuccesses(assert: TestResult, asserts: TestResult*): TestResult = asserts.foldLeft(assert)(_ && _)
 
   def allSuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =

--- a/test/shared/src/main/scala/zio/test/TestTrace.scala
+++ b/test/shared/src/main/scala/zio/test/TestTrace.scala
@@ -135,24 +135,32 @@ sealed trait TestTrace[+A] { self =>
   }
 
   /**
-   * Apply the code to every node in the tree.
+   * Apply the complete code to every node in the tree, but only if a value is
+   * provided. (Mirrors the guarding pattern used by `withCode`,
+   * `withCustomLabel`, `withLocation` etc., so that wrapping a trace in an
+   * outer `Meta` whose `completeCode` is `None` does not clobber a
+   * `completeCode` already present on the inner trace.)
    */
   final def withCompleteCode(completeCode: Option[String]): TestTrace[A] =
-    self match {
-      case node: TestTrace.Node[_] =>
-        node.copy(completeCode = completeCode, children = node.children.map(_.withCompleteCode(completeCode)))
-      case TestTrace.AndThen(left, right) =>
-        TestTrace.AndThen(left.withCompleteCode(completeCode), right.withCompleteCode(completeCode))
-      case and: TestTrace.And =>
-        TestTrace
-          .And(and.left.withCompleteCode(completeCode), and.right.withCompleteCode(completeCode))
-          .asInstanceOf[TestTrace[A]]
-      case or: TestTrace.Or =>
-        TestTrace
-          .Or(or.left.withCompleteCode(completeCode), or.right.withCompleteCode(completeCode))
-          .asInstanceOf[TestTrace[A]]
-      case not: TestTrace.Not =>
-        TestTrace.Not(not.trace.withCompleteCode(completeCode)).asInstanceOf[TestTrace[A]]
+    if (completeCode.isDefined) {
+      self match {
+        case node: TestTrace.Node[_] =>
+          node.copy(completeCode = completeCode, children = node.children.map(_.withCompleteCode(completeCode)))
+        case TestTrace.AndThen(left, right) =>
+          TestTrace.AndThen(left.withCompleteCode(completeCode), right.withCompleteCode(completeCode))
+        case and: TestTrace.And =>
+          TestTrace
+            .And(and.left.withCompleteCode(completeCode), and.right.withCompleteCode(completeCode))
+            .asInstanceOf[TestTrace[A]]
+        case or: TestTrace.Or =>
+          TestTrace
+            .Or(or.left.withCompleteCode(completeCode), or.right.withCompleteCode(completeCode))
+            .asInstanceOf[TestTrace[A]]
+        case not: TestTrace.Not =>
+          TestTrace.Not(not.trace.withCompleteCode(completeCode)).asInstanceOf[TestTrace[A]]
+      }
+    } else {
+      self
     }
 
   final def withGenFailureDetails(genFailureDetails: Option[GenFailureDetails]): TestTrace[A] =


### PR DESCRIPTION
~~`TestResult.result` and `failures` were `lazy val`s, evaluated only when the runner inspected the result (via `failures` / `isSuccess`). This happened AFTER the test body's ZIO completed — including after any `ZIO.scoped` block had closed its scope. Captured `assertTrue` expressions referencing scope-managed resources therefore observed torn-down state ("Result was false" against a freshly-released AtomicBoolean, etc.).~~

~~Switch both `result` and `failures` to `val` so the captured `TestArrow` chain is evaluated at construction (i.e. inside the user's effect chain), not at observation. The trace-evaluation cost is small relative to the cost of running the test, and the alternative preserves a silent correctness bug whenever `assertTrue` arguments reference Scope-managed state.~~

The initial suggested solution was breaking tons of other tests; my bad I didn't check them all locally before opening the pull-request; sorry.

The current proposed fix is not as simple, but shouldn't break other tests.

Adds `ScopeAssertEvalSpec` as a regression test: one assertion against a `Scope.acquireRelease`'d `AtomicBoolean` (fails without the fix) plus two controls (eagerly-bound boolean, `ZIO.succeed` before yield) that bracket the symptom and confirm the bug is specific to `TestResult.result` lazy evaluation.