### PR TITLE
Add Scala 3 Config derivation

### DIFF
--- a/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
+++ b/core-tests/shared/src/test/scala-3/zio/ConfigDerivationSpec.scala
@@ -1,0 +1,44 @@
+package zio
+
+import zio.test._
+
+object ConfigDerivationSpec extends ZIOBaseSpec {
+
+  final case class DatabaseConfig(url: String, poolSize: Int) derives Config
+
+  final case class ServiceConfig(
+    database: DatabaseConfig,
+    enabled: Boolean,
+    ports: List[Int],
+    tags: Set[String],
+    token: Option[String]
+  ) derives Config
+
+  def spec =
+    suite("ConfigDerivationSpec")(
+      test("derives config for product types") {
+        val configProvider =
+          ConfigProvider.fromMap(
+            Map(
+              "database.url"      -> "jdbc:postgresql://localhost:5432/zio",
+              "database.poolSize" -> "16",
+              "enabled"           -> "true",
+              "ports"             -> "8080,8081",
+              "tags"              -> "api,public"
+            )
+          )
+
+        for {
+          config <- configProvider.load(summon[Config[ServiceConfig]])
+        } yield assertTrue(
+          config == ServiceConfig(
+            database = DatabaseConfig("jdbc:postgresql://localhost:5432/zio", 16),
+            enabled = true,
+            ports = List(8080, 8081),
+            tags = Set("api", "public"),
+            token = None
+          )
+        )
+      }
+    )
+}

--- a/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-2/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio
+
+private[zio] trait ConfigCompanionVersionSpecific

--- a/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
+++ b/core/shared/src/main/scala-3/zio/ConfigCompanionVersionSpecific.scala
@@ -1,0 +1,52 @@
+package zio
+
+import scala.compiletime.{constValue, erasedValue, error, summonInline}
+import scala.deriving.Mirror
+
+private[zio] trait ConfigCompanionVersionSpecific {
+
+  inline def derived[A](using mirror: Mirror.Of[A]): Config[A] =
+    inline mirror match {
+      case product: Mirror.ProductOf[A] => deriveProduct(product)
+      case _: Mirror.SumOf[A]           => error("Config can only be derived for product types")
+    }
+
+  private inline def deriveProduct[A](mirror: Mirror.ProductOf[A]): Config[A] =
+    deriveFields[mirror.MirroredElemLabels, mirror.MirroredElemTypes].map(fields => mirror.fromProduct(fields))
+
+  private inline def deriveFields[Labels <: Tuple, Types <: Tuple]: Config[Types] =
+    inline (erasedValue[Labels], erasedValue[Types]) match {
+      case (_: EmptyTuple, _: EmptyTuple) =>
+        Config.succeed(EmptyTuple).asInstanceOf[Config[Types]]
+      case (_: (label *: labels), _: (field *: fields)) =>
+        val name = constValue[label].asInstanceOf[String]
+        configFor[field].nested(name).zipWith(deriveFields[labels, fields])(_ *: _).asInstanceOf[Config[Types]]
+    }
+
+  private inline def configFor[A]: Config[A] =
+    inline erasedValue[A] match {
+      case _: BigDecimal               => Config.bigDecimal.asInstanceOf[Config[A]]
+      case _: BigInt                   => Config.bigInt.asInstanceOf[Config[A]]
+      case _: Boolean                  => Config.boolean.asInstanceOf[Config[A]]
+      case _: Chunk[t]                 => Config.chunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Double                   => Config.double.asInstanceOf[Config[A]]
+      case _: Float                    => Config.float.asInstanceOf[Config[A]]
+      case _: Int                      => Config.int.asInstanceOf[Config[A]]
+      case _: List[t]                  => Config.listOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Long                     => Config.long.asInstanceOf[Config[A]]
+      case _: Map[String, value]       => Config.table(configFor[value]).asInstanceOf[Config[A]]
+      case _: NonEmptyChunk[t]         => Config.nonEmptyChunkOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: Option[t]                => configFor[t].optional.asInstanceOf[Config[A]]
+      case _: Config.Secret            => Config.secret.asInstanceOf[Config[A]]
+      case _: Set[t]                   => Config.setOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: String                   => Config.string.asInstanceOf[Config[A]]
+      case _: Vector[t]                => Config.vectorOf(configFor[t]).asInstanceOf[Config[A]]
+      case _: java.net.URI             => Config.uri.asInstanceOf[Config[A]]
+      case _: java.time.LocalDate      => Config.localDate.asInstanceOf[Config[A]]
+      case _: java.time.LocalDateTime  => Config.localDateTime.asInstanceOf[Config[A]]
+      case _: java.time.LocalTime      => Config.localTime.asInstanceOf[Config[A]]
+      case _: java.time.OffsetDateTime => Config.offsetDateTime.asInstanceOf[Config[A]]
+      case _: zio.Duration             => Config.duration.asInstanceOf[Config[A]]
+      case _                           => summonInline[Config[A]]
+    }
+}

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -150,7 +150,7 @@ sealed trait Config[+A] { self =>
   def zipWith[B, C](that: => Config[B])(f: (A, B) => C): Config[C] =
     self.zip(that).map(f.tupled)
 }
-object Config {
+object Config extends ConfigCompanionVersionSpecific {
   final class Secret private (private val raw: Array[Char]) { self =>
     override def equals(that: Any): Boolean =
       that match {


### PR DESCRIPTION
Adds `Config.derived` for Scala 3 so product case classes can use `derives Config` directly from the core `Config` companion. Scala 2 keeps an empty version-specific stub, so existing cross-build behavior is unchanged.

The implementation derives field configs from product labels, supports existing primitive/collection config constructors, and falls back to an in-scope `Config[A]` for custom field types.

Verification:
- RED: `++3.3.7; coreTestsJVM/testOnly zio.ConfigDerivationSpec` failed with `value derived is not a member of object zio.Config` before implementation
- GREEN: `++3.3.7; coreTestsJVM/testOnly zio.ConfigDerivationSpec`
- `++2.13.18; coreJVM/compile`
- `fmtCheck`
- `git diff --check`

Demo: the Scala 3 regression test demonstrates `case class ... derives Config` loading nested product, list, set, and optional fields from `ConfigProvider.fromMap`.

/claim #9268