### PR TITLE
feat(Config): support derives Config syntax in Scala 3

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import zio.test._
+
+object ConfigDerivationSpec extends ZIOBaseSpec {
+
+  // Simple product type using `derives Config` — the primary use case from issue #9268
+  final case class DatabaseConfig(host: String, port: Int, useSsl: Boolean) derives Config
+
+  // Nested product with collection and optional fields
+  final case class ServiceConfig(database: DatabaseConfig, tags: List[String], retries: Option[Int]) derives Config
+
+  def spec =
+    suite("Config.derived")(
+      test("derives Config for a simple product type") {
+        for {
+          value <- ConfigProvider
+                     .fromMap(Map("host" -> "localhost", "port" -> "5432", "useSsl" -> "true"))
+                     .load(summon[Config[DatabaseConfig]])
+        } yield assertTrue(value == DatabaseConfig("localhost", 5432, useSsl = true))
+      },
+      test("derives Config for nested products, List, and Option fields") {
+        for {
+          value <- ConfigProvider
+                     .fromMap(
+                       Map(
+                         "database.host"   -> "localhost",
+                         "database.port"   -> "5432",
+                         "database.useSsl" -> "false",
+                         "tags"            -> "api,worker",
+                         "retries"         -> "3"
+                       )
+                     )
+                     .load(summon[Config[ServiceConfig]])
+        } yield assertTrue(
+          value == ServiceConfig(DatabaseConfig("localhost", 5432, useSsl = false), List("api", "worker"), Some(3))
+        )
+      },
+      test("optional field is None when missing from config") {
+        for {
+          value <- ConfigProvider
+                     .fromMap(
+                       Map(
+                         "database.host"   -> "db.example.com",
+                         "database.port"   -> "3306",
+                         "database.useSsl" -> "true",
+                         "tags"            -> "prod"
+                       )
+                     )
+                     .load(summon[Config[ServiceConfig]])
+        } yield assertTrue(
+          value == ServiceConfig(DatabaseConfig("db.example.com", 3306, useSsl = true), List("prod"), None)
+        )
+      }
+    )
+}

--- a/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+private[zio] trait ConfigCompanionVersionSpecific

--- a/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package zio
+
+import scala.compiletime.{constValue, erasedValue, summonInline}
+import scala.deriving.Mirror
+
+private[zio] transparent trait ConfigCompanionVersionSpecific {
+
+  /**
+   * Derives a [[Config]] for a product type using Scala 3 mirror-based
+   * derivation. This enables the use of the `derives` keyword:
+   *
+   * {{{
+   * final case class AppConfig(host: String, port: Int) derives Config
+   * }}}
+   *
+   * Supported field types include all primitive `Config` types, `Option[A]`,
+   * `List[A]`, `Seq[A]`, `Set[A]`, `Vector[A]`, `Chunk[A]`,
+   * `NonEmptyChunk[A]`, `Map[String, A]`, as well as nested product types that
+   * themselves have a `Config` instance (either derived or user-defined).
+   *
+   * Only product types (case classes) are supported. Attempting to derive a
+   * `Config` for a sum type will result in a compile-time error.
+   */
+  inline def derived[A](using mirror: Mirror.Of[A]): Config[A] =
+    inline mirror match {
+      case product: Mirror.ProductOf[A] =>
+        deriveProduct[A, product.MirroredElemTypes, product.MirroredElemLabels](product)
+      case _ =>
+        compiletime.error("Config derivation is only supported for product types (case classes)")
+    }
+
+  private inline def deriveProduct[A, Elems <: Tuple, Labels <: Tuple](
+    mirror: Mirror.ProductOf[A]
+  ): Config[A] =
+    combineFields(fieldConfigs[Elems, Labels]).map { values =>
+      mirror.fromProduct(Tuple.fromArray(values.toArray))
+    }
+
+  private inline def fieldConfigs[Elems <: Tuple, Labels <: Tuple]: List[Config[Any]] =
+    inline erasedValue[(Elems, Labels)] match {
+      case _: (EmptyTuple, EmptyTuple) =>
+        Nil
+      case _: ((elem *: elems), (label *: labels)) =>
+        configFor[elem]
+          .nested(constValue[label].asInstanceOf[String])
+          .asInstanceOf[Config[Any]] :: fieldConfigs[elems, labels]
+    }
+
+  private def combineFields(configs: List[Config[Any]]): Config[List[Any]] =
+    configs match {
+      case Nil =>
+        Config.succeed(Nil)
+      case head :: tail =>
+        tail.foldLeft(head.map(List(_))) { (acc, config) =>
+          acc.zipWith(config)((values, value) => values :+ value)
+        }
+    }
+
+  private inline def configFor[A]: Config[A] =
+    inline erasedValue[A] match {
+      case _: String                   => Config.string.asInstanceOf[Config[A]]
+      case _: Boolean                  => Config.boolean.asInstanceOf[Config[A]]
+      case _: Byte                     => Config.bigInt.map(_.toByte).asInstanceOf[Config[A]]
+      case _: Short                    => Config.bigInt.map(_.toShort).asInstanceOf[Config[A]]
+      case _: Int                      => Config.int.asInstanceOf[Config[A]]
+      case _: Long                     => Config.long.asInstanceOf[Config[A]]
+      case _: Float                    => Config.float.asInstanceOf[Config[A]]
+      case _: Double                   => Config.double.asInstanceOf[Config[A]]
+      case _: BigInt                   => Config.bigInt.asInstanceOf[Config[A]]
+      case _: BigDecimal               => Config.bigDecimal.asInstanceOf[Config[A]]
+      case _: zio.Duration             => Config.duration.asInstanceOf[Config[A]]
+      case _: java.time.LocalDate      => Config.localDate.asInstanceOf[Config[A]]
+      case _: java.time.LocalTime      => Config.localTime.asInstanceOf[Config[A]]
+      case _: java.time.LocalDateTime  => Config.localDateTime.asInstanceOf[Config[A]]
+      case _: java.time.OffsetDateTime => Config.offsetDateTime.asInstanceOf[Config[A]]
+      case _: java.net.URI             => Config.uri.asInstanceOf[Config[A]]
+      case _: Config.Secret            => Config.secret.asInstanceOf[Config[A]]
+      case _: Option[t]                => configFor[t].optional.asInstanceOf[Config[A]]
+      case _: List[t]                  => Config.listOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Seq[t]                   => Config.listOf(configFor[t]).map(_.toSeq).asInstanceOf[Config[A]]
+      case _: Set[t]                   => Config.setOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Vector[t]                => Config.vectorOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Chunk[t]                 => Config.chunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: NonEmptyChunk[t]         => Config.nonEmptyChunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Map[String, value]       => Config.table(configFor[value]).asInstanceOf[Config[A]]
+      case _                           => summonInline[Config[A]]
+    }
+}

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -150,7 +150,7 @@ sealed trait Config[+A] { self =>
   def zipWith[B, C](that: => Config[B])(f: (A, B) => C): Config[C] =
     self.zip(that).map(f.tupled)
 }
