### PR TITLE
Add Queue.shutdownCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,44 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause returns buffered values and reuses the winning cause") {
+      val defect = new RuntimeException("queue failed")
+      val cause  = Cause.die(defect)
+      for {
+        queue     <- Queue.bounded[Int](3)
+        _         <- queue.offerAll(List(1, 2, 3))
+        remaining <- queue.shutdownCause(cause)
+        take      <- queue.take.sandbox.either
+        second    <- queue.shutdownCause(Cause.interrupt(FiberId.None)).sandbox.either
+      } yield assert(remaining)(equalTo(Chunk(1, 2, 3))) &&
+        assert(take)(isLeft(equalTo(cause))) &&
+        assert(second)(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause fails pending takers with the supplied cause") {
+      val defect = new RuntimeException("take failed")
+      val cause  = Cause.die(defect)
+      for {
+        queue     <- Queue.bounded[Int](1)
+        fiber     <- queue.take.fork
+        _         <- waitForSize(queue, -1)
+        remaining <- queue.shutdownCause(cause)
+        result    <- fiber.join.sandbox.either
+      } yield assert(remaining)(isEmpty) &&
+        assert(result)(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause fails back-pressured offerers with the supplied cause") {
+      val defect = new RuntimeException("offer failed")
+      val cause  = Cause.die(defect)
+      for {
+        queue  <- Queue.bounded[Int](1)
+        _      <- queue.offer(1)
+        fiber  <- queue.offer(2).fork
+        _      <- waitForSize(queue, 2)
+        rem    <- queue.shutdownCause(cause)
+        result <- fiber.join.sandbox.either
+      } yield assert(rem)(equalTo(Chunk(1))) &&
+        assert(result)(isLeft(equalTo(cause)))
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -146,14 +146,7 @@ object Queue extends QueuePlatformSpecific {
     fiberId: FiberId
   )(implicit unsafe: Unsafe): Queue[A] = {
     val p = Promise.unsafe.make[Nothing, Unit](fiberId)
-    unsafeCreate(
-      queue,
-      new ConcurrentDeque[Promise[Nothing, A]],
-      p,
-      new AtomicBoolean(false),
-      new AtomicReference[Cause[Nothing]](null),
-      strategy
-    )
+    unsafeCreate(queue, new ConcurrentDeque[Promise[Nothing, A]], p, new AtomicBoolean(false), strategy)
   }
 
   private def unsafeCreate[A](
@@ -161,18 +154,18 @@ object Queue extends QueuePlatformSpecific {
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
-    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, shutdownCauseRef, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
-    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
   ) extends Queue[A] {
+    private[this] val shutdownCauseRef = new AtomicReference[Cause[Nothing]](null)
+    strategy.setShutdownCause(() => shutdownCause)
 
     override def capacity: Int = queue.capacity
 
@@ -187,7 +180,7 @@ object Queue extends QueuePlatformSpecific {
         if (shutdownFlag.get) failWithShutdownCause
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag, () => shutdownCause)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
         }
       }
 
@@ -227,7 +220,7 @@ object Queue extends QueuePlatformSpecific {
               strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag, () => shutdownCause).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -349,14 +342,20 @@ object Queue extends QueuePlatformSpecific {
   }
 
   private sealed abstract class Strategy[A] {
-    private[this] val draining = new AtomicBoolean(false)
+    private[this] val draining                                         = new AtomicBoolean(false)
+    @volatile private[this] var getShutdownCause: () => Cause[Nothing] = () => Cause.interrupt(FiberId.None)
+
+    final def setShutdownCause(shutdownCause: () => Cause[Nothing]): Unit =
+      getShutdownCause = shutdownCause
+
+    protected final def shutdownCause: Cause[Nothing] =
+      getShutdownCause()
 
     def handleSurplus(
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      isShutdown: AtomicBoolean,
-      shutdownCause: () => Cause[Nothing]
+      isShutdown: AtomicBoolean
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
@@ -428,8 +427,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean,
-        shutdownCause: () => Cause[Nothing]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
@@ -438,7 +436,7 @@ object Queue extends QueuePlatformSpecific {
             unsafeOffer(as, p)
             unsafeOnQueueEmptySpace(queue, takers)
             unsafeCompleteTakers(queue, takers)
-            val await = if (isShutdown.get) ZIO.failCause(shutdownCause()) else p.await
+            val await = if (isShutdown.get) ZIO.failCause(shutdownCause) else p.await
             await.ensuring(ZIO.succeed(unsafeRemove(p)))
           }
         }
@@ -509,8 +507,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean,
-        shutdownCause: () => Cause[Nothing]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
@@ -528,8 +525,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean,
-        shutdownCause: () => Cause[Nothing]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -29,6 +29,14 @@ import scala.annotation.tailrec
 sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
+   * Shuts down the queue with the specified cause and returns the values that
+   * were buffered in the queue at the moment this fiber won the shutdown race.
+   * Any fibers suspended on `offer` or `take`, as well as future queue
+   * interactions, will fail with the winning cause.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]]
+
+  /**
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
@@ -143,6 +151,7 @@ object Queue extends QueuePlatformSpecific {
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
       new AtomicBoolean(false),
+      new AtomicReference[Cause[Nothing]](null),
       strategy
     )
   }
@@ -152,25 +161,33 @@ object Queue extends QueuePlatformSpecific {
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, shutdownCauseRef, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
     shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
   ) extends Queue[A] {
 
     override def capacity: Int = queue.capacity
 
+    private def shutdownCause: Cause[Nothing] =
+      Option(shutdownCauseRef.get()).getOrElse(Cause.interrupt(FiberId.None))
+
+    private def failWithShutdownCause[B](implicit trace: Trace): UIO[B] =
+      ZIO.failCause(shutdownCause)
+
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownFlag.get) failWithShutdownCause
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag, () => shutdownCause)
         }
       }
 
@@ -193,7 +210,7 @@ object Queue extends QueuePlatformSpecific {
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownFlag.get) failWithShutdownCause
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -210,7 +227,7 @@ object Queue extends QueuePlatformSpecific {
               strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownFlag, () => shutdownCause).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -222,23 +239,32 @@ object Queue extends QueuePlatformSpecific {
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
-          ZIO.interrupt
+          failWithShutdownCause
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
+        shutdownCause(Cause.interrupt(fiberId)).catchAllCause(_ => Exit.unit).unit
+      }.uninterruptible
+
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      ZIO.suspendSucceed {
         if (shutdownFlag.compareAndSet(false, true)) {
           implicit val unsafe: Unsafe = Unsafe
+          shutdownCauseRef.set(cause)
           shutdownHook.unsafe.succeedUnit
-          val it = unsafePollAll(takers).iterator
+
+          val remaining = unsafePollAll(queue)
+          val it        = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.done(Exit.failCause(cause))
           }
-          strategy.shutdown(fiberId)
-        }
-        Exit.unit
+          strategy.shutdown(cause)
+
+          Exit.succeed(remaining)
+        } else ZIO.failCause(shutdownCause)
       }.uninterruptible
 
     override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
@@ -246,7 +272,7 @@ object Queue extends QueuePlatformSpecific {
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          if (shutdownFlag.get) failWithShutdownCause
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -280,7 +306,7 @@ object Queue extends QueuePlatformSpecific {
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
-          ZIO.interrupt
+          failWithShutdownCause
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
@@ -295,7 +321,7 @@ object Queue extends QueuePlatformSpecific {
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
-          ZIO.interrupt
+          failWithShutdownCause
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
@@ -310,7 +336,7 @@ object Queue extends QueuePlatformSpecific {
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
         if (shutdownFlag.get)
-          ZIO.interrupt
+          failWithShutdownCause
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
@@ -329,7 +355,8 @@ object Queue extends QueuePlatformSpecific {
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      isShutdown: AtomicBoolean
+      isShutdown: AtomicBoolean,
+      shutdownCause: () => Cause[Nothing]
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
@@ -339,7 +366,7 @@ object Queue extends QueuePlatformSpecific {
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -401,7 +428,8 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        isShutdown: AtomicBoolean,
+        shutdownCause: () => Cause[Nothing]
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
@@ -410,8 +438,9 @@ object Queue extends QueuePlatformSpecific {
             unsafeOffer(as, p)
             unsafeOnQueueEmptySpace(queue, takers)
             unsafeCompleteTakers(queue, takers)
-            if (isShutdown.get) ZIO.interrupt else p.await
-          }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
+            val await = if (isShutdown.get) ZIO.failCause(shutdownCause()) else p.await
+            await.ensuring(ZIO.succeed(unsafeRemove(p)))
+          }
         }
 
       private def unsafeOffer(as: Iterable[A], p: Promise[Nothing, Boolean]): Unit = {
@@ -464,11 +493,11 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = {
         var next = putters.poll()
         while (next ne null) {
           val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          if (isLast) promise.unsafe.done(Exit.failCause(cause))
           next = putters.poll()
         }
       }
@@ -480,7 +509,8 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        isShutdown: AtomicBoolean,
+        shutdownCause: () => Cause[Nothing]
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
@@ -490,7 +520,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -498,7 +528,8 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        isShutdown: AtomicBoolean,
+        shutdownCause: () => Cause[Nothing]
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {
@@ -531,7 +562,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -37,6 +37,7 @@ object MimaSettings {
         exclude[NewMixinForwarderProblem]("zio.Exit.unit"),
         exclude[Problem]("zio.Promise#internal*"),
         exclude[Problem]("zio.Promise$internal*"),
+        exclude[ReversedMissingMethodProblem]("zio.Queue.shutdownCause"),
         exclude[Problem]("zio.Queue#Strategy*.shutdown"),
         exclude[Problem]("zio.ZLayer$MemoMap*"),
         exclude[DirectMissingMethodProblem]("zio.ZLayer#MemoMap*"),

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -847,6 +847,9 @@ object ZSinkSpec extends ZIOBaseSpec {
 
             override def shutdown(implicit trace: Trace): UIO[Unit] = ZIO.succeed(this.isShutDown = true)
 
+            override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+              ZIO.succeed(this.isShutDown = true) *> q.takeAll
+
             override def size(implicit trace: Trace): UIO[Int] = q.size
 
             override def take(implicit trace: Trace): ZIO[Any, Nothing, A] = q.take


### PR DESCRIPTION
/claim #9844

## Summary
- add Queue.shutdownCause(Cause[Nothing]) as a compatibility-preserving shutdown path
- return buffered queue values to the winning shutdown caller
- fail pending takers, back-pressured offerers, and future queue interactions with the stored winning cause
- keep existing shutdown idempotent by delegating to shutdownCause(Cause.interrupt(fiberId)) and ignoring already-shutdown causes

## Testing
- sbt "coreTestsJVM/testOnly zio.QueueSpec -- -t shutdownCause"
- sbt "coreTestsJVM/testOnly zio.QueueSpec"
- sbt "coreJVM/scalafmt" "coreTestsJVM/scalafmt"
- git diff --check

Note: I also tried sbt "coreJVM/mimaReportBinaryIssues", but this checkout reports mimaPreviousArtifacts not set.
