### PR TITLE
Fix sampled Gen resampling

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -701,6 +701,50 @@ object GenSpec extends ZIOBaseSpec {
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
     },
+    test("runCollectN re-samples effectful generators before deterministic generators") {
+      val gen = for {
+        id <- Gen.uuid
+        _  <- Gen.fromIterable(0 until 100)
+      } yield id
+
+      assertZIO(gen.runCollectN(20).map(_.distinct.size))(isGreaterThan(1))
+    },
+    test("runCollectN re-samples effectful generators after deterministic generators") {
+      val gen = for {
+        _  <- Gen.fromIterable(0 until 100)
+        id <- Gen.uuid
+      } yield id
+
+      assertZIO(gen.runCollectN(20).map(_.distinct.size))(isGreaterThan(1))
+    },
+    test("checkN re-samples effectful generators before deterministic generators") {
+      val gen = for {
+        id <- Gen.uuid
+        _  <- Gen.fromIterable(0 until 100)
+      } yield id
+
+      for {
+        seen <- Ref.make(Set.empty[String])
+        _ <- CheckN(20)(gen) { id =>
+               seen.update(_ + id.toString).as(assertCompletes)
+             }
+        values <- seen.get
+      } yield assert(values.size)(isGreaterThan(1))
+    },
+    test("checkN re-samples effectful generators after deterministic generators") {
+      val gen = for {
+        _  <- Gen.fromIterable(0 until 100)
+        id <- Gen.uuid
+      } yield id
+
+      for {
+        seen <- Ref.make(Set.empty[String])
+        _ <- CheckN(20)(gen) { id =>
+               seen.update(_ + id.toString).as(assertCompletes)
+             }
+        values <- seen.get
+      } yield assert(values.size)(isGreaterThan(1))
+    },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))
     },

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -154,7 +154,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    sample.take(1).map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
 
   /**
    * Runs the generator returning the first value of the generator.

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -398,7 +398,9 @@ package object test extends CompileVariants {
     sourceLocation: SourceLocation,
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-    TestConfig.samples.flatMap(n => checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a))))
+    TestConfig.samples.flatMap(n =>
+      checkStream(rv.sample.take(1).forever.take(n.toLong))(a => checkConstructor(test(a)))
+    )
 
   /**
    * A version of `check` that accepts two random variables.
@@ -800,7 +802,7 @@ package object test extends CompileVariants {
     trace: Trace
   ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
     TestConfig.samples.flatMap(n =>
-      checkStreamPar(rv.sample.forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
+      checkStreamPar(rv.sample.take(1).forever.take(n.toLong), parallelism)(a => checkConstructor(test(a)))
     )
 
   /**
@@ -1009,7 +1011,7 @@ package object test extends CompileVariants {
         checkConstructor: CheckConstructor[R, In],
         trace: Trace
       ): ZIO[checkConstructor.OutEnvironment, checkConstructor.OutError, TestResult] =
-        checkStream(rv.sample.forever.take(n.toLong))(a => checkConstructor(test(a)))
+        checkStream(rv.sample.take(1).forever.take(n.toLong))(a => checkConstructor(test(a)))
       def apply[R <: ZAny, A, B, In](rv1: Gen[R, A], rv2: Gen[R, B])(
         test: (A, B) => In
       )(implicit


### PR DESCRIPTION
## Summary

Fixes sampled `Gen` execution so effectful generators are re-evaluated for each requested sample, even when followed by a long deterministic suffix such as `Gen.fromIterable`.

This is a targeted fix for #9101.

## Root Cause

The sampled paths used `rv.sample.forever.take(n)`. That works when the stream terminates because `forever` restarts the stream and re-runs effects.

When the composed generator stream is already long or infinite, `forever` never gets a chance to restart. In a composition like:

```scala
for {
  id <- Gen.uuid
  _  <- Gen.fromIterable(0 until 100)
} yield id
```

`Gen.uuid` is evaluated once and that same UUID is replayed across the deterministic suffix.

## Fix

Change sampled paths to take a single sample before restarting the stream:

```scala
rv.sample.take(1).forever.take(n.toLong)
```

This makes each sampled attempt restart the full generator expression, so effects such as `Gen.uuid` are re-run per sample. The changed paths are:

- `Gen.runCollectN`
- `check`
- `checkPar`
- `checkN`

Deterministic/exhaustive paths such as `runCollect` and `checkAll` are unchanged.

## Tests

Added regression coverage for both generator orderings:

- `runCollectN` re-samples effectful generators before deterministic generators
- `runCollectN` re-samples effectful generators after deterministic generators
- `checkN` re-samples effectful generators before deterministic generators
- `checkN` re-samples effectful generators after deterministic generators

## Verification

- `fmt`
- `++2.13.18 testTestsJVM/testOnly zio.test.GenSpec`
- `++2.13.18 coreTestsJVM/testOnly zio.QueueSpec zio.stm.THubSpec`

/claim #9101
