### PR TITLE
Optimize ZLayer macros

### DIFF
--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -89,19 +89,20 @@ private[zio] object LayerMacroUtils {
           Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ ZLayer.environment[t](trace) } })
         }
 
-        def rhsOutputType(rhs: LayerExpr[E]): TypeRepr =
-          rhs.asTerm.tpe.widen.dealias match {
+        def zlayerOutputType(layerTerm: Term): TypeRepr =
+          layerTerm.tpe.widen.dealias match {
             case AppliedType(_, List(_, _, out)) => out
             case other =>
               report.errorAndAbort(
-                s"Internal layer macro invariant violated: expected ZLayer[_, _, _] for rhs, got ${other.show}"
+                s"Internal layer macro invariant violated: expected ZLayer[_, _, _], got ${other.show}"
               )
           }
 
-        def composeH(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
-          rhs.asTerm match {
+        def composeH(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] = {
+          val rhsTerm = rhs.asTerm
+          rhsTerm match {
             case _: Ident =>
-              rhsOutputType(rhs).asType match {
+              zlayerOutputType(rhsTerm).asType match {
                 case '[o] =>
                   '{
                     $lhs
@@ -115,6 +116,7 @@ private[zio] object LayerMacroUtils {
                   $rhs.asInstanceOf[ZLayer[Any, E, Any]]
               }
           }
+        }
 
         def composeV(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
           '{
@@ -160,19 +162,19 @@ private[zio] object LayerMacroUtils {
 
         val builtExpr = builder.build
 
-        def intersect(types: List[TypeRepr]): TypeRepr = types match {
+        def andType(types: List[TypeRepr]): TypeRepr = types match {
           case Nil          => TypeRepr.of[Any]
           case head :: tail => tail.foldLeft(head)(AndType(_, _))
         }
 
-        val inputRepr  = intersect(inferredInputs.toList)
-        val outputRepr = intersect(builder.target)
+        val inputRepr  = andType(inferredInputs.toList)
+        val outputRepr = andType(builder.target)
 
         inputRepr.asType match {
           case '[in] =>
             outputRepr.asType match {
               case '[out] =>
-                '{ ${builtExpr.asExprOf[ZLayer[Any, E, Any]]}.asInstanceOf[ZLayer[in, E, out]] }
+                '{ $builtExpr.asInstanceOf[ZLayer[in, E, out]] }
             }
         }
       }

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -22,9 +22,7 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[R0, E, R]] = {
     import quotes.reflect._
 
-    val typeless = constructTypelessLayer[R0, R, E](layers, provideMethod, false)
-      .asExprOf[ZLayer[Any, E, Any]]
-    '{ $typeless.asInstanceOf[ZLayer[R0, E, R]] }
+    constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, R]]
   }
 
   def constructStaticSomeLayer[R0: Type, R: Type, E: Type](using Quotes)(
@@ -42,9 +40,7 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[_, E, R]] = {
     import quotes.reflect._
 
-    val typeless = constructTypelessLayer[Nothing, R, E](layers, provideMethod, true)
-      .asExprOf[ZLayer[Any, E, Any]]
-    '{ $typeless.asInstanceOf[ZLayer[Any, E, R]] }
+    constructTypelessLayer[Nothing, R, E](layers, provideMethod, true).asExprOf[ZLayer[_, E, R]]
   }
 
   private def constructTypelessLayer[R0: Type, R: Type, E: Type](using Quotes)(
@@ -86,8 +82,12 @@ private[zio] object LayerMacroUtils {
       val trace = summonInline[Trace]
 
       ${
-        def typeToNode(tpe: TypeRepr): Node[TypeRepr, LayerExpr[E]] =
+        val inferredInputs = scala.collection.mutable.LinkedHashSet.empty[TypeRepr]
+
+        def typeToNode(tpe: TypeRepr): Node[TypeRepr, LayerExpr[E]] = {
+          if (inferRemainder) inferredInputs += tpe
           Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ ZLayer.environment[t](trace) } })
+        }
 
         def rhsOutputType(rhs: LayerExpr[E]): TypeRepr =
           rhs.asTerm.tpe.widen.dealias match {
@@ -158,7 +158,23 @@ private[zio] object LayerMacroUtils {
           reportError = report.errorAndAbort
         )
 
-        builder.build.asTerm.asExprOf[ZLayer[_, _, _]]
+        val builtExpr = builder.build
+
+        def intersect(types: List[TypeRepr]): TypeRepr = types match {
+          case Nil          => TypeRepr.of[Any]
+          case head :: tail => tail.foldLeft(head)(AndType(_, _))
+        }
+
+        val inputRepr  = intersect(inferredInputs.toList)
+        val outputRepr = intersect(builder.target)
+
+        inputRepr.asType match {
+          case '[in] =>
+            outputRepr.asType match {
+              case '[out] =>
+                '{ ${builtExpr.asExprOf[ZLayer[Any, E, Any]]}.asInstanceOf[ZLayer[in, E, out]] }
+            }
+        }
       }
     }
   }

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -22,7 +22,9 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[R0, E, R]] = {
     import quotes.reflect._
 
-    constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, R]]
+    val typeless = constructTypelessLayer[R0, R, E](layers, provideMethod, false)
+      .asExprOf[ZLayer[Any, E, Any]]
+    '{ $typeless.asInstanceOf[ZLayer[R0, E, R]] }
   }
 
   def constructStaticSomeLayer[R0: Type, R: Type, E: Type](using Quotes)(
@@ -31,7 +33,9 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[R0, E, _]] = {
     import quotes.reflect._
 
-    constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, _]]
+    val typeless = constructTypelessLayer[R0, R, E](layers, provideMethod, false)
+      .asExprOf[ZLayer[Any, E, Any]]
+    '{ $typeless.asInstanceOf[ZLayer[R0, E, Any]] }
   }
 
   def constructDynamicLayer[R: Type, E: Type](using Quotes)(
@@ -40,7 +44,9 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[_, E, R]] = {
     import quotes.reflect._
 
-    constructTypelessLayer[Nothing, R, E](layers, provideMethod, true).asExprOf[ZLayer[_, E, R]]
+    val typeless = constructTypelessLayer[Nothing, R, E](layers, provideMethod, true)
+      .asExprOf[ZLayer[Any, E, Any]]
+    '{ $typeless.asInstanceOf[ZLayer[Any, E, R]] }
   }
 
   private def constructTypelessLayer[R0: Type, R: Type, E: Type](using Quotes)(
@@ -85,25 +91,39 @@ private[zio] object LayerMacroUtils {
         def typeToNode(tpe: TypeRepr): Node[TypeRepr, LayerExpr[E]] =
           Node(Nil, List(tpe), tpe.asType match { case '[t] => '{ ZLayer.environment[t](trace) } })
 
+        def rhsOutputType(rhs: LayerExpr[E]): TypeRepr =
+          rhs.asTerm.tpe.widen.dealias match {
+            case AppliedType(_, List(_, _, out)) => out
+            case other =>
+              report.errorAndAbort(
+                s"Internal layer macro invariant violated: expected ZLayer[_, _, _] for rhs, got ${other.show}"
+              )
+          }
+
         def composeH(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
-          lhs match {
-            case '{ $lhs: ZLayer[i, E, o] } =>
-              rhs match {
-                case '{ $rhs: ZLayer[i2, E, o2] } =>
-                  rhs.asTerm match {
-                    case _: Ident => '{ $lhs.++($rhs)(summonInline) }
-                    case _        => '{ $lhs +!+ $rhs }
+          rhs.asTerm match {
+            case _: Ident =>
+              rhsOutputType(rhs).asType match {
+                case '[o] =>
+                  '{
+                    $lhs
+                      .asInstanceOf[ZLayer[Any, E, Any]]
+                      .++[E, Any, Any, o]($rhs.asInstanceOf[ZLayer[Any, E, o]])(summonInline)
                   }
+              }
+            case _ =>
+              '{
+                $lhs.asInstanceOf[ZLayer[Any, E, Any]] +!+
+                  $rhs.asInstanceOf[ZLayer[Any, E, Any]]
               }
           }
 
         def composeV(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
-          lhs match {
-            case '{ $lhs: ZLayer[i, E, o] } =>
-              rhs match {
-                case '{ $rhs: ZLayer[`o`, E, o2] } =>
-                  '{ composeLayer($lhs, $rhs)(using trace) }
-              }
+          '{
+            composeLayer[Any, E, Any, Any](
+              $lhs.asInstanceOf[ZLayer[Any, E, Any]],
+              $rhs.asInstanceOf[ZLayer[Any, E, Any]]
+            )(using trace)
           }
 
         def buildFinalTree(tree: LayerTree[LayerExpr[E]]): LayerExpr[E] = {

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -33,9 +33,7 @@ private[zio] object LayerMacroUtils {
   ): Expr[ZLayer[R0, E, _]] = {
     import quotes.reflect._
 
-    val typeless = constructTypelessLayer[R0, R, E](layers, provideMethod, false)
-      .asExprOf[ZLayer[Any, E, Any]]
-    '{ $typeless.asInstanceOf[ZLayer[R0, E, Any]] }
+    constructTypelessLayer[R0, R, E](layers, provideMethod, false).asExprOf[ZLayer[R0, E, _]]
   }
 
   def constructDynamicLayer[R: Type, E: Type](using Quotes)(


### PR DESCRIPTION
Our projects use `makeSome` with many dependencies( ~ 80 layers) and I find it takes long to compile. 
This PR optimizes scala3 macros of `LayerMacroUtils`.
I measured the compilation time of the project that uses `makeSome` with many layers, and it was reduced from 76s to 42s (1.8x faster).

The main bottleneck is quoted patterns with pattern type variables in `composeH`/`composeV` like below,

```scala
       def composeV(lhs: LayerExpr[E], rhs: LayerExpr[E]): LayerExpr[E] =
          lhs match {
            case '{ $lhs: ZLayer[i, E, o] } =>
              rhs match {
                case '{ $rhs: ZLayer[`o`, E, o2] } =>
                  '{ composeLayer($lhs, $rhs)(using trace) }
              }
          }
```
which is shown from async-profiler.

The changes that I made sacrifices type safety of expanded codes, but as far as I understand, type safety is already guaranteed from `build` method of `LayerBuilder`. So it should be safe as before.