### PR TITLE
Use shared Diff rendering for classic equalTo

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/AssertionSpec.scala
@@ -137,6 +137,20 @@ object AssertionSpec extends ZIOBaseSpec {
         }
         case _ => false
       },
+      test("equalTo must use Diff when one is available") {
+        assert(List(1, 2, 3))(equalTo(List(1, 4, 3, 5)))
+      } @@ TestAspect.failing[String] {
+        case TestFailure.Assertion(result, _) =>
+          val failures = FailureCase.fromTrace(result.failures.get, Chunk.empty)
+          val errorString = failures(0).errorMessage.lines
+            .flatMap(_.fragments.map(_.text))
+            .mkString("\n")
+          errorString.contains("There was a difference") &&
+          errorString.contains("Expected") &&
+          errorString.contains("Diff") &&
+          errorString.contains("List(")
+        case _ => false
+      },
       test("equalTo should succeed for same CharSequence value") {
         val probe: CharSequence = "test"
         assert(probe)(equalTo(probe))

--- a/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.12/zio/test/AssertionVariants.scala
@@ -18,6 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.internal.EqualToRenderer
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants extends FieldExtractorPlatformSpecific {
@@ -76,10 +77,12 @@ trait AssertionVariants extends FieldExtractorPlatformSpecific {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            EqualToRenderer.render(actual, expected, result) {
+              if (expected.isInstanceOf[Product]) {
+                M.text(diffProduct(actual, expected))
+              } else {
+                M.pretty(actual) + M.equals + M.pretty(expected)
+              }
             }
           }
         }

--- a/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-2.13/zio/test/AssertionVariants.scala
@@ -18,6 +18,7 @@ package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.internal.EqualToRenderer
 import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
@@ -75,10 +76,12 @@ trait AssertionVariants {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            EqualToRenderer.render(actual, expected, result) {
+              if (expected.isInstanceOf[Product]) {
+                M.text(diffProduct(actual, expected))
+              } else {
+                M.pretty(actual) + M.equals + M.pretty(expected)
+              }
             }
           }
         }

--- a/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
+++ b/test/shared/src/main/scala-3/zio/test/AssertionVariants.scala
@@ -17,8 +17,9 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.test.{ErrorMessage => M}
 import zio.test.Assertion.Arguments.valueArgument
