### PR TITLE
Fix Native WeakConcurrentBag storage

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/WeakConcurrentBagSpec.scala
@@ -1,23 +1,24 @@
 package zio.internal
 
 import zio.test._
-import zio.test.TestAspect.{flaky, jvmOnly}
-import zio.ZIOBaseSpec
+import zio.test.TestAspect.{flaky, jvmOnly, nativeOnly}
+import zio.{ZIO, ZIOBaseSpec}
 
 object WeakConcurrentBagSpec extends ZIOBaseSpec {
   final case class Wrapper[A](value: A)
 
   def spec =
-    suite("WeakConcurrentBagSpec") {
-      test("size of singleton bag") {
-        val bag = WeakConcurrentBag[Wrapper[String]](10)
+    suite("WeakConcurrentBagSpec")(
+      suite("JVM")(
+        test("size of singleton bag") {
+          val bag = WeakConcurrentBag[Wrapper[String]](10)
 
-        val value = Wrapper("foo")
+          val value = Wrapper("foo")
 
-        bag.add(value)
+          bag.add(value)
 
-        assertTrue(bag.size == 1)
-      } +
+          assertTrue(bag.size == 1)
+        },
         test("iteration over 100 (nursery size: 100)") {
           val bag = WeakConcurrentBag[Wrapper[String]](100)
 
@@ -30,7 +31,7 @@ object WeakConcurrentBagSpec extends ZIOBaseSpec {
           }
 
           assertTrue((bag.size == 100) && (bag.iterator.toSet == hard))
-        } +
+        },
         test("manual gc") {
           val bag = WeakConcurrentBag[Wrapper[String]](100)
 
@@ -54,7 +55,7 @@ object WeakConcurrentBagSpec extends ZIOBaseSpec {
           bag.gc()
 
           assertTrue(bag.size == 50)
-        } @@ flaky +
+        } @@ flaky,
         test("auto gc") {
           val bag = WeakConcurrentBag[Wrapper[String]](100)
 
@@ -70,5 +71,13 @@ object WeakConcurrentBagSpec extends ZIOBaseSpec {
 
           assertTrue(bag.size <= 100)
         } @@ flaky
-    } @@ jvmOnly
+      ) @@ jvmOnly,
+      test("many concurrent additions on Native") {
+        val bag = WeakConcurrentBag[Wrapper[Int]](16)
+
+        ZIO.foreachParDiscard(1 to 10000)(i => ZIO.succeed(bag.add(Wrapper(i)))) *>
+          ZIO.succeed(bag.graduate()) *>
+          ZIO.succeed(assertTrue(bag.size >= 0))
+      } @@ nativeOnly
+    )
 }

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -18,7 +18,7 @@ package zio.internal
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.{HashMap, HashSet, Map => JMap, Set => JSet}
+import java.util.{Collection => JCollection, HashMap, HashSet, Map => JMap, Set => JSet}
 
 private[zio] trait PlatformSpecific {
 
@@ -88,6 +88,9 @@ private[zio] trait PlatformSpecific {
   final def newConcurrentSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
     new HashSet[A](initialCapacity)
+
+  final def newConcurrentBagStorage[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JCollection[A] =
+    newConcurrentSet[A](initialCapacity)
 
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] = new HashSet[A]()
 

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -20,7 +20,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
-import java.util.{Collections, Map => JMap, Set => JSet, WeakHashMap}
+import java.util.{Collection => JCollection, Collections, Map => JMap, Set => JSet, WeakHashMap}
 
 private[zio] trait PlatformSpecific {
 
@@ -96,6 +96,9 @@ private[zio] trait PlatformSpecific {
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
     ConcurrentHashMap.newKeySet[A](initialCapacity)
+
+  final def newConcurrentBagStorage[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JCollection[A] =
+    newConcurrentSet[A](initialCapacity)
 
   final def newWeakReference[A](value: A)(implicit unsafe: zio.Unsafe): () => A = {
     val ref = new WeakReference[A](value)

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -18,8 +18,8 @@ package zio.internal
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentHashMap
-import java.util.{Collections, WeakHashMap, Map => JMap, Set => JSet}
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
+import java.util.{Collection => JCollection, Collections, WeakHashMap, Map => JMap, Set => JSet}
 
 private[zio] trait PlatformSpecific {
 
@@ -88,6 +88,11 @@ private[zio] trait PlatformSpecific {
 
   final def newConcurrentSet[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JSet[A] =
     ConcurrentHashMap.newKeySet[A](initialCapacity)
+
+  final def newConcurrentBagStorage[A](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JCollection[A] = {
+    blackhole(initialCapacity)
+    new ConcurrentLinkedQueue[A]()
+  }
 
   private def blackhole(a: Any): Unit = {
     val _ = a

--- a/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
+++ b/core/shared/src/main/scala/zio/internal/WeakConcurrentBag.scala
@@ -4,6 +4,7 @@ import zio.internal.WeakConcurrentBag.IsAlive
 import zio.{Chunk, Duration, Unsafe}
 
 import java.lang.ref.WeakReference
+import java.util.{Collection => JCollection}
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Predicate
@@ -27,9 +28,10 @@ private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsA
   private[this] val nursery           = new PartitionedRingBuffer[WeakReference[A]](nCpu * 4, nurserySize, roundToPow2 = true)
   private[this] val nurseryActualSize = nursery.capacity
 
-  private[this] val graduates = Platform.newConcurrentSet[WeakReference[A]](nurseryActualSize * 2)(Unsafe.unsafe)
-  private[this] val gcStatus  = new AtomicBoolean(false)
-  private[this] val autoGc    = new AtomicBoolean(false)
+  private[this] val graduates: JCollection[WeakReference[A]] =
+    Platform.newConcurrentBagStorage[WeakReference[A]](nurseryActualSize * 2)(Unsafe.unsafe)
+  private[this] val gcStatus = new AtomicBoolean(false)
+  private[this] val autoGc   = new AtomicBoolean(false)
 
   private[this] val notAlive = new Predicate[WeakReference[A]] {
     def test(ref: WeakReference[A]): Boolean = {
@@ -149,10 +151,11 @@ private[zio] class WeakConcurrentBag[A <: AnyRef](nurserySize: Int, isAlive: IsA
       @tailrec
       def prefetch(): A =
         if (it.hasNext) {
-          val next = it.next().get()
+          val ref  = it.next()
+          val next = ref.get()
 
           if (next eq null) {
-            it.remove() // Remove dead reference since we're iterating over the set
+            graduates.remove(ref) // Remove dead reference since we're iterating over storage
             prefetch()
           } else next
         } else {


### PR DESCRIPTION
## Summary

- Add platform-specific storage for `WeakConcurrentBag` graduates.
- Keep JVM and JS backed by the existing concurrent set behavior.
- Use `ConcurrentLinkedQueue` for Scala Native long-term bag storage to avoid the `ConcurrentHashMap.newKeySet` path involved in the reported Native failure.
- Add Native-only regression coverage for many concurrent additions.

Fixes #9681.

## Testing

- `sbt "coreTestsJVM/Test/compile"`
- `sbt "coreTestsJS/Test/compile"`
- `sbt "coreNative/Compile/compile"`
- `sbt "coreJVM/scalafmtCheck" "coreNative/scalafmtCheck" "coreJS/scalafmtCheck" "coreTestsJVM/scalafmtCheck"`
