### PR TITLE
Optimize ZScheduler worker unparking checks

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -39,6 +39,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val cache           = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
+  private[this] val allActive       = poolSize << 16
   private[this] val state           = new AtomicInteger(poolSize << 16)
   private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
 
@@ -154,7 +155,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         handleFullWorkerQueue(worker, runnable)
       } else ()
       val currentState = state.get
-      maybeUnparkWorker(currentState)
+      if (shouldMaybeUnparkWorker(currentState)) {
+        maybeUnparkWorker(currentState)
+      }
       true
     }
   }
@@ -189,7 +192,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
       if (notify) {
         val currentState = state.get
-        maybeUnparkWorker(currentState)
+        if (shouldMaybeUnparkWorker(currentState)) {
+          maybeUnparkWorker(currentState)
+        }
       }
       true
     }
@@ -387,7 +392,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
               }
               if (notify) {
                 val currentState = state.get
-                maybeUnparkWorker(currentState)
+                if (shouldMaybeUnparkWorker(currentState)) {
+                  maybeUnparkWorker(currentState)
+                }
               }
             }
             while (!active && !isInterrupted) {
@@ -398,7 +405,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             if (searching) {
               searching = false
               val currentState = state.decrementAndGet()
-              maybeUnparkWorker(currentState)
+              if (shouldMaybeUnparkWorker(currentState)) {
+                maybeUnparkWorker(currentState)
+              }
             }
             currentRunnable = runnable
             runnable.run()
@@ -455,6 +464,11 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         LockSupport.unpark(worker)
       }
     }
+  }
+
+  private def shouldMaybeUnparkWorker(currentState: Int): Boolean = {
+    val currentSearching = currentState & 0xffff
+    currentSearching == 0 && (currentState & 0xffff0000) != allActive
   }
 
   private[this] def submitBlocking(runnable: Runnable)(implicit unsafe: Unsafe): Boolean =


### PR DESCRIPTION
 Closes #9878

  This avoids entering `maybeUnparkWorker` when the scheduler state already makes it clear that no worker should be unparked.

  In workloads with many short-lived fibers, `maybeUnparkWorker` is called very frequently from submit/yield paths, but most calls return
  immediately because another worker is already searching or all workers are active. This adds a cheap guard at the call sites while keeping
  the original checks inside `maybeUnparkWorker` as a concurrency safety net.

  Local validation:
  - Directly compiled `core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala`
  - Ran a local scheduler probe with 100,000 short fork/yield/await fibers
  - Before the guard, diagnostic runs showed `maybeUnparkWorker` entered ~210k times for ~900 actual unparks
  - With the guard, equivalent runs entered `maybeUnparkWorker` only when an unpark was possible

  Note: I could not run the full sbt/JMH suite locally because the environment could not resolve sbt plugins from Maven repositories.