### PR TITLE
Fix Gen.fromIterable with non-definite iterables

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -672,6 +672,18 @@ object GenSpec extends ZIOBaseSpec {
       val actual     = exhaustive.zipWith(exhaustive)(_ + _)
       checkFinite(actual)(equalTo(expected))
     },
+    test("fromIterable does not cause preceding random generators to repeat indefinitely") {
+      val integers = new Iterable[Int] {
+        override def hasDefiniteSize: Boolean = false
+        def iterator: Iterator[Int]           = Iterator.iterate(0)(_ + 1)
+      }
+      val gen = for {
+        uuid <- Gen.uuid
+        _    <- Gen.fromIterable(integers)
+      } yield uuid
+
+      assertZIO(gen.runCollectN(10).map(_.distinct.size))(isGreaterThan(1))
+    },
     test("size can be modified locally") {
       val getSize = Gen.size.sample.map(_.value).runCollect.map(_.head)
       val result = for {

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -440,13 +440,20 @@ object Gen extends GenZIO with FunctionVariants with TimeVariants {
 
   /**
    * Constructs a deterministic generator that only generates the specified
-   * fixed values.
+   * fixed values. Non-definite iterables emit one value per sample stream so
+   * that they do not starve generators composed before them.
    */
   def fromIterable[R, A](
     as: Iterable[A],
     shrinker: A => ZStream[R, Nothing, A] = defaultShrinker
   )(implicit trace: Trace): Gen[R, A] =
-    Gen(ZStream.fromIterable(as).map(a => Sample.unfold(a)(a => (a, shrinker(a)))))
+    Gen {
+      val stream =
+        if (as.hasDefiniteSize) ZStream.fromIterable(as)
+        else ZStream.fromIterable(as).take(1)
+
+      stream.map(a => Sample.unfold(a)(a => (a, shrinker(a))))
+    }
 
   /**
    * Constructs a generator from a function that uses randomness. The returned


### PR DESCRIPTION
/claim #9101

Closes #9101.

## Summary

This updates `Gen.fromIterable` so non-definite iterables emit one value per sample stream instead of creating an exhaustive infinite sample stream that can starve generators composed before them. Definite-size iterables keep the existing exhaustive behavior.

This fixes the case where a random generator such as `Gen.uuid` appears before an infinite / non-definite iterable in a for-comprehension and the first random value is repeated indefinitely.

## Testing

- `testTestsJVM/testOnly zio.test.GenSpec -- -t fromIterable`
- `testTestsJVM/testOnly zio.test.GenSpec`
- `++2.12.21 testTestsJVM/testOnly zio.test.GenSpec -- -t fromIterable`
- `testTestsJVM/scalafmtCheck`
- `git diff --check`