### PR TITLE
Fix Scala 2 assertTrue flatMap compilation

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -218,6 +218,14 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       val list: List[Int] = List(1, 2, 3, 4)
       assertTrue(list.filter(_ => false) == List.empty[Int])
     },
+    test("assertTrue compiles when returned from flatMap in Scala 2") {
+      val resultZIO = typeCheck("""
+      ZIO.succeed(1).flatMap(value => assertTrue(value == 1))
+      """)
+      for {
+        result <- resultZIO
+      } yield assertTrue(result.isRight)
+    } @@ scala2Only,
     test("equalTo compiles when comparing different primitive types") {
       val a = 1
       val b = 1L

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -20,6 +20,8 @@ import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{Trace, UIO, ZIO}
 
+import scala.language.implicitConversions
+
 trait CompileVariants {
 
   /**
@@ -36,6 +38,9 @@ trait CompileVariants {
    */
   def assertTrue(expr: Boolean, exprs: Boolean*): TestResult = macro SmartAssertMacros.assert_impl
   def assertTrue(expr: Boolean): TestResult = macro SmartAssertMacros.assertOne_impl
+
+  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    TestResult.liftTestResultToZIO(result)
 
   /**
    * Checks the assertion holds for the given value.

--- a/test/shared/src/main/scala-2/zio/test/TestResultVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/TestResultVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.test
+
+trait TestResultVersionSpecific

--- a/test/shared/src/main/scala-3/zio/test/TestResultVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/TestResultVersionSpecific.scala
@@ -1,0 +1,10 @@
+package zio.test
+
+import zio.{Trace, ZIO}
+
+import scala.language.implicitConversions
+
+trait TestResultVersionSpecific {
+  implicit def liftTestResultToZIOImplicit[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    TestResult.liftTestResultToZIO(result)
+}

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -44,7 +44,7 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
     TestResult(arrow.setGenFailureDetails(details))
 }
 
-object TestResult {
+object TestResult extends TestResultVersionSpecific {
   def allSuccesses(assert: TestResult, asserts: TestResult*): TestResult = asserts.foldLeft(assert)(_ && _)
 
   def allSuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
@@ -55,7 +55,7 @@ object TestResult {
   def anySuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     anySuccesses(!assertCompletes, asserts.toSeq: _*)
 
-  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+  def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
     if (result.isSuccess)
       ZIO.succeed(result)
     else


### PR DESCRIPTION
Fixes #8668.

  This fixes Scala 2 compilation for:

  ZIO.succeed(1).flatMap(value => assertTrue(value == 1))

  The change keeps TestResult-to-ZIO conversion version-specific:
  - Scala 2 exposes the conversion through CompileVariants to fix implicit resolution.
  - Scala 3 keeps the conversion available from the TestResult companion for narrow import cases.

  A regression test covers the Scala 2 flatMap case.