### PR TITLE
Route external scheduler submissions by load

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
@@ -7,7 +7,7 @@ import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 import zio.BenchmarkUtil._
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -76,6 +76,10 @@ class ZSchedulerBenchmarks {
     zioYieldMany(fixedThreadPool)
 
   @Benchmark
+  def zioFixedThreadPoolExternalSubmitMany(): Int =
+    zioExternalSubmitMany(fixedThreadPool)
+
+  @Benchmark
   def zioSchedulerChainedFork(): Int =
     zioChainedFork(zScheduler)
 
@@ -90,6 +94,10 @@ class ZSchedulerBenchmarks {
   @Benchmark
   def zioSchedulerYieldMany(): Int =
     zioYieldMany(zScheduler)
+
+  @Benchmark
+  def zioSchedulerExternalSubmitMany(): Int =
+    zioExternalSubmitMany(zScheduler)
 
   def catsChainedFork(runtime: IORuntime): Int = {
 
@@ -215,5 +223,20 @@ class ZSchedulerBenchmarks {
     } yield 0
 
     unsafeRun(io.onExecutor(executor))
+  }
+
+  def zioExternalSubmitMany(executor: zio.Executor): Int = {
+    val latch                   = new CountDownLatch(10000)
+    implicit val unsafe: Unsafe = Unsafe.unsafe
+    var i                       = 0
+    while (i < 10000) {
+      executor.submit(new Runnable {
+        def run(): Unit =
+          latch.countDown()
+      })
+      i += 1
+    }
+    latch.await()
+    0
   }
 }

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -149,7 +149,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       submitBlocking(runnable)
     } else {
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        submitExternal(runnable)
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
       } else ()
@@ -166,7 +166,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     } else {
       var notify = true
       if ((worker eq null) || worker.blocking) {
-        globalQueue.offer(runnable)
+        submitExternal(runnable)
       }
       // Attempt resumption in the current Thread
       else if ((worker.nextRunnable eq null) && worker.localQueue.isEmpty()) {
@@ -192,6 +192,37 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         maybeUnparkWorker(currentState)
       }
       true
+    }
+  }
+
+  private[this] def submitExternal(runnable: Runnable): Unit =
+    if (!offerToLeastLoadedWorker(runnable)) {
+      globalQueue.offer(runnable)
+    }
+
+  // Keep idle-worker wakeups on the global queue; direct placement only helps once every worker is active.
+  private[this] def offerToLeastLoadedWorker(runnable: Runnable): Boolean = {
+    val currentState  = state.get
+    val currentActive = (currentState & 0xffff0000) >> 16
+    if (currentActive != poolSize) {
+      false
+    } else {
+      val offset = ThreadLocalRandom.current.nextInt(poolSize)
+      var worker = null.asInstanceOf[ZScheduler.Worker]
+      var size   = Int.MaxValue
+      var i      = 0
+      while (i != poolSize && size != 0) {
+        val candidate = workers((i + offset) % poolSize)
+        if (!candidate.blocking) {
+          val candidateSize = candidate.localQueue.size()
+          if (candidateSize < size) {
+            worker = candidate
+            size = candidateSize
+          }
+        }
+        i += 1
+      }
+      (worker ne null) && worker.localQueue.offer(runnable)
     }
   }
 


### PR DESCRIPTION
/claim #9356

This keeps the existing `ZScheduler` worker loop, local resumption path, blocking handling, and work stealing intact. The change is limited to external submissions: once every scheduler worker is active, external tasks are offered to the least-loaded non-blocking worker queue instead of always entering through the global queue. If any worker is idle, or if direct placement cannot offer to a worker queue, the scheduler falls back to the existing global queue path so idle-worker wakeups keep their current behavior.

I also added a JMH benchmark case for external submissions so this path can be measured directly against the fixed thread pool and the existing scheduler benchmark set.

Verification run locally on JDK 17:

- `/tmp/sbt -batch coreJVM/compile`
- `/tmp/sbt -batch benchmarks/compile`
- `/tmp/sbt -batch 'coreTestsJVM/testOnly zio.RuntimeSpecJVM'`
- `/tmp/sbt -batch 'coreJVM/scalafmtCheck' 'benchmarks/scalafmtCheck'`
- `git diff --check`