### PR TITLE
Use map-backed concurrent set on Scala Native

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/PlatformSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/PlatformSpec.scala
@@ -1,0 +1,28 @@
+package zio.internal
+
+import zio.test.TestAspect.exceptJS
+import zio.test._
+import zio.{Unsafe, ZIO, ZIOBaseSpec}
+
+object PlatformSpec extends ZIOBaseSpec {
+  private final class Colliding(val value: Int) {
+    override def equals(that: Any): Boolean =
+      that match {
+        case that: Colliding => value == that.value
+        case _               => false
+      }
+
+    override def hashCode(): Int = 0
+  }
+
+  def spec =
+    suite("PlatformSpec")(
+      test("newConcurrentSet handles many colliding keys") {
+        val set = Platform.newConcurrentSet[Colliding](32)(Unsafe.unsafe)
+
+        for {
+          _ <- ZIO.foreachParDiscard(1 to 1024)(i => ZIO.succeed(set.add(new Colliding(i))))
+        } yield assertTrue(set.size == 1024)
+      } @@ exceptJS
+    )
+}

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -84,10 +84,10 @@ private[zio] trait PlatformSpecific {
     Collections.newSetFromMap(new WeakHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A]()
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean]())
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
-    ConcurrentHashMap.newKeySet[A](initialCapacity)
+    Collections.newSetFromMap(new ConcurrentHashMap[A, java.lang.Boolean](initialCapacity))
 
   private def blackhole(a: Any): Unit = {
     val _ = a


### PR DESCRIPTION
/claim #9681

## Summary
- replace Scala Native `ConcurrentHashMap.newKeySet` usage with a `Collections.newSetFromMap(new ConcurrentHashMap(...))` backed set
- add a regression check for `Platform.newConcurrentSet` with many colliding keys

## Why
`WeakConcurrentBag` uses `Platform.newConcurrentSet` for graduated weak references. On Scala Native, `ConcurrentHashMap.newKeySet` can hit the `treeifyBin` NPE path under high-concurrency fiber registration, as reported in #9681.

## Validation
- `git diff --check`
- Local sbt tests were not run because `sbt` is not installed in this environment.