### PR TITLE
fix(streams): flush groupedWithin after schedule fires

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1711,6 +1711,17 @@ object ZStreamSpec extends ZIOBaseSpec {
                 assert(result4)(equalTo(29))
             }
           },
+          testM("group based on time passed (#8686)") {
+            assertM(for {
+              result <- ZStream
+                          .fromIterable(Seq(1, 2))
+                          .concat(ZStream.fromIterable(Seq(1)).filter(_ == 0).forever)
+                          .groupedWithin(3, 2.seconds)
+                          .provideCustomLayer(Clock.live)
+                          .take(1)
+                          .runCollect
+            } yield result)(equalTo(Chunk(Chunk(1, 2))))
+          } @@ timeout(4.seconds) @@ TestAspect.jvmOnly,
           testM("group immediately when chunk size is reached") {
             assertM(ZStream(1, 2, 3, 4).groupedWithin(2, 10.seconds).runCollect)(
               equalTo(Chunk(Chunk(1, 2), Chunk(3, 4)))

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -267,6 +267,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
         scheduleFiber <- ZRef.makeManaged[Option[Fiber[Nothing, Option[Q]]]](None)
         sdriver       <- schedule.driver.toManaged_
         lastChunk     <- ZRef.makeManaged[Chunk[P]](Chunk.empty)
+        scheduleFired <- ZRef.makeManaged(false)
         producer       = Take.fromPull(pull).repeatWhileM(take => handoff.offer(take).as(take.isSuccess))
         consumer = {
           // Advances the state of the schedule, which may or may not terminate
@@ -285,7 +286,7 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
             scheduleFiber.getAndSet(None).flatMap {
               case None      => updateSchedule
               case Some(fib) => fib.join
-            }
+            } <* scheduleFired.set(true)
 
           def updateLastChunk(take: Take[_, P]): UIO[Unit] =
             take.tap(lastChunk.set(_))
@@ -324,34 +325,48 @@ abstract class ZStream[-R, +E, +O](val process: ZManaged[R, Nothing, ZIO[R, Opti
           def go(race: Boolean): ZIO[R1 with Clock, Option[E1], Chunk[Take[E1, Either[Q, P]]]] =
             if (!race)
               waitForProducer.flatMap(handleTake(_, None)) <* raceNextTime.set(true)
-            else
-              waitForSchedule.raceWith[R1 with Clock, Nothing, Option[E1], Take[E1, O], Chunk[Take[E1, Either[Q, P]]]](
-                waitForProducer
-              )(
-                (scheduleDone, producerWaiting) =>
-                  ZIO.done(scheduleDone).flatMap {
-                    case None =>
-                      for {
-                        lastQ         <- lastChunk.set(Chunk.empty) *> sdriver.last.orDie <* sdriver.reset
-                        scheduleResult = Take.single(Left(lastQ))
-                        take          <- Take.fromPull(push(None).asSomeError).tap(updateLastChunk)
-                        _             <- raceNextTime.set(false)
-                        _             <- waitingFiber.set(Some(producerWaiting))
-                      } yield Chunk(scheduleResult, take.map(Right(_)))
+            else {
+              val raceResult =
+                waitForSchedule
+                  .raceWith[R1 with Clock, Nothing, Option[E1], Take[E1, O], Chunk[Take[E1, Either[Q, P]]]](
+                    waitForProducer
+                  )(
+                    (scheduleDone, producerWaiting) =>
+                      ZIO.done(scheduleDone).flatMap {
+                        case None =>
+                          for {
+                            lastQ         <- lastChunk.set(Chunk.empty) *> sdriver.last.orDie <* sdriver.reset
+                            scheduleResult = Take.single(Left(lastQ))
+                            take          <- Take.fromPull(push(None).asSomeError).tap(updateLastChunk)
+                            _             <- raceNextTime.set(false)
+                            _             <- scheduleFired.set(false)
+                            _             <- waitingFiber.set(Some(producerWaiting))
+                          } yield Chunk(scheduleResult, take.map(Right(_)))
 
-                    case Some(_) =>
-                      for {
-                        ps <- Take.fromPull(push(None).asSomeError).tap(updateLastChunk)
-                        _  <- raceNextTime.set(false)
-                        _  <- waitingFiber.set(Some(producerWaiting))
-                      } yield Chunk.single(ps.map(Right(_)))
-                  },
-                (
-                  producerDone,
-                  scheduleWaiting
-                ) => handleTake(Take(producerDone.flatMap(_.exit)), Some(scheduleWaiting)),
-                Some(ZScope.global)
+                        case Some(_) =>
+                          for {
+                            ps <- Take.fromPull(push(None).asSomeError).tap(updateLastChunk)
+                            _  <- raceNextTime.set(false)
+                            _  <- scheduleFired.set(false)
+                            _  <- waitingFiber.set(Some(producerWaiting))
+                          } yield Chunk.single(ps.map(Right(_)))
+                      },
+                    (
+                      producerDone,
+                      scheduleWaiting
+                    ) => handleTake(Take(producerDone.flatMap(_.exit)), Some(scheduleWaiting)),
+                    Some(ZScope.global)
+                  )
+
+              ZIO.ifM(scheduleFired.get.negate)(
+                raceResult,
+                for {
+                  ps <- Take.fromPull(push(None).asSomeError).tap(updateLastChunk)
+                  _  <- raceNextTime.set(false)
+                  _  <- scheduleFired.set(false)
+                } yield Chunk.single(ps.map(Right(_)))
               )
+            }
 
           raceNextTime.get
             .flatMap(go)


### PR DESCRIPTION
Fixes #8686

## Problem

On `series/1.x`, `ZStream.groupedWithin` can hang when the stream has accumulated elements below `chunkSize`, the schedule fires, and upstream continues forever while producing empty chunks, for example through filtering or collecting.

In that state, the schedule can fire but the next consumer step may wait for another producer value instead of flushing the pending transducer state.

## Solution

Track when the schedule has fired and, if the previous producer step emitted an empty transducer output, flush the pending state with `push(None)` before racing the producer again.

## Verification

Added regression test `group based on time passed (#8686)`.

I confirmed this test times out on baseline before the patch. After the patch, these checks passed locally:

- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "group based on time passed (#8686)"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "groupedWithin"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "aggregateAsyncWithin"`
- `streamsJVM/scalafmtCheck`
- `streamsTestsJVM/scalafmtCheck`

For the demo requirement: this is a stream semantics regression rather than UI behavior, so the focused red/green test above is the demo evidence. I can add a short terminal recording if maintainers prefer that format.

/claim #8686
