### PR TITLE
Prioritize saturated external submissions in ZScheduler

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
@@ -7,7 +7,7 @@ import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 import zio.BenchmarkUtil._
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -76,6 +76,10 @@ class ZSchedulerBenchmarks {
     zioYieldMany(fixedThreadPool)
 
   @Benchmark
+  def zioFixedThreadPoolExternalSubmitMany(): Int =
+    zioExternalSubmitMany(fixedThreadPool)
+
+  @Benchmark
   def zioSchedulerChainedFork(): Int =
     zioChainedFork(zScheduler)
 
@@ -90,6 +94,10 @@ class ZSchedulerBenchmarks {
   @Benchmark
   def zioSchedulerYieldMany(): Int =
     zioYieldMany(zScheduler)
+
+  @Benchmark
+  def zioSchedulerExternalSubmitMany(): Int =
+    zioExternalSubmitMany(zScheduler)
 
   def catsChainedFork(runtime: IORuntime): Int = {
 
@@ -215,5 +223,23 @@ class ZSchedulerBenchmarks {
     } yield 0
 
     unsafeRun(io.onExecutor(executor))
+  }
+
+  def zioExternalSubmitMany(executor: zio.Executor): Int = {
+    val latch = new CountDownLatch(10000)
+
+    Unsafe.unsafe { implicit unsafe =>
+      var i = 0
+      while (i < 10000) {
+        executor.submit(new Runnable {
+          def run(): Unit =
+            latch.countDown()
+        })
+        i += 1
+      }
+    }
+
+    latch.await()
+    0
   }
 }

--- a/core-tests/jvm-native/src/test/scala/zio/ZSchedulerSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/ZSchedulerSpec.scala
@@ -1,0 +1,58 @@
+package zio
+
+import zio.test.Assertion._
+import zio.test.TestAspect._
+import zio.test._
+
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+
+object ZSchedulerSpec extends ZIOBaseSpec {
+
+  def spec = suite("ZSchedulerSpec")(
+    test("external submissions complete when the scheduler is saturated") {
+      val completed =
+        ZIO.attemptBlocking {
+          val executor = Executor.makeDefault(autoBlocking = false)
+          val workers  = java.lang.Runtime.getRuntime.availableProcessors()
+          val started  = new CountDownLatch(workers)
+          val release  = new CountDownLatch(1)
+          val done     = new CountDownLatch(10000)
+
+          try {
+            Unsafe.unsafe { implicit unsafe =>
+              var i = 0
+              while (i < workers) {
+                executor.submit(new Runnable {
+                  def run(): Unit = {
+                    started.countDown()
+                    release.await()
+                  }
+                })
+                i += 1
+              }
+
+              if (!started.await(10, TimeUnit.SECONDS)) {
+                false
+              } else {
+                i = 0
+                while (i < 10000) {
+                  executor.submit(new Runnable {
+                    def run(): Unit =
+                      done.countDown()
+                  })
+                  i += 1
+                }
+
+                release.countDown()
+                done.await(10, TimeUnit.SECONDS)
+              }
+            }
+          } finally {
+            release.countDown()
+          }
+        }
+
+      assertZIO(completed)(isTrue)
+    } @@ nonFlaky @@ timeout(15.seconds)
+  )
+}

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -35,13 +35,13 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   import Trace.{empty => emptyTrace}
   import ZScheduler.{poolSize, workerOrNull}
 
-  private[this] val globalQueue     = new PartitionedLinkedQueue[Runnable](poolSize * 4)
-  private[this] val cache           = new ConcurrentLinkedQueue[ZScheduler.Worker]()
-  private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
-  private[this] val globalLocations = makeLocations()
-  private[this] val state           = new AtomicInteger(poolSize << 16)
-  private[this] val externalCursor  = new AtomicInteger(0)
-  private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
+  private[this] val globalQueue         = new PartitionedLinkedQueue[Runnable](poolSize * 4)
+  private[this] val cache               = new ConcurrentLinkedQueue[ZScheduler.Worker]()
+  private[this] val idle                = new ConcurrentLinkedQueue[ZScheduler.Worker]()
+  private[this] val globalLocations     = makeLocations()
+  private[this] val state               = new AtomicInteger(poolSize << 16)
+  private[this] val externalSubmissions = new AtomicInteger(0)
+  private[this] val workers             = Array.ofDim[ZScheduler.Worker](poolSize)
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
 
@@ -149,16 +149,19 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      val currentState = state.get
+      var external = false
       if (worker eq null) {
-        if (!submitExternal(runnable, currentState)) {
-          globalQueue.offer(runnable)
-        }
+        globalQueue.offer(runnable)
+        external = true
       } else if (worker.blocking) {
         globalQueue.offer(runnable)
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
       } else ()
+      val currentState = state.get
+      if (external) {
+        signalExternalSubmit(currentState)
+      }
       maybeUnparkWorker(currentState)
       true
     }
