### PR TITLE
Prioritize non-failure causes during recovery

### DIFF
--- a/core-tests/shared/src/test/scala/zio/CauseSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/CauseSpec.scala
@@ -37,6 +37,30 @@ object CauseSpec extends ZIOBaseSpec {
         val n     = 100000
         val cause = List.fill(n)(Cause.fail("fail")).reduce(_ && _)
         assert(cause.failures.length)(equalTo(n))
+      },
+      test("`Cause#failureOrCause` prioritizes defects and interruptions over failures") {
+        val defect  = Cause.die(new RuntimeException("boom"))
+        val failure = Cause.fail("boom")
+        val interrupt = Cause.interrupt(
+          FiberId.Runtime(0, 0L, Trace.empty)
+        )
+
+        assert(defect && failure)(hasField("failureOrCause", _.failureOrCause, isRight(equalTo(defect)))) &&
+        assert(failure && defect)(hasField("failureOrCause", _.failureOrCause, isRight(equalTo(defect)))) &&
+        assert(interrupt && failure)(hasField("failureOrCause", _.failureOrCause, isRight(equalTo(interrupt))))
+      },
+      test("`Cause#failureTraceOrCause` prioritizes defects and interruptions over failures") {
+        val defect  = Cause.die(new RuntimeException("boom"))
+        val failure = Cause.fail("boom")
+        val interrupt = Cause.interrupt(
+          FiberId.Runtime(0, 0L, Trace.empty)
+        )
+
+        assert(defect && failure)(hasField("failureTraceOrCause", _.failureTraceOrCause, isRight(equalTo(defect)))) &&
+        assert(failure && defect)(hasField("failureTraceOrCause", _.failureTraceOrCause, isRight(equalTo(defect)))) &&
+        assert(interrupt && failure)(
+          hasField("failureTraceOrCause", _.failureTraceOrCause, isRight(equalTo(interrupt)))
+        )
       }
     ),
     suite("Then")(

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -129,9 +129,14 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * no checked errors return the rest of the `Cause` that is known to contain
    * only `Die` or `Interrupt` causes.
    */
-  final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  final def failureOrCause: Either[E, Cause[Nothing]] = {
+    val nonFailures = stripFailures
+    if (!nonFailures.isEmpty) Right(nonFailures)
+    else
+      failureOption match {
+        case Some(error) => Left(error)
+        case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
   }
 
   /**
@@ -139,9 +144,14 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * if there are no checked errors return the rest of the `Cause` that is known
    * to contain only `Die` or `Interrupt` causes.
    */
-  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+  final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = {
+    val nonFailures = stripFailures
+    if (!nonFailures.isEmpty) Right(nonFailures)
+    else
+      failureTraceOption match {
+        case Some(errorAndTrace) => Left(errorAndTrace)
+        case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+      }
   }
 
   /**


### PR DESCRIPTION
## Summary
- make `failureOrCause` and `failureTraceOrCause` preserve co-occurring defects instead of selecting a recoverable failure first
- leave interruption-plus-failure behavior unchanged to preserve existing parallel combinator semantics
- add regression coverage for both `Die && Fail` and `Fail && Die` ordering

/claim #9874

## Verification
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home .tools/cs launch sbt:1.12.11 -- "coreTestsJVM/testOnly zio.CauseSpec"`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home .tools/cs launch sbt:1.12.11 -- "coreTestsJVM/testOnly zio.ZIOSpec -- -t \"foreachPar\""`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home .tools/cs launch sbt:1.12.11 -- "coreTestsJVM/testOnly zio.ZIOSpec -- -t \"collectAllParNDiscard\" -t \"validateFirstPar\""`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home .tools/cs launch sbt:1.12.11 -- "coreTestsJVM/test"` — 2880 passed, 0 failed, 4 ignored
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home .tools/cs launch sbt:1.12.11 -- scalafmtCheckAll`
- `git diff --check`

Note: I used a temporary workspace-local Coursier launcher for SBT because this checkout does not include an `sbt` script and `sbt` was not on PATH; it was not committed.