### PR TITLE
Implement runtime operation logging

### DIFF
--- a/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/RuntimeFlagsSpec.scala
@@ -112,6 +112,18 @@ object RuntimeFlagsSpec extends ZIOBaseSpec {
                 )
             }
         } +
+        suite("op log") {
+          test("logs evaluated effects when enabled") {
+            for {
+              _ <- ZIO
+                     .succeed(1)
+                     .flatMap(i => ZIO.succeed(i + 1))
+                     .provideLayer(Runtime.enableOpLog)
+              output <- ZTestLogger.logOutput
+            } yield assertTrue(output.exists(_.logLevel == LogLevel.Debug)) &&
+              assertTrue(output.exists(_.message().startsWith("ZIO operation: ")))
+          }
+        } +
         suite("EagerShiftBack") {
           test("enabled") {
             for {

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1103,6 +1103,16 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     }
 
     while (true) {
+      if (RuntimeFlags.opLog(_runtimeFlags)) {
+        val current = cur
+        log(
+          () => s"ZIO operation: ${current.toString}",
+          Cause.empty,
+          Some(LogLevel.Debug),
+          current.trace
+        )
+      }
+
       if (RuntimeFlags.opSupervision(_runtimeFlags)) {
         self.getSupervisor().onEffect(self, cur)(Unsafe)
       }


### PR DESCRIPTION
### Summary

Implements runtime operation logging for `RuntimeFlag.OpLog`.

When `Runtime.enableOpLog` is provided, `FiberRuntime.runLoop` now logs each evaluated ZIO operation at `Debug` level using the existing fiber logger infrastructure. The implementation captures the current operation in a stable local value before constructing the lazy log message, avoiding closure capture of the mutable `cur` loop variable.

### Tests

- `sbt "coreTestsJVM/testOnly zio.RuntimeFlagsSpec"`
- `sbt "coreTestsJS/testOnly zio.RuntimeFlagsSpec"`
- `sbt "coreTestsNative/testOnly zio.RuntimeFlagsSpec"`
- `sbt scalafmtCheckAll`

Freshness check before submission:

- `gh issue view 9170 --repo zio/zio` showed the issue is still open with no assignees.
- `gh pr list --repo zio/zio --state open --search '9170 OR "Runtime Operation Logging" OR OpLog'` returned `[]`.

Demo:

- The regression test exercises `Runtime.enableOpLog` and asserts that debug log output contains the `ZIO operation: ` prefix.
- Latest JVM verification: 13 tests passed, 0 failed, completed 2026-05-11 14:48:57 Asia/Seoul.

### Claim

`/claim #9170`
