### PR TITLE
Fix ZStream buffer backpressure

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,31 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("backpressures upstream once buffer capacity is full") {
+            for {
+              downstreamStarted <- Promise.make[Nothing, Unit]
+              releaseDownstream <- Promise.make[Nothing, Unit]
+              secondComplete    <- Promise.make[Nothing, Unit]
+              thirdStarted      <- Promise.make[Nothing, Unit]
+              stream = ZStream
+                         .fromIterable(1 to 3, 1)
+                         .mapZIO { n =>
+                           thirdStarted.succeed(()).when(n == 3) *>
+                             secondComplete.succeed(()).when(n == 2).as(n)
+                         }
+                         .buffer(1)
+              fiber <- stream.runForeach { n =>
+                         if (n == 1) downstreamStarted.succeed(()) *> releaseDownstream.await
+                         else ZIO.unit
+                       }.fork
+              _            <- downstreamStarted.await
+              _            <- secondComplete.await
+              _            <- ZIO.yieldNow.repeatN(10)
+              thirdStarted <- thirdStarted.poll
+              _            <- releaseDownstream.succeed(())
+              _            <- fiber.join
+            } yield assert(thirdStarted)(isNone)
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,10 +391,31 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def producer(
+      permits: TSemaphore,
+      queue: Queue[Exit[Option[E], A]]
+    ): ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+      ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+        in =>
+          ZChannel.fromZIO {
+            ZIO.foreachDiscard(in)(value => permits.acquire.commit *> queue.offer(Exit.succeed(value)))
+          } *> producer(permits, queue),
+        cause => ZChannel.fromZIO(queue.offer(Exit.failCause(cause.map(Some(_))))),
+        _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
+      )
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          requestedCapacity <- ZIO.succeed {
+                                 val requestedCapacity = capacity
+                                 require(requestedCapacity > 0)
+                                 requestedCapacity
+                               }
+          permits <- TSemaphore.makeCommit(requestedCapacity.toLong)
+          queue   <- ZIO.acquireRelease(Queue.unbounded[Exit[Option[E], A]])(_.shutdown)
+          _       <- (self.channel >>> producer(permits, queue)).runScoped.forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
               queue.take
@@ -403,7 +424,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.write(Chunk.single(value)) *> ZChannel.fromZIO(permits.release.commit) *> process
               )
             }
 


### PR DESCRIPTION
Fixes #9810.

## Summary
- Gate `ZStream#buffer` with permits so upstream cannot evaluate another element once the configured buffer capacity is occupied.
- Release permits after values are handed downstream, preserving existing producer progress while a consumer is active.
- Add a regression that keeps the downstream consumer blocked after the first element and verifies the third upstream effect does not start while the second element is buffered.

## Testing
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "buffer"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec`
- `scalafmtCheckAll`
- `streamsJS/Test/compile`
- `streamsNative/Test/compile`
- `git diff --check`