### PR TITLE
Make tapSink read-ahead test deterministic

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -4325,13 +4325,16 @@ object ZStreamSpec extends ZIOBaseSpec {
           },
           test("does not read ahead") {
             for {
-              ref    <- Ref.make(0)
-              stream  = ZStream(1, 2, 3, 4, 5).rechunk(1).forever
-              sink    = ZSink.foreach((n: Int) => ref.update(_ + n))
-              _      <- stream.tapSink(sink).take(3).runDrain
-              result <- ref.get
-            } yield assertTrue(result == 6)
-          } @@ TestAspect.flaky
+              ref   <- Ref.make(Chunk.empty[Int])
+              stream = ZStream(1, 2, 3, 4, 5).rechunk(1).forever
+              // Downstream cancellation may interrupt the sink before it drains,
+              // so the invariant is prefix order, not full prefix processing.
+              sink      = ZSink.foreach((n: Int) => ZIO.yieldNow *> ref.update(_ :+ n))
+              elements <- stream.tapSink(sink).take(3).runCollect
+              result   <- ref.get
+            } yield assertTrue(elements == Chunk(1, 2, 3)) &&
+              assertTrue(result == elements.take(result.length))
+          }
         ),
         suite("throttleEnforce")(
           test("free elements") {


### PR DESCRIPTION
## Summary

This fixes the flaky `tapSink / does not read ahead` test without changing `tapSink` behavior.

The old assertion required the sink to finish processing `1 + 2 + 3` by the time `take(3)` completed. That is racy: downstream cancellation can interrupt the sink before it drains.

The actual invariant is simpler: the sink must never observe values that downstream did not consume. This test now records sink values and checks that they are an ordered prefix of the downstream result, `Chunk(1, 2, 3)`.

That is stricter than `result <= 6`, because it catches read-ahead, duplicates, and out-of-order values. It also leaves the stream implementation, fiber lifecycle, backpressure, and cancellation behavior untouched.

## Verification

- `streamsTestsJVM/Test/compile`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "tapSink"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "does not read ahead"` passed 10/10 locally
- `streamsTestsJVM/scalafmtCheck`
- `git diff --check`

I did not run full `sbt test` locally because this machine has about 4 GiB free, which is not enough headroom for the full build.

Fixes #8792

/claim #8792
