### PR TITLE
Fix fresh layer reuse in ZLayer.make

### DIFF
--- a/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/autowire/AutoWireSpec.scala
@@ -2,7 +2,7 @@ package zio.autowire
 
 import zio._
 import zio.internal.macros.StringUtils.StringOps
-import zio.test.Assertion.{anything, equalTo, isLeft}
+import zio.test.Assertion._
 import zio.test._
 
 import scala.annotation.nowarn
@@ -132,6 +132,25 @@ object AutoWireSpec extends ZIOBaseSpec {
               ZLayer.make[Int](intLayer, stringLayer, doubleLayer)
             val provided = ZIO.service[Int].provideLayer(layer)
             assertZIO(provided)(equalTo(128))
+          },
+          test("building fresh layer only once") {
+            var timesBuilt = 0
+
+            trait Service1
+            object Service1 {
+              val live: ZLayer[Any, Throwable, Service1] =
+                ZLayer.fromZIO(ZIO.attempt(timesBuilt += 1).as(new Service1 {}))
+            }
+
+            trait Service2
+            object Service2 {
+              val live: ZLayer[Service1, Nothing, Service2] =
+                ZLayer.fromZIO(ZIO.unit.as(new Service2 {}))
+            }
+
+            assertZIO(
+              ZLayer.make[Service1 & Service2](Service1.live.fresh, Service2.live).build *> ZIO.succeed(timesBuilt)
+            )(equalTo(1))
           },
           test("correctly decomposes nested, aliased intersection types") {
             type StringAlias           = String
@@ -272,10 +291,97 @@ object AutoWireSpec extends ZIOBaseSpec {
                   containsStringWithoutAnsi("provideSome[Engine]")
               )
             )
+          },
+          test("makeSome 1 layer") {
+            val test1 = typeCheck {
+              """def test1[A, B](a: ZLayer[A, Nothing, B]): ZLayer[A, Nothing, B] =
+              ZLayer.makeSome[A, B](a)"""
+            }
+
+            val test2 = typeCheck {
+              """def test2[A](a: ZLayer[A, Nothing, Int]): ZLayer[A, Nothing, A & Int] =
+              ZLayer.makeSome[A, A & Int](a)"""
+            }
+
+            assertZIO(test1)(isRight(anything)) &&
+            assertZIO(test2)(isRight(anything))
+          },
+          test("makeSome 2 simple layers") {
+
+            def test1[I1, O1, I2](
+              a: ZLayer[I1, Nothing, O1],
+              b: ZLayer[I2, Nothing, Int]
+            ): ZLayer[I1 & I2, Nothing, O1 & Int] =
+              ZLayer.makeSome[I1 & I2, O1 & Int](a, b)
+
+            def test2[I1, O1](a: ZLayer[I1, Nothing, O1], b: ZLayer[O1, Nothing, Int]): ZLayer[I1, Nothing, O1 & Int] =
+              ZLayer.makeSome[I1, O1 & Int](a, b)
+
+            def test3[I1, O1](a: ZLayer[I1, Nothing, O1], b: ZLayer[I1, Nothing, Int]): ZLayer[I1, Nothing, O1 & Int] =
+              ZLayer.makeSome[I1, O1 & Int](a, b)
+
+            val t1 = test1 _
+            val t2 = test2 _
+            val t3 = test3 _
+
+            assertTrue(dummy(t1, t2, t3))
+          },
+          test("makeSome 2 complex layers") {
+
+            def test1[R, R1](a: ZLayer[R1 & Int, Nothing, R], b: ZLayer[Int, Nothing, R1]): ZLayer[Int, Nothing, R] =
+              ZLayer.makeSome[Int, R](a, b)
+
+            def test2[I1, I3, O1, O2](
+              a: ZLayer[I1 & Double, Nothing, O1 & O2],
+              b: ZLayer[I3 & Float, Nothing, Int]
+            ): ZLayer[I1 & Double & I3 & Float, Nothing, O1 & O2 & Int] =
+              ZLayer.makeSome[I1 & Double & I3 & Float, O1 & O2 & Int](a, b)
+
+            def test3[I1, I4, O1, O2](
+              a: ZLayer[I1 & Double, Nothing, O1 & O2],
+              b: ZLayer[I1 & Float, Nothing, Int]
+            ): ZLayer[I1 & Double & Float, Nothing, O1 & O2 & Int] =
+              ZLayer.makeSome[I1 & Double & Float, O1 & O2 & Int](a, b)
+
+            def test4[I1, O1](
+              a: ZLayer[I1 & Double, Nothing, O1 & String],
+              b: ZLayer[O1 & Float, Nothing, Int]
+            ): ZLayer[I1 & Double & Float, Nothing, O1 & String & Int] =
+              ZLayer.makeSome[I1 & Double & Float, O1 & String & Int](a, b)
+
+            val t1 = test1 _
+            val t2 = test2 _
+            val t3 = test3 _
+            val t4 = test4 _
+
+            assertTrue(dummy(t1, t2, t3, t4))
+          },
+          test("makeSome complex layer and providing") {
+
+            def test1[R, R1](a: ZLayer[R1 & Int, Nothing, R], b: ZLayer[Int, Nothing, R1]): ZLayer[Int, Nothing, R] =
+              ZLayer.makeSome[Int, R](a, b)
+
+            val la = ZLayer {
+              (ZIO.service[String] <*> ZIO.service[Int]).map { case (str, int) =>
+                (str.length + int).toLong
+              }
+            }
+            val lb = ZLayer(ZIO.service[Int].map(n => n.toString))
+
+            val program =
+              ZIO.service[Long].provideLayer(ZLayer.succeed(8) >>> test1(la, lb))
+
+            assertZIO(program)(equalTo(9.toLong))
           }
         )
       )
     )
