### PR TITLE
Add FiberSet for fiber tracking

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala
@@ -1,0 +1,151 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+import zio.{Fiber, FiberId, FiberRefs, RuntimeFlags, Trace}
+
+import java.util
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@State(Scope.Benchmark)
+private[this] class FiberSetContext {
+  @Param(Array("10000"))
+  var size: Int = _
+
+  private[this] val nextId = new AtomicInteger(0)
+
+  var fiberSet: FiberSet                                        = _
+  var weakConcurrentBag: WeakConcurrentBag[Fiber.Runtime[_, _]] = _
+  var synchronizedWeakSet: util.Set[Fiber.Runtime[_, _]]        = _
+  var fibers: Array[Fiber.Runtime[_, _]]                        = _
+
+  @Setup(Level.Iteration)
+  def setup(): Unit = {
+    fiberSet = FiberSet(size)
+    weakConcurrentBag = WeakConcurrentBag[Fiber.Runtime[_, _]](size, _.isAlive())
+    synchronizedWeakSet = Collections.synchronizedSet(
+      Collections.newSetFromMap(new util.WeakHashMap[Fiber.Runtime[_, _], java.lang.Boolean]())
+    )
+    fibers = new Array[Fiber.Runtime[_, _]](size)
+
+    var i = 0
+    while (i < fibers.length) {
+      fibers(i) = newFiber()
+      fiberSet.add(fibers(i))
+      weakConcurrentBag.add(fibers(i))
+      synchronizedWeakSet.add(fibers(i))
+      i += 1
+    }
+  }
+
+  def newFiber(): Fiber.Runtime[_, _] =
+    FiberRuntime[Any, Any](
+      FiberId.Runtime(nextId.incrementAndGet(), 0L, Trace.empty),
+      FiberRefs.empty,
+      RuntimeFlags.default
+    )
+
+  def nextFiber(): Fiber.Runtime[_, _] = {
+    val index = Math.floorMod(nextId.incrementAndGet(), fibers.length)
+    fibers(index)
+  }
+
+  def removeAndReaddFiberSet(): Boolean = {
+    val fiber   = nextFiber()
+    val removed = fiberSet.remove(fiber)
+    fiberSet.add(fiber)
+    removed
+  }
+
+  def removeAndReaddSynchronizedWeakSet(): Boolean = {
+    val fiber   = nextFiber()
+    val removed = synchronizedWeakSet.remove(fiber)
+    synchronizedWeakSet.add(fiber)
+    removed
+  }
+
+  def addWeakConcurrentBag(): Unit =
+    weakConcurrentBag.add(newFiber())
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetAddBenchmark {
+
+  @Benchmark
+  def fiberSetAdd(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.fiberSet.add(ctx.newFiber()))
+
+  @Benchmark
+  def synchronizedWeakSetAdd(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.synchronizedWeakSet.add(ctx.newFiber()))
+
+  @Benchmark
+  def weakConcurrentBagAdd(ctx: FiberSetContext): Unit =
+    ctx.addWeakConcurrentBag()
+
+  @Threads(6)
+  @Benchmark
+  def fiberSetAddConcurrent(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.fiberSet.add(ctx.newFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def synchronizedWeakSetAddConcurrent(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.synchronizedWeakSet.add(ctx.newFiber()))
+
+  @Threads(6)
+  @Benchmark
+  def weakConcurrentBagAddConcurrent(ctx: FiberSetContext): Unit =
+    ctx.addWeakConcurrentBag()
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetRemoveBenchmark {
+
+  @Benchmark
+  def fiberSetRemove(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.removeAndReaddFiberSet())
+
+  @Benchmark
+  def synchronizedWeakSetRemove(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.removeAndReaddSynchronizedWeakSet())
+
+  @Threads(6)
+  @Benchmark
+  def fiberSetRemoveConcurrent(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.removeAndReaddFiberSet())
+
+  @Threads(6)
+  @Benchmark
+  def synchronizedWeakSetRemoveConcurrent(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    blackhole.consume(ctx.removeAndReaddSynchronizedWeakSet())
+}
+
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 2, time = 2)
+@Fork(1)
+private[this] class FiberSetIterationBenchmark {
+
+  @Benchmark
+  def fiberSetIterate(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    ctx.fiberSet.foreach(fiber => blackhole.consume(fiber))
+
+  @Benchmark
+  def synchronizedWeakSetIterate(ctx: FiberSetContext, blackhole: Blackhole): Unit = {
+    val iterator = ctx.synchronizedWeakSet.iterator()
+    while (iterator.hasNext) blackhole.consume(iterator.next())
+  }
+
+  @Benchmark
+  def weakConcurrentBagIterate(ctx: FiberSetContext, blackhole: Blackhole): Unit =
+    ctx.weakConcurrentBag.iterator.foreach(fiber => blackhole.consume(fiber))
+}

--- a/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberSetSpec.scala
@@ -1,0 +1,71 @@
+package zio.internal
+
+import zio.test._
+import zio.{Fiber, FiberId, FiberRefs, RuntimeFlags, Trace, ZIO, ZIOBaseSpec}
+
+object FiberSetSpec extends ZIOBaseSpec {
+
+  def spec =
+    suite("FiberSetSpec")(
+      test("add and remove a live fiber") {
+        val set   = FiberSet()
+        val fiber = runtimeFiber(1)
+
+        assertTrue(
+          set.add(fiber),
+          set.iterator.contains(fiber),
+          set.remove(fiber),
+          set.isEmpty
+        )
+      },
+      test("does not add a completed fiber") {
+        for {
+          fiber <- ZIO.unit.fork
+          _     <- fiber.await
+          set    = FiberSet()
+        } yield assertTrue(!set.add(fiber), set.isEmpty)
+      },
+      test("supports concurrent add and remove") {
+        val set    = FiberSet()
+        val fibers = (1 to 1000).map(runtimeFiber)
+
+        for {
+          _    <- ZIO.foreachParDiscard(fibers)(fiber => ZIO.succeed(set.add(fiber)))
+          size <- ZIO.succeed(set.size)
+          _    <- ZIO.foreachParDiscard(fibers)(fiber => ZIO.succeed(set.remove(fiber)))
+        } yield assertTrue(size == fibers.size, set.isEmpty)
+      },
+      test("iterator drops interrupted fibers") {
+        val set = FiberSet()
+
+        for {
+          fiber <- ZIO.never.fork
+          _      = set.add(fiber)
+          _     <- fiber.interrupt
+        } yield assertTrue(set.isEmpty)
+      },
+      test("gc keeps live fibers visible") {
+        val set   = FiberSet()
+        val fiber = runtimeFiber(2)
+
+        set.add(fiber)
+        set.gc()
+
+        assertTrue(set.iterator.contains(fiber), set.size == 1)
+      },
+      test("Fiber.roots excludes completed daemon fibers") {
+        def rootContains(fiberId: FiberId): ZIO[Any, Nothing, Boolean] =
+          Fiber.roots.map(_.exists(_.id == fiberId))
+
+        for {
+          fiber <- ZIO.never.forkDaemon
+          _     <- rootContains(fiber.id).repeatUntil(identity)
+          _     <- fiber.interrupt
+          roots <- Fiber.roots
+        } yield assertTrue(!roots.exists(_.id == fiber.id))
+      }
+    )
+
+  private def runtimeFiber(id: Int): FiberRuntime[Any, Any] =
+    FiberRuntime(FiberId.Runtime(id, 0L, Trace.empty), FiberRefs.empty, RuntimeFlags.default)
+}

--- a/core/js/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/js/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,7 @@
+package zio.internal
+
+import zio.Duration
+
+private object FiberSetGc {
+  def start(set: FiberSet, every: Duration): Unit = ()
+}

--- a/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/js/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -94,6 +94,8 @@ private[zio] trait PlatformSpecific {
   final def newWeakHashMap[A, B]()(implicit unsafe: zio.Unsafe): JMap[A, B] = new HashMap[A, B]()
 
   final def newConcurrentMap[A, B]()(implicit unsafe: zio.Unsafe): JMap[A, B] = new HashMap[A, B]()
+  final def newConcurrentMap[A, B](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JMap[A, B] =
+    new HashMap[A, B](initialCapacity)
 
   final def newWeakReference[A](value: A)(implicit unsafe: zio.Unsafe): () => A = { () => value }
 }

--- a/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/FiberSetGc.scala
@@ -1,0 +1,33 @@
+package zio.internal
+
+import zio.Duration
+
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.locks.LockSupport
+
+private final class FiberSetGc private (
+  set: FiberSet,
+  sleepFor: Duration
+) extends Thread {
+  override def run(): Unit = {
+    val sleepForNanos = sleepFor.toNanos
+    while (!isInterrupted) {
+      LockSupport.parkNanos(sleepForNanos)
+      set.gc()
+    }
+  }
+}
+
+private object FiberSetGc {
+  private val i = new AtomicInteger(0)
+
+  def start(set: FiberSet, every: Duration): Unit = {
+    assert(every.toMillis >= 1000, "Auto-gc interval must be >= 1 second")
+
+    val thread = new FiberSetGc(set, every)
+    thread.setName(s"zio.internal.FiberSet.GcThread-${i.getAndIncrement()}")
+    thread.setPriority(4)
+    thread.setDaemon(true)
+    thread.start()
+  }
+}

--- a/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/jvm/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -85,6 +85,9 @@ private[zio] trait PlatformSpecific {
   final def newConcurrentMap[A, B]()(implicit unsafe: zio.Unsafe): JMap[A, B] =
     new ConcurrentHashMap[A, B]()
 
+  final def newConcurrentMap[A, B](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JMap[A, B] =
+    new ConcurrentHashMap[A, B](initialCapacity)
+
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
     Collections.synchronizedSet(newWeakSet[A]())
 

--- a/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
+++ b/core/native/src/main/scala/zio/internal/PlatformSpecific.scala
@@ -77,6 +77,9 @@ private[zio] trait PlatformSpecific {
   final def newConcurrentMap[A, B]()(implicit unsafe: zio.Unsafe): JMap[A, B] =
     new ConcurrentHashMap[A, B]()
 
+  final def newConcurrentMap[A, B](initialCapacity: Int)(implicit unsafe: zio.Unsafe): JMap[A, B] =
+    new ConcurrentHashMap[A, B](initialCapacity)
+
   final def newConcurrentWeakSet[A]()(implicit unsafe: zio.Unsafe): JSet[A] =
     Collections.synchronizedSet(newWeakSet[A]())
 

--- a/core/shared/src/main/scala/zio/Fiber.scala
+++ b/core/shared/src/main/scala/zio/Fiber.scala
@@ -16,12 +16,11 @@
 
 package zio
 
-import zio.internal.{FiberRenderer, FiberScope}
+import zio.internal.{FiberRenderer, FiberScope, FiberSet}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import scala.concurrent.Future
-import zio.internal.WeakConcurrentBag
 
 /**
  * A fiber is a lightweight thread of execution that never consumes more than a
@@ -1070,7 +1069,7 @@ object Fiber extends FiberPlatformSpecific {
   private[zio] val _currentFiber: ThreadLocal[Fiber.Runtime[_, _]] =
     new ThreadLocal[Fiber.Runtime[_, _]]()
 
-  private[zio] val _roots: WeakConcurrentBag[Fiber.Runtime[_, _]] =
-    WeakConcurrentBag[Fiber.Runtime[_, _]](10000, _.isAlive())
+  private[zio] val _roots: FiberSet =
+    FiberSet(10000)
       .withAutoGc(5.seconds)
 }

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -24,7 +24,6 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
 
 final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, runtimeFlags0: RuntimeFlags)
@@ -43,7 +42,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
   private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
-  private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
+  private var _children       = null.asInstanceOf[FiberSet]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]
   private var _stack          = null.asInstanceOf[Array[Continuation]]
@@ -84,12 +83,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
       )
   }
 
-  private[this] def childrenChunk(children: java.util.Set[Fiber.Runtime[?, ?]]): Chunk[Fiber.Runtime[_, _]] =
+  private[this] def childrenChunk(children: FiberSet): Chunk[Fiber.Runtime[_, _]] =
     // may be executed by a foreign fiber (under Sync), hence we're risking a race over the _children variable being set back to null by a concurrent transferChildren call
     if (children eq null) Chunk.empty
     else {
       val bldr = Chunk.newBuilder[Fiber.Runtime[_, _]]
-      children.forEach { child =>
+      children.foreach { child =>
         if ((child ne null) && child.isAlive())
           bldr.addOne(child)
       }
@@ -178,7 +177,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private[zio] def addChild(child: Fiber.Runtime[_, _]): Unit =
     if (child.isAlive()) {
       if (isAlive()) {
-        getChildren().add(child)
+        val _ = getChildren().add(child)
 
         if (shouldInterrupt())
           child.tellInterrupt(getInterruptedCause())
@@ -197,15 +196,16 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
         while (iter.hasNext) {
           val child = iter.next()
           if (child.isAlive()) {
-            childs.add(child)
+            val _ = childs.add(child)
             child.tellInterrupt(cause)
           }
         }
       } else {
         while (iter.hasNext) {
           val child = iter.next()
-          if (child.isAlive())
-            childs.add(child)
+          if (child.isAlive()) {
+            val _ = childs.add(child)
+          }
         }
       }
     } else {
@@ -568,11 +568,11 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    *
    * '''NOTE''': This method must be invoked by the fiber itself.
    */
-  private def getChildren(): JavaSet[Fiber.Runtime[_, _]] = {
+  private def getChildren(): FiberSet = {
     // executed by the fiber itself, no risk of racing with transferChildren
     var children = _children
     if (children eq null) {
-      children = Platform.newConcurrentWeakSet[Fiber.Runtime[_, _]]()(Unsafe)
+      children = FiberSet()
       _children = children
     }
     children
@@ -738,7 +738,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
    */
   private def interruptAllChildren(): UIO[Any] =
     if (sendInterruptSignalToAllChildren(_children)) {
-      val iterator = _children.iterator()
+      val iterator = _children.iterator
       _children = null
 
       var curr: Fiber.Runtime[_, _] = null
@@ -788,7 +788,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     val children0 = _children
     if ((children0 eq null) || (_exitValue ne null)) false
     else {
-      val it = children0.iterator()
+      val it = children0.iterator
       while (it.hasNext) {
         val child = it.next()
         if ((child ne null) && child.isAlive()) return true
@@ -1019,7 +1019,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private def removeChild(child: FiberRuntime[_, _]): Unit = {
     val children = _children
     if (children ne null) {
-      children.remove(child)
+      val _ = children.remove(child)
       ()
     }
   }
@@ -1358,12 +1358,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   }
 
   private def sendInterruptSignalToAllChildren(
-    children: JavaSet[Fiber.Runtime[_, _]]
+    children: FiberSet
   ): Boolean =
     if ((children eq null) || children.isEmpty) false
     else {
       // Initiate asynchronous interruption of all children:
-      val iterator = children.iterator()
+      val iterator = children.iterator
       var told     = false
       val cause    = Cause.interrupt(fiberId)
 

--- a/core/shared/src/main/scala/zio/internal/FiberScope.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberScope.scala
@@ -63,7 +63,7 @@ private[zio] object FiberScope {
       unsafe: Unsafe
     ): Unit =
       if (RuntimeFlags.fiberRoots(runtimeFlags)) {
-        Fiber._roots.add(child)
+        val _ = Fiber._roots.add(child)
       }
 
     private[zio] def addAll(
@@ -75,8 +75,8 @@ private[zio] object FiberScope {
       unsafe: Unsafe
     ): Unit =
       if (RuntimeFlags.fiberRoots(runtimeFlags)) {
-        children.foreach {
-          Fiber._roots.add(_)
+        children.foreach { child =>
+          val _ = Fiber._roots.add(child)
         }
       }
   }

--- a/core/shared/src/main/scala/zio/internal/FiberSet.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberSet.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio.{Duration, Fiber, FiberId, Unsafe}
+
+import java.lang.ref.{ReferenceQueue, WeakReference}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger}
+import java.util.{Map => JMap}
+import scala.annotation.tailrec
+
+/**
+ * A weak, concurrently updatable collection specialized for ZIO runtime fibers.
+ *
+ * The collection is keyed by `FiberId`, not by the fiber itself, so the backing
+ * map never keeps fibers strongly reachable. Values are weak references backed
+ * by a reference queue, which lets the structure remove collected fibers
+ * without scanning the whole map on every operation.
+ */
+private[zio] final class FiberSet private (initialCapacity: Int) { self =>
+
+  import FiberSet._
+
+  private[this] val fibers: JMap[FiberId, Node] =
+    Platform.newConcurrentMap[FiberId, Node](initialCapacity)(Unsafe)
+  private[this] val queue   = new ReferenceQueue[Fiber.Runtime[_, _]]
+  private[this] val opCount = new AtomicInteger(0)
+  private[this] val autoGc  = new AtomicBoolean(false)
+
+  def add(fiber: Fiber.Runtime[_, _]): Boolean =
+    if ((fiber eq null) || !fiber.isAlive()) false
+    else {
+      drainQueuePeriodically()
+      fibers.put(fiber.id, new Node(fiber.id, fiber, queue)) eq null
+    }
+
+  def remove(fiber: Fiber.Runtime[_, _]): Boolean =
+    if (fiber eq null) false
+    else {
+      drainQueuePeriodically()
+      fibers.remove(fiber.id) ne null
+    }
+
+  def clear(): Unit =
+    fibers.clear()
+
+  def gc(): Unit =
+    drainQueue()
+
+  /**
+   * Schedules periodic cleanup of references that have already been cleared by
+   * the garbage collector.
+   *
+   * This is used by the global root-fiber set so it does not require calls to
+   * `Fiber.roots` to shed cleared entries. On Scala.js this is a no-op.
+   */
+  def withAutoGc(every: Duration): FiberSet = {
+    if (autoGc.compareAndSet(false, true)) {
+      FiberSetGc.start(self, every)
+    }
+    self
+  }
+
+  def isEmpty: Boolean =
+    !iterator.hasNext
+
+  def size: Int = {
+    drainQueue()
+
+    var size = 0
+    val it   = fibers.values().iterator()
+    while (it.hasNext) {
+      val node  = it.next()
+      val fiber = node.get()
+      if ((fiber ne null) && fiber.isAlive()) size += 1
+      else removeNode(node)
+    }
+    size
+  }
+
+  def iterator: Iterator[Fiber.Runtime[_, _]] = {
+    drainQueue()
+
+    new Iterator[Fiber.Runtime[_, _]] {
+      private[this] val it        = fibers.values().iterator()
+      private[this] var nextFiber = findNext()
+
+      @tailrec
+      private def findNext(): Fiber.Runtime[_, _] =
+        if (it.hasNext) {
+          val node  = it.next()
+          val fiber = node.get()
+          if ((fiber ne null) && fiber.isAlive()) fiber
+          else {
+            removeNode(node)
+            findNext()
+          }
+        } else null.asInstanceOf[Fiber.Runtime[_, _]]
+
+      def hasNext: Boolean =
+        nextFiber ne null
+
+      def next(): Fiber.Runtime[_, _] =
+        if (nextFiber eq null) throw new NoSuchElementException("FiberSet iterator is empty")
+        else {
+          val fiber = nextFiber
+          nextFiber = findNext()
+          fiber
+        }
+    }
+  }
+
+  def foreach[U](f: Fiber.Runtime[_, _] => U): Unit =
+    iterator.foreach(f)
+
+  private def drainQueuePeriodically(): Unit =
+    if ((opCount.incrementAndGet() & CleanupMask) == 0) drainQueue()
+
+  private def drainQueue(): Unit = {
+    var node = queue.poll().asInstanceOf[Node]
+    while (node ne null) {
+      removeNode(node)
+      node = queue.poll().asInstanceOf[Node]
+    }
+  }
+
+  private def removeNode(node: Node): Unit = {
+    val _ = fibers.remove(node.fiberId)
+    ()
+  }
+}
+
+private[zio] object FiberSet {
+  private final val DefaultInitialCapacity = 1024
+  private final val CleanupMask            = 63
+
+  def apply(initialCapacity: Int = DefaultInitialCapacity): FiberSet =
+    new FiberSet(initialCapacity)
+
+  private final class Node(
+    val fiberId: FiberId,
+    fiber: Fiber.Runtime[_, _],
+    queue: ReferenceQueue[Fiber.Runtime[_, _]]
+  ) extends WeakReference[Fiber.Runtime[_, _]](fiber, queue)
+}

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,6 +14,7 @@ object MimaSettings {
         exclude[Problem]("zio.stm.ZSTM#internal*"),
         exclude[Problem]("zio.stm.ZSTM$internal*"),
         exclude[Problem]("zio.stream.internal*"),
+        exclude[IncompatibleResultTypeProblem]("zio.Fiber._roots"),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.todo"),
         exclude[DirectMissingMethodProblem]("zio.stm.TRef.versioned_="),
         exclude[IncompatibleResultTypeProblem]("zio.stm.TRef.versioned"),


### PR DESCRIPTION
Fixes #8861

/claim #8861

## Summary

- add an internal `FiberSet` for weakly held runtime-fiber tracking, keyed by `FiberId` so the backing map never keeps fibers strongly reachable
- drain cleared weak references through a `ReferenceQueue`, including periodic background cleanup for the global root-fiber set
- replace `Fiber._roots` and `FiberRuntime` child tracking with `FiberSet` while preserving weakly consistent iteration
- add focused coverage for add/remove, concurrent churn, completed-fiber filtering, manual cleanup, and root-fiber integration
- add JMH coverage comparing `FiberSet` against the synchronized weak-set baseline and the existing `WeakConcurrentBag` add/iterate path

## Notes

This keeps the implementation deliberately small and reviewable: the root set keeps the previous periodic cleanup behavior, child tracking gains explicit removal support, and JS keeps the same single-threaded platform semantics through the existing `Platform` helpers.

## Validation

- `git diff --check`
- `scalafmt --check benchmarks/src/main/scala/zio/internal/FiberSetBenchmark.scala`
- `scalafmt --check project/MimaSettings.scala`
- `sbt "benchmarks / Compile / compile"`
- `sbt "coreTestsJVM/testOnly zio.internal.FiberSetSpec"`
- `sbt mimaChecks`
