### PR TITLE
Reduce redundant ZScheduler unparks

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -398,7 +398,9 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             if (searching) {
               searching = false
               val currentState = state.decrementAndGet()
-              maybeUnparkWorker(currentState)
+              if (!localQueue.isEmpty() || !globalQueue.isEmpty()) {
+                maybeUnparkWorker(currentState)
+              }
             }
             currentRunnable = runnable
             runnable.run()


### PR DESCRIPTION
/claim #9878

## Summary

This reduces one redundant `LockSupport.unpark` path in `ZScheduler`: when a worker leaves search mode because it found work, it now replenishes another searcher only if follow-on work is already visible in its local queue or the global queue.

## Why

The unconditional wake-up at the `searching -> running` transition can wake an idle worker even when the current worker has already consumed the only visible runnable. That newly woken worker then searches, finds no work, and parks again, which is the park/unpark churn described in #9878.

This keeps the submit paths unchanged, so externally enqueued work still wakes a worker immediately. If a submit races this visibility check, either the work is already visible and we wake a searcher, or the submitter observes the decremented searcher count and performs the wake-up from the existing submit path.

## Notes

This intentionally avoids new scheduler state, timers, batching, or spin-waiting. It revives the small caller-side gate approach from the abandoned #10773, keeping the fix focused on the asymmetric call site.

## Validation

- `git diff --check`
- Could not run the JVM benchmark/test suite locally because this environment has no usable Java runtime or `sbt` on PATH.
