### PR TITLE
fix(native): use Collections.newSetFromMap in newConcurrentSet to avoid treeifyBin NPE

### DIFF
--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -83,11 +83,16 @@ private[zio] trait PlatformSpecific {
   final def newWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
+  // Use Collections.newSetFromMap(new ConcurrentHashMap) instead of
+  // ConcurrentHashMap.newKeySet() to avoid a NPE in the Scala Native
+  // implementation of ConcurrentHashMap.treeifyBin under high concurrency.
+  // See: https://github.com/zio/zio/issues/9681
+  // See: https://github.com/scala-native/scala-native/issues/4388
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
## Summary

Fixes #9681 -- Scala Native `WeakConcurrentBag` NPE when forking 10K fibers.

### Root cause

`ConcurrentHashMap.newKeySet()` in Scala Native's javalib returns a `KeySetView`
that triggers `treeifyBin` when the set grows large enough. The Scala Native
implementation of `treeifyBin` contains a race condition that dereferences a
null pointer under concurrent stress (forking ~10K fibers).

Upstream report: https://github.com/scala-native/scala-native/issues/4388

### Fix

In `core/native/src/main/scala/zio/internal/PlatformSpecific.scala`, both
`newConcurrentSet` overloads now use `Collections.newSetFromMap(new ConcurrentHashMap(...))` instead of `ConcurrentHashMap.newKeySet(...)`. The `newSetFromMap` path routes insertions through `Map.put()` which never reaches `treeifyBin`, eliminating the NPE.

### Scope

- Scala Native only -- `core/native/src/.../PlatformSpecific.scala`
- JVM and JS paths are unchanged
- No API surface changes; minimal diff (2 lines changed + explanatory comment)

### Build note

Scala Native requires clang/LLVM and does not build on Windows. CI will validate the Native target. The JVM `WeakConcurrentBagSpec` (@@ jvmOnly) passes locally and is unaffected.

/claim #9681