### PR TITLE
feat(runtime): implement OpLog runtime flag

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -138,9 +138,8 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             val yieldNowEffect = ZIO.YieldNow(Trace.empty, forceAsync = true)
             val flatMapEffect =
               ZIO.FlatMap[Any, Nothing, Unit, Unit](Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.unit)
-            val updateValue = RuntimeFlags.enable(RuntimeFlag.Interruption)
             val updateRuntimeFlagsEffect =
-              ZIO.UpdateRuntimeFlags(Trace.empty, updateValue)
+              ZIO.UpdateRuntimeFlags(Trace.empty, RuntimeFlags.enable(RuntimeFlag.Interruption))
             val foldZioEffect =
               ZIO
                 .FoldZIO[Any, Nothing, Unit, Unit, Unit](
@@ -157,23 +156,35 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
               ZIO.UpdateRuntimeFlagsWithin
                 .DynamicNoBox[Any, Nothing, Unit](
                   Trace.empty,
-                  updateValue,
+                  RuntimeFlags.enable(RuntimeFlag.Interruption),
                   (_: Int) => ZIO.succeed(())
                 )
 
             val exitSuccessEffect = Exit.succeed(0)
             val exitFailureEffect = Exit.fail("boom")
 
-            assertTrue(ZIO.render(syncEffect) == "Sync()") &&
-            assertTrue(ZIO.render(whileLoopEffect) == "WhileLoop()") &&
-            assertTrue(ZIO.render(statefulEffect) == "Stateful()") &&
-            assertTrue(ZIO.render(yieldNowEffect) == "YieldNow(forceAsync=true)") &&
-            assertTrue(ZIO.render(flatMapEffect) == "FlatMap(first=Sync())") &&
-            assertTrue(ZIO.render(updateRuntimeFlagsEffect) == s"UpdateRuntimeFlags(update=$updateValue)") &&
-            assertTrue(ZIO.render(foldZioEffect) == "FoldZIO(first=Sync())") &&
-            assertTrue(ZIO.render(asyncEffect) == "Async()") &&
+            assertTrue(ZIO.render(syncEffect) == s"Sync(trace=${syncEffect.trace})") &&
+            assertTrue(ZIO.render(whileLoopEffect) == s"WhileLoop(trace=${whileLoopEffect.trace})") &&
+            assertTrue(ZIO.render(statefulEffect) == s"Stateful(trace=${statefulEffect.trace})") &&
+            assertTrue(ZIO.render(yieldNowEffect) == s"YieldNow(trace=${yieldNowEffect.trace}, forceAsync=true)") &&
             assertTrue(
-              ZIO.render(dynamicNoBoxEffect) == s"UpdateRuntimeFlagsWithin.DynamicNoBox(update=$updateValue)"
+              ZIO.render(
+                flatMapEffect
+              ) == s"FlatMap(trace=${flatMapEffect.trace}, first=Sync(trace=${flatMapEffect.first.trace}))"
+            ) &&
+            assertTrue(
+              ZIO.render(updateRuntimeFlagsEffect) == s"UpdateRuntimeFlags(trace=${updateRuntimeFlagsEffect.trace})"
+            ) &&
+            assertTrue(
+              ZIO.render(
+                foldZioEffect
+              ) == s"FoldZIO(trace=${foldZioEffect.trace}, first=Sync(trace=${foldZioEffect.first.trace}))"
+            ) &&
+            assertTrue(ZIO.render(asyncEffect) == s"Async(trace=${asyncEffect.trace})") &&
+            assertTrue(
+              ZIO.render(
+                dynamicNoBoxEffect
+              ) == s"UpdateRuntimeFlagsWithin.DynamicNoBox(trace=${dynamicNoBoxEffect.trace})"
             ) &&
             assertTrue(ZIO.render(exitSuccessEffect) == "Exit.Success(value=0)") &&
             assertTrue(

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+import zio.AcquireReleaseWithTypeInferenceSpec.E
 import zio.test._
 
 object RuntimeFlagsSpec extends ZIOBaseSpec {
@@ -127,6 +128,41 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                 name <- ZIO.succeed(Thread.currentThread().getName)
               } yield assertTrue(name.startsWith("ZScheduler-Worker"))
             }.provide(Runtime.enableFlags(RuntimeFlag.EagerShiftBack))
-        } @@ TestAspect.jvmOnly
+        } @@ TestAspect.jvmOnly +
+        suite("OpLog") {
+          test("enabled") {
+            val syncEffect               = ZIO.Sync(Trace.empty, () => {})
+            val whileLoopEffect          = ZIO.WhileLoop(Trace.empty, () => true, () => ZIO.succeed(()), (_: Any) => {})
+            val statefulEffect           = ZIO.Stateful(Trace.empty, (_: Any, _) => ZIO.succeed(()))
+            val yieldNowEffect           = ZIO.YieldNow(Trace.empty, forceAsync = true)
+            val flatMapEffect            = ZIO.FlatMap(Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.unit)
+            val updateValue              = RuntimeFlags.enable(RuntimeFlag.Interruption)
+            val updateRuntimeFlagsEffect = ZIO.UpdateRuntimeFlags(Trace.empty, updateValue)
+            val foldZioEffect =
+              ZIO.FoldZIO(Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.succeed(()), (_: Any) => ZIO.fail(()))
+            val asyncEffect = ZIO.Async(Trace.empty, (_: Any) => ZIO.succeed(()), () => FiberId.None)
+            val dynamicNoBoxEffect = ZIO.UpdateRuntimeFlagsWithin.DynamicNoBox(
+              Trace.empty,
+              RuntimeFlags.disable(RuntimeFlag.WindDown),
+              (_: Int) => ZIO.succeed(()): ZIO[Any, E, Unit]
+            )
+            val exitSuccessEffect = Exit.succeed(0)
+            val exitFailureEffect = Exit.fail("boom")
+
+            assertTrue(ZIO.render(syncEffect) == "Sync()") &&
+            assertTrue(ZIO.render(whileLoopEffect) == "WhileLoop()") &&
+            assertTrue(ZIO.render(statefulEffect) == "Stateful()") &&
+            assertTrue(ZIO.render(yieldNowEffect) == "YieldNow(forceAsync=true)") &&
+            assertTrue(ZIO.render(flatMapEffect) == "FlatMap(first=Sync())") &&
+            assertTrue(ZIO.render(updateRuntimeFlagsEffect) == s"UpdateRuntimeFlags(update=$updateValue)") &&
+            assertTrue(ZIO.render(foldZioEffect) == "FoldZIO(first=Sync())") &&
+            assertTrue(ZIO.render(asyncEffect) == "Async()")
+            assertTrue(ZIO.render(dynamicNoBoxEffect).startsWith("UpdateRuntimeFlagsWithin.DynamicNoBox(update=")) &&
+            assertTrue(ZIO.render(exitSuccessEffect) == "Exit.Success(value=0)") &&
+            assertTrue(
+              ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"
+            )
+          }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
+        }
     }
 }

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -129,7 +129,7 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             }.provide(Runtime.enableFlags(RuntimeFlag.EagerShiftBack))
         } @@ TestAspect.jvmOnly +
         suite("OpLog") {
-          test("enabled") {
+          test("rendered") {
             val syncEffect = ZIO.Sync(Trace.empty, () => {})
             val whileLoopEffect = ZIO
               .WhileLoop[Any, Nothing, Unit](Trace.empty, () => true, () => ZIO.succeed(()), (_: Any) => {})
@@ -159,7 +159,6 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                   RuntimeFlags.enable(RuntimeFlag.Interruption),
                   (_: Int) => ZIO.succeed(())
                 )
-
             val exitSuccessEffect = Exit.succeed(0)
             val exitFailureEffect = Exit.fail("boom")
 
@@ -190,6 +189,15 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             assertTrue(
               ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"
             )
+          }
+          test("enabled") {
+            val effect         = ZIO.succeed(0)
+            val effectRendered = ZIO.render(effect)
+
+            for {
+              _      <- effect
+              output <- ZTestLogger.logOutput
+            } yield assertTrue(output.exists(_.message() == effectRendered))
           }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
         }
     }

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -131,21 +131,37 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
         } @@ TestAspect.jvmOnly +
         suite("OpLog") {
           test("enabled") {
-            val syncEffect               = ZIO.Sync(Trace.empty, () => {})
-            val whileLoopEffect          = ZIO.WhileLoop(Trace.empty, () => true, () => ZIO.succeed(()), (_: Any) => {})
-            val statefulEffect           = ZIO.Stateful(Trace.empty, (_: Any, _) => ZIO.succeed(()))
-            val yieldNowEffect           = ZIO.YieldNow(Trace.empty, forceAsync = true)
-            val flatMapEffect            = ZIO.FlatMap(Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.unit)
-            val updateValue              = RuntimeFlags.enable(RuntimeFlag.Interruption)
-            val updateRuntimeFlagsEffect = ZIO.UpdateRuntimeFlags(Trace.empty, updateValue)
+            val syncEffect = ZIO.Sync(Trace.empty, () => {})
+            val whileLoopEffect = ZIO
+              .WhileLoop[Any, Nothing, Unit](Trace.empty, () => true, () => ZIO.succeed(()), (_: Any) => {})
+            val statefulEffect =
+              ZIO.Stateful[Any, Nothing, Unit](Trace.empty, (_: Any, _) => ZIO.succeed(()))
+            val yieldNowEffect = ZIO.YieldNow(Trace.empty, forceAsync = true)
+            val flatMapEffect =
+              ZIO.FlatMap[Any, Nothing, Unit, Unit](Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.unit)
+            val updateValue = RuntimeFlags.enable(RuntimeFlag.Interruption)
+            val updateRuntimeFlagsEffect =
+              ZIO.UpdateRuntimeFlags(Trace.empty, updateValue)
             val foldZioEffect =
-              ZIO.FoldZIO(Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.succeed(()), (_: Any) => ZIO.fail(()))
-            val asyncEffect = ZIO.Async(Trace.empty, (_: Any) => ZIO.succeed(()), () => FiberId.None)
-            val dynamicNoBoxEffect = ZIO.UpdateRuntimeFlagsWithin.DynamicNoBox(
-              Trace.empty,
-              RuntimeFlags.disable(RuntimeFlag.WindDown),
-              (_: Int) => ZIO.succeed(()): ZIO[Any, E, Unit]
-            )
+              ZIO
+                .FoldZIO[Any, Nothing, Unit, Unit, Unit](
+                  Trace.empty,
+                  ZIO.succeed(()),
+                  (_: Any) => ZIO.succeed(()),
+                  (_: Any) => ZIO.fail(())
+                )
+
+            val asyncEffect = ZIO
+              .Async[Any, Nothing, Unit](Trace.empty, (_: Any) => ZIO.succeed(()), () => FiberId.None)
+
+            val dynamicNoBoxEffect =
+              ZIO.UpdateRuntimeFlagsWithin
+                .DynamicNoBox[Any, Nothing, Unit](
+                  Trace.empty,
+                  updateValue,
+                  (_: Int) => ZIO.succeed(())
+                )
+
             val exitSuccessEffect = Exit.succeed(0)
             val exitFailureEffect = Exit.fail("boom")
 
@@ -156,8 +172,10 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             assertTrue(ZIO.render(flatMapEffect) == "FlatMap(first=Sync())") &&
             assertTrue(ZIO.render(updateRuntimeFlagsEffect) == s"UpdateRuntimeFlags(update=$updateValue)") &&
             assertTrue(ZIO.render(foldZioEffect) == "FoldZIO(first=Sync())") &&
-            assertTrue(ZIO.render(asyncEffect) == "Async()")
-            assertTrue(ZIO.render(dynamicNoBoxEffect).startsWith("UpdateRuntimeFlagsWithin.DynamicNoBox(update=")) &&
+            assertTrue(ZIO.render(asyncEffect) == "Async()") &&
+            assertTrue(
+              ZIO.render(dynamicNoBoxEffect) == s"UpdateRuntimeFlagsWithin.DynamicNoBox(update=$updateValue)"
+            ) &&
             assertTrue(ZIO.render(exitSuccessEffect) == "Exit.Success(value=0)") &&
             assertTrue(
               ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -189,16 +189,19 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             assertTrue(
               ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"
             )
-          }
-          test("enabled") {
-            val effect         = ZIO.succeed(0)
-            val effectRendered = ZIO.render(effect)
+          } +
+            test("enabled") {
+              val effect = for {
+                a <- ZIO.succeed(1)
+                b <- ZIO.succeed(2)
+                c  = a + b
+              } yield c
 
-            for {
-              _      <- effect
-              output <- ZTestLogger.logOutput
-            } yield assertTrue(output.exists(_.message() == effectRendered))
-          }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
+              for {
+                _      <- effect
+                output <- ZTestLogger.logOutput
+              } yield assertTrue(output.exists(_.message() == ZIO.render(effect)))
+            }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
         }
     }
 }

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -1,6 +1,5 @@
 package zio
 
