### PR TITLE
Prioritize defects in error handling

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -283,6 +283,20 @@ object ZIOSpec extends ZIOBaseSpec {
         zio.map(assert(_)(isTrue))
       }
     ),
+    suite("catchAll")(
+      test("does not recover when the cause also contains a defect") {
+        val boom  = new RuntimeException("boom")
+        val cause = Cause.die(boom) && Cause.fail("failure")
+
+        assertZIO(ZIO.failCause(cause).catchAll(_ => ZIO.succeed("recovered")).exit)(dies(equalTo(boom)))
+      },
+      test("recovers checked failures when the cause only also contains interruption") {
+        for {
+          fiberId <- ZIO.fiberId
+          value   <- ZIO.failCause(Cause.interrupt(fiberId) && Cause.fail("failure")).catchAll(ZIO.succeed(_))
+        } yield assert(value)(equalTo("failure"))
+      }
+    ) @@ zioTag(errors),
     suite("catchAllDefect")(
       test("recovers from all defects") {
         val s   = "division by zero"

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -130,8 +130,8 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * only `Die` or `Interrupt` causes.
    */
   final def failureOrCause: Either[E, Cause[Nothing]] = failureOption match {
-    case Some(error) => Left(error)
-    case None        => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(error) if keepDefects.isEmpty => Left(error)
+    case _                                  => Right(stripFailures)
   }
 
   /**
@@ -140,8 +140,8 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
    * to contain only `Die` or `Interrupt` causes.
    */
   final def failureTraceOrCause: Either[(E, StackTrace), Cause[Nothing]] = failureTraceOption match {
-    case Some(errorAndTrace) => Left(errorAndTrace)
-    case None                => Right(self.asInstanceOf[Cause[Nothing]]) // no E inside this cause, can safely cast
+    case Some(errorAndTrace) if keepDefects.isEmpty => Left(errorAndTrace)
+    case _                                          => Right(stripFailures)
   }
 
   /**

--- a/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
+++ b/test-tests/jvm-native/src/test/scala/zio/test/results/ResultFileOpsJsonSpec.scala
@@ -7,7 +7,7 @@ import java.nio.file.Path
 
 object ResultFileOpsJsonSpec extends ZIOBaseSpec {
   def spec = suite("ResultFileOpsJsonSpec")(
-    test("trailing comma from last entry is removed")(
+    test("entries without trailing commas are preserved")(
       for {
         path    <- writeToTestFile(parallel = false)("\naaa", "\nbbb", "\nccc")
         results <- readFile(path)
@@ -44,7 +44,7 @@ object ResultFileOpsJsonSpec extends ZIOBaseSpec {
         } yield assertTrue(union == linesToWrite)
       }
     }
-  )
+  ) @@ TestAspect.sequential
 
   private def writeToTestFile(parallel: Boolean)(content: String*): Task[Path] =
     ZIO.scoped(for {


### PR DESCRIPTION
## Summary

- prevents typed error recovery from handling causes that also contain defects
- preserves checked-failure recovery when a cause contains interruption but no defects
- adds regression coverage for `catchAll` with mixed `Die & Fail` and `Interrupt & Fail` causes

Fixes #9874
/claim #9874

## Validation

- `git diff --check`
- `java -Dsbt.log.noformat=true -jar /tmp/sbt-launch-1.12.11.jar "coreTestsJVM/testOnly zio.ZIOSpec -- -t catchAll"`: 7 tests passed, 0 failed
- `java -Xmx6G -XX:+UseG1GC -Dsbt.log.noformat=true -jar /tmp/sbt-launch-1.12.11.jar "coreTestsJVM/testOnly zio.ZIOSpec -- -t \"interrupts effects on first failure\""`: 2 tests passed, 0 failed
- `java -Xmx6G -XX:+UseG1GC -Dsbt.log.noformat=true -jar /tmp/sbt-launch-1.12.11.jar "coreJVM/scalafmt; coreTestsJVM/scalafmtCheck"`