+import zio.test.internal.EqualToRenderer
+import zio.test.{ErrorMessage => M}
 
 trait AssertionVariants {
   private def diffProduct[T](
@@ -78,10 +79,12 @@ trait AssertionVariants {
             case (left, right)                             => left == right
           }
           TestTrace.boolean(result) {
-            if (expected.isInstanceOf[Product]) {
-              M.text(diffProduct(actual, expected))
-            } else {
-              M.pretty(actual) + M.equals + M.pretty(expected)
+            EqualToRenderer.render(actual, expected, result) {
+              if (expected.isInstanceOf[Product]) {
+                M.text(diffProduct(actual, expected))
+              } else {
+                M.pretty(actual) + M.equals + M.pretty(expected)
+              }
             }
           }
         }

--- a/test/shared/src/main/scala/zio/test/internal/EqualToRenderer.scala
+++ b/test/shared/src/main/scala/zio/test/internal/EqualToRenderer.scala
@@ -1,0 +1,114 @@
+package zio.test.internal
+
+import zio.{Chunk, NonEmptyChunk}
+import zio.internal.ansi.AnsiStringOps
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.test.diff.{Diff, DiffResult}
+import zio.test.{ConsoleUtils, ErrorMessage => M, PrettyPrint}
+
+import java.lang.reflect.{Array => JArray}
+import scala.collection.mutable.{ArrayBuffer, ListBuffer}
+
+private[test] object EqualToRenderer {
+
+  def render(
+    actual: Any,
+    expected: Any,
+    result: Boolean
+  )(fallback: => zio.test.ErrorMessage): zio.test.ErrorMessage =
+    if (result) {
+      fallback
+    } else {
+      runtimeDiff(expected, actual).fold(fallback)(renderDiff(_, expected, fallback))
+    }
+
+  def render[A](
+    actual: => A,
+    expected: => A,
+    result: Boolean,
+    diff: OptionalImplicit[Diff[A]]
+  )(fallback: => zio.test.ErrorMessage): zio.test.ErrorMessage =
+    diff.value match {
+      case Some(diff) if !diff.isLowPriority && !result =>
+        try {
+          renderDiff(diff.diff(expected, actual), expected, fallback)
+        } catch {
+          case _: ClassCastException => fallback
+        }
+      case _ =>
+        fallback
+    }
+
+  private def renderDiff(
+    diffResult: DiffResult,
+    expected: => Any,
+    fallback: => zio.test.ErrorMessage
+  ): zio.test.ErrorMessage =
+    diffResult match {
+      case DiffResult.Different(_, _, None) =>
+        fallback
+      case diffResult =>
+        M.choice("There was no difference", "There was a difference") ++
+          M.custom(ConsoleUtils.underlined("Expected")) ++
+          M.custom(PrettyPrint(expected)) ++
+          M.custom(
+            ConsoleUtils.underlined("Diff") + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
+          ) ++
+          M.custom(scala.Console.RESET + diffResult.render)
+    }
+
+  private def arrayElements(array: AnyRef): Vector[Any] = {
+    val length = JArray.getLength(array)
+    Vector.tabulate(length)(index => JArray.get(array, index))
+  }
+
+  private def runtimeDiff(expected: Any, actual: Any): Option[DiffResult] =
+    (expected, actual) match {
+      case (left: AnyRef, right: AnyRef) if left.getClass.isArray && right.getClass.isArray =>
+        Some(
+          Diff
+            .mkSeqDiff[Vector, Any]("Array")(identity)(Diff.anyDiff[Any])
+            .diff(arrayElements(left), arrayElements(right))
+        )
+      case (left: String, right: String) =>
+        Some(Diff.stringDiff.diff(left, right))
+      case (left: List[_], right: List[_]) =>
+        Some(Diff.listDiff[Any](Diff.anyDiff[Any]).diff(left, right))
+      case (left: Vector[_], right: Vector[_]) =>
+        Some(Diff.vectorDiff[Any](Diff.anyDiff[Any]).diff(left, right))
+      case (left: Chunk[_], right: Chunk[_]) =>
+        Some(Diff.chunkDiff[Any](Diff.anyDiff[Any]).diff(left.asInstanceOf[Chunk[Any]], right.asInstanceOf[Chunk[Any]]))
+      case (left: NonEmptyChunk[_], right: NonEmptyChunk[_]) =>
+        Some(
+          Diff
+            .nonEmptyChunk[Any](Diff.anyDiff[Any])
+            .diff(left.asInstanceOf[NonEmptyChunk[Any]], right.asInstanceOf[NonEmptyChunk[Any]])
+        )
+      case (left: ArrayBuffer[_], right: ArrayBuffer[_]) =>
+        Some(
+          Diff
+            .arrayBufferDiff[Any](Diff.anyDiff[Any])
+            .diff(left.asInstanceOf[ArrayBuffer[Any]], right.asInstanceOf[ArrayBuffer[Any]])
+        )
+      case (left: ListBuffer[_], right: ListBuffer[_]) =>
+        Some(
+          Diff
+            .listBufferDiff[Any](Diff.anyDiff[Any])
+            .diff(left.asInstanceOf[ListBuffer[Any]], right.asInstanceOf[ListBuffer[Any]])
+        )
+      case (left: Seq[_], right: Seq[_]) =>
+        Some(Diff.seqDiff[Any](Diff.anyDiff[Any]).diff(left, right))
+      case (left: Option[_], right: Option[_]) =>
+        Some(Diff.optionDiff[Any](Diff.anyDiff[Any]).diff(left, right))
+      case (left: Map[_, _], right: Map[_, _]) =>
+        Some(
+          Diff
+            .mapDiff[Any, Any](Diff.anyDiff[Any])
+            .diff(left.asInstanceOf[Map[Any, Any]], right.asInstanceOf[Map[Any, Any]])
+        )
+      case (left: Set[_], right: Set[_]) =>
+        Some(Diff.setDiff[Any](Diff.anyDiff[Any]).diff(left.asInstanceOf[Set[Any]], right.asInstanceOf[Set[Any]]))
+      case _ =>
+        None
+    }
+}

--- a/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
+++ b/test/shared/src/main/scala/zio/test/internal/SmartAssertions.scala
@@ -2,8 +2,7 @@ package zio.test.internal
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio._
-import zio.internal.ansi.AnsiStringOps
-import zio.test.diff.{Diff, DiffResult}
+import zio.test.diff.Diff
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -364,25 +363,7 @@ object SmartAssertions {
         }
 
         TestTrace.boolean(result) {
-          diff.value match {
-            case Some(diff) if !diff.isLowPriority && !result =>
-              val diffResult = diff.diff(that, a)
-              diffResult match {
-                case DiffResult.Different(_, _, None) =>
-                  M.pretty(a) + M.equals + M.pretty(that)
-                case diffResult =>
-                  M.choice("There was no difference", "There was a difference") ++
-                    M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(that)) ++
-                    M.custom(
-                      ConsoleUtils.underlined(
-                        "Diff"
-                      ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
-                    ) ++
-                    M.custom(scala.Console.RESET + diffResult.render)
-              }
-            case _ =>
-              M.pretty(a) + M.equals + M.pretty(that)
-          }
+          EqualToRenderer.render(a, that, result, diff)(M.pretty(a) + M.equals + M.pretty(that))
         }
       }
 
@@ -395,25 +376,7 @@ object SmartAssertions {
         }
 
         TestTrace.boolean(result) {
-          diff.value match {
-            case Some(diff) if !diff.isLowPriority && !result =>
-              val diffResult = diff.diff(that, conv(a))
-              diffResult match {
-                case DiffResult.Different(_, _, None) =>
-                  M.pretty(a) + M.equals + M.pretty(that)
-                case diffResult =>
-                  M.choice("There was no difference", "There was a difference") ++
-                    M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(that)) ++
-                    M.custom(
-                      ConsoleUtils.underlined(
-                        "Diff"
-                      ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
-                    ) ++
-                    M.custom(scala.Console.RESET + diffResult.render)
-              }
-            case _ =>
-              M.pretty(a) + M.equals + M.pretty(that)
-          }
+          EqualToRenderer.render(conv(a), that, result, diff)(M.pretty(a) + M.equals + M.pretty(that))
         }
       }
 