-import zio.AcquireReleaseWithTypeInferenceSpec.E
 import zio.test._
 
 object RuntimeFlagsSpec extends ZIOBaseSpec {

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -191,16 +191,20 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
             )
           } +
             test("enabled") {
+              val effect1 = ZIO.succeed(1)
               val effect = for {
-                a <- ZIO.succeed(1)
+                a <- effect1
                 b <- ZIO.succeed(2)
                 c  = a + b
               } yield c
 
+              val effectRendered =
+                s"FlatMap(trace=${effect.trace}, first=Sync(trace=${effect1.trace}))"
+
               for {
                 _      <- effect
                 output <- ZTestLogger.logOutput
-              } yield assertTrue(output.exists(_.message() == ZIO.render(effect)))
+              } yield assertTrue(output.exists(_.message() == effectRendered))
             }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
         }
     }

--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -150,7 +150,7 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                 )
 
             val asyncEffect = ZIO
-              .Async[Any, Nothing, Unit](Trace.empty, (_: Any) => ZIO.succeed(()), () => FiberId.None)
+              .Async[Any, Nothing, Unit](Trace.empty, (_: Any) => Right(ZIO.succeed(())), () => FiberId.None)
 
             val dynamicNoBoxEffect =
               ZIO.UpdateRuntimeFlagsWithin
