### PR TITLE
Fix WeakConcurrentBag NPE on Scala Native

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
@@ -1,8 +1,8 @@
 package zio.internal
 
 import zio.test._
-import zio.test.TestAspect.{flaky, jvmOnly}
-import zio.ZIOBaseSpec
+import zio.test.TestAspect.{flaky, jvmOnly, nonFlaky}
+import zio.{ZIO, ZIOBaseSpec}
 
 object WeakConcurrentBagSpec extends ZIOBaseSpec {
   final case class Wrapper[A](value: A)
@@ -70,5 +70,33 @@ object WeakConcurrentBagSpec extends ZIOBaseSpec {
 
           assertTrue(bag.size <= 100)
         } @@ flaky
-    } @@ jvmOnly
+    } @@ jvmOnly +
+      suite("WeakConcurrentBagConcurrentSpec") {
+        test("concurrent add of 10K elements does not throw NPE") {
+          val bag = WeakConcurrentBag[Wrapper[Int]](1000)
+
+          for {
+            fibers <- ZIO.foreach(1 to 10000) { i =>
+                        ZIO.succeed(bag.add(Wrapper(i))).fork
+                      }
+            _      <- ZIO.foreach(fibers)(_.join)
+          } yield assertTrue(bag.size > 0)
+        } @@ nonFlaky(10) +
+          test("concurrent add and iterate does not throw NPE") {
+            val bag = WeakConcurrentBag[Wrapper[Int]](100)
+
+            for {
+              addFibers <- ZIO.foreach(1 to 10000) { i =>
+                             ZIO.succeed(bag.add(Wrapper(i))).fork
+                           }
+              iterFibers <- ZIO.foreach(1 to 100) { _ =>
+                              ZIO.succeed {
+                                bag.iterator.foreach(_ => ())
+                              }.fork
+                            }
+              _ <- ZIO.foreach(addFibers)(_.join)
+              _ <- ZIO.foreach(iterFibers)(_.join)
+            } yield assertTrue(bag.size > 0)
+          } @@ nonFlaky(10)
+      }
 }

--- a/core/native/src/main/scala/zio/internal/RingBuffer.scala
+++ b/core/native/src/main/scala/zio/internal/RingBuffer.scala
@@ -101,7 +101,11 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
 
     if (state == STATE_RESERVED) {
       buf(curIdx) = a.asInstanceOf[AnyRef]
-      aSeq.lazySet(curIdx, curTail + 1)
+      // Use set (volatile write) instead of lazySet to ensure the buf write is
+      // visible to other threads before the sequence update on Scala Native.
+      // On Scala Native, lazySet may not provide the store-store barrier needed
+      // to prevent reordering of the buf write and the seq write.
+      aSeq.set(curIdx, curTail + 1)
       true
     } else {
       false
@@ -163,7 +167,7 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
         val a = as.next()
         curIdx = posToIdx(enqHead, aCapacity)
         buf(curIdx) = a.asInstanceOf[AnyRef]
-        aSeq.lazySet(curIdx, enqHead + 1)
+        aSeq.set(curIdx, enqHead + 1)
         enqHead += 1
       }
     }
@@ -216,7 +220,7 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
       val deqElement = aBuf(curIdx)
       aBuf(curIdx) = null
 
-      aSeq.lazySet(curIdx, curHead + aCapacity)
+      aSeq.set(curIdx, curHead + aCapacity)
 
       deqElement.asInstanceOf[A]
     } else {
@@ -277,7 +281,7 @@ private[zio] abstract class RingBuffer[A](override final val capacity: Int)
         curIdx = posToIdx(deqHead, aCapacity)
         val a = buf(curIdx).asInstanceOf[A]
         buf(curIdx) = null
-        aSeq.lazySet(curIdx, deqHead + aCapacity)
+        aSeq.set(curIdx, deqHead + aCapacity)
         builder.addOne(a)
         deqHead += 1
       }

--- a/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
+++ b/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
@@ -127,9 +127,11 @@ private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsA
     var i    = 0
     val iter = chunk.chunkIterator
     while (iter.hasNextAt(i)) {
-      val ref   = iter.nextAt(i)
-      val value = ref.get()
-      if ((value ne null) && isAlive(value)) graduates.add(ref)
+      val ref = iter.nextAt(i)
+      if (ref ne null) {
+        val value = ref.get()
+        if ((value ne null) && isAlive(value)) graduates.add(ref)
+      }
       i += 1
     }
   }
@@ -149,12 +151,18 @@ private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsA
       @tailrec
       def prefetch(): A =
         if (it.hasNext) {
-          val next = it.next().get()
+          val ref = it.next()
 
-          if (next eq null) {
-            it.remove() // Remove dead reference since we're iterating over the set
+          if (ref eq null) {
             prefetch()
-          } else next
+          } else {
+            val next = ref.get()
+
+            if (next eq null) {
+              it.remove() // Remove dead reference since we're iterating over the set
+              prefetch()
+            } else next
+          }
         } else {
           null.asInstanceOf[A]
         }


### PR DESCRIPTION
## Summary

Fix `NullPointerException` in `WeakConcurrentBag` when forking 10K+ fibers on Scala Native.

## Root Cause

The Native `RingBuffer` uses `AtomicLongArray.lazySet` to publish sequence numbers after writing to the buffer array. On Scala Native, `lazySet` does not provide the same store-store barrier that the JVM guarantees via `putOrderedLong`. This allows reordering of the `buf[idx] = value` write after the `seq.lazySet(idx, ...)` write. When another thread sees the sequence number update, it reads a null from the buffer.

## Fix

1. **RingBuffer (Native)**: Replace `lazySet` with `set` (volatile write) to ensure proper memory ordering on Scala Native.
2. **WeakConcurrentBag (shared)**: Add defensive null checks in `addToLongTermStorage` and `iterator.prefetch` to guard against null refs from `pollUpTo`.
3. **Tests**: Add concurrent stress test that forks 10K fibers with concurrent adds and iteration.

## Notes

- The `lazySet` → `set` change only affects the Native platform's RingBuffer. The JVM version is unchanged.
- Performance impact on Native is minimal since the `set` vs `lazySet` difference is primarily relevant on JVM's JIT-optimized hot paths.

Closes #9681