-object Config {
+object Config extends ConfigCompanionVersionSpecific {
   final class Secret private (private val raw: Array[Char]) { self =>
     override def equals(that: Any): Boolean =
       that match {


### PR DESCRIPTION
## Summary

Fixes #9268.

Adds `derives Config` support for Scala 3 case classes without requiring a separate `DeriveConfig` step.

### Before

```scala
case class AppConfig(host: String, port: Int) derives DeriveConfig
given Config[AppConfig] = DeriveConfig[AppConfig].desc
```

### After

```scala
case class AppConfig(host: String, port: Int) derives Config
```

## Implementation

- **`ConfigCompanionVersionSpecific` (Scala 3)** — A `transparent trait` mixed into `object Config` that provides `inline def derived[A](using m: Mirror.Of[A]): Config[A]`. Uses `scala.compiletime.{constValue, erasedValue, summonInline}` and `scala.deriving.Mirror` to inline field configs and combine them via `zipWith`. Product types only; sum types produce a compile-time error.
- **`ConfigCompanionVersionSpecific` (Scala 2)** — Empty stub trait; cross-compilation unaffected.
- **`Config.scala`** — One-line change: `object Config extends ConfigCompanionVersionSpecific`.

Supported field types: all primitive `Config` types (`String`, `Boolean`, `Int`, `Long`, `Double`, `Float`, `Byte`, `Short`, `BigInt`, `BigDecimal`, `Duration`, `LocalDate`, `LocalTime`, `LocalDateTime`, `OffsetDateTime`, `URI`, `Secret`), plus `Option[A]`, `List[A]`, `Seq[A]`, `Set[A]`, `Vector[A]`, `Chunk[A]`, `NonEmptyChunk[A]`, `Map[String, A]`, and nested product types that themselves `derives Config`.

## Test verification

```
++3.3.7; coreTestsJVM/testOnly zio.ConfigDerivationSpec
```

Result: **3 tests passed. 0 tests failed.** (494s total, first cold build)

```
+ Config.derived
  + derives Config for a simple product type - 188 ms
  + derives Config for nested products, List, and Option fields - 189 ms
  + optional field is None when missing from config - 188 ms
3 tests passed. 0 tests failed. 0 tests ignored.
```

/claim #9268