### PR TITLE
Add `memoizeSuccess` functions to ZIO

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1603,6 +1603,90 @@ object ZIOSpec extends ZIOBaseSpec {
         )
       }
     ),
+    suite("memoizeSuccess")(
+      test("memoizeSuccess returns the same instance on repeated calls") {
+        val ioMemo = RandomLive.nextString(10).memoizeSuccess
+        ioMemo
+          .flatMap(io => io <*> io)
+          .map(tuple => assert(tuple._1)(equalTo(tuple._2)))
+      },
+      test("ZIO.memoizeSuccess returns the same result on repeated calls") {
+        for {
+          memoized <- ZIO.memoizeSuccess((n: Int) => RandomLive.nextString(n))
+          a        <- memoized(10)
+          b        <- memoized(10)
+          c        <- memoized(11)
+          d        <- memoized(11)
+        } yield assert(a)(equalTo(b)) &&
+          assert(b)(not(equalTo(c))) &&
+          assert(c)(equalTo(d))
+      },
+      test("memoizeSuccess does not memoize errors") {
+        for {
+          ref      <- Ref.make(0)
+          memoized <- (ref.updateAndGet(_ + 1) *> ZIO.fail("error")).memoizeSuccess
+          a        <- memoized.either
+          b        <- memoized.either
+        } yield assertTrue(
+          a == Left("error"),
+          b == Left("error"),
+          a == b
+        ) && assert(a)(equalTo(b))
+      },
+      test("ZIO.memoizeSuccess does not memoize errors") {
+        for {
+          ref      <- Ref.make(0)
+          memoized <- ZIO.memoizeSuccess((_: Int) => ref.updateAndGet(_ + 1) *> ZIO.fail("error"))
+          a        <- memoized(10).either
+          b        <- memoized(10).either
+          c        <- ref.get
+        } yield assertTrue(
+          a == Left("error"),
+          b == Left("error"),
+          c == 2
+        )
+      },
+      test("memoizeSuccess does not memoize interruption") {
+        for {
+          p1 <- Promise.make[Nothing, Unit]
+          p2 <- Promise.make[Nothing, Unit]
+
+          memo <-
+            (p1.succeedUnit *> p2.await *> RandomLive.nextString(10)).memoizeSuccess
+
+          first <- memo.fork
+          _     <- p1.await
+          calls <- memo.fork.replicateZIO(50)
+          res1  <- first.interrupt
+          _     <- p2.succeed(())
+          res2  <- ZIO.foreach(calls)(_.join)
+          res3  <- memo
+        } yield assertTrue(
+          res1.isInterrupted,
+          res2.forall(_ == res3)
+        )
+      },
+      test("ZIO.memoizeSuccess does not memoize interruption") {
+        for {
+          p1 <- Promise.make[Nothing, Unit]
+          p2 <- Promise.make[Nothing, Unit]
+
+          memo <-
+            ZIO.memoizeSuccess((_: Any) => p1.succeedUnit *> p2.await *> RandomLive.nextString(10))
+
+          first <- memo("call").fork
+          _     <- p1.await
+          calls <- memo("call").fork.replicateZIO(50)
+          res1  <- first.interrupt
+          _     <- p2.succeed(())
+          res2  <- ZIO.foreach(calls)(_.join)
+          res3  <- memo("call")
+        } yield assertTrue(
+          res1.isInterrupted,
+          res2.forall(_ == res3)
+        )
+      }
+    ),
     suite("merge")(
       test("on flipped result") {
         val zio: IO[Int, Int] = ZIO.succeed(1)

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -1018,9 +1018,25 @@ sealed trait ZIO[-R, +E, +A]
   /**
    * Returns an effect that, if evaluated, will return the lazily computed
    * result of this effect.
+   *
+   * @see
+   *   [[memoizeSuccess]] For a variant that caches the result of the effect
+   *   after its first successful execution.
    */
   final def memoize(implicit trace: Trace): UIO[ZIO[R, E, A]] =
     ZIO.memoize((_: Unit) => self).map(_.apply(()))
+
+  /**
+   * Caches the result of the effect after its first successful execution. The
+   * effect is executed only once, and subsequent invocations return the cached
+   * result without re-executing the effect.
+   *
+   * @see
+   *   [[memoize]] For a variant that caches the result of the effect after its
+   *   first execution, regardless of success or failure.
+   */
+  final def memoizeSuccess(implicit trace: Trace): UIO[ZIO[R, E, A]] =
+    ZIO.memoizeSuccess((_: Unit) => self).map(_.apply(()))
 
   /**
    * Returns a new effect where the error channel has been merged into the
@@ -4366,16 +4382,42 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     logWarningCause("", cause)
 
   /**
-   * Returns a memoized version of the specified effectual function.
+   * Returns a memoized version of the specified effectual function. This
+   * variant will memoize the result of the function, whether it succeeds or
+   * fails.
+   *
+   * @see
+   *   [[memoizeSuccess]] For a variant that caches only successful results.
    */
   def memoize[R, E, A, B](f: A => ZIO[R, E, B])(implicit trace: Trace): UIO[A => ZIO[R, E, B]] =
+    memoizeImpl(f, successOnly = false)
+
+  /**
+   * Returns a memoized version of the provided effectful function, caching only
+   * successful results.
+   *
+   * @see
+   *   [[memoize]] For a variant that caches both successful and failed results.
+   */
+  def memoizeSuccess[R, E, A, B](f: A => ZIO[R, E, B])(implicit trace: Trace): UIO[A => ZIO[R, E, B]] =
+    memoizeImpl(f, successOnly = true)
+
+  private def memoizeImpl[R, E, A, B](f: A => ZIO[R, E, B], successOnly: Boolean)(implicit
+    trace: Trace
+  ): UIO[A => ZIO[R, E, B]] =
     ZIO.succeed {
       @inline implicit def u: Unsafe = Unsafe
 
+      def nonCacheable(exit: Exit[?, ?]): Boolean = exit match {
+        case Exit.Failure(c) => successOnly || c.isInterruptedOnly
+        case _               => false
+      }
+
       val ref = Ref.unsafe.make(Map.empty[A, Promise[E, (FiberRefs.Patch, B)]])
+
       def loop(a: A): ZIO[R, E, B] =
         ZIO.fiberIdWith { fiberId =>
-          val isSetter = new AtomicBoolean()
+          val isSetter = new AtomicBoolean(false)
           for {
             promise <- ref.modify { map =>
                          map.getOrElse(a, null) match {
@@ -4383,14 +4425,12 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                              val p = Promise.unsafe.make[E, (FiberRefs.Patch, B)](fiberId)
                              val f2 = ZIO.uninterruptibleMask { restore =>
                                isSetter.set(true)
-                               restore(f(a).diffFiberRefs).exitWith {
-                                 case ex if ex.isInterruptedOnly =>
+                               restore(f(a).diffFiberRefs).exitWith { ex =>
+                                 if (nonCacheable(ex)) {
                                    ref.unsafe.update(_ - a)
-                                   p.unsafe.done(ex)
-                                   Exit.unit
-                                 case ex =>
-                                   p.unsafe.done(ex)
-                                   Exit.unit
+                                 }
+                                 p.unsafe.done(ex)
+                                 Exit.unit
                                }.fork
                              }
                              (f2.as(p), map.updated(a, p))
@@ -4398,9 +4438,9 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                          }
                        }.flatten
             b <- promise.await.exitWith {
-                   case Exit.Success((patch, b))                      => ZIO.patchFiberRefs(patch).as(b)
-                   case ex if !isSetter.get() && ex.isInterruptedOnly => loop(a)
-                   case ex                                            => ex.asInstanceOf[Exit[E, Nothing]]
+                   case Exit.Success((patch, b))                  => ZIO.patchFiberRefs(patch).as(b)
+                   case ex if !isSetter.get() && nonCacheable(ex) => loop(a)
+                   case ex                                        => ex.asInstanceOf[Exit[E, Nothing]]
                  }
           } yield b
         }


### PR DESCRIPTION
Alternative implementation of #10791 that uses the same codepath as the new interruption handling