### PR TITLE
feat(runtime): implement RuntimeFlag.OpLog to log effects in runLoop

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -127,6 +127,79 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                 name <- ZIO.succeed(Thread.currentThread().getName)
               } yield assertTrue(name.startsWith("ZScheduler-Worker"))
             }.provide(Runtime.enableFlags(RuntimeFlag.EagerShiftBack))
-        } @@ TestAspect.jvmOnly
+        } @@ TestAspect.jvmOnly +
+        suite("OpLog") {
+          test("render produces expected strings for ZIO instruction types") {
+            val syncEffect = ZIO.Sync(Trace.empty, () => {})
+            val whileLoopEffect =
+              ZIO.WhileLoop[Any, Nothing, Unit](Trace.empty, () => true, () => ZIO.succeed(()), (_: Any) => {})
+            val statefulEffect =
+              ZIO.Stateful[Any, Nothing, Unit](Trace.empty, (_: Any, _) => ZIO.succeed(()))
+            val yieldNowEffect = ZIO.YieldNow(Trace.empty, forceAsync = true)
+            val flatMapEffect =
+              ZIO.FlatMap[Any, Nothing, Unit, Unit](Trace.empty, ZIO.succeed(()), (_: Any) => ZIO.unit)
+            val updateRuntimeFlagsEffect =
+              ZIO.UpdateRuntimeFlags(Trace.empty, RuntimeFlags.enable(RuntimeFlag.Interruption))
+            val foldZioEffect =
+              ZIO.FoldZIO[Any, Nothing, Unit, Unit, Unit](
+                Trace.empty,
+                ZIO.succeed(()),
+                (_: Any) => ZIO.succeed(()),
+                (_: Any) => ZIO.fail(())
+              )
+            val asyncEffect =
+              ZIO.Async[Any, Nothing, Unit](
+                Trace.empty,
+                (_: ZIO[Any, Nothing, Unit] => Unit) => Right(Exit.unit),
+                () => FiberId.None
+              )
+            val dynamicNoBoxEffect =
+              ZIO.UpdateRuntimeFlagsWithin.DynamicNoBox[Any, Nothing, Unit](
+                Trace.empty,
+                RuntimeFlags.enable(RuntimeFlag.Interruption),
+                (_: Int) => ZIO.succeed(())
+              )
+            val exitSuccessEffect = Exit.succeed(0)
+            val exitFailureEffect = Exit.fail("boom")
+
+            assertTrue(ZIO.render(syncEffect) == s"Sync(trace=${syncEffect.trace})") &&
+            assertTrue(ZIO.render(whileLoopEffect) == s"WhileLoop(trace=${whileLoopEffect.trace})") &&
+            assertTrue(ZIO.render(statefulEffect) == s"Stateful(trace=${statefulEffect.trace})") &&
+            assertTrue(ZIO.render(yieldNowEffect) == s"YieldNow(trace=${yieldNowEffect.trace}, forceAsync=true)") &&
+            assertTrue(
+              ZIO.render(flatMapEffect) == s"FlatMap(trace=${flatMapEffect.trace}, first=Sync(trace=${flatMapEffect.first.trace}))"
+            ) &&
+            assertTrue(
+              ZIO.render(updateRuntimeFlagsEffect) == s"UpdateRuntimeFlags(trace=${updateRuntimeFlagsEffect.trace})"
+            ) &&
+            assertTrue(
+              ZIO.render(foldZioEffect) == s"FoldZIO(trace=${foldZioEffect.trace}, first=Sync(trace=${foldZioEffect.first.trace}))"
+            ) &&
+            assertTrue(ZIO.render(asyncEffect) == s"Async(trace=${asyncEffect.trace})") &&
+            assertTrue(
+              ZIO.render(dynamicNoBoxEffect) == s"UpdateRuntimeFlagsWithin.DynamicNoBox(trace=${dynamicNoBoxEffect.trace})"
+            ) &&
+            assertTrue(ZIO.render(exitSuccessEffect) == "Exit.Success(value=0)") &&
+            assertTrue(
+              ZIO.render(exitFailureEffect) == "Exit.Failure(cause=Fail(boom,Stack trace for thread \"zio-fiber-\":\n))"
+            )
+          } +
+            test("enabling OpLog causes effects to be logged at Debug level") {
+              val effect1 = ZIO.succeed(1)
+              val effect = for {
+                a <- effect1
+                b <- ZIO.succeed(2)
+                c  = a + b
+              } yield c
+
+              val effectRendered =
+                s"FlatMap(trace=${effect.trace}, first=Sync(trace=${effect1.trace}))"
+
+              for {
+                _      <- effect
+                output <- ZTestLogger.logOutput
+              } yield assertTrue(output.exists(_.message() == effectRendered))
+            }.provide(Runtime.enableFlags(RuntimeFlag.OpLog))
+        }
     }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6407,6 +6407,36 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         ZIO.succeed(bf.fromSpecific(as)(array.asInstanceOf[Array[B]]))
     }
 
