### PR TITLE
feat: Loom-friendly concurrent weak FiberSet (#8861)

### DIFF
--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.Fiber
+
+import java.lang.ref.WeakReference
+import scala.annotation.tailrec
+
+private[zio] abstract class FiberSet {
+  def add[A](fiber: Fiber.Runtime[A, _]): Unit
+  def remove[A](fiber: Fiber.Runtime[A, _]): Unit
+  def fibers: Iterable[Fiber.Runtime[_, _]]
+}
+
+private[zio] object FiberSet {
+
+  private val SIZE_ESTIMATE = 1024
+
+  def make(): FiberSet = {
+    val map = Platform.newConcurrentSet[WeakReference[Fiber.Runtime[_, _]]](SIZE_ESTIMATE)(Unsafe.unsafe)
+    new FiberSetImpl(map)
+  }
+
+  private final class FiberSetImpl(
+    private val map: JSet[WeakReference[Fiber.Runtime[_, _]]]
+  ) extends FiberSet {
+
+    def add[A](fiber: Fiber.Runtime[A, _]): Unit = {
+      val ref = new WeakReference(fiber)
+      if (!map.add(ref)) {
+        map.remove(ref)
+        map.add(ref)
+      }
+    }
+
+    def remove[A](fiber: Fiber.Runtime[A, _]): Unit = {
+      val ref = new WeakReference(fiber)
+      map.remove(ref)
+    }
+
+    def fibers: Iterable[Fiber.Runtime[_, _]] =
+      new Iterable[Fiber.Runtime[_, _]] {
+        def iterator: Iterator[Fiber.Runtime[_, _]] = {
+          val mapIterator = map.iterator()
+          new Iterator[Fiber.Runtime[_, _]] {
+            private var _next: Fiber.Runtime[_, _] = prefetchOrNull()
+
+            @tailrec
+            private def prefetchOrNull(): Fiber.Runtime[_, _] = {
+              if (!mapIterator.hasNext) {
+                null.asInstanceOf[Fiber.Runtime[_, _]]
+              } else {
+                val ref = mapIterator.next()
+                val fiber = ref.get
+                if (fiber eq null) {
+                  mapIterator.remove()
+                  prefetchOrNull()
+                } else if (!fiber.isAlive()) {
+                  mapIterator.remove()
+                  prefetchOrNull()
+                } else {
+                  fiber
+                }
+              }
+            }
+
+            def hasNext: Boolean = _next ne null
+
+            def next(): Fiber.Runtime[_, _] = {
+              val result = _next
+              if (result eq null) {
+                throw new NoSuchElementException("No more fibers in FiberSet")
+              }
+              _next = prefetchOrNull()
+              result
+            }
+          }
+        }
+      }
+  }
+
+  type JSet[A] = java.util.Set[A]
+
+}

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -16,7 +16,8 @@
 
 package zio.internal
 
-import zio.Fiber
+import zio.{Fiber, Unsafe}
+import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.ref.WeakReference
 import scala.annotation.tailrec
@@ -41,7 +42,7 @@ private[zio] object FiberSet {
   ) extends FiberSet {
 
     def add[A](fiber: Fiber.Runtime[A, _]): Unit = {
-      val ref = new WeakReference(fiber)
+      val ref = new WeakReference[Fiber.Runtime[_, _]](fiber)
       if (!map.add(ref)) {
         map.remove(ref)
         map.add(ref)
@@ -49,7 +50,7 @@ private[zio] object FiberSet {
     }
 
     def remove[A](fiber: Fiber.Runtime[A, _]): Unit = {
-      val ref = new WeakReference(fiber)
+      val ref = new WeakReference[Fiber.Runtime[_, _]](fiber)
       map.remove(ref)
     }
 
@@ -61,11 +62,11 @@ private[zio] object FiberSet {
             private var _next: Fiber.Runtime[_, _] = prefetchOrNull()
 
             @tailrec
-            private def prefetchOrNull(): Fiber.Runtime[_, _] = {
+            private def prefetchOrNull(): Fiber.Runtime[_, _] =
               if (!mapIterator.hasNext) {
                 null.asInstanceOf[Fiber.Runtime[_, _]]
               } else {
-                val ref = mapIterator.next()
+                val ref   = mapIterator.next()
                 val fiber = ref.get
                 if (fiber eq null) {
                   mapIterator.remove()
@@ -77,7 +78,6 @@ private[zio] object FiberSet {
                   fiber
                 }
               }
-            }
 
             def hasNext: Boolean = _next ne null
 


### PR DESCRIPTION
Introduces FiberSet in zio.internal for tracking active fibers using weak references. FiberSet provides O(1) add/remove operations and supports concurrent iteration, suitable for virtual threads (Loom).