### PR TITLE
Optimize Semaphore reservation fast path

### DIFF
--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -155,13 +155,15 @@ object Semaphore {
           else if (n == 0L)
             ZIO.succeed(Reservation.zero)
           else
-            Promise.make[Nothing, Unit].flatMap { promise =>
+            ZIO.fiberIdWith { fiberId =>
               ref.modify {
                 case Right(permits) if permits >= n =>
                   Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
                 case Right(permits) =>
+                  val promise = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
                   Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
                 case Left(queue) =>
+                  val promise = Promise.unsafe.make[Nothing, Unit](fiberId)(Unsafe)
                   Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
               }
             }
@@ -169,11 +171,11 @@ object Semaphore {
         def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =
           ref.modify {
             case Left(queue) =>
-              queue
-                .find(_._1 == promise)
-                .fold(releaseN(n) -> Left(queue)) { case (_, permits) =>
-                  releaseN(n - permits) -> Left(queue.filter(_._1 != promise))
-                }
+              val (before, after) = queue.span(_._1 ne promise)
+              after.dequeueOption match {
+                case None                       => releaseN(n)           -> Left(queue)
+                case Some(((_, permits), rest)) => releaseN(n - permits) -> Left(before ++ rest)
+              }
             case Right(permits) => ZIO.unit -> Right(permits + n)
           }.flatten
 
@@ -183,8 +185,8 @@ object Semaphore {
           def loop(
             n: Long,
             state: Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long],
-            acc: UIO[Any]
-          ): (UIO[Any], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
+            acc: List[Promise[Nothing, Unit]]
+          ): (List[Promise[Nothing, Unit]], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
             state match {
               case Right(permits) => acc -> Right(permits + n)
               case Left(queue) =>
@@ -192,15 +194,19 @@ object Semaphore {
                   case None => acc -> Right(n)
                   case Some(((promise, permits), queue)) =>
                     if (n > permits)
-                      loop(n - permits, Left(queue), acc *> promise.succeedUnit)
+                      loop(n - permits, Left(queue), promise :: acc)
                     else if (n == permits)
-                      (acc *> promise.succeedUnit) -> Left(queue)
+                      (promise :: acc) -> Left(queue)
                     else
                       acc -> Left((promise -> (permits - n)) +: queue)
                 }
             }
 
-          ref.modify(loop(n, _, ZIO.unit)).flatten
+          ref.modify(loop(n, _, Nil)).flatMap {
+            case Nil            => ZIO.unit
+            case promise :: Nil => promise.succeedUnit
+            case promises       => ZIO.foreachDiscard(promises.reverse)(_.succeedUnit)
+          }
         }
       }
   }


### PR DESCRIPTION
/claim #9093

## Summary

This PR optimizes `Semaphore.reserve` for the common fast path where enough permits are immediately available.

The previous implementation allocated a `Promise` before checking permit availability, so uncontended `withPermit` / `withPermits` paid waiter-allocation cost even when no fiber would suspend. This change creates the promise only after the state check determines that the reservation must wait.

It also makes two related queue paths cheaper:

- `restore` now finds and removes the waiter in one traversal using `span`, instead of `find` followed by `filter`.
- `releaseN` now collects waiters to complete and completes them after the `Ref.modify`, avoiding nested `acc *> promise.succeedUnit` chains while preserving FIFO completion order.

Fixes #9093.

## Verification

Ran locally on JDK 21.0.10:

```text
java -Xmx4G -jar .tools/sbt-launch-1.12.11.jar "coreTestsJVM/testOnly zio.SemaphoreSpec"
```

Result: 10 tests passed, 0 failed, each repeated 100x.

JMH smoke checks using:

```text
benchmarks/Jmh/run -wi 1 -i 2 -f 1 -p nSTM=1 -p fibers=2 zio.stm.SemaphoreBenchmark.semaphoreContention
benchmarks/Jmh/run -wi 1 -i 2 -f 1 -p nSTM=1 -p fibers=10 zio.stm.SemaphoreBenchmark.semaphoreContention
```

Results on the same machine/JDK:

| Parameters | Baseline | Patched | Delta |
| --- | ---: | ---: | ---: |
| fibers=2,nSTM=1 | 275.009 ops/s | 362.497 ops/s | +31.8% |
| fibers=10,nSTM=1 | 130.906 ops/s | 137.116 ops/s | +4.7% |

These are short smoke runs, not a full benchmark matrix, but they validate the intended fast-path improvement and did not show a regression in the higher-contention smoke case.