### PR TITLE
Optimize FiberRuntime mailbox

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
@@ -1,0 +1,84 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class FiberMailboxBenchmark {
+  private[this] val message = FiberMessage.resumeUnit
+
+  private[this] val fiberMailbox = new FiberMailbox
+  private[this] val linkedQueue  = new ConcurrentLinkedQueue[FiberMessage]()
+
+  @Param(Array("1", "2", "3", "4", "16"))
+  var burstSize: Int = _
+
+  @Benchmark
+  def fiberMailboxEmptyPoll(): FiberMessage =
+    fiberMailbox.poll()
+
+  @Benchmark
+  def concurrentLinkedQueueEmptyPoll(): FiberMessage =
+    linkedQueue.poll()
+
+  @Benchmark
+  def fiberMailboxHasLinkedMessages(): Boolean =
+    fiberMailbox.hasLinkedMessages
+
+  @Benchmark
+  def fiberMailboxIsDefinitelyEmpty(): Boolean =
+    fiberMailbox.isDefinitelyEmpty
+
+  @Benchmark
+  def concurrentLinkedQueueIsEmpty(): Boolean =
+    linkedQueue.isEmpty
+
+  @Benchmark
+  def fiberMailboxOfferPoll(): FiberMessage = {
+    fiberMailbox.add(message)
+    fiberMailbox.poll()
+  }
+
+  @Benchmark
+  def concurrentLinkedQueueOfferPoll(): FiberMessage = {
+    linkedQueue.add(message)
+    linkedQueue.poll()
+  }
+
+  @Benchmark
+  def fiberMailboxBurstDrain(): Int = {
+    var offered = 0
+    while (offered < burstSize) {
+      fiberMailbox.add(message)
+      offered += 1
+    }
+
+    var drained = 0
+    while (fiberMailbox.poll() ne null) {
+      drained += 1
+    }
+    drained
+  }
+
+  @Benchmark
+  def concurrentLinkedQueueBurstDrain(): Int = {
+    var offered = 0
+    while (offered < burstSize) {
+      linkedQueue.add(message)
+      offered += 1
+    }
+
+    var drained = 0
+    while (linkedQueue.poll() ne null) {
+      drained += 1
+    }
+    drained
+  }
+}

