### PR TITLE
Fix ZStream buffer capacity back pressure

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,25 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffered upstream effects respect capacity while downstream is back pressured") {
+            for {
+              started        <- Ref.make(Chunk.empty[Int])
+              firstDelivered <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .fromIterable(1 to 3)
+                         .mapZIO { n =>
+                           started.update(_ :+ n) *> ZIO.sleep(1.second).as(n)
+                         }
+                         .buffer(1)
+                         .runForeach(n => if (n == 1) firstDelivered.succeed(()) *> ZIO.never else ZIO.unit)
+                         .fork
+              _       <- TestClock.adjust(1.second)
+              _       <- firstDelivered.await
+              _       <- TestClock.adjust(1.second)
+              started <- started.get
+              _       <- fiber.interrupt
+            } yield assert(started)(equalTo(Chunk(1, 2)))
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -390,14 +390,39 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    * @note
    *   Prefer capacities that are powers of 2 for better performance.
    */
-  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+  def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] =
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          capacity0 <- ZIO.succeed(capacity)
+          queue     <- ZIO.acquireRelease(Queue.bounded[Exit[Option[E], A]](capacity0))(_.shutdown)
+          tokens    <- ZIO.acquireRelease(Queue.bounded[Unit](capacity0))(_.shutdown)
+          _         <- tokens.offerAll(Chunk.fill(capacity0)(()))
+          pull      <- self.rechunk(1).toPull
+          _ <- {
+                 lazy val produce: ZIO[R, Nothing, Unit] =
+                   tokens.take *>
+                     pull.foldZIO(
+                       {
+                         case None    => queue.offer(Exit.fail(None)).unit
+                         case Some(e) => queue.offer(Exit.fail(Some(e))).unit
+                       },
+                       chunk =>
+                         chunk.headOption match {
+                           case Some(value) => queue.offer(Exit.succeed(value)) *> produce
+                           case None        => tokens.offer(()) *> produce
+                         }
+                     )
+
+                 produce
+               }.forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
-              queue.take
+              queue.take.onExit {
+                case Exit.Success(_) => tokens.offer(())
+                case _               => ZIO.unit
+              }
             }.flatMap { (exit: Exit[Option[E], A]) =>
               exit.foldExit(
                 Cause
@@ -411,7 +436,6 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
         }
       }
     )
-  }
 
   /**
    * Allows a faster producer to progress independently of a slower consumer by


### PR DESCRIPTION
Fixes #9810.

/claim #9810

`ZStream.buffer` now reserves buffer capacity before pulling upstream, so `buffer(1)` no longer starts an extra upstream effect while downstream is back pressured.

Adds a regression test covering this behavior.

Verification:
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "buffered upstream effects respect capacity while downstream is back pressured"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec` (all buffer tests passed; one unrelated `mapZIOParUnordered` timeout reproduced as passing when rerun alone)
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "interrupts pending tasks when one of the tasks fails U"`
