### PR TITLE
Use Scala Native ConcurrentLinkedDeque

### DIFF
--- a/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,6 +1,6 @@
 package zio
 
 private[zio] trait QueuePlatformSpecific {
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in ScalaJS or Scala Native, so we use an ArrayDeque instead
+  // java.util.concurrent.ConcurrentLinkedDeque is not available in Scala.js, so we use an ArrayDeque instead.
   type ConcurrentDeque[A] = java.util.ArrayDeque[A]
 }

--- a/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/QueuePlatformSpecific.scala
@@ -1,27 +1,31 @@
 package zio
 
-import java.util.concurrent.ConcurrentLinkedQueue
-import scala.collection.mutable
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.function.Predicate
 
 private[zio] trait QueuePlatformSpecific {
+  private[zio] final class ConcurrentDeque[A <: AnyRef] {
+    private[this] val deque = new ConcurrentLinkedDeque[A]
 
-  // java.util.concurrent.ConcurrentLinkedDeque is not available in Scala Native, so we need to createa custom `addFirst` method
-  private[zio] final class ConcurrentDeque[A <: AnyRef] extends ConcurrentLinkedQueue[A] {
+    def addFirst(a: A): Unit =
+      deque.synchronized(deque.addFirst(a))
 
-    def addFirst(a: A): Unit = {
-      var popped = poll()
-      if (popped eq null) {
-        offer(a)
-      } else {
-        val buf = new mutable.ArrayBuffer[A]
-        while (popped ne null) {
-          buf += popped
-          popped = poll()
-        }
-        offer(a)
-        buf.foreach(offer)
-      }
-    }
+    def isEmpty(): Boolean =
+      deque.synchronized(deque.isEmpty())
 
+    def offer(a: A): Boolean =
+      deque.synchronized(deque.offer(a))
+
+    def poll(): A =
+      deque.synchronized(deque.poll())
+
+    def remove(a: Any): Boolean =
+      deque.synchronized(deque.remove(a))
+
+    def removeIf(filter: Predicate[_ >: A]): Boolean =
+      deque.synchronized(deque.removeIf(filter))
+
+    def size(): Int =
+      deque.synchronized(deque.size())
   }
 }

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -346,7 +346,7 @@ object Queue extends QueuePlatformSpecific {
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]]
     ): Unit =
-      if (!takers.isEmpty && draining.compareAndSet(false, true)) {
+      if (!takers.isEmpty() && draining.compareAndSet(false, true)) {
         try {
           var keepPolling      = !queue.isEmpty()
           val empty            = null.asInstanceOf[A]
@@ -430,7 +430,7 @@ object Queue extends QueuePlatformSpecific {
         takers: ConcurrentDeque[Promise[Nothing, A]]
       ): Unit = {
         val putters0 = putters
-        if (!putters0.isEmpty && notifying.compareAndSet(false, true)) {
+        if (!putters0.isEmpty() && notifying.compareAndSet(false, true)) {
           var keepPolling = !queue.isFull()
 
           try {
@@ -551,7 +551,7 @@ object Queue extends QueuePlatformSpecific {
     q.pollUpTo(Int.MaxValue)
 
   private def unsafePollAll[A <: AnyRef](q: ConcurrentDeque[A]): Chunk[A] = {
-    val cb   = ChunkBuilder.make[A](q.size)
+    val cb   = ChunkBuilder.make[A](q.size())
     var loop = true
     while (loop) {
       val a = q.poll()


### PR DESCRIPTION
## Summary

Use `java.util.concurrent.ConcurrentLinkedDeque` for the Scala Native queue platform implementation now that the Scala Native version on this branch provides it. The Native adapter keeps only the operations ZIO Queue needs and serializes access through the underlying deque, avoiding the old `ConcurrentLinkedQueue` workaround whose `addFirst` path had to drain and replay the whole queue.

Also updates the Scala.js platform comment so it no longer says Scala Native lacks `ConcurrentLinkedDeque`, and normalizes shared `ConcurrentDeque` calls to the Java `isEmpty()` / `size()` style so the Native adapter compiles under Scala 3.

Fixes #9189

@algora-pbc /claim #9189

## Testing

- `java '-Dsbt.supershell=false' -jar "$env:USERPROFILE\.cache\codex-sbt\sbt-launch-1.12.11.jar" "coreNative/compile"`
- `java '-Dsbt.supershell=false' -jar "$env:USERPROFILE\.cache\codex-sbt\sbt-launch-1.12.11.jar" "++3.3.7 coreNative/compile"`
- `java '-Dsbt.supershell=false' -jar "$env:USERPROFILE\.cache\codex-sbt\sbt-launch-1.12.11.jar" "coreTestsJVM/testOnly zio.QueueSpec"`
- `java '-Dsbt.supershell=false' -jar "$env:USERPROFILE\.cache\codex-sbt\sbt-launch-1.12.11.jar" "coreTestsNative/testOnly zio.QueueSpec -- -t bounded queue preserves ordering"` reached Native test compilation successfully, then failed before execution because local Windows environment has no `clang`/`LLVM_BIN`.