+
+  def dummy(f: Any*): Boolean = {
+    var l: List[Any] = f.toList
+    l = Nil
+    l.isEmpty
+  }
 
   object TestLayer {
     trait OldLady {

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -159,6 +159,7 @@ private[zio] trait LayerMacroUtils {
     intersectionTypes
       .map(_.dealias)
       .filterNot(_.isAny)
+      .filterNot(t => typeOf[Any] <:< t)
       .distinct
   }
 

--- a/core/shared/src/main/scala/zio/internal/macros/Graph.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/Graph.scala
@@ -5,51 +5,166 @@ import zio.internal.macros.LayerTree._
 final case class Graph[Key, A](
   nodes: List[Node[Key, A]],
   keyEquals: (Key, Key) => Boolean,
-  unknownLayerFactory: Key => Option[Node[Key, A]]
+  environment: Key => Node[Key, A],
+  envKeys: List[Key]
 ) {
 
-  def buildComplete(outputs: List[Key]): Either[::[GraphError[Key, A]], LayerTree[A]] =
-    forEach(outputs) { output =>
-      getNodeWithOutput[GraphError[Key, A]](output, error = GraphError.MissingTopLevelDependency(output))
-        .flatMap(node => buildNode(node, Set(node)))
-    }
-      .map(_.distinct.combineHorizontally)
+  // Map assigning to each type the times that it must be built
+  // -1 designs a `Key` from the environment
+  private var neededKeys: Map[Key, Int] = Map.empty
+  // Dependencies to pass to next iteration of buildComplete
+  private var dependencies: List[Key]    = Nil
+  private var envDependencies: List[Key] = Nil
 
-  def buildNodes(nodes: List[Node[Key, A]]): Either[::[GraphError[Key, A]], LayerTree[A]] =
-    forEach(nodes)(buildNode).map(_.combineHorizontally)
+  private var usedEnvKeys: Set[Key] = Set.empty
+  def usedRemainders(): Set[A]      = usedEnvKeys.map(environment(_)).map(_.value)
+
+  def buildNodes(
+    outputs: List[Key],
+    sideEffectNodes: List[Node[Key, A]]
+  ): Either[::[GraphError[Key, A]], LayerTree[A]] = for {
+    _           <- mkNeededKeys(outputs ++ sideEffectNodes.flatMap(_.inputs), true)
+    sideEffects <- forEach(sideEffectNodes)(buildNode).map(_.combineHorizontally)
+    rightTree   <- build(outputs).map(_._1)
+    leftTree    <- buildComplete(constructDeps())
+  } yield leftTree >>> (rightTree ++ sideEffects)
+
+  private def buildComplete(outputs: List[Key]): Either[::[GraphError[Key, A]], LayerTree[A]] =
+    if (!outputs.isEmpty)
+      for {
+        _         <- Right(restartKeys())
+        _         <- mkNeededKeys(outputs)
+        rightTree <- build(outputs).map(_._1)
+        leftTree  <- buildComplete(constructDeps())
+      } yield leftTree >>> rightTree
+    else Right(LayerTree.empty)
+
+  private def constructDeps(): List[Key] =
+    if (dependencies.isEmpty) dependencies
+    else distinctKeys(dependencies) ++ distinctKeys(envDependencies)
+
+  /**
+   * Restarts variables for next iteration of buildComplete
+   */
+  private def restartKeys(): Unit = {
+    neededKeys = Map.empty
+    dependencies = Nil
+    envDependencies = Nil
+  }
+
+  private def distinctKeys(keys: List[Key]): List[Key] = {
+    var distinct: List[Key] = List.empty
+    for (k <- keys) {
+      if (!distinct.exists(k2 => keyEquals(k, k2) || keyEquals(k2, k))) distinct = k :: distinct
+    }
+    distinct.reverse
+  }
+
+  /**
+   * Initializes neededKeys
+   */
+  def mkNeededKeys(
+    outputs: List[Key],
+    topLevel: Boolean = false,
+    seen: Set[Node[Key, A]] = Set.empty,
+    parent: Option[Node[Key, A]] = None
+  ): Either[::[GraphError[Key, A]], Unit] = {
+    var created: List[Key]          = List.empty
+    var (envOutputs, normalOutputs) = outputs.partition(isEnv(_))
+
+    envOutputs.map(addEnv(_))
+
+    forEach(normalOutputs) { output =>
+      if (created.exists(k => keyEquals(k, output))) {
+        if (neededKeys.get(output).isEmpty) throw new Throwable("This can't happen.")
+        Right(())
+      } else {
+        for {
+          node <- getNodeWithOutput[GraphError[Key, A]](
+                    output,
+                    error =
+                      if (topLevel || parent.isEmpty) Some(GraphError.MissingTopLevelDependency(output))
+                      else Some(GraphError.missingTransitiveDependency(parent.get, output))
+                  )
+          nodeOutputs = node.outputs.map(out => findKey(out, outputs))
+          _          <- Right(nodeOutputs.map(addKey(_)))
+          _          <- Right { created = nodeOutputs ++ created }
+          _ <- parent match {
+                 case Some(p) => assertNonCircularDependency(p, seen, node)
+                 case None    => Right(())
+               }
+          _ <- mkNeededKeys(node.inputs, false, seen + node, Some(node))
+        } yield ()
+      }
+    }.map(_ => ())
+  }
+
+  private def findKey(key: Key, keys: List[Key]): Key =
+    keys.find(k => keyEquals(key, k)).getOrElse(key)
+
+  private def addEnv(key: Key): Unit = {
+    val keyFromEnv = envKeys
+      .find(env => keyEquals(key, env) || keyEquals(env, key))
+      .getOrElse(throw new Throwable("This shouldn't happen"))
+    usedEnvKeys = usedEnvKeys + keyFromEnv
+    neededKeys.get(key) match {
+      case Some(_) => ()
+      case None    => neededKeys = neededKeys + (key -> -1)
+    }
+  }
+  private def addKey(key: Key): Unit =
+    neededKeys.get(key) match {
+      case Some(-1) => ()
+      case Some(n)  => neededKeys = neededKeys + (key -> (n + 1))
+      case None     => neededKeys = neededKeys + (key -> 1)
+    }
 
   private def buildNode(node: Node[Key, A]): Either[::[GraphError[Key, A]], LayerTree[A]] =
-    forEach(node.inputs) { output =>
-      getNodeWithOutput[GraphError[Key, A]](output, error = GraphError.missingTransitiveDependency(node, output))
-        .flatMap(node => buildNode(node, Set(node)))
+    build(node.inputs).map { case (deps, allEnv) =>
+      if (allEnv) LayerTree.succeed(node.value)
+      else deps >>> LayerTree.succeed(node.value)
     }
-      .map(_.distinct.combineHorizontally)
-      .map(_ >>> LayerTree.succeed(node.value))
+
+  private def tapKey(key: Key): Option[Int] =
+    neededKeys.get(key) match {
+      case Some(n) => Some(n)
+      case None    => neededKeys.find(pair => keyEquals(pair._1, key) || keyEquals(key, pair._1)).map(_._2)
+    }
+
+  /**
+   * Builds a layer containing only types that appears once. Types appearing
+   * more than once are replaced with ZLayer.environment[_] and left for the
+   * next iteration of buildComplete to create.
+   */
+  private def build(outputs: List[Key]): Either[::[GraphError[Key, A]], (LayerTree[A], Boolean)] =
+    forEach(outputs) { output =>
+      if (isEnv(output)) {
+        envDependencies = output :: envDependencies
+        Right((LayerTree.succeed(environment(output).value), true))
+      } else
+        tapKey(output) match {
+          case None => throw new Throwable(s"This can't happen")
+          case Some(1) =>
+            getNodeWithOutput[GraphError[Key, A]](output).flatMap(node => buildNode(node).map(tree => (tree, false)))
+          case Some(n) => {
+            dependencies = output :: dependencies
+            Right((LayerTree.succeed(environment(output).value), true))
+          }
+        }
+    }.map { deps =>
+      (deps.map(_._1).distinct.combineHorizontally, deps.forall(_._2))
+    }
 
   def map[B](f: A => B): Graph[Key, B] =
-    Graph(nodes.map(_.map(f)), keyEquals, unknownLayerFactory(_).map(_.map(f)))
+    Graph(nodes.map(_.map(f)), keyEquals, key => environment(key).map(f), envKeys)
 
-  private val nodeWithOutputCache = new java.util.HashMap[Key, Option[Node[Key, A]]]
+  private def getNodeWithOutput[E](output: Key, error: Option[E] = None): Either[::[E], Node[Key, A]] =
+    nodes
+      .find(_.outputs.exists(keyEquals(_, output)))
+      .toRight(error.map(e => ::(e, Nil)).getOrElse(throw new Throwable("This can't happen")))
 
-  private def getNodeWithOutput[E](output: Key, error: => E): Either[::[E], Node[Key, A]] =
-    nodeWithOutputCache.computeIfAbsent(output, findNodeWithOutput).toRight(::(error, Nil))
-
-  private def findNodeWithOutput(output: Key): Option[Node[Key, A]] =
-    nodes.find(_.outputs.exists(keyEquals(_, output))).orElse(unknownLayerFactory(output))
-
-  private def buildNode(
-    node: Node[Key, A],
-    seen: Set[Node[Key, A]]
-  ): Either[::[GraphError[Key, A]], LayerTree[A]] =
-    forEach(node.inputs) { input =>
-      for {
-        out    <- getNodeWithOutput(input, error = GraphError.missingTransitiveDependency(node, input))
-        _      <- assertNonCircularDependency(node, seen, out)
-        result <- buildNode(out, seen + out)
-      } yield result
-    }.map {
-      _.distinct.combineHorizontally >>> LayerTree.succeed(node.value)
-    }
+  private def isEnv(key: Key): Boolean =
+    envKeys.exists(env => keyEquals(key, env) || keyEquals(env, key))
 
   private def assertNonCircularDependency(
     node: Node[Key, A],

--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -101,32 +101,22 @@ final case class LayerBuilder[Type, Expr](
   def build: Expr = {
     assertNoAmbiguity()
 
-    val remainderTypeFactory = remainder match {
-      case RemainderMethod.Provided(_) => (_: Type) => None
-      case RemainderMethod.Inferred    => (t: Type) => Some(typeToNode(t))
-    }
-
     /**
      * Build the layer tree. This represents the structure of a successfully
      * constructed ZLayer that will build the target types. This, of course, may
      * fail with one or more GraphErrors.
      */
-    val layerTreeEither: Either[::[GraphError[Type, Expr]], LayerTree[Expr]] = {
-      val nodes: List[Node[Type, Expr]] = providedLayerNodes ++ remainderNodes ++ sideEffectNodes
-      val graph                         = Graph(nodes, typeEquals, remainderTypeFactory)
-
-      for {
-        original    <- graph.buildComplete(target)
-        sideEffects <- graph.buildNodes(sideEffectNodes)
-      } yield sideEffects ++ original
-    }
+    val nodes: List[Node[Type, Expr]] = providedLayerNodes ++ sideEffectNodes
+    val graph                         = Graph(nodes, typeEquals, typeToNode, remainder.providedTypes)
+    val layerTreeEither: Either[::[GraphError[Type, Expr]], LayerTree[Expr]] =
+      graph.buildNodes(target.filterNot(typeEquals(_, sideEffectType)), sideEffectNodes)
 
     layerTreeEither match {
       case Left(buildErrors) =>
         reportBuildErrors(buildErrors)
 
       case Right(tree) =>
-        warnUnused(tree)
+        warnUnused(tree, graph.usedRemainders())
         maybeDebug.foreach(debugLayer(_, tree))
         foldTree(tree)
     }
@@ -173,7 +163,7 @@ final case class LayerBuilder[Type, Expr](
    * used. This will also warn about any specified remainders that aren't
    * actually required, in the case of provideSome/provideCustom.
    */
-  private def warnUnused(tree: LayerTree[Expr]): Unit = {
+  private def warnUnused(tree: LayerTree[Expr], usedRemainders: Set[Expr]): Unit = {
     val usedLayers =
       tree.map(showExpr).toSet
 
@@ -185,7 +175,8 @@ final case class LayerBuilder[Type, Expr](
       reportWarn(message)
     }
 
-    val unusedRemainderLayers = remainderNodes.filterNot(node => usedLayers(showExpr(node.value)))
+    val unusedRemainderLayers =
+      remainderNodes.filterNot(node => usedRemainders.map(showExpr(_)).apply(showExpr(node.value)))
 
     method match {
       case ProvideMethod.Provide => ()


### PR DESCRIPTION
Closes #8272

/claim #8272

This fixes automatic layer construction when a fresh layer is required by multiple outputs. Instead of treating every repeated dependency as another build of the same layer, the graph now lifts repeated dependencies through `ZLayer.environment`, while keeping explicitly provided remainders distinct from graph-built dependencies.

It also keeps side-effect layers available to dependency resolution, so layers that both provide services and add side effects, such as supervisor layers, are not incorrectly reported as missing or executed twice.

Validation:
- `sbt "coreTestsJVM/testOnly zio.autowire.AutoWireSpec"`
- `sbt "coreTestsJVM/testOnly zio.SupervisorSpec"`