### PR TITLE
fix(perf): optimize ZIO.timeoutTo by eliminating one fiber via direct Scheduler.schedule

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,48 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, State, Scope => JScope}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.TimeoutException
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TimeoutBenchmark {
+  import BenchmarkUtil.unsafeRun
+
+  @Param(Array("0", "100", "10000"))
+  var n: Int = _
+
+  val effect = ZIO.foldLeft(0 until n)(0) { case (prev, x) =>
+    ZIO.succeed(prev + x)
+  }
+
+  @Benchmark
+  def zioBaseline = {
+    val _ = unsafeRun {
+      effect
+    }
+  }
+
+  @Benchmark
+  def zioTimeoutAlt = {
+    val _ = unsafeRun {
+      effect
+        .timeoutTo(ZIO.fail(new TimeoutException))
+        .apply(ZIO.succeed(_))(100.minutes)
+        .flatten
+    }
+  }
+
+  @Benchmark
+  def zioTimeoutOrig = {
+    val _ = unsafeRun {
+      effect
+        .timeoutTo(ZIO.fail(new TimeoutException))
+        .applyOrig(ZIO.succeed(_))(100.minutes)
+        .flatten
+    }
+  }
+
+}

--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,6 +1,6 @@
 package zio
 
-import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, State, Scope => JScope}
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, Setup, State, Scope => JScope}
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.TimeoutException
@@ -14,9 +14,13 @@ class TimeoutBenchmark {
   @Param(Array("0", "100", "10000"))
   var n: Int = _
 
-  val effect = ZIO.foldLeft(0 until n)(0) { case (prev, x) =>
-    ZIO.succeed(prev + x)
-  }
+  var effect: ZIO[Any, Nothing, Int] = _
+
+  @Setup
+  def setup(): Unit =
+    effect = ZIO.foldLeft(0 until n)(0) { case (prev, x) =>
+      ZIO.succeed(prev + x)
+    }
 
   @Benchmark
   def zioBaseline = {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -29,6 +29,8 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+
 /**
  * A `ZIO[R, E, A]` value is an immutable value (called an "effect") that
  * describes an async, concurrent workflow. In order to be executed, the
@@ -5643,7 +5645,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   }
 
   final class TimeoutTo[-R, +E, +A, +B](self: ZIO[R, E, A], b: () => B) {
-    def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
+    //todo: kept here for reference, drop this once the new impl is approved (makre sure to drop the referencing benchmarks in zio.TimeoutBenchmark)
+    def applyOrig[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
       ZIO.fiberIdWith { parentFiberId =>
@@ -5663,6 +5666,105 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
           FiberScope.global
         )
       }
+
+    def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
+      trace: Trace
+    ): ZIO[R, E, B1] =
+      ZIO.clockWith(_.scheduler).flatMap { scheduler =>
+        ZIO.withFiberRuntime[R, E, B1] { (fibRt, r) =>
+          ZIO
+            .asyncInterrupt[R, Nothing, Either[B, zio.Exit[E, A]]] { cb =>
+              //todo: optimize away when the timeout is <= 0 ?
+              val fib = ZIO.unsafe.makeChildFiber(
+                trace,
+                self,
+                fibRt,
+                r.runtimeFlags,
+                null
+              )(zio.Unsafe.unsafe)
+              import TimeoutTo._
+              val bypassState = new AtomicReference[BypassState[E, A]](BypassPossible)
+              val cancellable = scheduler
+                .schedule(
+                  () => {
+                    //race both with the fiber and the supervisor
+                    //fiber attempts to CAS state into BypassPendingResult while supervisor attempts to CAS into BypassDenied,
+                    //if we won the race or lost to the supervisor, we're now racing with the fiber.
+                    //otherwise, fiber existed early and the coordinator is still able to bypass cb
+                    if (bypassState.compareAndSet(BypassPossible, BypassDenied)) //won the race
+                      cb(ZIO.left(b()).ensuring(fib.interrupt *> fib.inheritAll))
+                    else if (bypassState.get /*Plain*/ eq BypassDenied) //supervisor won
+                      cb(ZIO.left(b()).ensuring(fib.interrupt *> fib.inheritAll))
+                  },
+                  duration
+                )(zio.Unsafe.unsafe)
+
+              if (
+                bypassState.get /*Plain*/ () eq BypassDenied
+              ) //no need to actually start the fiber (todo: remove it from the fibers scope?)
+                {
+                  fib.startSuspended()(zio.Unsafe.unsafe)
+                  Left(ZIO.unit)
+                } //todo: can we bypass here? it'd require the scheduler to change state into BypassPendingResult and adding a state so the scheduler does the right thing for 'late' timeout
+              else {
+                fib.addObserver { ex =>
+                  if (!bypassState.compareAndSet(BypassPossible, BypassPendingResult(ex))) {
+                    //lost the race, either to parent fiber or to the scheduler
+                    //in either case the state is BypassDenied and we're in race with the scheduler, and we know for sure this entire effect will be completed via cb.
+                    //since cb CAN be invoked multiple times, we simply delegate the race to cb
+                    // * notice that changing the scheduler to use bypass as well will require modifying this logic as state may be BypassPendingResult, violating the assumption behind this logic.
+                    cancellable.apply()
+                    cb {
+                      (fib.inheritAll.as(Right(ex)))
+                    }
+                  } //else: fiber won, parent now owns cb and can bypass it
+                }(zio.Unsafe.unsafe)
+                fib.start(self)
+
+                bypassState.get() match {
+                  case BypassPendingResult(ex) =>
+                    //early fiber exit
+                    cancellable.apply()
+                    Right(fib.inheritAll.as(Right(ex)))
+                  case BypassDenied =>
+                    //scheduler already won, so cb is already invoked and we don't even have a cancellation action to provide
+                    Left(ZIO.unit)
+                  case BypassPossible =>
+                    if (bypassState.compareAndSet(BypassPossible, BypassDenied)) {
+                      Left(
+                        ZIO.succeed(cancellable.apply())
+                      ) //todo: interrupt fib? it'd be interrupted anyway as a child fiber
+                    } else {
+                      //lost the race to either the fiber or the scheduler,
+                      //now state can be either BypassPendingResult(_) or BypassDenied
+                      //furthermore, this is the final state (no loop required)
+                      bypassState.get /*Plain*/ () match { //the CAS already read the value, since we lost the CAS we also know state will no longer change (the nature of the STM)
+                        case BypassPendingResult(ex) =>
+                          //early fiber exit
+                          cancellable.apply()
+                          Right(fib.inheritAll.as(Right(ex)))
+                        case BypassDenied =>
+                          //scheduler already won (notice the fiber does not attempt to set the state to BypassDenied), so cb is already invoked and we don't even have a cancellation action to provide
+                          Left(ZIO.unit)
+                      }
+                    }
+                }
+              }
+            }
+            .flatMap {
+              case Left(b) =>
+                zio.Exit.Success(b)
+              case Right(ex) =>
+                ex.map(f)
+            }
+        }
+      }
+  }
+  private object TimeoutTo {
+    sealed trait BypassState[+E, +A]
+    case object BypassPossible                                 extends BypassState[Nothing, Nothing]
+    case object BypassDenied                                   extends BypassState[Nothing, Nothing]
+    case class BypassPendingResult[+E, +A](ex: zio.Exit[E, A]) extends BypassState[E, A]
   }
 
   final class Acquire[-R, +E, +A](private val acquire: () => ZIO[R, E, A]) extends AnyVal {

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 import scala.reflect.ClassTag
 
-import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A `ZIO[R, E, A]` value is an immutable value (called an "effect") that
@@ -5645,7 +5645,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   }
 
   final class TimeoutTo[-R, +E, +A, +B](self: ZIO[R, E, A], b: () => B) {
-    //todo: kept here for reference, drop this once the new impl is approved (makre sure to drop the referencing benchmarks in zio.TimeoutBenchmark)
+    //Note: kept inside TimeoutTo as private[zio] so the benchmark can compare the old vs new implementations. Remove once this PR is approved (also drop the referencing benchmarks in zio.TimeoutBenchmark).
     private[zio] def applyOrig[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
@@ -5691,22 +5691,26 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                     //race both with the fiber and the supervisor
                     //fiber attempts to CAS state into BypassPendingResult while supervisor attempts to CAS into BypassDenied,
                     //if we won the race or lost to the supervisor, we're now racing with the fiber.
-                    //otherwise, fiber existed early and the coordinator is still able to bypass cb
+                    //otherwise, fiber exited early and the coordinator is still able to bypass cb
                     if (bypassState.compareAndSet(BypassPossible, BypassDenied)) //won the race
                       cb(ZIO.left(b()).ensuring(fib.interrupt *> fib.inheritAll))
-                    else if (bypassState.get /*Plain*/ eq BypassDenied) //supervisor won
+                    else if (bypassState.get eq BypassDenied) //supervisor won
                       cb(ZIO.left(b()).ensuring(fib.interrupt *> fib.inheritAll))
                   },
                   duration
                 )(zio.Unsafe.unsafe)
 
               if (
-                bypassState.get /*Plain*/ () eq BypassDenied
-              ) //no need to actually start the fiber (todo: remove it from the fibers scope?)
-                {
-                  fib.startSuspended()(zio.Unsafe.unsafe)
-                  Left(fib.interruptFork)
-                } //todo: can we bypass here? it'd require the scheduler to change state into BypassPendingResult and adding a state so the scheduler does the right thing for 'late' timeout
+                bypassState.get () eq BypassDenied
+              ) {
+                //Scheduler already won and invoked cb. Drive fib through its
+                //exit pipeline so it leaves the parent scope promptly
+                //instead of accumulating across repeated immediate timeouts.
+                //interruptFork is idempotent w.r.t. the Callback's
+                //single-shot AtomicBoolean.
+                fib.startSuspended()(zio.Unsafe.unsafe)
+                Left(fib.interruptFork)
+              }
               else {
                 fib.addObserver { ex =>
                   if (!bypassState.compareAndSet(BypassPossible, BypassPendingResult(ex))) {
@@ -5739,7 +5743,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                       //lost the race to either the fiber or the scheduler,
                       //now state can be either BypassPendingResult(_) or BypassDenied
                       //furthermore, this is the final state (no loop required)
-                      bypassState.get /*Plain*/ () match { //the CAS already read the value, since we lost the CAS we also know state will no longer change (the nature of the STM)
+                      bypassState.get () match { //the CAS already read the value, since we lost the CAS we also know state will no longer change (the nature of the STM)
                         case BypassPendingResult(ex) =>
                           //early fiber exit
                           cancellable.apply()
@@ -5747,6 +5751,9 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                         case BypassDenied =>
                           //scheduler already won (notice the fiber does not attempt to set the state to BypassDenied), so cb is already invoked and we don't even have a cancellation action to provide
                           Left(ZIO.unit)
+                        case BypassPossible =>
+                          //Unreachable: a failed CAS from BypassPossible implies the state already transitioned.
+                          throw new IllegalStateException("TimeoutTo.apply: BypassState invariant violated")
                       }
                     }
                 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5646,7 +5646,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
 
   final class TimeoutTo[-R, +E, +A, +B](self: ZIO[R, E, A], b: () => B) {
     //todo: kept here for reference, drop this once the new impl is approved (makre sure to drop the referencing benchmarks in zio.TimeoutBenchmark)
-    def applyOrig[B1 >: B](f: A => B1)(duration: => Duration)(implicit
+    private[zio] def applyOrig[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
       ZIO.fiberIdWith { parentFiberId =>
@@ -5672,12 +5672,13 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     ): ZIO[R, E, B1] =
       ZIO.clockWith(_.scheduler).flatMap { scheduler =>
         ZIO.withFiberRuntime[R, E, B1] { (fibRt, r) =>
+          val graftedSelf = ZIO.Grafter(fibRt).applyOnExit(self)
           ZIO
             .asyncInterrupt[R, Nothing, Either[B, zio.Exit[E, A]]] { cb =>
               //todo: optimize away when the timeout is <= 0 ?
               val fib = ZIO.unsafe.makeChildFiber(
                 trace,
-                self,
+                graftedSelf,
                 fibRt,
                 r.runtimeFlags,
                 null
@@ -5704,7 +5705,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
               ) //no need to actually start the fiber (todo: remove it from the fibers scope?)
                 {
                   fib.startSuspended()(zio.Unsafe.unsafe)
-                  Left(ZIO.unit)
+                  Left(fib.interruptFork)
                 } //todo: can we bypass here? it'd require the scheduler to change state into BypassPendingResult and adding a state so the scheduler does the right thing for 'late' timeout
               else {
                 fib.addObserver { ex =>
@@ -5719,7 +5720,7 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                     }
                   } //else: fiber won, parent now owns cb and can bypass it
                 }(zio.Unsafe.unsafe)
-                fib.start(self)
+                fib.start(graftedSelf)
 
                 bypassState.get() match {
                   case BypassPendingResult(ex) =>

--- a/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -26,7 +26,7 @@ private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
-            runtime.unsafe.fork(sleep(duration) *> ZIO.succeed(runnable.run()))
+            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible)
           () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
         }
       }

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -32,7 +32,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
-            runtime.unsafe.fork(((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible))
+            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible)
           () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
         }
 

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -32,7 +32,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
-            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())))
+            runtime.unsafe.fork(((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible))
           () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
         }
 


### PR DESCRIPTION
Closes #9211 · `/claim #9211`

## Background

`ZIO.timeoutTo` currently uses `raceFibersWith(ZIO.sleep(duration))`, which forks an extra fiber for the sleep half of the race. Per the original issue this introduces a ~10× overhead vs the underlying effect — especially painful for streams (`ZStream.timeoutXXX` forks per pull, destroying throughput).

## Approach (continuing @eyalfa's work)

This PR rebases and squashes @eyalfa's previous work, both of which were closed by the author:
- #9261 — original `ZIO.scala`-only rewrite using `Scheduler.schedule` directly + lock-free `BypassState` machine.
- #9266 — second attempt that introduced "recoverable interruption" inside `FiberRuntime`.

Since `FiberRuntime`-level changes from #9266 looked invasive, this PR keeps changes contained to `ZIO.scala` (the #9261 path) and rebases onto current `series/2.x`. Authorship of the core implementation is preserved as `Eyal Farago <efarago@salesforce.com>`.

## Mechanism

- `Clock.scheduler.schedule(callback, duration)` schedules the timeout directly — no fiber.
- The work effect is forked as a single child fiber via `unsafe.makeChildFiber`.
- The work effect is wrapped in `ZIO.Grafter(parent).applyOnExit` so children forked inside the work transfer back to the parent scope on exit (matches `raceFibersWith`'s grafting semantics).
- A lock-free `AtomicReference[BypassState]` resolves the three-way race between scheduler-fires, fiber-completes, and caller-cancels. Terminal states: `BypassPossible` / `BypassDenied` / `BypassPendingResult`.
- If the scheduler wins before `fib.start`, the canceller drives the suspended child fiber through `interruptFork` so it leaves the parent scope promptly (no dead-child accumulation across repeated immediate timeouts).
- `cb` is a `ZIO.asyncInterrupt` callback. The `Callback`'s single-shot `AtomicBoolean` (in `FiberRuntime`) makes redundant invocations from the late-loser branches benign.

## Benchmark (TimeoutBenchmark.scala, JMH Throughput)

Reproduced on this PR (current `series/2.x`, JDK 17.0.18, 4-core / 16 GB Codespace, `-i 3 -wi 2 -f 1`):

```
Benchmark                          (n)   Mode  Cnt        Score         Error  Units
TimeoutBenchmark.zioBaseline         0  thrpt    3  7483572.177 ±  335115.188  ops/s
TimeoutBenchmark.zioBaseline       100  thrpt    3   556388.240 ±   29016.292  ops/s
TimeoutBenchmark.zioBaseline     10000  thrpt    3     6411.080 ±     325.448  ops/s
TimeoutBenchmark.zioTimeoutAlt       0  thrpt    3   726776.200 ±  268576.116  ops/s
TimeoutBenchmark.zioTimeoutAlt     100  thrpt    3   253434.472 ±  152042.190  ops/s
TimeoutBenchmark.zioTimeoutAlt   10000  thrpt    3     5340.642 ±     298.881  ops/s
TimeoutBenchmark.zioTimeoutOrig      0  thrpt    3    24711.620 ±   10395.285  ops/s
TimeoutBenchmark.zioTimeoutOrig    100  thrpt    3    22281.404 ±     194.560  ops/s
TimeoutBenchmark.zioTimeoutOrig  10000  thrpt    3     4016.631 ±     313.478  ops/s
```

Speedup of new `apply` over the previous implementation (kept as `private[zio] applyOrig` for benchmark verification only):
- `n=0`: ~24.7k → ~727k ops/s (**~29.4×**)
- `n=100`: ~22.3k → ~253k ops/s (**~11.4×**)
- `n=10000`: ~4.0k → ~5.3k ops/s (**~1.33×** — effect dominates, timeout overhead amortised)

`zioTimeoutAlt` calls the new `apply`. `zioTimeoutOrig` calls the old `raceFibersWith(ZIO.sleep(duration))` implementation that has been moved inside `TimeoutTo` as `private[zio] applyOrig`, intended for removal once this PR is approved (see Notes).

Reduced JMH iterations were used for CI-friendly run time. Full `-i 5 -wi 5 -f 5` runs from @eyalfa's #9261 reproduced the same direction (e.g. 89k → 1.37M ops/s at `n=0`).

## Test coverage

- Full `coreTestsJVM/ZIOSpec` (568 tests) passes locally on the same Codespace, including all `timeout`-tagged cases plus the deeply uninterruptible-region tests inside `RTS interruption` and `RTS failure` suites.
- The `timeout with interrupt doesn't cause deadlock (i10255)` regression test (10 000 repetitions) passes.
- The `coreTestsJVM/ZIOSpec` "interruption of uninterruptible region" test was kept on `series/2.x`'s upstream version (eyalfa's branch had a `ZIO.scopeWith`-based rewrite for JVM-shutdown reasons that no longer apply post-rebase).

## Notes

- `applyOrig` is `private[zio]` so it does not leak into the public 2.x API; it is accessible to the benchmark in package `zio`. It can (should) be removed in a follow-up commit before this lands, together with the `zioTimeoutOrig` benchmark.
- No changes to `FiberRuntime` / interrupt semantics — all surface contained to `core/shared/src/main/scala/zio/ZIO.scala` plus a small `.interruptible` fix in `TestClockPlatformSpecific` so the test-clock scheduler honours cancellation.
- The inner `bypassState.get() match` adds an `IllegalStateException` arm for the unreachable `BypassPossible` case to satisfy `-Xfatal-warnings` exhaustiveness.
- Co-authored-by: Eyal Farago <efarago@salesforce.com>
