### PR TITLE
Support Scala 3 derives Config

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
@@ -1,0 +1,38 @@
+package zio
+
+import zio.test._
+
+object ConfigDerivationSpec extends ZIOBaseSpec {
+
+  final case class DatabaseConfig(host: String, port: Int, useSsl: Boolean) derives Config
+
+  final case class ServiceConfig(database: DatabaseConfig, tags: List[String], retries: Option[Int]) derives Config
+
+  def spec =
+    suite("Config.derived")(
+      test("derives Config for a product type") {
+        for {
+          value <- ConfigProvider
+                     .fromMap(Map("host" -> "localhost", "port" -> "5432", "useSsl" -> "true"))
+                     .load(summon[Config[DatabaseConfig]])
+        } yield assertTrue(value == DatabaseConfig("localhost", 5432, useSsl = true))
+      },
+      test("derives Config for nested products and supported collections") {
+        for {
+          value <- ConfigProvider
+                     .fromMap(
+                       Map(
+                         "database.host"   -> "localhost",
+                         "database.port"   -> "5432",
+                         "database.useSsl" -> "false",
+                         "tags"            -> "api,worker",
+                         "retries"         -> "3"
+                       )
+                     )
+                     .load(summon[Config[ServiceConfig]])
+        } yield assertTrue(
+          value == ServiceConfig(DatabaseConfig("localhost", 5432, useSsl = false), List("api", "worker"), Some(3))
+        )
+      }
+    )
+}

--- a/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio
+
+private[zio] trait ConfigCompanionVersionSpecific

--- a/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,73 @@
+package zio
+
+import scala.compiletime.{constValue, erasedValue, summonInline}
+import scala.deriving.Mirror
+
+private[zio] trait ConfigCompanionVersionSpecific {
+
+  inline def derived[A](using mirror: Mirror.Of[A]): Config[A] =
+    inline mirror match {
+      case product: Mirror.ProductOf[A] =>
+        deriveProduct[A, product.MirroredElemTypes, product.MirroredElemLabels](product)
+      case _ =>
+        compiletime.error("Config can only be derived for product types")
+    }
+
+  private inline def deriveProduct[A, Elems <: Tuple, Labels <: Tuple](
+    mirror: Mirror.ProductOf[A]
+  ): Config[A] =
+    combineFields(fieldConfigs[Elems, Labels]).map { values =>
+      mirror.fromProduct(Tuple.fromArray(values.toArray))
+    }
+
+  private inline def fieldConfigs[Elems <: Tuple, Labels <: Tuple]: List[Config[Any]] =
+    inline erasedValue[(Elems, Labels)] match {
+      case _: (EmptyTuple, EmptyTuple) =>
+        Nil
+      case _: ((elem *: elems), (label *: labels)) =>
+        configFor[elem]
+          .nested(constValue[label].asInstanceOf[String])
+          .asInstanceOf[Config[Any]] :: fieldConfigs[elems, labels]
+    }
+
+  private def combineFields(configs: List[Config[Any]]): Config[List[Any]] =
+    configs match {
+      case Nil =>
+        Config.succeed(Nil)
+      case head :: tail =>
+        tail.foldLeft(head.map(List(_))) { (acc, config) =>
+          acc.zipWith(config)((values, value) => values :+ value)
+        }
+    }
+
+  private inline def configFor[A]: Config[A] =
+    inline erasedValue[A] match {
+      case _: String                  => Config.string.asInstanceOf[Config[A]]
+      case _: Boolean                 => Config.boolean.asInstanceOf[Config[A]]
+      case _: Byte                    => Config.bigInt.map(_.toByte).asInstanceOf[Config[A]]
+      case _: Short                   => Config.bigInt.map(_.toShort).asInstanceOf[Config[A]]
+      case _: Int                     => Config.int.asInstanceOf[Config[A]]
+      case _: Long                    => Config.long.asInstanceOf[Config[A]]
+      case _: Float                   => Config.float.asInstanceOf[Config[A]]
+      case _: Double                  => Config.double.asInstanceOf[Config[A]]
+      case _: BigInt                  => Config.bigInt.asInstanceOf[Config[A]]
+      case _: BigDecimal              => Config.bigDecimal.asInstanceOf[Config[A]]
+      case _: zio.Duration            => Config.duration.asInstanceOf[Config[A]]
+      case _: java.time.LocalDate     => Config.localDate.asInstanceOf[Config[A]]
+      case _: java.time.LocalTime     => Config.localTime.asInstanceOf[Config[A]]
+      case _: java.time.LocalDateTime => Config.localDateTime.asInstanceOf[Config[A]]
+      case _: java.time.OffsetDateTime =>
+        Config.offsetDateTime.asInstanceOf[Config[A]]
+      case _: java.net.URI       => Config.uri.asInstanceOf[Config[A]]
+      case _: Config.Secret      => Config.secret.asInstanceOf[Config[A]]
+      case _: Option[t]          => configFor[t].optional.asInstanceOf[Config[A]]
+      case _: List[t]            => Config.listOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Seq[t]             => Config.listOf(configFor[t]).map(_.toSeq).asInstanceOf[Config[A]]
+      case _: Set[t]             => Config.setOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Vector[t]          => Config.vectorOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Chunk[t]           => Config.chunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: NonEmptyChunk[t]   => Config.nonEmptyChunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Map[String, value] => Config.table(configFor[value]).asInstanceOf[Config[A]]
+      case _                     => summonInline[Config[A]]
+    }
+}

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -150,7 +150,7 @@ sealed trait Config[+A] { self =>
   def zipWith[B, C](that: => Config[B])(f: (A, B) => C): Config[C] =
     self.zip(that).map(f.tupled)
 }
-object Config {
+object Config extends ConfigCompanionVersionSpecific {
   final class Secret private (private val raw: Array[Char]) { self =>
     override def equals(that: Any): Boolean =
       that match {


### PR DESCRIPTION
## Summary

Adds Scala 3 `derives Config` support so users can write:

```scala
final case class AppConfig(host: String, port: Int) derives Config
```

without separately deriving an intermediate config descriptor.

## Details

- Adds a Scala 3-only `Config.derived` implementation.
- Supports product types, nested product configs, primitives, options, lists, sets, vectors, chunks, non-empty chunks, and `Map[String, A]`.
- Keeps Scala 2 behavior unchanged.
- Adds Scala 3 regression tests.

## Verification

Ran:

```bash
++3.3.7; coreTestsJVM/testOnly zio.ConfigDerivationSpec
```

Result: 2 tests passed, 0 failed.

/claim #9268
