### PR TITLE
Fix ZStream buffer capacity enforcement

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,32 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("does not run more effects than requested capacity") {
+            for {
+              firstConsumed <- Promise.make[Nothing, Unit]
+              releaseFirst  <- Promise.make[Nothing, Unit]
+              secondStarted <- Promise.make[Nothing, Unit]
+              thirdStarted  <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .fromIterator(Iterator.from(1))
+                         .mapZIO { n =>
+                           secondStarted.succeed(()).when(n == 2) *>
+                             thirdStarted.succeed(()).when(n == 3).as(n)
+                         }
+                         .buffer(1)
+                         .runForeach { n =>
+                           if (n == 1) firstConsumed.succeed(()) *> releaseFirst.await
+                           else ZIO.unit
+                         }
+                         .fork
+              _     <- firstConsumed.await
+              _     <- secondStarted.await
+              _     <- ZIO.yieldNow
+              third <- thirdStarted.poll
+              _     <- releaseFirst.succeed(())
+              _     <- fiber.interrupt
+            } yield assert(third)(isNone)
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,10 +391,33 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    // Permits are released after an element is written downstream so elements
+    // emitted but not yet pulled by the consumer still count against capacity.
+    def producer(
+      queue: Queue[Exit[Option[E], A]],
+      semaphore: TSemaphore
+    ): ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] = {
+      def offer(exit: Exit[Option[E], A]): ZIO[Any, Nothing, Unit] =
+        for {
+          _ <- semaphore.acquire.commit
+          _ <- queue.offer(exit)
+        } yield ()
+
+      ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+        in => ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => offer(Exit.succeed(a)))) *> producer(queue, semaphore),
+        err => ZChannel.fromZIO(offer(Exit.failCause(err.map(Some(_))))),
+        _ => ZChannel.fromZIO(offer(Exit.fail(None)))
+      )
+    }
+
+    val queue = ZIO.acquireRelease(Queue.unbounded[Exit[Option[E], A]])(_.shutdown)
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          queue     <- queue
+          semaphore <- TSemaphore.makeCommit(capacity.toLong)
+          _         <- (self.channel >>> producer(queue, semaphore)).runScoped.forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
               queue.take
@@ -402,8 +425,10 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
               exit.foldExit(
                 Cause
                   .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](
+                    ZChannel.fromZIO(semaphore.release.commit)
+                  )(cause => ZChannel.fromZIO(semaphore.release.commit) *> ZChannel.refailCause(cause)),
+                value => ZChannel.write(Chunk.single(value)) *> ZChannel.fromZIO(semaphore.release.commit) *> process
               )
             }
 


### PR DESCRIPTION
 Fixes #9810.

  `ZStream.buffer` previously freed queue capacity as soon as an element was taken from the internal queue, before that element had actually
  been handed to downstream. This allowed one extra upstream effect to run beyond the requested buffer capacity.

  This changes `buffer` to track capacity with a `TSemaphore`, releasing a permit only after the element is written downstream. A regression
  test covers `buffer(1)` so that the second effect may be prefetched but the third effect is not started while the first element is still
  being processed.