### PR TITLE
fix: reduce spurious ZScheduler park/unpark cycles (#9878)

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -164,9 +164,10 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      var notify = true
+      var workAdded = false
       if ((worker eq null) || worker.blocking) {
         globalQueue.offer(runnable)
+        workAdded = true
       }
       // Attempt resumption in the current Thread
       else if ((worker.nextRunnable eq null) && worker.localQueue.isEmpty()) {
@@ -175,19 +176,22 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         // Happy path, global queue is empty, so we can proceed to run the current runnable
         if (fromGlobal eq null) {
           worker.nextRunnable = runnable
-          notify = false
         } else {
           // Less common path, global queue is not empty, so we have to prioritize the runnable from it
           worker.nextRunnable = fromGlobal
           worker.localQueue.offer(runnable)
+          workAdded = true
         }
       }
       // We have to yield, add the runnable to the local / global queue so that it can be scheduled accordingly
       else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
+        workAdded = true
+      } else {
+        workAdded = true
       }
 
-      if (notify) {
+      if (workAdded) {
         val currentState = state.get
         maybeUnparkWorker(currentState)
       }
@@ -391,7 +395,10 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
               }
             }
             while (!active && !isInterrupted) {
-              LockSupport.park()
+              if (!workSignaled) {
+                LockSupport.park()
+              }
+              workSignaled = false
             }
             searching = true
           } else {
@@ -451,6 +458,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       val worker = idle.poll()
       if (worker ne null) {
         state.getAndAdd(0x10001)
+        worker.workSignaled = true
         worker.active = true
         LockSupport.unpark(worker)
       }
@@ -578,6 +586,15 @@ private object ZScheduler {
     @volatile
     var opCount: Long =
       0L
+
+    /**
+     * A flag indicating that this worker has been signaled to wake up. Used to
+     * avoid an unnecessary `LockSupport.park` call when a signal arrives just
+     * before the worker would have parked.
+     */
+    @volatile
+    var workSignaled: Boolean =
+      false
 
     def markAsBlocking(): Unit
 


### PR DESCRIPTION
Reduces spurious park/unpark cycles in ZScheduler by tracking work signals with a volatile flag and only unparking workers when work is genuinely added to queues.