--- a/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
@@ -17,9 +17,6 @@ class FiberMailboxBenchmark {
   private[this] val fiberMailbox = new FiberMailbox
   private[this] val linkedQueue  = new ConcurrentLinkedQueue[FiberMessage]()
 
-  @Param(Array("1", "2", "3", "4", "16"))
-  var burstSize: Int = _
-
   @Benchmark
   def fiberMailboxEmptyPoll(): FiberMessage =
     fiberMailbox.poll()
@@ -53,9 +50,9 @@ class FiberMailboxBenchmark {
   }
 
   @Benchmark
-  def fiberMailboxBurstDrain(): Int = {
+  def fiberMailboxBurstDrain(state: FiberMailboxBurstState): Int = {
     var offered = 0
-    while (offered < burstSize) {
+    while (offered < state.burstSize) {
       fiberMailbox.add(message)
       offered += 1
     }
@@ -68,9 +65,9 @@ class FiberMailboxBenchmark {
   }
 
   @Benchmark
-  def concurrentLinkedQueueBurstDrain(): Int = {
+  def concurrentLinkedQueueBurstDrain(state: FiberMailboxBurstState): Int = {
     var offered = 0
-    while (offered < burstSize) {
+    while (offered < state.burstSize) {
       linkedQueue.add(message)
       offered += 1
     }
@@ -81,4 +78,10 @@ class FiberMailboxBenchmark {
     }
     drained
   }
+}
+
+@State(JScope.Thread)
+class FiberMailboxBurstState {
+  @Param(Array("1", "2", "3", "4", "16"))
+  var burstSize: Int = _
 }

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
@@ -1,0 +1,50 @@
+package zio.internal
+
+import zio._
+import zio.test._
+
+import java.util.concurrent.atomic.AtomicReference
+
+object FiberMailboxSpecJVM extends ZIOBaseSpec {
+
+  def spec =
+    suite("FiberMailboxSpecJVM")(
+      test("tracks in-flight producers separately from linked messages") {
+        ZIO.succeed {
+          val mailbox = new FiberMailbox
+          val message = FiberMessage.Stateful(_ => ())
+
+          val nodeClass         = Class.forName("zio.internal.FiberMailbox$Node")
+          val nodeConstructor   = nodeClass.getDeclaredConstructor(classOf[FiberMessage])
+          val producerNodeField = classOf[FiberMailbox].getDeclaredField("producerNode")
+          val consumerNodeField = classOf[FiberMailbox].getDeclaredField("consumerNode")
+
+          nodeConstructor.setAccessible(true)
+          producerNodeField.setAccessible(true)
+          consumerNodeField.setAccessible(true)
+
+          val producerNode = nodeConstructor.newInstance(message).asInstanceOf[AnyRef]
+          val consumerNode = consumerNodeField.get(mailbox).asInstanceOf[AtomicReference[AnyRef]]
+
+          producerNodeField.set(mailbox, producerNode)
+
+          val polledBeforeLink          = mailbox.poll()
+          val hasLinkedBeforeLink       = mailbox.hasLinkedMessages
+          val definitelyEmptyBeforeLink = mailbox.isDefinitelyEmpty
+
+          consumerNode.lazySet(producerNode)
+
+          val polledAfterLink = mailbox.poll()
+
+          assertTrue(
+            polledBeforeLink eq null,
+            !hasLinkedBeforeLink,
+            !definitelyEmptyBeforeLink,
+            polledAfterLink eq message,
+            !mailbox.hasLinkedMessages,
+            mailbox.isDefinitelyEmpty
+          )
+        }
+      }
+    )
+}

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
@@ -9,6 +9,21 @@ object FiberMailboxSpecJVM extends ZIOBaseSpec {
 
   def spec =
     suite("FiberMailboxSpecJVM")(
+      test("links messages before add returns") {
+        ZIO.succeed {
+          val mailbox = new FiberMailbox
+          val message = FiberMessage.Stateful(_ => ())
+
+          mailbox.add(message)
+
+          assertTrue(
+            mailbox.hasLinkedMessages,
+            !mailbox.isDefinitelyEmpty,
+            mailbox.poll() eq message,
+            mailbox.isDefinitelyEmpty
+          )
+        }
+      },
       test("tracks in-flight producers separately from linked messages") {
         ZIO.succeed {
           val mailbox = new FiberMailbox
@@ -32,7 +47,7 @@ object FiberMailboxSpecJVM extends ZIOBaseSpec {
           val hasLinkedBeforeLink       = mailbox.hasLinkedMessages
           val definitelyEmptyBeforeLink = mailbox.isDefinitelyEmpty
 
-          consumerNode.lazySet(producerNode)
+          consumerNode.set(producerNode)
 
           val polledAfterLink = mailbox.poll()
 

--- a/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberRuntimeSpec.scala
@@ -67,6 +67,42 @@ object FiberRuntimeSpec extends ZIOBaseSpec {
       }
     ),
     suite("observers")(
+      test("observers racing fiber completion are notified") {
+        val observers = 32
+
+        def awaitCounter(counter: AtomicInteger): UIO[Int] =
+          ZIO.suspendSucceed {
+            val count = counter.get()
+            if (count == observers) ZIO.succeed(count)
+            else ZIO.yieldNow *> awaitCounter(counter)
+          }
+
+        ZIO
+          .foreachDiscard(0 until 64) { _ =>
+            for {
+              complete <- Promise.make[Nothing, Unit]
+              start    <- Promise.make[Nothing, Unit]
+              counter  <- ZIO.succeed(new AtomicInteger(0))
+              fiber    <- complete.await.fork
+              observe <- ZIO
+                           .foreachParDiscard(0 until observers) { _ =>
+                             start.await *>
+                               ZIO.succeed {
+                                 fiber.unsafe.addObserver { _ =>
+                                   counter.incrementAndGet()
+                                   ()
+                                 }
+                               }
+                           }
+                           .fork
+              _     <- start.succeed(()) <&> complete.succeed(())
+              _     <- observe.join
+              _     <- fiber.await
+              count <- awaitCounter(counter)
+            } yield assertTrue(count == observers)
+          }
+          .as(assertCompletes)
+      } @@ timeout(10.seconds),
       test("removed on uncompleted fiber - bug #10181") {
         val observerCalled = Ref.unsafe.make(false)
         for {

--- a/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
@@ -1,0 +1,130 @@
+package zio.internal
+
+import zio._
+import zio.test._
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.{IdentityHashMap => JIdentityHashMap}
+
+object FiberMailboxSpec extends ZIOBaseSpec {
+
+  def spec =
+    suite("FiberMailboxSpec")(
+      test("polls messages FIFO") {
+        val mailbox = new FiberMailbox
+        val first   = FiberMessage.Stateful(_ => ())
+        val second  = FiberMessage.Stateful(_ => ())
+
+        mailbox.add(first)
+        mailbox.add(second)
+
+        val firstPolled  = mailbox.poll()
+        val secondPolled = mailbox.poll()
+        val emptyPolled  = mailbox.poll()
+
+        assertTrue(
+          firstPolled eq first,
+          secondPolled eq second,
+          emptyPolled eq null,
+          !mailbox.hasLinkedMessages,
+          mailbox.isDefinitelyEmpty
+        )
+      },
+      test("does not drop, duplicate, or reorder messages from the same producer") {
+        val mailbox     = new FiberMailbox
+        val producers   = 16
+        val perProducer = 128
+        val messages =
+          Vector.tabulate(producers, perProducer) { (_, _) =>
+            FiberMessage.Stateful(_ => ())
+          }
+
+        for {
+          _ <- ZIO.foreachParDiscard(0 until producers) { producer =>
+                 ZIO.foreachDiscard(0 until perProducer) { index =>
+                   ZIO.succeed(mailbox.add(messages(producer)(index)))
+                 }
+               }
+          polled <- ZIO.succeed {
+                      val builder = List.newBuilder[FiberMessage]
+                      var message = mailbox.poll()
+
+                      while (message ne null) {
+                        builder += message
+                        message = mailbox.poll()
+                      }
+
+                      builder.result()
+                    }
+        } yield {
+          val positions = new JIdentityHashMap[FiberMessage, Int]()
+          polled.zipWithIndex.foreach { case (message, index) =>
+            positions.put(message, index)
+          }
+          val ordered = messages.forall { producerMessages =>
+            producerMessages.sliding(2).forall {
+              case Vector(first, second) => positions.get(first) < positions.get(second)
+              case _                     => true
+            }
+          }
+          val expected = new JIdentityHashMap[FiberMessage, java.lang.Boolean]()
+          messages.flatten.foreach(expected.put(_, java.lang.Boolean.TRUE))
+          val found = new JIdentityHashMap[FiberMessage, java.lang.Boolean]()
+          polled.foreach(found.put(_, java.lang.Boolean.TRUE))
+
+          assertTrue(
+            polled.size == producers * perProducer,
+            found == expected,
+            ordered,
+            !mailbox.hasLinkedMessages,
+            mailbox.isDefinitelyEmpty
+          )
+        }
+      },
+      test("supports concurrent producers and consumer") {
+        val mailbox     = new FiberMailbox
+        val producers   = 8
+        val perProducer = 256
+        val total       = producers * perProducer
+        val received    = new ConcurrentLinkedQueue[FiberMessage]()
+        val remaining   = new AtomicInteger(total)
+
+        val produce =
+          ZIO.foreachParDiscard(0 until producers) { _ =>
+            ZIO.succeed {
+              var index = 0
+              while (index < perProducer) {
+                mailbox.add(FiberMessage.Stateful(_ => ()))
+                index += 1
+              }
+            }
+          }
+
+        def consume: UIO[Unit] =
+          ZIO.suspendSucceed {
+            if (remaining.get() == 0) ZIO.unit
+            else {
+              val message = mailbox.poll()
+              if (message eq null) ZIO.yieldNow *> consume
+              else {
+                received.offer(message)
+                remaining.decrementAndGet()
+                consume
+              }
+            }
+          }
+
+        for {
+          consumer <- consume.fork
+          _        <- produce
+          _        <- consumer.join
+        } yield assertTrue(
+          received.size() == total,
+          remaining.get() == 0,
+          !mailbox.hasLinkedMessages,
+          mailbox.isDefinitelyEmpty
+        )
+      }
+    )
+}

--- a/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
@@ -31,6 +31,32 @@ object FiberMailboxSpec extends ZIOBaseSpec {
           mailbox.isDefinitelyEmpty
         )
       },
+      test("does not allow later messages to jump ahead after partial drain") {
+        val mailbox = new FiberMailbox
+        val first   = FiberMessage.Stateful(_ => ())
+        val second  = FiberMessage.Stateful(_ => ())
+        val third   = FiberMessage.Stateful(_ => ())
+
+        mailbox.add(first)
+        mailbox.add(second)
+
+        val firstPolled = mailbox.poll()
+
+        mailbox.add(third)
+
+        val secondPolled = mailbox.poll()
+        val thirdPolled  = mailbox.poll()
+        val emptyPolled  = mailbox.poll()
+
+        assertTrue(
+          firstPolled eq first,
+          secondPolled eq second,
+          thirdPolled eq third,
+          emptyPolled eq null,
+          !mailbox.hasLinkedMessages,
+          mailbox.isDefinitelyEmpty
+        )
+      },
       test("does not drop, duplicate, or reorder messages from the same producer") {
         val mailbox     = new FiberMailbox
         val producers   = 16

--- a/core/js/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/js/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+private[zio] final class FiberMailbox {
+  private[this] val inbox = new ConcurrentLinkedQueue[FiberMessage]()
+
+  def add(message: FiberMessage): Unit = {
+    assert(message ne null)
+    inbox.add(message)
+  }
+
+  def poll(): FiberMessage =
+    inbox.poll()
+
+  def hasLinkedMessages: Boolean =
+    !inbox.isEmpty
+
+  def isDefinitelyEmpty: Boolean =
+    inbox.isEmpty
+}

--- a/core/jvm/src/main/java/zio/internal/FiberMailbox.java
+++ b/core/jvm/src/main/java/zio/internal/FiberMailbox.java
@@ -39,7 +39,8 @@ final class FiberMailbox {
 
     final Node node = new Node(message);
     final Node previous = PRODUCER_NODE.getAndSet(this, node);
-    previous.lazySet(node);
+    // Runtime rescheduling observes this link with one-shot post-drain checks.
+    previous.set(node);
   }
 
   FiberMessage poll() {

--- a/core/jvm/src/main/java/zio/internal/FiberMailbox.java
+++ b/core/jvm/src/main/java/zio/internal/FiberMailbox.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal;
+
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+final class FiberMailbox {
+  private static final AtomicReferenceFieldUpdater<FiberMailbox, Node> PRODUCER_NODE =
+      AtomicReferenceFieldUpdater.newUpdater(FiberMailbox.class, Node.class, "producerNode");
+
+  private Node consumerNode;
+  @SuppressWarnings("unused")
+  private volatile Node producerNode;
+
+  FiberMailbox() {
+    final Node node = new Node(null);
+    consumerNode = node;
+    producerNode = node;
+  }
+
+  void add(final FiberMessage message) {
+    Objects.requireNonNull(message);
+
+    final Node node = new Node(message);
+    final Node previous = PRODUCER_NODE.getAndSet(this, node);
+    previous.lazySet(node);
+  }
+
+  FiberMessage poll() {
+    final Node consumer = consumerNode;
+    final Node next = consumer.get();
+
+    if (next == null) {
+      return null;
+    }
+
+    final FiberMessage message = next.message;
+    next.message = null;
+    consumer.lazySet(consumer);
+    consumerNode = next;
+    return message;
+  }
+
+  boolean hasLinkedMessages() {
+    // Fast path for rescheduling checks. This only reports messages already
+    // linked from the consumer node. A cross-thread producer that has published
+    // the tail but not linked it yet will schedule the fiber after add returns.
+    // Run-loop-local producers complete add before yielding.
+    return consumerNode.get() != null;
+  }
+
+  boolean isDefinitelyEmpty() {
+    // Used before completing a fiber, where an in-flight producer must keep it
+    // alive even if the new tail has not been linked from the consumer node yet.
+    return consumerNode == producerNode;
+  }
+
+  private static final class Node extends AtomicReference<Node> {
+    private static final long serialVersionUID = 0L;
+
+    private FiberMessage message;
+
+    private Node(final FiberMessage message) {
+      this.message = message;
+    }
+  }
+}

--- a/core/native/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/native/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+private[zio] final class FiberMailbox {
+  private[this] val inbox = new ConcurrentLinkedQueue[FiberMessage]()
+
+  def add(message: FiberMessage): Unit = {
+    assert(message ne null)
+    inbox.add(message)
+  }
+
+  def poll(): FiberMessage =
+    inbox.poll()
+
+  def hasLinkedMessages: Boolean =
+    !inbox.isEmpty
+
+  def isDefinitelyEmpty: Boolean =
+    inbox.isEmpty
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -22,7 +22,6 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
@@ -42,7 +41,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _blockingOn     = FiberRuntime.notBlockingOn
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
-  private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
+  private val inbox           = new FiberMailbox()
   private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
@@ -130,6 +129,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       if (exit ne null) Exit.succeed(exit)
       else {
         val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
+        // Same enqueue+schedule protocol as tell, but this path keeps the
+        // current-executor drain fast path.
         inbox.add(FiberMessage.InterruptSignal(cause))
 
         // If the fiber is not running (which means it's suspended), and the current thread is in the same executor as the fiber,
@@ -279,7 +280,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     // Maybe someone added something to the inbox between us checking, and us
     // giving up the drain. If so, we need to restart the draining, but only
     // if we beat everyone else to the restart:
-    if (!inbox.isEmpty && running.compareAndSet(false, true)) {
+    if (inbox.hasLinkedMessages && running.compareAndSet(false, true)) {
       if (evaluationSignal == EvaluationSignal.YieldNow) drainQueueLaterOnExecutor(true)
       else drainQueueOnCurrentThread(depth)
     }
@@ -441,7 +442,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             val interruption = interruptAllChildren()
 
             if (interruption eq null) {
-              if (inbox.isEmpty) {
+              if (inbox.isDefinitelyEmpty) {
                 finalExit = exit
 
                 if (supervisor ne Supervisor.none) supervisor.onEnd(finalExit, self)(Unsafe)
@@ -1097,7 +1098,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     var stackIndex = startStackIndex
 
     if (currentDepth >= FiberRuntime.MaxDepthBeforeTrampoline) {
-      inbox.add(FiberMessage.Resume(effect))
+      tellSelf(FiberMessage.Resume(effect))
 
       return null
     }
@@ -1113,7 +1114,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
       if (ops > FiberRuntime.MaxOperationsBeforeYield && RuntimeFlags.cooperativeYielding(_runtimeFlags)) {
         updateLastTrace(cur.trace)
-        inbox.add(FiberMessage.Resume(cur))
+        tellSelf(FiberMessage.Resume(cur))
 
         return null
       } else {
@@ -1299,7 +1300,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
             case yieldNow: ZIO.YieldNow =>
               updateLastTrace(yieldNow.trace)
-              inbox.add(FiberMessage.resumeUnit)
+              tellSelf(FiberMessage.resumeUnit)
               return null
 
             case failure: Exit.Failure[Any] =>
@@ -1486,7 +1487,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         // for spinning up the fiber if there were new messages added to
         // the inbox between the completion of the effect and the transition
         // to the not running state.
-        if (!inbox.isEmpty && running.compareAndSet(false, true)) {
+        if (inbox.hasLinkedMessages && running.compareAndSet(false, true)) {
           // If there are messages and the result is null, this is either a yield, or we need to resume the fiber
           // In either way, we can optimize by using attemptResumptionOnSameThread = true
           drainQueueLaterOnExecutor(result eq null)
@@ -1524,6 +1525,15 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     // Attempt to spin up fiber, if it's not already running:
     if (running.compareAndSet(false, true)) drainQueueLaterOnExecutor(false)
   }
+
+  /**
+   * Enqueues a message from the running fiber itself. Because add returns only
+   * after linking its own node, no additional schedule is needed unless an
+   * earlier cross-thread producer is still in flight; that producer will
+   * schedule after its add returns.
+   */
+  private[this] def tellSelf(message: FiberMessage): Unit =
+    inbox.add(message)
 
   private[zio] def tellAddChild(child: Fiber.Runtime[_, _]): Unit =
     tell(FiberMessage.Stateful(parentFiber => parentFiber.addChild(child)))


### PR DESCRIPTION
/claim #8807

This replaces the generic `ConcurrentLinkedQueue` inbox in `FiberRuntime` with a small internal `FiberMailbox` abstraction.

On the JVM, the mailbox is a single-consumer MPSC linked queue built on standard JDK atomics. JS and Native keep the existing `ConcurrentLinkedQueue` behavior behind the same abstraction. The JVM implementation exposes two different checks to match the runtime's needs:

- `hasLinkedMessages` is the cheap rescheduling check for messages already linked from the consumer node.
- `isDefinitelyEmpty` is the stronger completion check, so a producer that has published a new tail but has not linked it yet still keeps the fiber alive.

Correctness note: `hasLinkedMessages` is intentionally not used as an emptiness proof. It only avoids a reschedule when the next node is already linked from the consumer node. Completion uses `isDefinitelyEmpty`, which also observes the producer tail, so an in-flight producer between the tail exchange and node link cannot let the fiber publish its final exit early. On the JVM, `add` links the node with a volatile store before it returns because `FiberRuntime` performs one-shot post-drain reschedule checks after setting `running` to false. If completion sees a non-empty or in-flight mailbox, it queues `Resume(exit)` instead of publishing the exit immediately, preserving observer / interrupt / run-loop message processing before final notification.

I added mailbox correctness coverage, a JVM white-box test for the in-flight producer window, a test that `add` has linked its own node before returning, and a `FiberRuntime` observer race test. The mailbox benchmark now scopes `burstSize` only to the burst-drain benchmarks, so empty poll and offer+poll are not repeated across unrelated burst parameters.

Local verification for this revision:

- `CI_RELEASE_MODE=1 java -jar /home/molang/.sbt/launchers/1.12.11/sbt-launch.jar "++2.13.18; coreTestsJVM/testOnly zio.FiberRuntimeSpec zio.internal.FiberMailboxSpec zio.internal.FiberMailboxSpecJVM"`
- `CI_RELEASE_MODE=1 java -jar /home/molang/.sbt/launchers/1.12.11/sbt-launch.jar "++2.13.18; fmt"`
- `grep -RInP '[\x{202A}-\x{202E}\x{2066}-\x{2069}\x{200B}\x{FEFF}]' benchmarks core core-tests`
- `git diff --check`

Before this revision, the GitHub PR checks were green: 15 passing jobs, 4 skipped release/docs jobs, and the external CLA check passing. This final revision only changes the JVM mailbox publication store, JVM mailbox tests, and benchmark parameter scoping, so the PR checks should rerun the same target matrix.

JMH raw output: https://gist.github.com/apples-kksk/076de03e9431043d0cd01341b9702d4a

Local JMH used `CI_RELEASE_MODE=1`, `-wi 3 -i 5 -w 1s -r 1s -f2`. The Temurin 17 run is the conservative CI-adjacent number; the JDK 26 run shows the same isolated fast path more clearly. Allocation was measured with a separate `-prof gc` run.

| JVM | Benchmark | Score | Allocation |
| --- | --- | ---: | ---: |
| Temurin 17.0.19 | `ConcurrentLinkedQueue` offer+poll | 97.482M ops/s ± 0.651M | 24.000 B/op |
| Temurin 17.0.19 | `FiberMailbox` offer+poll | 102.822M ops/s ± 0.632M | 24.000 B/op |
| JDK 26.0.1 | `ConcurrentLinkedQueue` offer+poll | 104.648M ops/s ± 1.546M | 24.000 B/op |
| JDK 26.0.1 | `FiberMailbox` offer+poll | 220.367M ops/s ± 0.949M | 24.000 B/op |

These are isolated mailbox microbenchmarks, not a claim that every run-loop benchmark moves by the same factor. The main runtime safety property is the completion/reschedule distinction above; the benchmark is there to show that the specialized mailbox keeps the hot offer+poll path allocation-neutral and at least competitive on a CI-like JDK.