+  private[zio] def render(zio: ZIO.Erased): String =
+    zio match {
+      case Sync(trace, _)               => s"Sync(trace=$trace)"
+      case WhileLoop(trace, _, _, _)    => s"WhileLoop(trace=$trace)"
+      case Stateful(trace, _)           => s"Stateful(trace=$trace)"
+      case GenerateStackTrace(trace)    => s"GenerateStackTrace(trace=$trace)"
+      case YieldNow(trace, forceAsync)  => s"YieldNow(trace=$trace, forceAsync=$forceAsync)"
+      case FlatMap(trace, first, _)     => s"FlatMap(trace=$trace, first=${render(first)})"
+      case Mapped(trace, first, _)      => s"Mapped(trace=$trace, first=${render(first)})"
+      case UpdateRuntimeFlags(trace, _) => s"UpdateRuntimeFlags(trace=$trace)"
+      case FoldZIO(trace, first, _, _)  => s"FoldZIO(trace=$trace, first=${render(first)})"
+      case Async(trace, _, _)           => s"Async(trace=$trace)"
+      case within: UpdateRuntimeFlagsWithin[_, _, _] =>
+        within match {
+          case UpdateRuntimeFlagsWithin.Interruptible(trace, effect) =>
+            s"UpdateRuntimeFlagsWithin.Interruptible(trace=$trace, effect=${render(effect)})"
+          case UpdateRuntimeFlagsWithin.Uninterruptible(trace, effect) =>
+            s"UpdateRuntimeFlagsWithin.Uninterruptible(trace=$trace, effect=${render(effect)})"
+          case UpdateRuntimeFlagsWithin.Dynamic(trace, _, _) =>
+            s"UpdateRuntimeFlagsWithin.Dynamic(trace=$trace)"
+          case UpdateRuntimeFlagsWithin.DynamicNoBox(trace, _, _) =>
+            s"UpdateRuntimeFlagsWithin.DynamicNoBox(trace=$trace)"
+        }
+      case exit: Exit[_, _] =>
+        exit match {
+          case Exit.Success(value) => s"Exit.Success(value=$value)"
+          case Exit.Failure(cause) => s"Exit.Failure(cause=$cause)"
+        }
+    }
+
   private def foreachParUnboundedDiscard[R, E, A](
     as: Iterable[A],
     size: Int

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1107,6 +1107,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         self.getSupervisor().onEffect(self, cur)(Unsafe)
       }
 
+      if (RuntimeFlags.opLog(_runtimeFlags)) {
+        val safeCur = cur
+        log(() => ZIO.render(safeCur), Cause.empty, ZIO.someDebug, safeCur.trace)
+      }
+
       cur = drainQueueWhileRunning(cur)
 
       ops += 1


### PR DESCRIPTION
Implements #9170.

/claim #9170

## Summary

`RuntimeFlag.OpLog` existed as a flag but had no implementation. This PR wires it up:

- **`ZIO.render(zio: ZIO.Erased): String`** — pattern-matches all ZIO instruction types to produce human-readable, trace-annotated debug strings for each effect.
- **`FiberRuntime.runLoop`** — adds an `opLog` check (mirroring the existing `opSupervision` pattern); when enabled, logs each effect at `Debug` level via the fiber's logger before every operation.
- **`RuntimeFlagsSpec`** — adds two tests:
  - `render produces expected strings for ZIO instruction types` — unit-tests the render output for `Sync`, `WhileLoop`, `Stateful`, `YieldNow`, `FlatMap`, `UpdateRuntimeFlags`, `FoldZIO`, `Async`, `UpdateRuntimeFlagsWithin.DynamicNoBox`, `Exit.Success`, and `Exit.Failure`
  - `enabling OpLog causes effects to be logged at Debug level` — integration test that enables `RuntimeFlag.OpLog`, runs a for-comprehension, and asserts the expected render string appears in `ZTestLogger` output

## Files changed

- `core/shared/src/main/scala/zio/ZIO.scala` — added `private[zio] def render`
- `core/shared/src/main/scala/zio/internal/FiberRuntime.scala` — 5-line OpLog hook in `runLoop`
- `core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala` — added `OpLog` test suite

## Notes

Zero overhead when `OpLog` is disabled (single bitwise flag check per loop iteration, same as `opSupervision`).