### PR TITLE
fix(schedule): drop wrong interval in Intervals.intersect

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -608,10 +608,6 @@ object ScheduleSpec extends ZIOBaseSpec {
         assert(actual.map(_.getMinute))(forall(equalTo(20)))
     },
     test("intersect of an outer interval with a union retains all sub-intervals (#7783)") {
-      // Regression: `Intervals.intersect` used to advance whichever side started
-      // earlier, which silently dropped subsequent intervals on the longer side.
-      // Concretely: `[18:00, 19:00) ∩ {[18:53, 18:54), [18:58, 18:59)}` returned
-      // only `[18:53, 18:54)`, losing `[18:58, 18:59)`.
       val now      = OffsetDateTime.parse("2023-02-04T18:48:00+03:00")
       val schedule = Schedule.hourOfDay(18) && (Schedule.minuteOfHour(53) || Schedule.minuteOfHour(58))
       for {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -607,6 +607,23 @@ object ScheduleSpec extends ZIOBaseSpec {
       } yield assert(actual.map(_.getHour))(forall(equalTo(4))) &&
         assert(actual.map(_.getMinute))(forall(equalTo(20)))
     },
+    test("intersect of an outer interval with a union retains all sub-intervals (#7783)") {
+      // Regression: `Intervals.intersect` used to advance whichever side started
+      // earlier, which silently dropped subsequent intervals on the longer side.
+      // Concretely: `[18:00, 19:00) ∩ {[18:53, 18:54), [18:58, 18:59)}` returned
+      // only `[18:53, 18:54)`, losing `[18:58, 18:59)`.
+      val now      = OffsetDateTime.parse("2023-02-04T18:48:00+03:00")
+      val schedule = Schedule.hourOfDay(18) && (Schedule.minuteOfHour(53) || Schedule.minuteOfHour(58))
+      for {
+        result <- schedule.step(now, (), schedule.initial)
+        intervals = result._3 match {
+                      case Schedule.Decision.Continue(is) => is.intervals
+                      case Schedule.Decision.Done         => List.empty
+                    }
+      } yield assertTrue(intervals.size == 2) &&
+        assertTrue(intervals.head.start == OffsetDateTime.parse("2023-02-04T18:53:00+03:00")) &&
+        assertTrue(intervals(1).start == OffsetDateTime.parse("2023-02-04T18:58:00+03:00"))
+    },
     test("union composes") {
       val monday            = Schedule.dayOfWeek(1)
       val wednesday         = Schedule.dayOfWeek(3)

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1783,9 +1783,6 @@ object Schedule {
           case (left :: lefts, right :: rights) =>
             val interval  = left.intersect(right)
             val intervals = if (interval.isEmpty) acc else interval :: acc
-            // Advance the interval that ends first; the longer-running one may still
-            // overlap with subsequent intervals on the other side. Comparing by start
-            // (Interval.<) drops those subsequent intersections (see issue #7783).
             if (left.end.isBefore(right.end)) loop(lefts, right :: rights, intervals)
             else if (right.end.isBefore(left.end)) loop(left :: lefts, rights, intervals)
             else loop(lefts, rights, intervals)

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1781,10 +1781,14 @@ object Schedule {
           case (_, Nil)   =>
             Intervals(acc.reverse)
           case (left :: lefts, right :: rights) =>
-            val interval = left.intersect(right)
+            val interval  = left.intersect(right)
             val intervals = if (interval.isEmpty) acc else interval :: acc
-            if (left < right) loop(lefts, right :: rights, intervals)
-            else loop(left :: lefts, rights, intervals)
+            // Advance the interval that ends first; the longer-running one may still
+            // overlap with subsequent intervals on the other side. Comparing by start
+            // (Interval.<) drops those subsequent intersections (see issue #7783).
+            if (left.end.isBefore(right.end)) loop(lefts, right :: rights, intervals)
+            else if (right.end.isBefore(left.end)) loop(left :: lefts, rights, intervals)
+            else loop(lefts, rights, intervals)
         }
 
       loop(self.intervals, that.intervals, List.empty)


### PR DESCRIPTION

## Problem

When intersecting two `Intervals` lists, the loop popped the side that started earlier (`Interval.<`). When that side's interval extended past the other's end, all subsequent intervals on the longer side were silently dropped.

For example, `[18:00, 19:00) ∩ {[18:53, 18:54), [18:58, 18:59)}`  returning only `[18:53, 18:54)` instead of both intervals, which made schedules like `hourOfDay(18) && (minuteOfHour(53) || minuteOfHour(58))` never fire on `:58` (see issue #7783). Reason being that as far as I can tell currently `Interval.<` has the logic of "min comes first" so for the inequality

$$
[18:00, 19:00) < [18:53, 18:54) = \top
$$

as left starts earlier and they clearly overlap. The result of that is then the following call which hits the base `case (Nil, _)`

```
loop(
  left  = [],                           // <- left exhausted
  right = [ [18:53, 18:54), [18:58, 18:59) ],
  acc   = [ [18:53, 18:54) ]
)
```

We return the accumulated result missing the latter half of the right set despite it still being within the interval of the LHS.

## Fix

So what we want to do is is account for the fact that if the RHS's end is still within that of the LHS there is the potential that the disjunction has remaining members within the specified range we should also visit before we pop the LHS. If my reasoning is wrong here then I apologize but I think it tracks. I also added a test to account for this case.

Refs #7783

> Note: #7783 was closed without identifying the actual cause. Adam's earlier comment was rejecting a proposed fix to the leaf primitives (`nextDay` etc.), which we are not changing. The leaves still produce the same intervals; this PR fixes a separate bug in the merge-sweep logic of `Intervals.intersect` that drops valid intersections. I found this issue through it being ref'd in #10174. The approach to #10174 seems a bit more involved and possibly open to discussion so I wanted to hold off there.  

## Verification 

- New regression test: `intersect of an outer interval with a union retains all sub-intervals (#7783)` in `ScheduleSpec`
- `coreTestsJVM/test` - 2881 passed, 0 failed
- `testJVM` (full JVM aggregate) - clean
- Scala 3.3.7 cross-compile - clean
- `scalafmtCheckAll` - clean