### PR TITLE
Fix ZStream buffer backpressure

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,31 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("back pressures upstream after capacity is reached") {
+            for {
+              downstreamStarted <- Promise.make[Nothing, Unit]
+              releaseDownstream <- Promise.make[Nothing, Unit]
+              secondCompleted   <- Promise.make[Nothing, Unit]
+              thirdStarted      <- Promise.make[Nothing, Unit]
+              stream = ZStream
+                         .fromIterable(1 to 3, 1)
+                         .mapZIO { n =>
+                           thirdStarted.succeed(()).when(n == 3) *>
+                             secondCompleted.succeed(()).when(n == 2).as(n)
+                         }
+                         .buffer(1)
+              fiber <- stream.runForeach { n =>
+                         if (n == 1) downstreamStarted.succeed(()) *> releaseDownstream.await
+                         else ZIO.unit
+                       }.fork
+              _            <- downstreamStarted.await
+              _            <- secondCompleted.await
+              _            <- ZIO.yieldNow.repeatN(10)
+              thirdStarted <- thirdStarted.poll
+              _            <- releaseDownstream.succeed(())
+              _            <- fiber.join
+            } yield assert(thirdStarted)(isNone)
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,10 +391,34 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def producer(
+      permits: TSemaphore,
+      queue: Queue[Exit[Option[E], A]]
+    ): ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] = {
+      def offer(chunk: Chunk[A], index: Int): UIO[Unit] =
+        if (index < chunk.length)
+          permits.acquire.commit *> queue.offer(Exit.succeed(chunk(index))) *> offer(chunk, index + 1)
+        else ZIO.unit
+
+      ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+        in => ZChannel.fromZIO(offer(in, 0)) *> producer(permits, queue),
+        err => ZChannel.fromZIO(queue.offer(Exit.failCause(err.map(Some(_))))),
+        _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
+      )
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          capacity0 <- ZIO.succeed {
+                         val capacity0 = capacity
+                         require(capacity0 > 0)
+                         capacity0
+                       }
+          permits <- TSemaphore.makeCommit(capacity0.toLong)
+          queue   <- ZIO.acquireRelease(Queue.unbounded[Exit[Option[E], A]])(_.shutdown)
+          _       <- (self.channel >>> producer(permits, queue)).drain.runScoped.forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
               queue.take
@@ -403,7 +427,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.write(Chunk.single(value)) *> ZChannel.fromZIO(permits.release.commit) *> process
               )
             }
 


### PR DESCRIPTION
Fixes #9810.

`ZStream#buffer` previously used a bounded element queue as the only backpressure signal. Once the downstream fiber took the buffered element, upstream could enqueue and start evaluating one more element even though the downstream was still processing the first value, so `buffer(1)` effectively let two elements get ahead.

This changes `buffer` to keep an explicit permit per buffered/downstream-in-flight element. The producer acquires a permit before offering each element, and the consumer releases it only after the element is written downstream.

Verification:
- `streamsTestsJVM/testOnly *ZStreamSpec -- -t "back pressures upstream after capacity is reached"`
- `streamsTestsJVM/testOnly *ZStreamSpec -- -t "buffer"`
- `streamsJVM/Compile/scalafmtCheck;streamsTestsJVM/Test/scalafmtCheck;streamsTestsJVM/Test/compile`
- `git diff --check`

/claim #9810
