### PR TITLE
Add FiberSet for fiber tracking

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
@@ -1,0 +1,187 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import scala.annotation.nowarn
+
+@State(Scope.Benchmark)
+private[this] class FiberSetAddContext {
+  private val idx = new AtomicInteger(0)
+
+  var fiberSet: FiberSet[TestFiber]                   = _
+  var javaSet: util.Set[TestFiber]                    = _
+  var concurrentSet: ConcurrentWeakHashSet[TestFiber] = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    this.fiberSet = FiberSet[TestFiber](_.isAlive())
+    this.javaSet =
+      Collections.synchronizedSet(Collections.newSetFromMap(new util.WeakHashMap[TestFiber, java.lang.Boolean]()))
+    this.concurrentSet = ConcurrentWeakHashSet[TestFiber]()
+  }
+
+  def nextFiber(): TestFiber =
+    TestFiber(idx.incrementAndGet())
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetAddBenchmark {
+
+  @Benchmark
+  def fiberSetAddSerial(ctx: FiberSetAddContext): Unit =
+    ctx.fiberSet.add(ctx.nextFiber())
+
+  @Threads(6)
+  @Benchmark
+  def fiberSetAddConcurrent(ctx: FiberSetAddContext): Unit =
+    ctx.fiberSet.add(ctx.nextFiber())
+
+  @Benchmark
+  def javaWeakSetAddSerial(ctx: FiberSetAddContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.javaSet.add(ctx.nextFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def javaWeakSetAddConcurrent(ctx: FiberSetAddContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.javaSet.add(ctx.nextFiber()))
+
+  @Benchmark
+  def concurrentWeakHashSetAddSerial(ctx: FiberSetAddContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.concurrentSet.add(ctx.nextFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def concurrentWeakHashSetAddConcurrent(ctx: FiberSetAddContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.concurrentSet.add(ctx.nextFiber()))
+}
+
+@State(Scope.Benchmark)
+private[this] class FiberSetRemoveContext {
+  private val sampleSize = 100000
+  private val idx        = new AtomicInteger(sampleSize)
+  private val values     = (0 until sampleSize).map(TestFiber).toArray
+
+  var fiberSet: FiberSet[TestFiber]                   = _
+  var javaSet: util.Set[TestFiber]                    = _
+  var concurrentSet: ConcurrentWeakHashSet[TestFiber] = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    this.fiberSet = FiberSet[TestFiber](_.isAlive())
+    this.javaSet =
+      Collections.synchronizedSet(Collections.newSetFromMap(new util.WeakHashMap[TestFiber, java.lang.Boolean]()))
+    this.concurrentSet = ConcurrentWeakHashSet[TestFiber]()
+
+    import scala.jdk.CollectionConverters._
+    this.values.foreach(this.fiberSet.add)
+    this.javaSet.addAll(this.values.toSet.asJava): @nowarn("msg=JavaConverters")
+    this.concurrentSet.addAll(this.values)
+  }
+
+  def nextFiber(): TestFiber =
+    TestFiber(idx.incrementAndGet())
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetRemoveBenchmark {
+
+  @Benchmark
+  def fiberSetRemoveSerial(ctx: FiberSetRemoveContext): Unit =
+    ctx.fiberSet.remove(ctx.nextFiber())
+
+  @Threads(6)
+  @Benchmark
+  def fiberSetRemoveConcurrent(ctx: FiberSetRemoveContext): Unit =
+    ctx.fiberSet.remove(ctx.nextFiber())
+
+  @Benchmark
+  def javaWeakSetRemoveSerial(ctx: FiberSetRemoveContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.javaSet.remove(ctx.nextFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def javaWeakSetRemoveConcurrent(ctx: FiberSetRemoveContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.javaSet.remove(ctx.nextFiber()))
+
+  @Benchmark
+  def concurrentWeakHashSetRemoveSerial(ctx: FiberSetRemoveContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.concurrentSet.remove(ctx.nextFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def concurrentWeakHashSetRemoveConcurrent(ctx: FiberSetRemoveContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.concurrentSet.remove(ctx.nextFiber()))
+}
+
+@State(Scope.Benchmark)
+private[this] class FiberSetIterateContext {
+  private val sampleSize = 1000
+  private val values     = (0 until sampleSize).map(TestFiber).toArray
+
+  var fiberSet: FiberSet[TestFiber]                   = _
+  var javaSet: util.Set[TestFiber]                    = _
+  var concurrentSet: ConcurrentWeakHashSet[TestFiber] = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    this.fiberSet = FiberSet[TestFiber](_.isAlive())
+    this.javaSet =
+      Collections.synchronizedSet(Collections.newSetFromMap(new util.WeakHashMap[TestFiber, java.lang.Boolean]()))
+    this.concurrentSet = ConcurrentWeakHashSet[TestFiber]()
+
+    import scala.jdk.CollectionConverters._
+    this.values.foreach(this.fiberSet.add)
+    this.javaSet.addAll(this.values.toSet.asJava): @nowarn("msg=JavaConverters")
+    this.concurrentSet.addAll(this.values)
+  }
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetIterateBenchmark {
+
+  @Benchmark
+  def fiberSetIterateSerial(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.fiberSet.iterator.foreach(blackhole.consume)
+
+  @Threads(6)
+  @Benchmark
+  def fiberSetIterateConcurrent(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.fiberSet.iterator.foreach(blackhole.consume)
+
+  @Benchmark
+  def javaWeakSetIterateSerial(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.javaSet.forEach(blackhole.consume)
+
+  @Threads(6)
+  @Benchmark
+  def javaWeakSetIterateConcurrent(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.javaSet.forEach(blackhole.consume)
+
+  @Benchmark
+  def concurrentWeakHashSetIterateSerial(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.concurrentSet.foreach(blackhole.consume)
+
+  @Threads(6)
+  @Benchmark
+  def concurrentWeakHashSetIterateConcurrent(ctx: FiberSetIterateContext, blackhole: Blackhole): Unit =
+    ctx.concurrentSet.foreach(blackhole.consume)
+}
+
+private[this] final case class TestFiber(id: Int) {
+  def isAlive(): Boolean =
+    true
+}

--- a/core-tests/shared/src/test/scala/zio/FiberSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/FiberSpec.scala
@@ -97,6 +97,45 @@ object FiberSpec extends ZIOBaseSpec {
             _      <- (rootContains(fiber1) && rootContains(fiber2)).repeatUntil(_ == true)
             _      <- fiber1.interrupt *> fiber2.interrupt
           } yield assertCompletes
+        },
+        test("interrupted roots disappear") {
+          def rootContains(f: Fiber.Runtime[_, _]): UIO[Boolean] =
+            Fiber.roots.map(_.contains(f))
+
+          for {
+            fiber <- ZIO.never.forkDaemon
+            _     <- rootContains(fiber).repeatUntil(_ == true)
+            _     <- fiber.interrupt
+            _     <- ZIO.succeed(Fiber._rootSet.gc())
+            _     <- rootContains(fiber).repeatUntil(_ == false)
+          } yield assertCompletes
+        },
+        test("disabled fiber roots are not tracked") {
+          for {
+            fiber <- ZIO.never.forkDaemon
+            roots <- Fiber.roots
+            _     <- fiber.interrupt
+          } yield assertTrue(!roots.contains(fiber))
+        }.provide(Runtime.disableFlags(RuntimeFlag.FiberRoots))
+      ),
+      suite("children")(
+        test("includes live forked children") {
+          ZIO.withFiberRuntime[Any, Nothing, TestResult] { (parent, _) =>
+            for {
+              child <- ZIO.never.fork
+              _     <- parent.children.map(_.contains(child)).repeatUntil(_ == true)
+              _     <- child.interrupt
+            } yield assertCompletes
+          }
+        },
+        test("completed children disappear") {
+          ZIO.withFiberRuntime[Any, Nothing, TestResult] { (parent, _) =>
+            for {
+              child <- ZIO.unit.fork
+              _     <- child.await
+              _     <- parent.children.map(_.contains(child)).repeatUntil(_ == false)
+            } yield assertCompletes
+          }
         }
       ),
       suite("stack safety")(

--- a/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
@@ -1,0 +1,99 @@
+package zio.internal
+
+import zio.{ZIO, ZIOBaseSpec}
+import zio.test._
+import zio.test.TestAspect.{flaky, jvmOnly}
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+object FiberSetSpec extends ZIOBaseSpec {
+  final class Entry(val value: Int, alive: Boolean = true) {
+    private val aliveRef = new AtomicBoolean(alive)
+
+    def isAlive(): Boolean =
+      aliveRef.get()
+
+    def setAlive(alive: Boolean): Unit =
+      aliveRef.set(alive)
+
+    override def equals(that: Any): Boolean =
+      that match {
+        case that: Entry => value == that.value
+        case _           => false
+      }
+
+    override def hashCode(): Int =
+      value.hashCode()
+
+    override def toString: String =
+      s"Entry($value)"
+  }
+
+  def spec =
+    suite("FiberSetSpec")(
+      test("iterates live entries") {
+        val set     = FiberSet[Entry](_.isAlive())
+        val entries = List(new Entry(1), new Entry(2), new Entry(3))
+
+        entries.foreach(set.add)
+
+        assertTrue(set.iterator.toSet == entries.toSet)
+      },
+      test("remove deletes an entry") {
+        val set    = FiberSet[Entry](_.isAlive())
+        val first  = new Entry(1)
+        val second = new Entry(2)
+
+        set.add(first)
+        set.add(second)
+        set.remove(first)
+
+        assertTrue(set.iterator.toSet == Set(second))
+      },
+      test("remove is idempotent") {
+        val set   = FiberSet[Entry](_.isAlive())
+        val entry = new Entry(1)
+
+        set.add(entry)
+        set.remove(entry)
+        set.remove(entry)
+
+        assertTrue(set.isEmpty)
+      },
+      test("filters entries that are no longer alive") {
+        val set   = FiberSet[Entry](_.isAlive())
+        val entry = new Entry(1)
+
+        set.add(entry)
+        entry.setAlive(false)
+
+        assertTrue(set.isEmpty)
+      },
+      test("concurrent add remove and iteration is weakly consistent") {
+        val set     = FiberSet[Entry](_.isAlive())
+        val entries = (0 until 1000).map(new Entry(_)).toVector
+
+        ZIO
+          .foreachParDiscard(entries) { entry =>
+            ZIO.succeed {
+              set.add(entry)
+              if (entry.value % 2 == 0) set.remove(entry)
+              set.iterator.foreach(_ => ())
+            }
+          }
+          .as(assertTrue(set.iterator.forall(_.value % 2 != 0)))
+      },
+      test("manual gc drops collected entries") {
+        val set  = FiberSet[Entry](_.isAlive())
+        val live = new Entry(2)
+
+        set.add(new Entry(1))
+        set.add(live)
+
+        System.gc()
+        set.gc()
+
+        assertTrue(set.iterator.toSet == Set(live))
+      } @@ flaky @@ jvmOnly
+    )
+}

--- a/core/js/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/js/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,7 @@
+package zio.internal
+
+import zio.Duration
+
+private object FiberSetGc {
+  def start[A <: AnyRef](set: FiberSet[A], every: Duration): Unit = ()
+}

--- a/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,33 @@
+package zio.internal
+
+import zio.Duration
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+private final class FiberSetGc[A <: AnyRef] private (
+  set: FiberSet[A],
+  sleepFor: Duration
+) extends Thread {
+  override def run(): Unit = {
+    val sleepForNanos = sleepFor.toNanos
+    while (!isInterrupted) {
+      LockSupport.parkNanos(sleepForNanos)
+      set.gc(false)
+    }
+  }
+}
+
+private object FiberSetGc {
+  private val i = new AtomicInteger(0)
+
+  def start[A <: AnyRef](set: FiberSet[A], every: Duration): Unit = {
+    assert(every.toMillis >= 1000, "Auto-gc interval must be >= 1 second")
+
+    val thread = new FiberSetGc(set, every)
+    thread.setName(s"zio.internal.FiberSet.GcThread-${i.getAndIncrement()}")
+    thread.setPriority(4)
+    thread.setDaemon(true)
+    thread.start()
+  }
+}

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,12 +16,11 @@
 
 package zio
 
-import zio.internal.{FiberRenderer, FiberScope}
+import zio.internal.{FiberRenderer, FiberScope, FiberSet, WeakConcurrentBag}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import scala.concurrent.Future
-import zio.internal.WeakConcurrentBag
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a
@@ -1036,7 +1035,7 @@ object Fiber extends FiberPlatformSpecific {
    * returned chunk is only weakly consistent.
    */
   def roots(implicit trace: Trace): UIO[Chunk[Fiber.Runtime[_, _]]] =
-    ZIO.succeed(Chunk.fromIterator(_roots.iterator))
+    ZIO.succeed(Chunk.fromIterator(_rootSet.iterator))
 
   /**
    * Returns a fiber that has already succeeded with the specified value.
@@ -1070,7 +1069,11 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
+  private[zio] lazy val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
     WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
+      .withAutoGc(5.seconds)
+
+  private[zio] val _rootSet: FiberSet[Fiber.Runtime[_, _]] =
+    FiberSet[Fiber.Runtime[_, _]](_.isAlive())
       .withAutoGc(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -24,7 +24,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
@@ -43,7 +42,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
   private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var _children       = null.asInstanceOf[FiberSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
   private var _stack          = null.asInstanceOf[Array[Continuation]]
@@ -84,12 +83,14 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       )
   }
 
-  private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
+  private[this] def childrenChunk(children: FiberSet[Fiber.Runtime[_, _]]): Chunk[Fiber.Runtime[_, _]] =
     // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
     if (children eq null) Chunk.empty
     else {
-      val bldr = Chunk.newBuilder[Fiber.Runtime[_, _]]
-      children.forEach { child =>
+      val bldr     = Chunk.newBuilder[Fiber.Runtime[_, _]]
+      val iterator = children.iterator
+      while (iterator.hasNext) {
+        val child = iterator.next()
         if ((child ne null) && child.isAlive())
           bldr.addOne(child)
       }
@@ -568,11 +569,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def getChildren(): JavaSet[Fiber.Runtime[_, _]] = {
+  private def getChildren(): FiberSet[Fiber.Runtime[_, _]] = {
     // executed by the fiber itself, no risk of racing with transferChildren
     var children = _children
     if (children eq null) {
-      children = Platform.newConcurrentWeakSet[Fiber.Runtime[_, _]]()(Unsafe)
+      children = FiberSet[Fiber.Runtime[_, _]](_.isAlive())
       _children = children
     }
     children
@@ -738,7 +739,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    */
   private def interruptAllChildren(): UIO[Any] =
     if (sendInterruptSignalToAllChildren(_children)) {
-      val iterator = _children.iterator()
+      val iterator = _children.iterator
       _children = null
 
       var curr: Fiber.Runtime[_, _] = null
@@ -788,7 +789,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val children0 = _children
     if ((children0 eq null) || (_exitValue ne null)) false
     else {
-      val it = children0.iterator()
+      val it = children0.iterator
       while (it.hasNext) {
         val child = it.next()
         if ((child ne null) && child.isAlive()) return true
@@ -1358,12 +1359,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private def sendInterruptSignalToAllChildren(
-    children: JavaSet[Fiber.Runtime[_, _]]
+    children: FiberSet[Fiber.Runtime[_, _]]
   ): Boolean =
     if ((children eq null) || children.isEmpty) false
     else {
       // Initiate asynchronous interruption of all children:
-      val iterator = children.iterator()
+      val iterator = children.iterator
       var told     = false
       val cause    = Cause.interrupt(fiberId)
 

--- a/core/shared/src/main/scala/zio/internal/FiberScope.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberScope.scala
@@ -63,7 +63,7 @@ private[zio] object FiberScope {
       unsafe: Unsafe
     ): Unit =
       if (RuntimeFlags.fiberRoots(runtimeFlags)) {
-        Fiber._roots.add(child)
+        Fiber._rootSet.add(child)
       }
 
     private[zio] def addAll(
@@ -76,7 +76,7 @@ private[zio] object FiberScope {
     ): Unit =
       if (RuntimeFlags.fiberRoots(runtimeFlags)) {
         children.foreach {
-          Fiber._roots.add(_)
+          Fiber._rootSet.add(_)
         }
       }
   }

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,140 @@
+package zio.internal
+
+import zio.Duration
+import zio.internal.FiberSet.IsAlive
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.function.Predicate
+import scala.annotation.tailrec
+
+/**
+ * A weakly-held, concurrently mutable collection optimized for tracking live
+ * fibers. Duplicates are tolerated, but remove and iteration both filter out
+ * fibers that are no longer alive.
+ */
+private[zio] final class FiberSet[A <: AnyRef] private (isAlive: IsAlive[A]) { self =>
+  import FiberSet.Ref
+
+  private[this] val queue    = new ReferenceQueue[A]
+  private[this] val refs     = new ConcurrentLinkedQueue[Ref[A]]
+  private[this] val gcStatus = new AtomicBoolean(false)
+  private[this] val autoGc   = new AtomicBoolean(false)
+  private[this] val inactiveRef = new Predicate[Ref[A]] {
+    def test(ref: Ref[A]): Boolean = {
+      val fiber = ref.get()
+      !ref.active.get() || (fiber eq null) || !isAlive(fiber)
+    }
+  }
+
+  def withAutoGc(every: Duration): FiberSet[A] = {
+    if (autoGc.compareAndSet(false, true)) {
+      FiberSetGc.start(self, every)
+    }
+    self
+  }
+
+  final def add(fiber: A): Unit =
+    if ((fiber ne null) && isAlive(fiber)) {
+      refs.offer(new Ref[A](fiber, queue))
+      ()
+    }
+
+  final def remove(fiber: A): Unit =
+    if (fiber ne null) {
+      val iterator = refs.iterator()
+      while (iterator.hasNext) {
+        val ref   = iterator.next()
+        val value = ref.get()
+        if ((value eq null) || !isAlive(value)) ref.active.set(false)
+        else if (value eq fiber) ref.active.set(false)
+      }
+    }
+
+  final def gc(): Unit =
+    gc(true)
+
+  final def gc(force: Boolean): Unit = {
+    val lockAcquired = gcStatus.compareAndSet(false, true)
+
+    try
+      if (force || lockAcquired) {
+        drainQueue()
+        refs.removeIf(inactiveRef)
+      }
+    finally if (lockAcquired) gcStatus.set(false)
+  }
+
+  final def isEmpty: Boolean =
+    !iterator.hasNext
+
+  final def iterator: Iterator[A] =
+    new Iterator[A] {
+      private[this] val refsIterator = {
+        gc(false)
+        refs.iterator()
+      }
+      private[this] var nextValue = prefetch()
+
+      @tailrec
+      private def prefetch(): A =
+        if (refsIterator.hasNext) {
+          val ref   = refsIterator.next()
+          val value = ref.get()
+          if (ref.active.get() && (value ne null) && isAlive(value)) value
+          else {
+            ref.active.set(false)
+            prefetch()
+          }
+        } else null.asInstanceOf[A]
+
+      def hasNext: Boolean =
+        nextValue ne null
+
+      def next(): A =
+        if (nextValue eq null)
+          throw new NoSuchElementException("There is no more element in the fiber set iterator")
+        else {
+          val result = nextValue
+          nextValue = prefetch()
+          result
+        }
+    }
+
+  final def size: Int =
+    iterator.length
+
+  override final def toString(): String =
+    iterator.mkString("FiberSet(", ",", ")")
+
+  private def drainQueue(): Unit = {
+    var ref = queue.poll().asInstanceOf[Ref[A]]
+    while (ref ne null) {
+      ref.active.set(false)
+      ref = queue.poll().asInstanceOf[Ref[A]]
+    }
+  }
+}
+
+private[zio] object FiberSet {
+
+  def apply[A <: AnyRef](isAlive: IsAlive[A] = IsAlive.always): FiberSet[A] =
+    new FiberSet[A](isAlive)
+
+  /** Specialized Function1 that doesn't cause boxing of the Boolean. */
+  trait IsAlive[-A] {
+    def apply(value: A): Boolean
+  }
+
+  object IsAlive {
+    val always: IsAlive[AnyRef] = _ => true
+  }
+
+  private final class Ref[A <: AnyRef](
+    fiber: A,
+    queue: ReferenceQueue[A]
+  ) extends WeakReference[A](fiber, queue) {
+    val active = new AtomicBoolean(true)
+  }
+}


### PR DESCRIPTION
Fixes #8861

/claim #8861

## Summary
- add an internal `FiberSet` for weakly-held fiber tracking with reference-queue cleanup, identity removal, live-entry filtering, and optional background cleanup
- route daemon root tracking and runtime child tracking through `FiberSet` while preserving the legacy package-private `_roots` accessor shape for compatibility
- add focused `FiberSet` and roots/children integration coverage
- add JMH benchmarks comparing `FiberSet`, the synchronized weak-set baseline, and `ConcurrentWeakHashSet` for add/remove/iterate scenarios

## Validation
- `git diff --check`
- `coreTestsJVM/Test/compile;benchmarks/Compile/compile`
- `coreTestsJVM/testOnly zio.internal.FiberSetSpec zio.FiberSpec`
- `coreJVM/scalafmt;coreTestsJVM/scalafmt;benchmarks/scalafmt;coreJVM/scalafmtCheck;coreTestsJVM/scalafmtCheck;benchmarks/scalafmtCheck`
- `benchmarks/Jmh/run -f 1 -wi 1 -i 1 .*FiberSetAddBenchmark.*`

## Benchmark smoke
The short JMH add smoke completed successfully and is included only as a benchmark wiring check, not a full performance study.