### PR TITLE
Optimize fiber mailbox

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
@@ -1,0 +1,102 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+class FiberMailboxBenchmark {
+
+  @Benchmark
+  def fiberMailboxEmptyPoll(state: FiberMailboxBatchState, blackhole: Blackhole): Unit =
+    blackhole.consume(state.fiberMailbox.poll())
+
+  @Benchmark
+  def concurrentLinkedQueueEmptyPoll(state: FiberMailboxBatchState, blackhole: Blackhole): Unit =
+    blackhole.consume(state.concurrentLinkedQueue.poll())
+
+  @Benchmark
+  def fiberMailboxOfferPoll(state: FiberMailboxBatchState, blackhole: Blackhole): Unit = {
+    var i = 0
+    while (i < state.pending) {
+      state.fiberMailbox.offer(state.messages(i))
+      i += 1
+    }
+
+    i = 0
+    while (i < state.pending) {
+      blackhole.consume(state.fiberMailbox.poll())
+      i += 1
+    }
+  }
+
+  @Benchmark
+  def concurrentLinkedQueueOfferPoll(state: FiberMailboxBatchState, blackhole: Blackhole): Unit = {
+    var i = 0
+    while (i < state.pending) {
+      state.concurrentLinkedQueue.offer(state.messages(i))
+      i += 1
+    }
+
+    i = 0
+    while (i < state.pending) {
+      blackhole.consume(state.concurrentLinkedQueue.poll())
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @Group("fiberMailboxMpsc")
+  @GroupThreads(2)
+  def fiberMailboxMpscOffer(state: FiberMailboxMpscState): Unit =
+    state.fiberMailbox.offer(state.message)
+
+  @Benchmark
+  @Group("fiberMailboxMpsc")
+  @GroupThreads(1)
+  def fiberMailboxMpscPoll(state: FiberMailboxMpscState, blackhole: Blackhole): Unit = {
+    blackhole.consume(state.fiberMailbox.poll())
+    blackhole.consume(state.fiberMailbox.poll())
+    blackhole.consume(state.fiberMailbox.poll())
+    blackhole.consume(state.fiberMailbox.poll())
+  }
+
+  @Benchmark
+  @Group("concurrentLinkedQueueMpsc")
+  @GroupThreads(2)
+  def concurrentLinkedQueueMpscOffer(state: FiberMailboxMpscState): Unit =
+    state.concurrentLinkedQueue.offer(state.message)
+
+  @Benchmark
+  @Group("concurrentLinkedQueueMpsc")
+  @GroupThreads(1)
+  def concurrentLinkedQueueMpscPoll(state: FiberMailboxMpscState, blackhole: Blackhole): Unit = {
+    blackhole.consume(state.concurrentLinkedQueue.poll())
+    blackhole.consume(state.concurrentLinkedQueue.poll())
+    blackhole.consume(state.concurrentLinkedQueue.poll())
+    blackhole.consume(state.concurrentLinkedQueue.poll())
+  }
+}
+
+@State(JScope.Thread)
+class FiberMailboxBatchState {
+  val fiberMailbox          = new FiberMailbox[AnyRef]
+  val concurrentLinkedQueue = new ConcurrentLinkedQueue[AnyRef]
+  val messages              = Array.fill[AnyRef](4)(new Object)
+
+  @Param(Array("1", "2", "4"))
+  var pending: Int = _
+}
+
+@State(JScope.Group)
+class FiberMailboxMpscState {
+  val fiberMailbox          = new FiberMailbox[AnyRef]
+  val concurrentLinkedQueue = new ConcurrentLinkedQueue[AnyRef]
+  val message               = new Object
+}

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
@@ -1,0 +1,137 @@
+package zio.internal
+
+import zio._
+import zio.test.TestAspect.timeout
+import zio.test._
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+object FiberMailboxSpecJVM extends ZIOBaseSpec {
+
+  def spec = suite("FiberMailboxSpecJVM")(
+    test("preserves all messages and per-producer order with concurrent producers") {
+      ZIO.attempt {
+        val producers       = math.max(2, java.lang.Runtime.getRuntime.availableProcessors())
+        val messagesPer     = 20000
+        val expectedTotal   = producers * messagesPer
+        val mailbox         = new FiberMailbox[Message]
+        val executorService = Executors.newFixedThreadPool(producers)
+        val start           = new CountDownLatch(1)
+        val done            = new CountDownLatch(producers)
+        val seen            = Array.fill(producers, messagesPer)(false)
+        val lastSeen        = Array.fill(producers)(-1)
+
+        (0 until producers).foreach { producerId =>
+          executorService.submit(new Runnable {
+            def run(): Unit =
+              try {
+                start.await()
+                (0 until messagesPer).foreach { sequence =>
+                  mailbox.offer(Message(producerId, sequence))
+                }
+              } finally {
+                done.countDown()
+              }
+          })
+        }
+
+        start.countDown()
+
+        var received        = 0
+        var duplicate       = false
+        var orderViolation  = false
+        val deadlineNanos   = java.lang.System.nanoTime() + TimeUnit.SECONDS.toNanos(30)
+        var keepConsuming   = true
+        var producersDone   = false
+        var completedInTime = false
+
+        while (keepConsuming) {
+          val message = mailbox.poll()
+
+          if (message eq null) {
+            if (received == expectedTotal) {
+              completedInTime = true
+              keepConsuming = false
+            } else if (java.lang.System.nanoTime() > deadlineNanos) {
+              keepConsuming = false
+            } else {
+              Thread.`yield`()
+            }
+          } else {
+            if (seen(message.producer)(message.sequence)) duplicate = true
+            seen(message.producer)(message.sequence) = true
+
+            if (message.sequence <= lastSeen(message.producer)) orderViolation = true
+            lastSeen(message.producer) = message.sequence
+
+            received = received + 1
+          }
+        }
+
+        producersDone = done.await(30, TimeUnit.SECONDS)
+        executorService.shutdownNow()
+
+        val allSeen =
+          seen.forall(_.forall(identity)) &&
+            lastSeen.forall(_ == messagesPer - 1)
+
+        assertTrue(
+          producersDone,
+          completedInTime,
+          received == expectedTotal,
+          !duplicate,
+          !orderViolation,
+          allSeen,
+          mailbox.isEmpty()
+        )
+      }
+    } @@ timeout(60.seconds),
+    test("does not retain the last consumed message") {
+      ZIO.attempt {
+        val mailbox = new FiberMailbox[RetentionToken]
+        val queue   = new ReferenceQueue[RetentionToken]
+        val ref     = offerAndPoll(mailbox, queue)
+
+        assertTrue(awaitCollection(ref, queue), mailbox.isEmpty())
+      }
+    } @@ timeout(10.seconds)
+  )
+
+  private final case class Message(producer: Int, sequence: Int)
+
+  private final class RetentionToken
+
+  private def offerAndPoll(
+    mailbox: FiberMailbox[RetentionToken],
+    queue: ReferenceQueue[RetentionToken]
+  ): WeakReference[RetentionToken] = {
+    var token = new RetentionToken
+    val ref   = new WeakReference(token, queue)
+
+    mailbox.offer(token)
+    if (mailbox.poll() ne token) throw new AssertionError("Mailbox did not return the offered token")
+    token = null
+
+    ref
+  }
+
+  private def awaitCollection(
+    ref: WeakReference[RetentionToken],
+    queue: ReferenceQueue[RetentionToken]
+  ): Boolean = {
+    var attempts = 0
+    var ballast  = Chunk.empty[Array[Byte]]
+
+    while ((queue.poll() eq null) && attempts < 50) {
+      java.lang.System.gc()
+      ballast = ballast :+ new Array[Byte](1024 * 1024)
+      Thread.sleep(10)
+      attempts = attempts + 1
+    }
+
+    ballast = Chunk.empty
+
+    ref.get() eq null
+  }
+}

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
@@ -89,9 +89,9 @@ object FiberMailboxSpecJVM extends ZIOBaseSpec {
     } @@ timeout(60.seconds),
     test("does not retain the last consumed message") {
       ZIO.attempt {
-        val mailbox = new FiberMailbox[RetentionToken]
-        val queue   = new ReferenceQueue[RetentionToken]
-        val ref     = offerAndPoll(mailbox, queue)
+        val mailbox   = new FiberMailbox[RetentionToken]
+        val queue     = new ReferenceQueue[RetentionToken]
+        val ref       = offerAndPoll(mailbox, queue)
         val collected = awaitCollection(ref, queue)
         val empty     = mailbox.isEmpty()
 

--- a/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
+++ b/core-tests/jvm/src/test/scala/zio/internal/FiberMailboxSpecJVM.scala
@@ -92,8 +92,10 @@ object FiberMailboxSpecJVM extends ZIOBaseSpec {
         val mailbox = new FiberMailbox[RetentionToken]
         val queue   = new ReferenceQueue[RetentionToken]
         val ref     = offerAndPoll(mailbox, queue)
+        val collected = awaitCollection(ref, queue)
+        val empty     = mailbox.isEmpty()
 
-        assertTrue(awaitCollection(ref, queue), mailbox.isEmpty())
+        assertTrue(collected, empty)
       }
     } @@ timeout(10.seconds)
   )

--- a/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
@@ -1,0 +1,54 @@
+package zio.internal
+
+import zio.ZIOBaseSpec
+import zio.test._
+
+object FiberMailboxSpec extends ZIOBaseSpec {
+
+  def spec = suite("FiberMailboxSpec")(
+    test("poll returns null for an empty mailbox") {
+      val mailbox = new FiberMailbox[String]
+
+      assertTrue(mailbox.poll() == null, mailbox.isEmpty())
+    },
+    test("polls messages in FIFO order from a single producer") {
+      val mailbox = new FiberMailbox[String]
+
+      mailbox.offer("a")
+      mailbox.offer("b")
+      mailbox.offer("c")
+
+      assertTrue(
+        !mailbox.isEmpty(),
+        mailbox.poll() == "a",
+        mailbox.poll() == "b",
+        mailbox.poll() == "c",
+        mailbox.poll() == null,
+        mailbox.isEmpty()
+      )
+    },
+    test("supports repeated drain and refill cycles") {
+      val mailbox = new FiberMailbox[String]
+
+      var round = 0
+      var ok    = true
+
+      while (round < 1000) {
+        mailbox.offer(s"$round-0")
+        mailbox.offer(s"$round-1")
+        mailbox.offer(s"$round-2")
+
+        ok = ok &&
+          mailbox.poll() == s"$round-0" &&
+          mailbox.poll() == s"$round-1" &&
+          mailbox.poll() == s"$round-2" &&
+          mailbox.poll() == null &&
+          mailbox.isEmpty()
+
+        round = round + 1
+      }
+
+      assertTrue(ok)
+    }
+  )
+}

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * A multiple-producer, single-consumer mailbox specialized for fiber messages.
+ *
+ * The fiber itself is the only consumer, while async callbacks, interruption,
+ * and supervision can enqueue from multiple producer threads.
+ */
+private[zio] final class FiberMailbox[A <: AnyRef] {
+  import FiberMailbox._
+
+  private[this] val stub = new Node[A](null.asInstanceOf[A])
+
+  private[this] var head  = stub
+  private[this] val tail  = new AtomicReference[Node[A]](stub)
+  private[this] val empty = null.asInstanceOf[A]
+
+  def offer(message: A): Unit = {
+    val node = new Node[A](message)
+    val prev = tail.getAndSet(node)
+
+    prev.next = node
+  }
+
+  def poll(): A = {
+    val currentHead = head
+    var next        = currentHead.next
+
+    if (next eq null) {
+      if (currentHead eq tail.get()) empty
+      else {
+        var spins = SpinLimit
+        while ((next eq null) && spins > 0) {
+          spins -= 1
+          next = currentHead.next
+        }
+
+        if (next eq null) empty
+        else pollNext(currentHead, next)
+      }
+    } else {
+      pollNext(currentHead, next)
+    }
+  }
+
+  def isEmpty(): Boolean = {
+    val currentHead = head
+
+    (currentHead.next eq null) && (currentHead eq tail.get())
+  }
+
+  private[this] def pollNext(currentHead: Node[A], next: Node[A]): A = {
+    val message = next.value
+
+    next.value = empty
+    head = next
+    currentHead.next = null
+
+    message
+  }
+}
+
+private[zio] object FiberMailbox {
+  private final val SpinLimit = 8
+
+  private final class Node[A <: AnyRef](var value: A) {
+    @volatile var next: Node[A] = null
+  }
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -22,7 +22,6 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
@@ -42,7 +41,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _blockingOn     = FiberRuntime.notBlockingOn
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
-  private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
+  private val inbox           = new FiberMailbox[FiberMessage]()
   private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
@@ -130,7 +129,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       if (exit ne null) Exit.succeed(exit)
       else {
         val cause = Cause.interrupt(fiberId, StackTrace(self.fiberId, Chunk.single(trace)))
-        inbox.add(FiberMessage.InterruptSignal(cause))
+        inbox.offer(FiberMessage.InterruptSignal(cause))
 
         // If the fiber is not running (which means it's suspended), and the current thread is in the same executor as the fiber,
         // then execute the runloop on the current thread, avoiding context switching and suspension
@@ -1097,7 +1096,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     var stackIndex = startStackIndex
 
     if (currentDepth >= FiberRuntime.MaxDepthBeforeTrampoline) {
-      inbox.add(FiberMessage.Resume(effect))
+      inbox.offer(FiberMessage.Resume(effect))
 
       return null
     }
@@ -1113,7 +1112,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
       if (ops > FiberRuntime.MaxOperationsBeforeYield && RuntimeFlags.cooperativeYielding(_runtimeFlags)) {
         updateLastTrace(cur.trace)
-        inbox.add(FiberMessage.Resume(cur))
+        inbox.offer(FiberMessage.Resume(cur))
 
         return null
       } else {
@@ -1299,7 +1298,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
             case yieldNow: ZIO.YieldNow =>
               updateLastTrace(yieldNow.trace)
-              inbox.add(FiberMessage.resumeUnit)
+              inbox.offer(FiberMessage.resumeUnit)
               return null
 
             case failure: Exit.Failure[Any] =>
@@ -1519,7 +1518,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    * Adds a message to be processed by the fiber on the fiber.
    */
   private[zio] def tell(message: FiberMessage): Unit = {
-    inbox.add(message)
+    inbox.offer(message)
 
     // Attempt to spin up fiber, if it's not already running:
     if (running.compareAndSet(false, true)) drainQueueLaterOnExecutor(false)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -278,7 +278,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     // Maybe someone added something to the inbox between us checking, and us
     // giving up the drain. If so, we need to restart the draining, but only
     // if we beat everyone else to the restart:
-    if (!inbox.isEmpty && running.compareAndSet(false, true)) {
+    if (!inbox.isEmpty() && running.compareAndSet(false, true)) {
       if (evaluationSignal == EvaluationSignal.YieldNow) drainQueueLaterOnExecutor(true)
       else drainQueueOnCurrentThread(depth)
     }
@@ -440,7 +440,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             val interruption = interruptAllChildren()
 
             if (interruption eq null) {
-              if (inbox.isEmpty) {
+              if (inbox.isEmpty()) {
                 finalExit = exit
 
                 if (supervisor ne Supervisor.none) supervisor.onEnd(finalExit, self)(Unsafe)
@@ -1485,7 +1485,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         // for spinning up the fiber if there were new messages added to
         // the inbox between the completion of the effect and the transition
         // to the not running state.
-        if (!inbox.isEmpty && running.compareAndSet(false, true)) {
+        if (!inbox.isEmpty() && running.compareAndSet(false, true)) {
           // If there are messages and the result is null, this is either a yield, or we need to resume the fiber
           // In either way, we can optimize by using attemptResumptionOnSameThread = true
           drainQueueLaterOnExecutor(result eq null)


### PR DESCRIPTION
## Summary

Fixes #8807.

Replaces `FiberRuntime`'s general-purpose `ConcurrentLinkedQueue[FiberMessage]` inbox with an internal `FiberMailbox` specialized for the runtime's multiple-producer / single-consumer message pattern.

The mailbox uses:

- an atomic producer tail
- a consumer-owned head
- volatile producer-to-consumer `next` publication
- FIFO linking
- a small bounded spin for the rare producer-swapped-tail-before-linking window
- consumed-value clearing so the last processed message is not retained

`FiberMessage` and public APIs are unchanged.

## Validation

- `coreTestsJVM/Test/compile`
- `benchmarks/Test/compile`
- `coreTestsJVM/testOnly zio.internal.FiberMailboxSpec zio.internal.FiberMailboxSpecJVM`
- `coreTestsJVM/testOnly zio.FiberRuntimeSpec zio.FiberSpec zio.PromiseSpec`
- `coreTestsJVM/testOnly zio.ZIOSpec -- -t FiberRuntime`
- `fmtCheck`
- `git diff --check`

## Benchmark Notes

Mailbox-focused JMH subset after tuning (`-wi 3 -i 3 -f1`):

- `fiberMailboxOfferPoll`, pending 1: `32.2M ops/s` vs CLQ `18.0M ops/s`
- `fiberMailboxOfferPoll`, pending 2: `19.5M ops/s` vs CLQ `9.6M ops/s`
- `fiberMailboxOfferPoll`, pending 4: `12.7M ops/s` vs CLQ `5.4M ops/s`
- `fiberMailboxMpsc`: `14.8M ops/s` vs CLQ `13.0M ops/s`

ZIO-only macrobench smoke (`-wi 3 -i 3 -f1`) completed for async resumption, deep async, `zioForkJoin`, and `zioForkDaemonJoin`. The existing `zioForkDaemonJoinNoFiberRoots` benchmark hit a `BenchmarkUtil.NoFiberRootsRuntime` initialization error in the forked JMH worker and was omitted from the final table.

/claim #8807