@@ -169,14 +172,11 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      var notify       = true
-      val currentState = state.get
+      var notify   = true
+      var external = false
       if (worker eq null) {
-        if (submitExternal(runnable, currentState)) {
-          notify = false
-        } else {
-          globalQueue.offer(runnable)
-        }
+        globalQueue.offer(runnable)
+        external = true
       } else if (worker.blocking) {
         globalQueue.offer(runnable)
       }
@@ -200,51 +200,21 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       }
 
       if (notify) {
+        val currentState = state.get
+        if (external) {
+          signalExternalSubmit(currentState)
+        }
         maybeUnparkWorker(currentState)
       }
       true
     }
   }
 
-  private[this] def submitExternal(runnable: Runnable, currentState: Int): Boolean = {
+  private[this] def signalExternalSubmit(currentState: Int): Unit = {
     val currentActive = (currentState & 0xffff0000) >> 16
 
-    if (currentActive != poolSize) {
-      false
-    } else {
-      val sampleSize = java.lang.Math.min(poolSize, 4)
-      val offset     = externalCursor.getAndIncrement()
-      var best       = null.asInstanceOf[ZScheduler.Worker]
-      var bestIndex  = -1
-      var bestSize   = Int.MaxValue
-      var i          = 0
-
-      while (i < sampleSize) {
-        val workerIndex = java.lang.Math.floorMod(offset + i, poolSize)
-        val worker      = workers(workerIndex)
-
-        if (worker.active && !worker.blocking && (worker.currentRunnable eq null)) {
-          val size = worker.localQueue.size() + (if (worker.nextRunnable ne null) 1 else 0)
-
-          if (size < bestSize) {
-            best = worker
-            bestIndex = workerIndex
-            bestSize = size
-          }
-        }
-
-        i += 1
-      }
-
-      val accepted =
-        (best ne null) && best.synchronized {
-          (workers(bestIndex) eq best) && best.active && !best.blocking && (best.currentRunnable eq null) &&
-          best.localQueue.offer(runnable)
-        }
-      if (accepted && !best.active) {
-        maybeUnparkWorker(state.get)
-      }
-      accepted
+    if (currentActive == poolSize) {
+      externalSubmissions.incrementAndGet()
     }
   }
 
@@ -359,7 +329,16 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             runnable = currentNextRunnable
             nextRunnable = null
           } else {
-            if ((currentOpCount & 63) == 0) {
+            val pendingExternal = externalSubmissions.get()
+            if (pendingExternal > 0) {
+              runnable = globalQueue.poll(random)
+              if (runnable eq null) {
+                externalSubmissions.compareAndSet(pendingExternal, 0)
+                runnable = localQueue.poll(null)
+              } else {
+                externalSubmissions.compareAndSet(pendingExternal, pendingExternal - 1)
+              }
+            } else if ((currentOpCount & 63) == 0) {
               runnable = globalQueue.poll(random)
               if (runnable eq null) {
                 runnable = localQueue.poll(null)
@@ -415,61 +394,39 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             }
           }
           if (runnable eq null) {
-            var currentState     = 0
-            var currentSearching = 0
-            var sleep            = false
-
-            // External submissions can target this worker's local queue while it is active.
-            // Pair the last local-queue check with the transition to inactive so work is not stranded.
-            self.synchronized {
-              if (!currentBlocking && (nextRunnable ne null)) {
-                runnable = nextRunnable
-                nextRunnable = null
-              } else if (!currentBlocking) {
-                runnable = localQueue.poll(null)
+            val currentState =
+              if (currentBlocking && searching) state.decrementAndGet()
+              else if (currentBlocking) state.get
+              else if (searching) state.addAndGet(0xfffeffff)
+              else state.addAndGet(0xffff0000)
+            val currentSearching = currentState & 0xffff
+            active = false
+            if (currentBlocking) {
+              cache.offer(self)
+            } else {
+              idle.offer(self)
+            }
+            if (currentSearching == 0 && searching) {
+              var i      = 0
+              var notify = false
+              while (i != poolSize && !notify) {
+                val worker = workers(i)
+                notify = !worker.localQueue.isEmpty()
+                i += 1
               }
-
-              if (runnable eq null) {
-                currentState =
-                  if (currentBlocking && searching) state.decrementAndGet()
-                  else if (currentBlocking) state.get
-                  else if (searching) state.addAndGet(0xfffeffff)
-                  else state.addAndGet(0xffff0000)
-                currentSearching = currentState & 0xffff
-                active = false
-                sleep = true
+              if (!notify) {
+                notify = !globalQueue.isEmpty()
+              }
+              if (notify) {
+                val currentState = state.get
+                maybeUnparkWorker(currentState)
               }
             }
-
-            if (sleep) {
-              if (currentBlocking) {
-                cache.offer(self)
-              } else {
-                idle.offer(self)
-              }
-              if (currentSearching == 0 && searching) {
-                var i      = 0
-                var notify = false
-                while (i != poolSize && !notify) {
-                  val worker = workers(i)
-                  notify = !worker.localQueue.isEmpty()
-                  i += 1
-                }
-                if (!notify) {
-                  notify = !globalQueue.isEmpty()
-                }
-                if (notify) {
-                  val currentState = state.get
-                  maybeUnparkWorker(currentState)
-                }
-              }
-              while (!active && !isInterrupted) {
-                LockSupport.park()
-              }
-              searching = true
+            while (!active && !isInterrupted) {
+              LockSupport.park()
             }
-          }
-          if (runnable ne null) {
+            searching = true
+          } else {
             if (searching) {
               searching = false
               val currentState = state.decrementAndGet()

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -223,7 +223,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
         val workerIndex = java.lang.Math.floorMod(offset + i, poolSize)
         val worker      = workers(workerIndex)
 
-        if (worker.active && !worker.blocking) {
+        if (worker.active && !worker.blocking && (worker.currentRunnable eq null)) {
           val size = worker.localQueue.size() + (if (worker.nextRunnable ne null) 1 else 0)
 
           if (size < bestSize) {
@@ -238,7 +238,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 
       val accepted =
         (best ne null) && best.synchronized {
-          (workers(bestIndex) eq best) && best.active && !best.blocking && best.localQueue.offer(runnable)
+          (workers(bestIndex) eq best) && best.active && !best.blocking && (best.currentRunnable eq null) &&
+          best.localQueue.offer(runnable)
         }
       if (accepted && !best.active) {
         maybeUnparkWorker(state.get)

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -169,7 +169,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      var notify = true
+      var notify       = true
       val currentState = state.get
       if (worker eq null) {
         if (submitExternal(runnable, currentState)) {
@@ -227,9 +227,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
           val size = worker.localQueue.size() + (if (worker.nextRunnable ne null) 1 else 0)
 
           if (size < bestSize) {
-            best      = worker
+            best = worker
             bestIndex = workerIndex
-            bestSize  = size
+            bestSize = size
           }
         }
 

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -227,9 +227,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
           val size = worker.localQueue.size() + (if (worker.nextRunnable ne null) 1 else 0)
 
           if (size < bestSize) {
-            best = worker
+            best      = worker
             bestIndex = workerIndex
-            bestSize = size
+            bestSize  = size
           }
         }
 

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -40,6 +40,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   private[this] val idle            = new ConcurrentLinkedQueue[ZScheduler.Worker]()
   private[this] val globalLocations = makeLocations()
   private[this] val state           = new AtomicInteger(poolSize << 16)
+  private[this] val externalCursor  = new AtomicInteger(0)
   private[this] val workers         = Array.ofDim[ZScheduler.Worker](poolSize)
 
   @volatile private[this] var blockingLocations: Set[Trace] = Set.empty
@@ -148,12 +149,16 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
-      if ((worker eq null) || worker.blocking) {
+      val currentState = state.get
+      if (worker eq null) {
+        if (!submitExternal(runnable, currentState)) {
+          globalQueue.offer(runnable)
+        }
+      } else if (worker.blocking) {
         globalQueue.offer(runnable)
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
       } else ()
-      val currentState = state.get
       maybeUnparkWorker(currentState)
       true
     }
@@ -165,7 +170,14 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       submitBlocking(runnable)
     } else {
       var notify = true
-      if ((worker eq null) || worker.blocking) {
+      val currentState = state.get
+      if (worker eq null) {
+        if (submitExternal(runnable, currentState)) {
+          notify = false
+        } else {
+          globalQueue.offer(runnable)
+        }
+      } else if (worker.blocking) {
         globalQueue.offer(runnable)
       }
       // Attempt resumption in the current Thread
@@ -188,10 +200,50 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       }
 
       if (notify) {
-        val currentState = state.get
         maybeUnparkWorker(currentState)
       }
       true
+    }
+  }
+
+  private[this] def submitExternal(runnable: Runnable, currentState: Int): Boolean = {
+    val currentActive = (currentState & 0xffff0000) >> 16
+
+    if (currentActive != poolSize) {
+      false
+    } else {
+      val sampleSize = java.lang.Math.min(poolSize, 4)
+      val offset     = externalCursor.getAndIncrement()
+      var best       = null.asInstanceOf[ZScheduler.Worker]
+      var bestIndex  = -1
+      var bestSize   = Int.MaxValue
+      var i          = 0
+
+      while (i < sampleSize) {
+        val workerIndex = java.lang.Math.floorMod(offset + i, poolSize)
+        val worker      = workers(workerIndex)
+
+        if (worker.active && !worker.blocking) {
+          val size = worker.localQueue.size() + (if (worker.nextRunnable ne null) 1 else 0)
+
+          if (size < bestSize) {
+            best = worker
+            bestIndex = workerIndex
+            bestSize = size
+          }
+        }
+
+        i += 1
+      }
+
+      val accepted =
+        (best ne null) && best.synchronized {
+          (workers(bestIndex) eq best) && best.active && !best.blocking && best.localQueue.offer(runnable)
+        }
+      if (accepted && !best.active) {
+        maybeUnparkWorker(state.get)
+      }
+      accepted
     }
   }
 

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -414,39 +414,61 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             }
           }
           if (runnable eq null) {
-            val currentState =
-              if (currentBlocking && searching) state.decrementAndGet()
-              else if (currentBlocking) state.get
-              else if (searching) state.addAndGet(0xfffeffff)
-              else state.addAndGet(0xffff0000)
-            val currentSearching = currentState & 0xffff
-            active = false
-            if (currentBlocking) {
-              cache.offer(self)
-            } else {
-              idle.offer(self)
-            }
-            if (currentSearching == 0 && searching) {
-              var i      = 0
-              var notify = false
-              while (i != poolSize && !notify) {
-                val worker = workers(i)
-                notify = !worker.localQueue.isEmpty()
-                i += 1
+            var currentState     = 0
+            var currentSearching = 0
+            var sleep            = false
+
+            // External submissions can target this worker's local queue while it is active.
+            // Pair the last local-queue check with the transition to inactive so work is not stranded.
+            self.synchronized {
+              if (!currentBlocking && (nextRunnable ne null)) {
+                runnable = nextRunnable
+                nextRunnable = null
+              } else if (!currentBlocking) {
+                runnable = localQueue.poll(null)
               }
-              if (!notify) {
-                notify = !globalQueue.isEmpty()
-              }
-              if (notify) {
-                val currentState = state.get
-                maybeUnparkWorker(currentState)
+
+              if (runnable eq null) {
+                currentState =
+                  if (currentBlocking && searching) state.decrementAndGet()
+                  else if (currentBlocking) state.get
+                  else if (searching) state.addAndGet(0xfffeffff)
+                  else state.addAndGet(0xffff0000)
+                currentSearching = currentState & 0xffff
+                active = false
+                sleep = true
               }
             }
-            while (!active && !isInterrupted) {
-              LockSupport.park()
+
+            if (sleep) {
+              if (currentBlocking) {
+                cache.offer(self)
+              } else {
+                idle.offer(self)
+              }
+              if (currentSearching == 0 && searching) {
+                var i      = 0
+                var notify = false
+                while (i != poolSize && !notify) {
+                  val worker = workers(i)
+                  notify = !worker.localQueue.isEmpty()
+                  i += 1
+                }
+                if (!notify) {
+                  notify = !globalQueue.isEmpty()
+                }
+                if (notify) {
+                  val currentState = state.get
+                  maybeUnparkWorker(currentState)
+                }
+              }
+              while (!active && !isInterrupted) {
+                LockSupport.park()
+              }
+              searching = true
             }
-            searching = true
-          } else {
+          }
+          if (runnable ne null) {
             if (searching) {
               searching = false
               val currentState = state.decrementAndGet()


### PR DESCRIPTION
/claim #9356

## Summary

This keeps external submissions on the global queue, but records when external work arrives while the scheduler is saturated. Active workers use that signal to prioritize polling the global queue before their local queue while external submissions are pending.

This is intentionally conservative: it does not enqueue externally submitted work directly into worker-local queues, so it avoids placing dependent work behind a worker that may be synchronously blocked under the default `autoBlocking = false` runtime.

## Why this shape

Prior attempts around #9356 showed that direct least-loaded routing can introduce subtle worker replacement, local queue, and blocking hazards. This version preserves the existing global-queue fallback and only changes how quickly active workers notice externally submitted work under saturation.

## Changes

- Track saturated external submissions with an atomic counter.
- Let active workers poll the global queue first while external submissions are pending.
- Keep internal worker submission and `submitAndYield` behavior intact.
- Add a focused JVM-native stress test for saturated external submissions.
- Add JMH hooks for measuring external submit throughput.

## Verification

- `++2.13; coreJVM/scalafmt; coreNative/scalafmt; coreTestsJVM/testOnly zio.ZSchedulerSpec zio.CancelableFutureSpecJVM; coreJVM/scalafmtCheck; coreNative/scalafmtCheck; coreTestsJVM/scalafmtCheck`
- GitHub CI is passing on the latest commit, including JVM tests, Java 11/17/25 jobs, JS, Native, website, and publishLocal checks.
