### PR TITLE
Fix: Prioritize Defects in Cause Handling #9874

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -246,6 +246,27 @@ object CauseSpec extends ZIOBaseSpec {
         }
       }
     ),
+    suite("Defect prioritization")(
+      test("Defects should be prioritized over failures") {
+        val dieCause: Cause[String] = Cause.die(new RuntimeException("boom"))
+        val combinedCause = dieCause && Cause.fail("boom")
+
+        for {
+          // Test with catchAll - should not recover from defect
+          result1 <- ZIO.failCause(combinedCause).catchAll { e =>
+            ZIO.succeed(s"handled: $e")
+          }.exit
+
+          // Test with just the defect - should not recover
+          result2 <- ZIO.failCause(dieCause).catchAll { e =>
+            ZIO.succeed(s"handled: $e")
+          }.exit
+        } yield {
+          assert(result1)(fails(equalTo(dieCause))) &&
+          assert(result2)(fails(equalTo(dieCause)))
+        }
+      }
+    ),
     suite("filter")(
       test("fail.filter(false)") {
         val f1 = Cause.fail(())

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -125,23 +125,31 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
     find { case Fail(e, trace) => (e, trace) }
 
   /**
-   * Retrieve the first checked error on the `Left` if available, if there are
-   * no checked errors return the rest of the `Cause` that is known to contain
-   * only `Die` or `Interrupt` causes.
+   * Retrieve the first checked error on the `Left` if available and there are no defects,
+   * otherwise return the defect cause on the `Right`.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  final def failureOrCause: Either[E, Cause[Nothing]] = {
+    // If there's a defect, prioritize it over failures
+    val defectCause = keepDefects
+    if (defectCause.isDefined) Right(defectCause.get)
+    else failureOption match {
+      case Some(error) => Left(error)
+      case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    }
   }
 
   /**
-   * Retrieve the first checked error and its trace on the `Left` if available,
-   * if there are no checked errors return the rest of the `Cause` that is known
-   * to contain only `Die` or `Interrupt` causes.
+   * Retrieve the first checked error and its trace on the `Left` if available and there are no defects,
+   * otherwise return the defect cause on the `Right`.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = {
+    // If there's a defect, prioritize it over failures
+    val defectCause = keepDefects
+    if (defectCause.isDefined) Right(defectCause.get)
+    else failureTraceOption match {
+      case Some(errorAndTrace) => Left(errorAndTrace)
+      case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    }
   }
 
   /**


### PR DESCRIPTION
This PR ensures that defects are properly prioritized over failures when a Cause contains both. By modifying the core deconstruction methods in Cause.scala to check for defects first, we prevent standard failure handlers from accidentally recovering from a defect.