@@ -426,25 +389,7 @@ object SmartAssertions {
         }
 
         TestTrace.boolean(result) {
-          diff.value match {
-            case Some(diff) if !diff.isLowPriority && !result =>
-              val diffResult = diff.diff(conv(that), a)
-              diffResult match {
-                case DiffResult.Different(_, _, None) =>
-                  M.pretty(a) + M.equals + M.pretty(that)
-                case diffResult =>
-                  M.choice("There was no difference", "There was a difference") ++
-                    M.custom(ConsoleUtils.underlined("Expected")) ++ M.custom(PrettyPrint(that)) ++
-                    M.custom(
-                      ConsoleUtils.underlined(
-                        "Diff"
-                      ) + s" ${scala.Console.RED}-expected ${scala.Console.GREEN}+obtained".faint
-                    ) ++
-                    M.custom(scala.Console.RESET + diffResult.render)
-              }
-            case _ =>
-              M.pretty(a) + M.equals + M.pretty(that)
-          }
+          EqualToRenderer.render(a, conv(that), result, diff)(M.pretty(a) + M.equals + M.pretty(that))
         }
       }
 


### PR DESCRIPTION
﻿/claim #8664

## Summary

This updates classic `equalTo` failures to reuse the same extracted Diff rendering used by smart assertions, while keeping the public `equalTo` signatures unchanged for compatibility.

## Details

- Extracts shared equalTo Diff message rendering into `EqualToRenderer`
- Reuses that renderer from `SmartAssertions.equalTo`, `equalToL`, and `equalToR`
- Routes classic `equalTo` failures for standard diffable values through the renderer (`Array`, `String`, `List`, `Vector`, `Chunk`, `NonEmptyChunk`, mutable buffers, `Seq`, `Option`, `Map`, `Set`)
- Preserves the existing product-field fallback for case classes and other values without a runtime Diff path
- Adds a regression test proving classic `equalTo` uses the Diff output when available, while the existing product fallback tests continue to pass

## Demo

The new regression test exercises the classic assertion rendering path directly: `equalTo must use Diff when one is available`. The existing product-message tests also remain green, covering the fallback behavior.

## Validation

- `sbt scalafmtAll scalafmtCheckAll`
- `sbt "++2.13.18 testTestsJVM/testOnly zio.test.AssertionSpec"`
- `sbt "++3.3.7 testTestsJVM/Test/compile"`
- `sbt "++2.12.21 testTestsJVM/Test/compile"`
