### PR TITLE
Add Queue.shutdownCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,75 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause returns buffered items and fails future interactions with the cause") {
+      val boom  = new RuntimeException("queue worker failed")
+      val cause = Cause.die(boom)
+
+      for {
+        queue     <- Queue.bounded[Int](4)
+        _         <- queue.offerAll(Chunk(1, 2, 3))
+        remaining <- queue.shutdownCause(cause)
+        offer     <- queue.offer(4).sandbox.either
+        take      <- queue.take.sandbox.either
+        takeAll   <- queue.takeAll.sandbox.either
+        takeUpTo  <- queue.takeUpTo(1).sandbox.either
+        size      <- queue.size.sandbox.either
+      } yield assertTrue(remaining == Chunk(1, 2, 3)) &&
+        assert(offer.left.map(_.untraced))(isLeft(equalTo(cause))) &&
+        assert(take.left.map(_.untraced))(isLeft(equalTo(cause))) &&
+        assert(takeAll.left.map(_.untraced))(isLeft(equalTo(cause))) &&
+        assert(takeUpTo.left.map(_.untraced))(isLeft(equalTo(cause))) &&
+        assert(size.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause fails a pending taker with the cause") {
+      val boom  = new RuntimeException("queue worker failed")
+      val cause = Cause.die(boom)
+
+      for {
+        queue     <- Queue.bounded[Int](1)
+        taker     <- queue.take.fork
+        _         <- waitForSize(queue, -1)
+        remaining <- queue.shutdownCause(cause)
+        res       <- taker.join.sandbox.either
+      } yield assertTrue(remaining.isEmpty) &&
+        assert(res.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause returns buffered items and fails a pending putter with the cause") {
+      val boom  = new RuntimeException("queue worker failed")
+      val cause = Cause.die(boom)
+
+      for {
+        queue     <- Queue.bounded[Int](1)
+        _         <- queue.offer(1)
+        putter    <- queue.offer(2).fork
+        _         <- waitForSize(queue, 2)
+        remaining <- queue.shutdownCause(cause)
+        res       <- putter.join.sandbox.either
+      } yield assertTrue(remaining == Chunk(1)) &&
+        assert(res.left.map(_.untraced))(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause is atomic and losing callers fail with the winning cause") {
+      val boom1  = new RuntimeException("first shutdown")
+      val boom2  = new RuntimeException("second shutdown")
+      val cause1 = Cause.die(boom1)
+      val cause2 = Cause.die(boom2)
+
+      for {
+        queue <- Queue.bounded[Int](4)
+        _     <- queue.offerAll(Chunk(1, 2))
+        left  <- queue.shutdownCause(cause1).sandbox.either.fork
+        right <- queue.shutdownCause(cause2).sandbox.either.fork
+        res1  <- left.join
+        res2  <- right.join
+      } yield (res1, res2) match {
+        case (Right(chunk), Left(failure)) =>
+          assertTrue(chunk == Chunk(1, 2), failure.untraced == cause1)
+        case (Left(failure), Right(chunk)) =>
+          assertTrue(failure.untraced == cause2, chunk == Chunk(1, 2))
+        case _ =>
+          assertTrue(false)
+      }
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -39,12 +39,29 @@ sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal
    */
   override final def isFull(implicit trace: Trace): UIO[Boolean] =
     size.map(_ >= capacity)
+
+  /**
+   * Shuts down the queue with the specified cause, returning any items still
+   * buffered in the queue.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+    shutdown.as(Chunk.empty)
 }
 
 object Queue extends QueuePlatformSpecific {
   private val interruptAsNone = ZIO.interruptAs(FiberId.None)(Trace.empty)
 
   private[zio] abstract class Internal[A] extends Queue[A]
+
+  private final class ShutdownState extends AtomicBoolean(false) {
+    val cause = new AtomicReference[Cause[Nothing]](null)
+
+    def shutdown(cause0: Cause[Nothing]): Boolean =
+      if (cause.compareAndSet(null, cause0)) {
+        set(true)
+        true
+      } else false
+  }
 
   /**
    * Makes a new bounded queue. When the capacity of the queue is reached, any
@@ -142,7 +159,7 @@ object Queue extends QueuePlatformSpecific {
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
-      new AtomicBoolean(false),
+      new ShutdownState,
       strategy
     )
   }
@@ -165,9 +182,19 @@ object Queue extends QueuePlatformSpecific {
 
     override def capacity: Int = queue.capacity
 
+    private val shutdownState = shutdownFlag.asInstanceOf[ShutdownState]
+
+    private def shutdownSignal(implicit trace: Trace): UIO[Nothing] = {
+      val cause = shutdownState.cause.get()
+      if (cause eq null) ZIO.interrupt else Exit.failCause(cause)
+    }
+
+    private def isShutdownNow: Boolean =
+      shutdownState.cause.get() ne null
+
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (isShutdownNow) shutdownSignal
         else {
           if (tryOffer(a)) Exit.`true`
           else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
@@ -193,7 +220,7 @@ object Queue extends QueuePlatformSpecific {
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (isShutdownNow) shutdownSignal
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -221,32 +248,44 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (isShutdownNow)
+          shutdownSignal
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
-      ZIO.fiberIdWith { fiberId =>
-        if (shutdownFlag.compareAndSet(false, true)) {
+      ZIO
+        .fiberIdWith(fiberId => shutdownWith(Cause.interrupt(fiberId)).unit)
+        .catchAllCause(_ => Exit.unit)
+        .uninterruptible
+
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      shutdownWith(cause).uninterruptible
+
+    private def shutdownWith(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      ZIO.suspendSucceed {
+        if (shutdownState.shutdown(cause)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
+          strategy.shutdown(cause)
           val it = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.done(Exit.failCause(cause))
           }
-          strategy.shutdown(fiberId)
+          Exit.succeed(unsafePollAll(queue))
+        } else {
+          val winner = shutdownState.cause.get()
+          if (winner eq null) ZIO.interrupt else Exit.failCause(winner)
         }
-        Exit.unit
-      }.uninterruptible
+      }
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(isShutdownNow)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          if (isShutdownNow) shutdownSignal
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -279,8 +318,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (isShutdownNow)
+          shutdownSignal
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
@@ -294,8 +333,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (isShutdownNow)
+          shutdownSignal
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
@@ -309,8 +348,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (isShutdownNow)
+          shutdownSignal
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
@@ -339,7 +378,7 @@ object Queue extends QueuePlatformSpecific {
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -410,7 +449,8 @@ object Queue extends QueuePlatformSpecific {
             unsafeOffer(as, p)
             unsafeOnQueueEmptySpace(queue, takers)
             unsafeCompleteTakers(queue, takers)
-            if (isShutdown.get) ZIO.interrupt else p.await
+            val cause = isShutdown.asInstanceOf[ShutdownState].cause.get()
+            if (cause eq null) p.await else Exit.failCause(cause)
           }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
         }
 
@@ -464,11 +504,11 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = {
         var next = putters.poll()
         while (next ne null) {
           val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          if (isLast) promise.unsafe.done(Exit.failCause(cause))
           next = putters.poll()
         }
       }
@@ -490,7 +530,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -531,7 +571,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -847,6 +847,9 @@ object ZSinkSpec extends ZIOBaseSpec {
 
             override def shutdown(implicit trace: Trace): UIO[Unit] = ZIO.succeed(this.isShutDown = true)
 
+            override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+              q.shutdownCause(cause) <* ZIO.succeed(this.isShutDown = true)
+
             override def size(implicit trace: Trace): UIO[Int] = q.size
 
             override def take(implicit trace: Trace): ZIO[Any, Nothing, A] = q.take

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5873,6 +5873,18 @@ object ZStreamSpec extends ZIOBaseSpec {
                           .take(3)
                           .runCollect
             } yield result)(forall(hasSize(isLessThanEqualTo(2))))
+          },
+          test("propagates shutdownCause defects") {
+            val boom  = new RuntimeException("queue worker failed")
+            val cause = Cause.die(boom)
+
+            for {
+              queue <- Queue.unbounded[Int]
+              fiber <- ZStream.fromQueue(queue).runDrain.sandbox.either.fork
+              _     <- fiber.status.repeatUntil(_.isSuspended)
+              _     <- queue.shutdownCause(cause)
+              res   <- fiber.join
+            } yield assert(res.left.map(_.untraced))(isLeft(equalTo(cause)))
           }
         ),
         test("fromTQueue") {


### PR DESCRIPTION
/claim #9844

## Summary
- Adds `Queue.shutdownCause(cause: Cause[Nothing]): UIO[Chunk[A]]` without changing the public `Queue[A]` type shape.
- Stores the first shutdown cause atomically, returns buffered items to the winning caller, and makes losing `shutdownCause` callers fail with the winner cause.
- Propagates the stored cause to pending takers, pending back-pressured putters, and future queue operations while preserving existing `shutdown` interruption behavior.
- Adds coverage for Queue behavior and `ZStream.fromQueue` defect propagation.

## Demo / verification
Short demo video: https://raw.githubusercontent.com/hacksurvivor/zio/codex/zio-9844-demo/zio-9844-demo.mp4

This is a library/runtime behavior change, so the executable verification is the focused test coverage plus broader regression checks.

```
JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH sbt -v "++2.13; coreTestsJVM/testOnly zio.QueueSpec -- -t shutdownCause; streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t shutdownCause"
# QueueSpec: 4 tests passed, 0 failed
# ZStreamSpec: 1 test passed, 0 failed

JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH sbt -v "++2.13; coreTestsJVM/testOnly zio.QueueSpec; streamsTestsJVM/testOnly zio.stream.ZSinkSpec -- -t fromQueueWithShutdown; streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t fromQueue"
# QueueSpec: 94 tests passed, 0 failed
# ZSinkSpec fromQueueWithShutdown: 1 test passed, 0 failed
# ZStreamSpec fromQueue: 3 tests passed, 0 failed

JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH sbt -v "++2.13; mimaChecks"
# success

JAVA_HOME=/opt/homebrew/opt/openjdk@17 PATH=/opt/homebrew/opt/openjdk@17/bin:$PATH sbt -v fmt
# success
```

Closes #9844