@@ -186,9 +186,7 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
               ) == s"UpdateRuntimeFlagsWithin.DynamicNoBox(trace=${dynamicNoBoxEffect.trace})"
             ) &&
             assertTrue(ZIO.render(exitSuccessEffect) == "Exit.Success(value=0)") &&
-            assertTrue(
-              ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"
-            )
+            assertTrue(ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,StackTrace.none))")
           } +
             test("enabled") {
               val effect1 = ZIO.succeed(1)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6444,6 +6444,36 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
           }
         }
     }
+
+  def render(zio: ZIO.Erased): String =
+    zio match {
+      case Sync(_, _)                    => s"Sync()"
+      case WhileLoop(_, _, _, _)         => s"WhileLoop()"
+      case Stateful(_, _)                => s"Stateful()"
+      case GenerateStackTrace(_)         => s"GenerateStackTrace()"
+      case YieldNow(_, forceAsync)       => s"YieldNow(forceAsync=$forceAsync)"
+      case FlatMap(_, first, _)          => s"FlatMap(first=${render(first)})"
+      case UpdateRuntimeFlags(_, update) => s"UpdateRuntimeFlags(update=$update)"
+      case FoldZIO(_, first, _, _)       => s"FoldZIO(first=${render(first)})"
+      case Async(_, _, _)                => s"Async()"
+      case within: UpdateRuntimeFlagsWithin[_, _, _] =>
+        within match {
+          case UpdateRuntimeFlagsWithin.Interruptible(_, effect) =>
+            s"UpdateRuntimeFlagsWithin.Interruptible(effect=$effect)"
+          case UpdateRuntimeFlagsWithin.Uninterruptible(_, effect) =>
+            s"UpdateRuntimeFlagsWithin.Uninterruptible(effect=$effect)"
+          case UpdateRuntimeFlagsWithin.Dynamic(_, update, _) =>
+            s"UpdateRuntimeFlagsWithin.Dynamic(update=$update)"
+          case UpdateRuntimeFlagsWithin.DynamicNoBox(_, update, _) =>
+            s"UpdateRuntimeFlagsWithin.DynamicNoBox(update=$update)"
+        }
+      case exit: Exit[_, _] =>
+        exit match {
+          case Exit.Success(value) => s"Exit.Success(value=$value)"
+          case Exit.Failure(cause) => s"Exit.Failure(cause=$cause)"
+        }
+      case _ => "Operation Not Found"
+    }
 }
 
 /**

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6447,32 +6447,31 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   def render(zio: ZIO.Erased): String =
     zio match {
-      case Sync(_, _)                    => s"Sync()"
-      case WhileLoop(_, _, _, _)         => s"WhileLoop()"
-      case Stateful(_, _)                => s"Stateful()"
-      case GenerateStackTrace(_)         => s"GenerateStackTrace()"
-      case YieldNow(_, forceAsync)       => s"YieldNow(forceAsync=$forceAsync)"
-      case FlatMap(_, first, _)          => s"FlatMap(first=${render(first)})"
-      case UpdateRuntimeFlags(_, update) => s"UpdateRuntimeFlags(update=$update)"
-      case FoldZIO(_, first, _, _)       => s"FoldZIO(first=${render(first)})"
-      case Async(_, _, _)                => s"Async()"
+      case Sync(trace, _)               => s"Sync(trace=$trace)"
+      case WhileLoop(trace, _, _, _)    => s"WhileLoop(trace=$trace)"
+      case Stateful(trace, _)           => s"Stateful(trace=$trace)"
+      case GenerateStackTrace(trace)    => s"GenerateStackTrace(trace=$trace)"
+      case YieldNow(trace, forceAsync)  => s"YieldNow(trace=$trace, forceAsync=$forceAsync)"
+      case FlatMap(trace, first, _)     => s"FlatMap(trace=$trace, first=${render(first)})"
+      case UpdateRuntimeFlags(trace, _) => s"UpdateRuntimeFlags(trace=$trace)"
+      case FoldZIO(trace, first, _, _)  => s"FoldZIO(trace=$trace, first=${render(first)})"
+      case Async(trace, _, _)           => s"Async(trace=$trace)"
       case within: UpdateRuntimeFlagsWithin[_, _, _] =>
         within match {
-          case UpdateRuntimeFlagsWithin.Interruptible(_, effect) =>
-            s"UpdateRuntimeFlagsWithin.Interruptible(effect=$effect)"
-          case UpdateRuntimeFlagsWithin.Uninterruptible(_, effect) =>
-            s"UpdateRuntimeFlagsWithin.Uninterruptible(effect=$effect)"
-          case UpdateRuntimeFlagsWithin.Dynamic(_, update, _) =>
-            s"UpdateRuntimeFlagsWithin.Dynamic(update=$update)"
-          case UpdateRuntimeFlagsWithin.DynamicNoBox(_, update, _) =>
-            s"UpdateRuntimeFlagsWithin.DynamicNoBox(update=$update)"
+          case UpdateRuntimeFlagsWithin.Interruptible(trace, effect) =>
+            s"UpdateRuntimeFlagsWithin.Interruptible(trace=$trace, effect=$effect)"
+          case UpdateRuntimeFlagsWithin.Uninterruptible(trace, effect) =>
+            s"UpdateRuntimeFlagsWithin.Uninterruptible(trace=$trace, effect=$effect)"
+          case UpdateRuntimeFlagsWithin.Dynamic(trace, _, _) =>
+            s"UpdateRuntimeFlagsWithin.Dynamic(trace=$trace)"
+          case UpdateRuntimeFlagsWithin.DynamicNoBox(trace, _, _) =>
+            s"UpdateRuntimeFlagsWithin.DynamicNoBox(trace=$trace)"
         }
       case exit: Exit[_, _] =>
         exit match {
           case Exit.Success(value) => s"Exit.Success(value=$value)"
           case Exit.Failure(cause) => s"Exit.Failure(cause=$cause)"
         }
-      case _ => "Operation Not Found"
     }
 }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6453,6 +6453,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       case GenerateStackTrace(trace)    => s"GenerateStackTrace(trace=$trace)"
       case YieldNow(trace, forceAsync)  => s"YieldNow(trace=$trace, forceAsync=$forceAsync)"
       case FlatMap(trace, first, _)     => s"FlatMap(trace=$trace, first=${render(first)})"
+      case Mapped(trace, first, _)      => s"Mapped(trace=$trace, first=${render(first)})"
       case UpdateRuntimeFlags(trace, _) => s"UpdateRuntimeFlags(trace=$trace)"
       case FoldZIO(trace, first, _, _)  => s"FoldZIO(trace=$trace, first=${render(first)})"
       case Async(trace, _, _)           => s"Async(trace=$trace)"

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6445,7 +6445,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         }
     }
 
-  def render(zio: ZIO.Erased): String =
+  private[zio] def render(zio: ZIO.Erased): String =
     zio match {
       case Sync(trace, _)               => s"Sync(trace=$trace)"
       case WhileLoop(trace, _, _, _)    => s"WhileLoop(trace=$trace)"

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6459,9 +6459,9 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       case within: UpdateRuntimeFlagsWithin[_, _, _] =>
         within match {
           case UpdateRuntimeFlagsWithin.Interruptible(trace, effect) =>
-            s"UpdateRuntimeFlagsWithin.Interruptible(trace=$trace, effect=$effect)"
+            s"UpdateRuntimeFlagsWithin.Interruptible(trace=$trace, effect=${render(effect)})"
           case UpdateRuntimeFlagsWithin.Uninterruptible(trace, effect) =>
-            s"UpdateRuntimeFlagsWithin.Uninterruptible(trace=$trace, effect=$effect)"
+            s"UpdateRuntimeFlagsWithin.Uninterruptible(trace=$trace, effect=${render(effect)})"
           case UpdateRuntimeFlagsWithin.Dynamic(trace, _, _) =>
             s"UpdateRuntimeFlagsWithin.Dynamic(trace=$trace)"
           case UpdateRuntimeFlagsWithin.DynamicNoBox(trace, _, _) =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6473,6 +6473,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
           case Exit.Success(value) => s"Exit.Success(value=$value)"
           case Exit.Failure(cause) => s"Exit.Failure(cause=$cause)"
         }
+      case other => s"${other.getClass.getSimpleName}()"
     }
 }
 

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1108,7 +1108,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       }
 
       if (RuntimeFlags.opLog(_runtimeFlags)) {
-        log(() => ZIO.render(cur), Cause.empty, Some(LogLevel.Info), cur.trace)
+        val safeCur = cur
+        log(() => ZIO.render(safeCur), Cause.empty, ZIO.someDebug, safeCur.trace)
       }
 
       cur = drainQueueWhileRunning(cur)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1107,6 +1107,10 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         self.getSupervisor().onEffect(self, cur)(Unsafe)
       }
 
+      if (RuntimeFlags.opLog(_runtimeFlags)) {
+        log(() => ZIO.render(cur), Cause.empty, Some(LogLevel.Info), cur.trace)
+      }
+
       cur = drainQueueWhileRunning(cur)
 
       ops += 1


### PR DESCRIPTION
## Summary

Implements `RuntimeFlag.OpLog` so that enabling it (e.g. via`Runtime.enableFlags(RuntimeFlag.OpLog)`) causes each ZIO effect evaluated by `FiberRuntime.runLoop` to be logged at `Debug` level. Until now the flag existed in the public API but did nothing.

Closes #9170 

## Relationship to prior work

This builds directly on @abdelfetah18's partially approved implementation in #9869. Their PR went through review and was approved by @hearnadam, then was closed December 2025 without an explicit reason - im guessing just bit-rot after sitting for ~6 months. The work in this PR is essentially a rebase of #9869 onto current `series/2.x` plus three bit-rot fixups and one safety improvement in the render pattern matching.

If the bounty is awarded here, I'd like to split it with @abdelfetah18 - the substantive work is theirs and it would be unfair for them to come away with nothing after getting that far. I'll try and get into contact if it is awarded.

## Changes vs. #9869 

- **`ZIO.Async` test constructor** - the second parameter's return type from `ZIO[R, E, A]` to `Either[URIO[R, Any], ZIO[R, E, A]]`, so the test now wraps in `Right(...)`.
- **`Mapped` case added to `ZIO.render`** - the `Mapped` instruction was introduced after #9869 was opened. Without an explicit case, `render` threw`MatchError` whenever a `.map` op was evaluated.
- **`Cause.Fail.toString` format** - changed from `"Fail(boom,Stack trace thread \"zio-fiber-\":\n)"` to `"Fail(boom,StackTrace.none)"`. Test expectation updated.
- **Catch-all fallback in `render`** - added `case other => s"${other.getClass.getSimpleName}()"` so future instruction types don't break OpLog when added. The existing approved cases still take precedence; the fallback only fires for unknown types.

## Demo 

```scala
  package zio.examples

  import zio._

  object OpLogDemo extends ZIOAppDefault {
    override val bootstrap = Runtime.enableFlags(RuntimeFlag.OpLog)

    val program =
      for {
        a <- ZIO.succeed(1)
        b <- ZIO.succeed(2)
      } yield a + b

    override val run = program.flatMap(r => Console.printLine(s"=== RESULT: $r ==="))
  }
```

With a `Debug`-level logger attached, the user-program portion of the run looks like:

```
[DEBUG] FlatMap(trace=zio.examples.OpLogDemo.run(OpLogDemo.scala:14),
first=FlatMap(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:10),
first=Sync(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:10))))
[DEBUG] FlatMap(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:10),
first=Sync(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:10)))
[DEBUG] Sync(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:10))
[DEBUG] Mapped(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:11),
first=Sync(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:11)))
[DEBUG] Sync(trace=zio.examples.OpLogDemo.program(OpLogDemo.scala:11))
... (runtime/scope ops)
=== RESULT: 3 ===
```

## Verification
- `coreTestsJVM/testOnly zio.RuntimeFlagsSpec`; 14/14 tests pass, including the new `OpLog` suite (`rendered` + `enabled`).
- `sbt fmtCheck`; clean.
- Mima not verifiable locally (`mimaPreviousArtifacts not set`); CI will validate.
- Cross-compile (Scala 2.12/3.x, JS, Native) only verified locally on JVM/2. Relying on CI for the rest.

  /claim #9170