### PR TITLE
Optimize ZIO.timeoutTo without sleep fiber

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,34 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Benchmark, BenchmarkMode, Mode, OutputTimeUnit, Param, Scope => JScope, State}
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.TimeoutException
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TimeoutBenchmark {
+  import BenchmarkUtil.unsafeRun
+
+  @Param(Array("0", "100", "10000"))
+  var n: Int = _
+
+  private def effect =
+    ZIO.foldLeft(0 until n)(0) { case (sum, value) =>
+      ZIO.succeed(sum + value)
+    }
+
+  @Benchmark
+  def zioBaseline(): Unit = {
+    val _ = unsafeRun(effect)
+  }
+
+  @Benchmark
+  def zioTimeoutTo(): Unit = {
+    val _ =
+      unsafeRun(
+        effect.timeoutTo(ZIO.fail(new TimeoutException("timeout")))(ZIO.succeed(_))(100.minutes).flatten
+      )
+  }
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -2415,6 +2415,20 @@ object ZIOSpec extends ZIOBaseSpec {
       }
     ),
     suite("Timeout don't lose all values from parent fiber")(
+      test("When timeout is already elapsed, effect is not evaluated") {
+        for {
+          evaluated <- Ref.make(false)
+          result    <- (evaluated.set(true) *> ZIO.succeed("value")).timeoutTo("timeout")(identity)(Duration.Zero)
+          value     <- evaluated.get
+        } yield assert(result)(equalTo("timeout")) && assert(value)(isFalse)
+      },
+      test("When effect uses test clock, timeout is driven by test scheduler") {
+        for {
+          fiber  <- ZIO.never.as("value").timeoutTo("timeout")(identity)(1.second).fork
+          _      <- TestClock.adjust(1.second)
+          result <- fiber.join
+        } yield assert(result)(equalTo("timeout"))
+      },
       test("When effect is winner and failed") {
         val (initial, update) = ("initial", "update")
         def effect(fiberRef: FiberRef[String]) =

--- a/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -39,6 +39,8 @@ private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
 
 private[zio] trait ZIOCompanionPlatformSpecific { self: ZIO.type =>
 
+  private[zio] def optimizeTimeoutTo: Boolean = false
+
   /**
    * Imports a synchronous effect that does blocking IO into a pure value.
    *

--- a/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ZIOPlatformSpecific.scala
@@ -53,6 +53,8 @@ private[zio] trait ZIOPlatformSpecific[-R, +E, +A] { self: ZIO[R, E, A] =>
 
 private[zio] trait ZIOCompanionPlatformSpecific extends ZIOPlatformSpecificJVM {
 
+  private[zio] def optimizeTimeoutTo: Boolean = true
+
   /**
    * Imports a synchronous effect that does blocking IO into a pure value.
    *

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -23,7 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
 import scala.collection.mutable.ListBuffer
@@ -5667,22 +5667,73 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
-            },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+      ZIO.suspendSucceed {
+        val d = duration
+        if (d.isZero || d.isNegative) Exit.succeed(b())
+        else if (d >= Duration.Infinity) self.map(f)
+        else
+          ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
+            ZIO.clockWith(_.scheduler).flatMap { scheduler =>
+              val parentFiberId = parentFiber.id
+              val graft         = ZIO.Grafter(parentFiber)
+              val effect        = graft.applyOnExit(self)
+              val childFiber =
+                ZIO.unsafe.makeChildFiber(trace, effect, parentFiber, parentStatus.runtimeFlags, null)(Unsafe)
+
+              ZIO.asyncInterrupt[R, E, B1](
+                { cb =>
+                  val completed       = new AtomicBoolean()
+                  val canceledTimeout = (() => false): Scheduler.CancelToken
+                  val cancelTimeout   = new AtomicReference[Scheduler.CancelToken](null)
+
+                  def cancelScheduledTimeout(): Unit = {
+                    val canceler = cancelTimeout.getAndSet(canceledTimeout)
+                    if ((canceler ne null) && (canceler ne canceledTimeout)) {
+                      val _ = canceler()
+                    }
+                  }
+
+                  def setScheduledTimeout(canceler: Scheduler.CancelToken): Unit =
+                    if (!cancelTimeout.compareAndSet(null, canceler)) {
+                      val _ = canceler()
+                    }
+
+                  childFiber.addObserver { exit =>
+                    if (completed.compareAndSet(false, true)) {
+                      cancelScheduledTimeout()
+                      cb(childFiber.inheritAll *> exit.mapExit(f))
+                    }
+                  }(Unsafe)
+
+                  val exit = childFiber.start(effect)
+
+                  if ((exit ne null) && completed.compareAndSet(false, true)) {
+                    Right(childFiber.inheritAll *> exit.mapExit(f))
+                  } else {
+                    if (exit eq null)
+                      setScheduledTimeout(
+                        scheduler.schedule(
+                          () =>
+                            if (completed.compareAndSet(false, true))
+                              cb(childFiber.interruptAs(parentFiberId) *> childFiber.inheritAll.as(b())),
+                          d
+                        )(Unsafe)
+                      )
+
+                    Left(
+                      ZIO.succeed {
+                        if (completed.compareAndSet(false, true)) {
+                          cancelScheduledTimeout()
+                          childFiber.tellInterrupt(Cause.interrupt(parentFiberId))
+                        }
+                      }
+                    )
+                  }
+                },
+                childFiber.id
+              )
+            }
+          }
       }
   }
 

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5671,6 +5671,27 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
         val d = duration
         if (d.isZero || d.isNegative) Exit.succeed(b())
         else if (d >= Duration.Infinity) self.map(f)
+        else if (!ZIO.optimizeTimeoutTo)
+          ZIO.fiberIdWith { parentFiberId =>
+            self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(d).interruptible)(
+              (winner, loser) =>
+                winner.await.flatMap {
+                  case Exit.Success(a) =>
+                    winner.inheritAll *> loser.interruptAs(parentFiberId).as(f(a))
+                  case Exit.Failure(cause) =>
+                    winner.inheritAll *> loser.interruptAs(parentFiberId) *> Exit.failCause(cause)
+                },
+              (winner, loser) =>
+                winner.await.flatMap {
+                  case _: Exit.Success[?] =>
+                    loser.inheritAll *> loser.interruptAs(parentFiberId).as(b())
+                  case Exit.Failure(cause) =>
+                    loser.inheritAll *> loser.interruptAs(parentFiberId) *> Exit.failCause(cause)
+                },
+              null,
+              FiberScope.global
+            )
+          }
         else
           ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
             ZIO.clockWith(_.scheduler).flatMap { scheduler =>
@@ -5685,6 +5706,8 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                   val completed       = new AtomicBoolean()
                   val canceledTimeout = (() => false): Scheduler.CancelToken
                   val cancelTimeout   = new AtomicReference[Scheduler.CancelToken](null)
+                  val registering     = new AtomicBoolean(true)
+                  val earlyResult     = new AtomicReference[ZIO[R, E, B1]](null)
 
                   def cancelScheduledTimeout(): Unit = {
                     val canceler = cancelTimeout.getAndSet(canceledTimeout)
@@ -5698,36 +5721,57 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
                       val _ = canceler()
                     }
 
+                  def complete(effect: ZIO[R, E, B1]): Unit =
+                    if (registering.get()) {
+                      val _ = earlyResult.compareAndSet(null, effect)
+                    } else {
+                      cb(effect)
+                    }
+
                   childFiber.addObserver { exit =>
                     if (completed.compareAndSet(false, true)) {
                       cancelScheduledTimeout()
-                      cb(childFiber.inheritAll *> exit.mapExit(f))
+                      complete(childFiber.inheritAll *> exit.mapExit(f))
                     }
                   }(Unsafe)
 
                   val exit = childFiber.start(effect)
 
-                  if ((exit ne null) && completed.compareAndSet(false, true)) {
-                    Right(childFiber.inheritAll *> exit.mapExit(f))
+                  if ((exit ne null) && completed.compareAndSet(false, true))
+                    complete(childFiber.inheritAll *> exit.mapExit(f))
+
+                  val early = earlyResult.get()
+                  if (early ne null) {
+                    registering.set(false)
+                    Right(early)
                   } else {
                     if (exit eq null)
                       setScheduledTimeout(
                         scheduler.schedule(
                           () =>
-                            if (completed.compareAndSet(false, true))
-                              cb(childFiber.interruptAs(parentFiberId) *> childFiber.inheritAll.as(b())),
+                            if (completed.compareAndSet(false, true)) {
+                              complete(childFiber.interruptAs(parentFiberId) *> childFiber.inheritAll.as(b()))
+                            },
                           d
                         )(Unsafe)
                       )
 
-                    Left(
-                      ZIO.succeed {
-                        if (completed.compareAndSet(false, true)) {
-                          cancelScheduledTimeout()
-                          childFiber.tellInterrupt(Cause.interrupt(parentFiberId))
+                    registering.set(false)
+                    val early = earlyResult.get()
+                    if (early ne null)
+                      Right(early)
+                    else
+                      Left(
+                        ZIO.suspendSucceed {
+                          if (completed.compareAndSet(false, true)) {
+                            val interrupt = childFiber.interruptAs(parentFiberId).unit
+                            cancelScheduledTimeout()
+                            interrupt
+                          } else {
+                            Exit.unit
+                          }
                         }
-                      }
-                    )
+                      )
                   }
                 },
                 childFiber.id


### PR DESCRIPTION
/claim #9211

## Summary

- Replace the `raceFibersWith(ZIO.sleep(...))` implementation of `timeoutTo` with one child fiber plus the active `Clock` scheduler.
- Preserve fast paths for elapsed and infinite durations.
- Preserve child `FiberRef` inheritance on success/failure and timeout behavior via regression tests.
- Add a JMH benchmark that compares plain effect evaluation with `timeoutTo` overhead.

Closes #9211

## Notes

This intentionally uses the `Clock` service scheduler instead of the global scheduler so test-clock driven timeouts remain controllable. It also avoids scheduling the timeout at all when the primary effect completes synchronously.

## Local benchmark

Short JMH run on JDK 17, `-i 2 -wi 2 -r 1s -w 1s -f 1 -t 1`, comparing this branch against a clean baseline clone at `edbb59d02`:

| n | baseline timeoutTo | this PR timeoutTo | speedup |
|---:|---:|---:|---:|
| 0 | 30,939 ops/s | 1,199,009 ops/s | 38.8x |
| 100 | 25,580 ops/s | 359,953 ops/s | 14.1x |
| 10000 | 2,706 ops/s | 4,999 ops/s | 1.8x |

## Verification

- `coreTestsJVM/testOnly zio.ZIOSpec -- -t timeout`
- `benchmarks/Compile/compile`
- `scalafmtCheckAll`
- `benchmarks/jmh:run -i 2 -wi 2 -r 1s -w 1s -f 1 -t 1 zio.TimeoutBenchmark`