### PR TITLE
Fix assertTrue flatMap compilation on Scala 2

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -401,6 +401,11 @@ object SmartAssertionSpec extends ZIOBaseSpec {
       test("Chunk and Seq diff") {
         assertTrue(Chunk(1, 2, 3) == Seq(1, 2, 3))
       },
+      test("assertTrue compiles when returned from flatMap in Scala 2") {
+        for {
+          result <- typeCheck("""ZIO.succeed(1).flatMap(value => assertTrue(value == 1))""")
+        } yield assertTrue(result.isRight)
+      } @@ scala2Only,
       test("Set diffs") {
         val l1 = Set(1, 2, 3, 4)
         val l2 = Set(1, 2, 8, 4, 5)

--- a/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
+++ b/test/shared/src/main/scala-2/zio/test/CompileVariants.scala
@@ -20,6 +20,8 @@ import zio.internal.stacktracer.SourceLocation
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 import zio.{Trace, UIO, ZIO}
 
+import scala.language.implicitConversions
+
 trait CompileVariants {
 
   /**
@@ -36,6 +38,9 @@ trait CompileVariants {
    */
   def assertTrue(expr: Boolean, exprs: Boolean*): TestResult = macro SmartAssertMacros.assert_impl
   def assertTrue(expr: Boolean): TestResult = macro SmartAssertMacros.assertOne_impl
+
+  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    TestResult.liftTestResultToZIO(result)
 
   /**
    * Checks the assertion holds for the given value.

--- a/test/shared/src/main/scala-2/zio/test/TestResultVersionSpecific.scala
+++ b/test/shared/src/main/scala-2/zio/test/TestResultVersionSpecific.scala
@@ -1,0 +1,3 @@
+package zio.test
+
+trait TestResultVersionSpecific

--- a/test/shared/src/main/scala-3/zio/test/TestResultVersionSpecific.scala
+++ b/test/shared/src/main/scala-3/zio/test/TestResultVersionSpecific.scala
@@ -1,0 +1,10 @@
+package zio.test
+
+import zio.{Trace, ZIO}
+
+import scala.language.implicitConversions
+
+trait TestResultVersionSpecific {
+  implicit def liftTestResultToZIOImplicit[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+    TestResult.liftTestResultToZIO(result)
+}

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -44,7 +44,7 @@ case class TestResult(arrow: TestArrow[Any, Boolean]) { self =>
     TestResult(arrow.setGenFailureDetails(details))
 }
 
-object TestResult {
+object TestResult extends TestResultVersionSpecific {
   def allSuccesses(assert: TestResult, asserts: TestResult*): TestResult = asserts.foldLeft(assert)(_ && _)
 
   def allSuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
@@ -55,7 +55,7 @@ object TestResult {
   def anySuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     anySuccesses(!assertCompletes, asserts.toSeq: _*)
 
-  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+  def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
     if (result.isSuccess)
       ZIO.succeed(result)
     else


### PR DESCRIPTION
Fixes #8668

/claim #8668

## Summary

- expose the existing `TestResult` to `ZIO` lift through the Scala 2 `CompileVariants` scope
- add a Scala 2 regression test for `ZIO.succeed(...).flatMap(value => assertTrue(...))`
- keep Scala 3 behavior unchanged

## Testing

- `java -Dsbt.global.base=/private/tmp/zio-8668-sbt-global -Dsbt.boot.directory=/private/tmp/zio-8668-sbt-boot -Dsbt.ivy.home=/private/tmp/zio-8668-ivy -Dsbt.coursier.home=/private/tmp/zio-8668-coursier -jar /private/tmp/sbt-launch-1.12.11.jar '++2.13.18 testTestsJVM/testOnly zio.test.SmartAssertionSpec'`
- `java -Dsbt.global.base=/private/tmp/zio-8668-sbt-global -Dsbt.boot.directory=/private/tmp/zio-8668-sbt-boot -Dsbt.ivy.home=/private/tmp/zio-8668-ivy -Dsbt.coursier.home=/private/tmp/zio-8668-coursier -jar /private/tmp/sbt-launch-1.12.11.jar '++2.12.21 testTestsJVM/testOnly zio.test.SmartAssertionSpec'`
- `java -Dsbt.global.base=/private/tmp/zio-8668-sbt-global -Dsbt.boot.directory=/private/tmp/zio-8668-sbt-boot -Dsbt.ivy.home=/private/tmp/zio-8668-ivy -Dsbt.coursier.home=/private/tmp/zio-8668-coursier -jar /private/tmp/sbt-launch-1.12.11.jar '++3.3.7 testTestsJVM/testOnly zio.test.SmartAssertionSpec'`
- After the first CI run exposed an ambiguity in broader core tests, amended and verified:
  - `java -Dsbt.global.base=/private/tmp/zio-8668-sbt-global -Dsbt.boot.directory=/private/tmp/zio-8668-sbt-boot -Dsbt.ivy.home=/private/tmp/zio-8668-ivy -Dsbt.coursier.home=/private/tmp/zio-8668-coursier -jar /private/tmp/sbt-launch-1.12.11.jar '++2.13.18 coreTestsJVM/Test/compile'`
  - `java -Dsbt.global.base=/private/tmp/zio-8668-sbt-global -Dsbt.boot.directory=/private/tmp/zio-8668-sbt-boot -Dsbt.ivy.home=/private/tmp/zio-8668-ivy -Dsbt.coursier.home=/private/tmp/zio-8668-coursier -jar /private/tmp/sbt-launch-1.12.11.jar '++2.12.21 coreTestsJVM/Test/compile'`
