### PR TITLE
Fix exact ZStream buffer capacity

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -579,21 +579,31 @@ object ZStreamSpec extends ZIOBaseSpec {
         ) @@ TestAspect.timeout(5.seconds) @@ nonFlaky,
         suite("buffer")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>
-            assertZIO(
-              ZStream
-                .fromChunks(chunk: _*)
-                .buffer(2)
-                .runCollect
-            )(equalTo(chunk.flatten))
+            for {
+              buffer1 <- ZStream
+                           .fromChunks(chunk: _*)
+                           .buffer(1)
+                           .runCollect
+              buffer2 <- ZStream
+                           .fromChunks(chunk: _*)
+                           .buffer(2)
+                           .runCollect
+            } yield assert(buffer1)(equalTo(chunk.flatten)) &&
+              assert(buffer2)(equalTo(chunk.flatten))
           }) @@ flaky,
           test("buffer the Stream with Error") {
             val e = new RuntimeException("boom")
-            assertZIO(
-              (ZStream.range(0, 10) ++ ZStream.fail(e))
-                .buffer(2)
-                .runCollect
-                .exit
-            )(fails(equalTo(e)))
+            for {
+              buffer1 <- (ZStream.range(0, 10) ++ ZStream.fail(e))
+                           .buffer(1)
+                           .runCollect
+                           .exit
+              buffer2 <- (ZStream.range(0, 10) ++ ZStream.fail(e))
+                           .buffer(2)
+                           .runCollect
+                           .exit
+            } yield assert(buffer1)(fails(equalTo(e))) &&
+              assert(buffer2)(fails(equalTo(e)))
           },
           test("fast producer progress independently") {
             for {
@@ -607,7 +617,58 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          },
+          test("does not evaluate more than capacity elements ahead") {
+            for {
+              secondStarted     <- Promise.make[Nothing, Unit]
+              thirdStarted      <- Promise.make[Nothing, Unit]
+              downstreamStarted <- Promise.make[Nothing, Unit]
+              releaseDownstream <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .fromIterator(Iterator.from(1))
+                         .take(3)
+                         .mapZIO { n =>
+                           ZIO.when(n == 2)(secondStarted.succeed(())) *>
+                             ZIO.when(n == 3)(thirdStarted.succeed(())) *>
+                             ZIO.succeed(n)
+                         }
+                         .buffer(1)
+                         .runForeach(_ => downstreamStarted.succeed(()) *> releaseDownstream.await)
+                         .fork
+              _               <- downstreamStarted.await
+              _               <- secondStarted.await
+              thirdWasStarted <- thirdStarted.isDone
+              _               <- releaseDownstream.succeed(())
+              _               <- fiber.interrupt
+            } yield assert(thirdWasStarted)(isFalse)
+          } @@ TestAspect.timeout(5.seconds),
+          test("does not evaluate more than capacity elements ahead for larger capacities") {
+            for {
+              secondStarted     <- Promise.make[Nothing, Unit]
+              thirdStarted      <- Promise.make[Nothing, Unit]
+              fourthStarted     <- Promise.make[Nothing, Unit]
+              downstreamStarted <- Promise.make[Nothing, Unit]
+              releaseDownstream <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .fromIterator(Iterator.from(1))
+                         .take(4)
+                         .mapZIO { n =>
+                           ZIO.when(n == 2)(secondStarted.succeed(())) *>
+                             ZIO.when(n == 3)(thirdStarted.succeed(())) *>
+                             ZIO.when(n == 4)(fourthStarted.succeed(())) *>
+                             ZIO.succeed(n)
+                         }
+                         .buffer(2)
+                         .runForeach(_ => downstreamStarted.succeed(()) *> releaseDownstream.await)
+                         .fork
+              _                <- downstreamStarted.await
+              _                <- secondStarted.await
+              _                <- thirdStarted.await
+              fourthWasStarted <- fourthStarted.isDone
+              _                <- releaseDownstream.succeed(())
+              _                <- fiber.interrupt
+            } yield assert(fourthWasStarted)(isFalse)
+          } @@ TestAspect.timeout(5.seconds)
         ),
         suite("bufferChunks")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -390,28 +390,56 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
-    new ZStream(
-      ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
+    ZStream.unwrap {
+      ZIO.succeed {
+        val capacity0 = capacity
+
+        def process(take: => UIO[Exit[Option[E], A]]): ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = {
+          lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
-              queue.take
+              take
             }.flatMap { (exit: Exit[Option[E], A]) =>
               exit.foldExit(
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.write(Chunk.single(value)) *> loop
               )
             }
 
-          process
+          loop
+        }
+
+        if (capacity0 <= 0) self
+        else if (capacity0 == 1) {
+          new ZStream(
+            ZChannel.unwrapScoped[R] {
+              for {
+                handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+                _ <- {
+                  lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+                    ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                      in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))) *> writer,
+                      err => ZChannel.fromZIO(handoff.offer(Exit.failCause(err.map(Some(_))))),
+                      _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+                    )
+
+                  (self.channel >>> writer).drain.runScoped.forkScoped
+                }
+              } yield process(handoff.take)
+            }
+          )
+        } else {
+          val queue = self.toQueueOfElements(capacity0 - 1)
+          new ZStream(
+            ZChannel.unwrapScoped[R] {
+              queue.map(queue => process(queue.take))
+            }
+          )
         }
       }
-    )
-  }
+    }
 
   /**
    * Allows a faster producer to progress independently of a slower consumer by
@@ -2970,7 +2998,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
   )(implicit trace: Trace): ZIO[R with Scope, Nothing, Unit] = {
     lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any] =
       ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any](
-        in => ZChannel.fromZIO(queue.offerAll(in.map(Exit.succeed(_)))) *> writer,
+        in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => queue.offer(Exit.succeed(a)))) *> writer,
         err => ZChannel.fromZIO(queue.offer(Exit.failCause(err.map(Some(_))))),
         _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
       )


### PR DESCRIPTION
/claim #9810

## Summary

This fixes `ZStream.buffer` so the requested capacity is enforced exactly.

- `buffer(1)` now uses `ZStream.Handoff`, avoiding the extra queued element that let it evaluate two elements ahead.
- `buffer(n)` for `n > 1` now uses an internal queue of `n - 1`, preserving the intended total in-flight capacity.
- `runIntoQueueElementsScoped` now offers elements one-by-one instead of chunking with `offerAll`, so chunk boundaries cannot bypass the configured buffer capacity.
- Regression coverage verifies `buffer(1)` and `buffer(2)` do not evaluate more than the configured capacity ahead. Existing ordering and error propagation coverage now checks both capacities.

## Demo

Terminal demo video: https://github.com/i0n/zio-9810-demo/blob/main/zio-9810-demo.mp4

The video shows the patched branch and runs:

```bash
sbt "streamsTestsJVM/testOnly *.ZStreamSpec -- -t capacity"
```

## Validation

Locally run:

```bash
sbt fmtCheck
sbt "streamsTestsJVM/testOnly *.ZStreamSpec -- -t buffer"
sbt "streamsTestsJS/testOnly *.ZStreamSpec -- -t buffer"
sbt "streamsTestsNative/testOnly *.ZStreamSpec -- -t buffer"
```

Also re-run immediately before opening this PR:

```bash
sbt "streamsTestsJVM/testOnly *.ZStreamSpec -- -t capacity"
```

Result:

```text
2 tests passed. 0 tests failed. 0 tests ignored.
[success] Total time: 2 s, completed 8 May 2026, 00:17:54
```
