### PR TITLE
Fix mapZIOPar parallelism when bufferSize is smaller than n

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -2985,6 +2985,47 @@ object ZStreamSpec extends ZIOBaseSpec {
               _     <- f.join
             } yield assertTrue(count == 0)
           } @@ TestAspect.jvmOnly @@ nonFlaky,
+          test("parallelism is not bounded by bufferSize (#9339)") {
+            val parallelism = 8
+            val bufferSize  = 2
+            for {
+              latch <- CountdownLatch.make(parallelism + 1)
+              fiber <- ZStream
+                         .range(0, 1000)
+                         .mapZIOPar(parallelism, bufferSize)(_ => latch.countDown *> latch.await)
+                         .runDrain
+                         .fork
+              _     <- Live.live(latch.count.delay(100.micros)).repeatUntil(_ == 1)
+              _     <- latch.countDown
+              count <- latch.count
+              _     <- fiber.join
+            } yield assertTrue(count == 0)
+          } @@ TestAspect.jvmOnly @@ TestAspect.nonFlaky @@ TestAspect.timeout(10.seconds),
+          test("fast effects are still backpressured by slow downstream (#9339)") {
+            val parallelism        = 8
+            val bufferSize         = 2
+            val maxExpectedPulls   = parallelism + 1
+            val downstreamIsActive = Promise.make[Nothing, Unit]
+            val downstreamGate     = Promise.make[Nothing, Unit]
+
+            for {
+              pulled <- Ref.make(0)
+              active <- downstreamIsActive
+              gate   <- downstreamGate
+              fiber <- ZStream
+                         .range(0, 1000)
+                         .tap(_ => pulled.update(_ + 1))
+                         .mapZIOPar(parallelism, bufferSize)(ZIO.succeed(_))
+                         .mapZIO(_ => active.succeed(()) *> gate.await)
+                         .runDrain
+                         .fork
+              _     <- active.await
+              _     <- Live.live(ZIO.sleep(50.millis))
+              count <- pulled.get
+              _     <- gate.succeed(())
+              _     <- fiber.join
+            } yield assertTrue(count <= maxExpectedPulls)
+          } @@ TestAspect.jvmOnly @@ nonFlaky(10) @@ TestAspect.timeout(10.seconds),
           test("accumulates parallel errors") {
             sealed abstract class DbError extends Product with Serializable
             case object Missing           extends DbError

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -5,6 +5,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.stream.ZChannel.unitFn2
 import zio.stream.internal.ChannelExecutor.ChannelState
 import zio.stream.internal.{AsyncInputConsumer, AsyncInputProducer, ChannelExecutor, SingleProducerAsyncInput}
+import zio.stm.TSemaphore
 
 import java.util.concurrent.atomic.AtomicReference
 
@@ -674,10 +675,19 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
         val queueReader = ZChannel.fromInput(input)
         val n0          = n.toLong
         val bufferSize0 = bufferSize
-        val outgoing    = Queue.unsafe.bounded[Fiber[Either[Unit, OutDone], OutElem2]](bufferSize0, fiberId)(Unsafe)
-        val errorSignal = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
-        val permits     = Semaphore.unsafe.make(n0)(Unsafe)
-        val failureRef  = Ref.unsafe.make[Cause[OutErr1]](Cause.empty)(Unsafe)
+        final case class PendingOutput(fiber: Fiber[Either[Unit, OutDone], OutElem2], releaseSlot: Boolean)
+        // Keep the bounded queue fast path unless it would cap parallelism.
+        // The lazy slot path avoids preallocating a queue of size n.
+        val needsLazySlots = n0 > bufferSize0.toLong
+        val outgoing =
+          if (needsLazySlots) Queue.unsafe.unbounded[PendingOutput](fiberId)(Unsafe)
+          else Queue.unsafe.bounded[PendingOutput](bufferSize0, fiberId)(Unsafe)
+        val lazySlots          = if (needsLazySlots) Some(TSemaphore.unsafe.make(n0)(Unsafe)) else None
+        val acquireHandoffSlot = lazySlots.fold[UIO[Unit]](Exit.unit)(_.acquire.commit)
+        val releaseHandoffSlot = lazySlots.fold[UIO[Unit]](Exit.unit)(_.release.commit)
+        val errorSignal        = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
+        val permits            = Semaphore.unsafe.make(n0)(Unsafe)
+        val failureRef         = Ref.unsafe.make[Cause[OutErr1]](Cause.empty)(Unsafe)
 
         val setFinalizer: UIO[Unit] =
           ZIO.uninterruptible {
@@ -688,45 +698,66 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
           _          <- setFinalizer
           pull       <- (queueReader >>> self).toPullInAlt(scope)
           childScope <- scope.fork
-          processElems = pull.flatMap { outElem =>
-                           val latch = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
+          processElems =
+            ZIO.uninterruptibleMask { restore =>
+              acquireHandoffSlot *>
+                restore {
+                  pull.flatMap { outElem =>
+                    val latch = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
 
-                           permits
-                             .withPermit(
-                               latch.succeedUnit *>
-                                 f(outElem).catchAllCause { cause =>
-                                   val continue =
-                                     errorSignal.succeedUnit *>
-                                       ZChannel.failLeftUnit
+                    permits
+                      .withPermit(
+                        latch.succeedUnit *>
+                          f(outElem).catchAllCause { cause =>
+                            val continue =
+                              errorSignal.succeedUnit *>
+                                ZChannel.failLeftUnit
 
-                                   if (cause.isInterruptedOnly) continue
-                                   else failureRef.update(_ && cause) *> continue
-                                 }
-                             )
-                             .interruptible
-                             .forkIn(childScope)
-                             .flatMap(fiber => latch.await *> outgoing.offer(fiber))
-                         }.forever.interruptible
-                           .onError(_.failureOrCause match {
-                             case Left(x: Left[OutErr, ?]) =>
-                               failureRef.update(_ && Cause.fail(x.value)) *>
-                                 outgoing.offer(Fiber.done(ZChannel.failLeftUnit))
-                             case Left(x: Right[?, OutDone]) =>
-                               permits.withPermits(n0)(ZIO.unit).interruptible *>
-                                 outgoing.offer(Fiber.fail(x.asInstanceOf[Either[Unit, OutDone]]))
-                             case Right(cause) =>
-                               val continue = outgoing.offer(Fiber.done(ZChannel.failLeftUnit))
+                            if (cause.isInterruptedOnly) continue
+                            else failureRef.update(_ && cause) *> continue
+                          }
+                      )
+                      .interruptible
+                      .forkIn(childScope)
+                      .flatMap(fiber => latch.await *> outgoing.offer(PendingOutput(fiber, needsLazySlots)))
+                  }
+                }.onExit {
+                  case _: Exit.Success[?] => Exit.unit
+                  case _                  => releaseHandoffSlot
+                }
+            }.forever.interruptible
+              .onError(_.failureOrCause match {
+                case Left(x: Left[OutErr, ?]) =>
+                  failureRef.update(_ && Cause.fail(x.value)) *>
+                    outgoing.offer(PendingOutput(Fiber.done(ZChannel.failLeftUnit), releaseSlot = false))
+                case Left(x: Right[?, OutDone]) =>
+                  permits.withPermits(n0)(ZIO.unit).interruptible *>
+                    outgoing
+                      .offer(PendingOutput(Fiber.fail(x.asInstanceOf[Either[Unit, OutDone]]), releaseSlot = false))
+                case Right(cause) =>
+                  val continue = outgoing.offer(PendingOutput(Fiber.done(ZChannel.failLeftUnit), releaseSlot = false))
 
-                               if (cause.isInterruptedOnly) continue
-                               else failureRef.update(_ && cause) *> continue
-                           })
-                           .ignore
+                  if (cause.isInterruptedOnly) continue
+                  else failureRef.update(_ && cause) *> continue
+              })
+              .ignore
 
-          _ <- (processElems raceFirst ZChannel.awaitErrorSignal(childScope, fiberId)(errorSignal)).forkIn(scope)
+          _ <-
+            (processElems raceFirst ZChannel.awaitErrorSignal(childScope, fiberId)(
+              errorSignal
+            ) raceFirst outgoing.awaitShutdown)
+              .forkIn(scope)
         } yield {
           lazy val writer: ZChannel[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] =
             ZChannel.unwrap[Env1, Any, Any, Any, OutErr1, OutElem2, OutDone] {
-              outgoing.take.flatMap(_.await).flatMap {
+              outgoing.take.flatMap { output =>
+                output.fiber.await
+                  .tap(_ => releaseHandoffSlot.when(output.releaseSlot))
+                  .onExit {
+                    case _: Exit.Success[?] => Exit.unit
+                    case _                  => releaseHandoffSlot.when(output.releaseSlot)
+                  }
+              }.flatMap {
                 case s: Exit.Success[OutElem2] => Exit.succeed(ZChannel.write(s.value) *> writer)
                 case f: Exit.Failure[Either[Unit, OutDone]] =>
                   val failure0 = failureRef.unsafe.get(Unsafe)
@@ -742,7 +773,7 @@ sealed trait ZChannel[-Env, -InErr, -InElem, -InDone, +OutErr, +OutElem, +OutDon
               }
             }
 
-          writer.embedInput(input).ensuring(outgoing.shutdown)
+          writer.embedInput(input).ensuring(outgoing.shutdown *> childScope.close(Exit.interrupt(fiberId)))
         }
       }
     }


### PR DESCRIPTION
Fixes #9339

This keeps the existing bounded queue path when `bufferSize >= n`. When `n > bufferSize`, it uses a lazy handoff slot so `mapZIOPar` can start up to `n` effects without allocating a queue of size `n`.

I added regression coverage for full parallelism with a smaller buffer, plus a slow-downstream case so fast effects do not run away.

Demo: the regression tests exercise the operator behavior directly.

Validation:
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t mapZIOPar`
- `++3.3; streamsTestsJVM/Test/compile`
- `++2.13; check; ++3.3; check`

/claim #9339