### PR TITLE
Add binary-compatible Queue.shutdownCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,47 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause returns buffered elements and uses cause for future interactions") {
+      val cause = Cause.die(new RuntimeException("queue failed")).untraced
+      for {
+        queue    <- Queue.bounded[Int](3)
+        _        <- queue.offerAll(List(1, 2))
+        buffered <- queue.shutdownCause(cause)
+        offer    <- queue.offer(3).sandbox.either.map(_.left.map(_.untraced))
+        take     <- queue.take.sandbox.either.map(_.left.map(_.untraced))
+        size     <- queue.size.sandbox.either.map(_.left.map(_.untraced))
+      } yield assert(buffered)(equalTo(Chunk(1, 2))) &&
+        assert(offer)(isLeft(equalTo(cause))) &&
+        assert(take)(isLeft(equalTo(cause))) &&
+        assert(size)(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause completes pending takers and back-pressured putters with cause") {
+      val cause = Cause.die(new RuntimeException("consumer failed")).untraced
+      for {
+        takingQueue <- Queue.bounded[Int](1)
+        take        <- takingQueue.take.fork
+        _           <- waitForSize(takingQueue, -1)
+        _           <- takingQueue.shutdownCause(cause)
+
+        offeringQueue <- Queue.bounded[Int](1)
+        _             <- offeringQueue.offer(1)
+        offer         <- offeringQueue.offer(2).fork
+        _             <- waitForSize(offeringQueue, 2)
+        _             <- offeringQueue.shutdownCause(cause)
+        o             <- offer.join.sandbox.either.map(_.left.map(_.untraced))
+        t             <- take.join.sandbox.either.map(_.left.map(_.untraced))
+      } yield assert(o)(isLeft(equalTo(cause))) &&
+        assert(t)(isLeft(equalTo(cause)))
+    },
+    test("first shutdownCause wins") {
+      val cause1 = Cause.die(new RuntimeException("first")).untraced
+      val cause2 = Cause.die(new RuntimeException("second")).untraced
+      for {
+        queue <- Queue.bounded[Int](1)
+        _     <- queue.shutdownCause(cause1)
+        res   <- queue.shutdownCause(cause2).sandbox.either.map(_.left.map(_.untraced))
+      } yield assert(res)(isLeft(equalTo(cause1)))
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -29,6 +29,14 @@ import scala.annotation.tailrec
 sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
+   * Shuts down the queue with the specified cause, returning any elements that
+   * are still buffered in the queue. Future interactions with the queue will
+   * fail with the same cause.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+    shutdown.as(Chunk.empty)
+
+  /**
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
@@ -162,15 +170,17 @@ object Queue extends QueuePlatformSpecific {
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
   ) extends Queue[A] {
+    private[this] val shutdownCauseRef = new AtomicReference[Cause[Nothing]](null)
 
     override def capacity: Int = queue.capacity
 
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null) ZIO.failCause(shutdownCause)
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag, shutdownCauseRef)
         }
       }
 
@@ -193,7 +203,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null) ZIO.failCause(shutdownCause)
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -210,7 +221,7 @@ object Queue extends QueuePlatformSpecific {
               strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownFlag, shutdownCauseRef).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -221,32 +232,42 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null)
+          ZIO.failCause(shutdownCause)
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
-        if (shutdownFlag.compareAndSet(false, true)) {
+        shutdownCause(Cause.interrupt(fiberId)).catchAllCause(_ => ZIO.unit).unit
+      }
+
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      ZIO.suspendSucceed {
+        if (shutdownCauseRef.compareAndSet(null, cause)) {
+          shutdownFlag.set(true)
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
           val it = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.failCause(cause)
           }
-          strategy.shutdown(fiberId)
+          strategy.shutdownCause(cause)
+          Exit.succeed(unsafePollAll(queue))
+        } else {
+          ZIO.failCause(shutdownCauseRef.get)
         }
-        Exit.unit
       }.uninterruptible
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownCauseRef.get ne null)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          val shutdownCause = shutdownCauseRef.get
+          if (shutdownCause ne null) ZIO.failCause(shutdownCause)
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -258,15 +279,22 @@ object Queue extends QueuePlatformSpecific {
 
                 takers.offer(p)
                 strategy.unsafeCompleteTakers(queue, takers)
-                restore(p.await).catchAllCause { c =>
-                  val removed = p.unsafe.completeWith(interruptAsNone)(Unsafe)
+                val shutdownCause = shutdownCauseRef.get
+                if (shutdownCause ne null) {
+                  val removed = p.unsafe.failCause(shutdownCause)(trace, Unsafe)
                   takers.remove(p)
-                  if (removed) Exit.failCause(c)
-                  else {
-                    // The promise was already completed, so if we interrupt here we'll drop the item
-                    // This is not ideal but instead of interrupting we recover temporarily.
-                    // Interruption will resume at the next point where it's enabled
-                    p.await
+                  if (removed) ZIO.failCause(shutdownCause) else p.await
+                } else {
+                  restore(p.await).catchAllCause { c =>
+                    val removed = p.unsafe.completeWith(interruptAsNone)(Unsafe)
+                    takers.remove(p)
+                    if (removed) Exit.failCause(c)
+                    else {
+                      // The promise was already completed, so if we interrupt here we'll drop the item
+                      // This is not ideal but instead of interrupting we recover temporarily.
+                      // Interruption will resume at the next point where it's enabled
+                      p.await
+                    }
                   }
                 }
               case item =>
@@ -279,8 +307,9 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null)
+          ZIO.failCause(shutdownCause)
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
@@ -294,8 +323,9 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null)
+          ZIO.failCause(shutdownCause)
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
@@ -309,8 +339,9 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val shutdownCause = shutdownCauseRef.get
+        if (shutdownCause ne null)
+          ZIO.failCause(shutdownCause)
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
@@ -332,6 +363,15 @@ object Queue extends QueuePlatformSpecific {
       isShutdown: AtomicBoolean
     )(implicit trace: Trace): UIO[Boolean]
 
+    def handleSurplus(
+      as: Iterable[A],
+      queue: MutableConcurrentQueue[A],
+      takers: ConcurrentDeque[Promise[Nothing, A]],
+      isShutdown: AtomicBoolean,
+      shutdownCauseRef: AtomicReference[Cause[Nothing]]
+    )(implicit trace: Trace): UIO[Boolean] =
+      handleSurplus(as, queue, takers, isShutdown)
+
     def unsafeOnQueueEmptySpace(
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]]
@@ -340,6 +380,9 @@ object Queue extends QueuePlatformSpecific {
     def surplusSize: Int
 
     def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+
+    def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit =
+      shutdown(FiberId.None)
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -414,6 +457,28 @@ object Queue extends QueuePlatformSpecific {
           }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
         }
 
+      override def handleSurplus(
+        as: Iterable[A],
+        queue: MutableConcurrentQueue[A],
+        takers: ConcurrentDeque[Promise[Nothing, A]],
+        isShutdown: AtomicBoolean,
+        shutdownCauseRef: AtomicReference[Cause[Nothing]]
+      )(implicit trace: Trace): UIO[Boolean] =
+        ZIO.fiberIdWith { fiberId =>
+          val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
+
+          ZIO.suspendSucceed {
+            unsafeOffer(as, p)
+            unsafeOnQueueEmptySpace(queue, takers)
+            unsafeCompleteTakers(queue, takers)
+            val shutdownCause = shutdownCauseRef.get
+            if (shutdownCause ne null) {
+              unsafeRemove(p)
+              ZIO.failCause(shutdownCause)
+            } else p.await
+          }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
+        }
+
       private def unsafeOffer(as: Iterable[A], p: Promise[Nothing, Boolean]): Unit = {
         val iterator = as.iterator
         var hasNext  = iterator.hasNext
@@ -469,6 +534,15 @@ object Queue extends QueuePlatformSpecific {
         while (next ne null) {
           val (_, promise, isLast) = next
           if (isLast) promise.unsafe.interruptAs(fiberId)
+          next = putters.poll()
+        }
+      }
+
+      override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = {
+        var next = putters.poll()
+        while (next ne null) {
+          val (_, promise, isLast) = next
+          if (isLast) promise.unsafe.failCause(cause)
           next = putters.poll()
         }
       }

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5873,6 +5873,15 @@ object ZStreamSpec extends ZIOBaseSpec {
                           .take(3)
                           .runCollect
             } yield result)(forall(hasSize(isLessThanEqualTo(2))))
+          },
+          test("fails when the queue is shut down with a defect cause") {
+            val cause = Cause.die(new RuntimeException("queue failed")).untraced
+            for {
+              queue <- Queue.unbounded[Int]
+              fiber <- ZStream.fromQueue(queue).runDrain.fork
+              _     <- queue.shutdownCause(cause)
+              exit  <- fiber.await.map(_.mapErrorCauseExit((cause: Cause[Nothing]) => cause.untraced))
+            } yield assert(exit)(failsCause[Nothing](equalTo(cause)))
           }
         ),
         test("fromTQueue") {


### PR DESCRIPTION
/claim #9844

## Summary
- Adds `Queue.shutdownCause(cause: Cause[Nothing]): UIO[Chunk[A]]` while keeping the existing `Queue[A]` API shape.
- Stores the first shutdown cause internally; the winning caller receives buffered elements, pending takers and back-pressured putters fail with that cause, and future queue interactions fail with the stored cause.
- Preserves `shutdown` as interrupt-based and idempotent by delegating to `shutdownCause(Cause.interrupt(...))` and swallowing the stored shutdown cause on repeat calls.
- Adds focused `QueueSpec` coverage plus a `ZStream.fromQueue` propagation test for defect shutdown causes.

## Compatibility
This keeps the existing `QueueImpl` constructor signature and the existing abstract `Strategy.handleSurplus(..., AtomicBoolean)` signature intact. The cause-aware strategy path is added as an overload/default method, avoiding the MiMa failures seen in #10909 where the constructor and abstract method signatures changed.

## Validation
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home /tmp/sbt/bin/sbt -v "++2.13; coreTestsJVM/Test/compile; streamsTestsJVM/Test/compile"`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home /tmp/sbt/bin/sbt -v "++2.13; coreTestsJVM/testOnly *.QueueSpec -- -t shutdownCause; streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t \"fails when the queue is shut down with a defect cause\""`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home /tmp/sbt/bin/sbt -v "++2.13; coreJVM/mimaReportBinaryIssues"`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home /tmp/sbt/bin/sbt -v fmtCheck`
- `git diff --check`