### PR TITLE
Add Queue shutdownCause support

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,53 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause fails pending takers with the winning cause") {
+      val boom = new RuntimeException("boom")
+      for {
+        queue <- Queue.bounded[Int](3)
+        fiber <- queue.take.fork
+        _     <- waitForSize(queue, -1)
+        items <- queue.shutdownCause(Cause.die(boom))
+        exit  <- fiber.await
+      } yield assert(items)(isEmpty) &&
+        assert(exit)(dies(equalTo(boom)))
+    },
+    test("shutdownCause returns buffered and back-pressured items in order") {
+      val boom = new RuntimeException("boom")
+      for {
+        queue <- Queue.bounded[Int](2)
+        _     <- queue.offerAll(List(1, 2))
+        fiber <- queue.offerAll(List(3, 4, 5)).fork
+        _     <- waitForSize(queue, 5)
+        items <- queue.shutdownCause(Cause.die(boom))
+        exit  <- fiber.await
+      } yield assert(items)(equalTo(Chunk(1, 2, 3, 4, 5))) &&
+        assert(exit)(dies(equalTo(boom)))
+    },
+    test("shutdownCause fails future operations with the winning cause") {
+      val boom = new RuntimeException("boom")
+      for {
+        queue    <- Queue.bounded[Int](2)
+        _        <- queue.offer(1)
+        buffered <- queue.shutdownCause(Cause.die(boom))
+        offer    <- queue.offer(2).exit
+        take     <- queue.take.exit
+        size     <- queue.size.exit
+      } yield assert(buffered)(equalTo(Chunk(1))) &&
+        assert(offer)(dies(equalTo(boom))) &&
+        assert(take)(dies(equalTo(boom))) &&
+        assert(size)(dies(equalTo(boom)))
+    },
+    test("shutdownCause is won by the first caller") {
+      val first  = new RuntimeException("first")
+      val second = new RuntimeException("second")
+      for {
+        queue <- Queue.bounded[Int](1)
+        win   <- queue.shutdownCause(Cause.die(first)).exit
+        lose  <- queue.shutdownCause(Cause.die(second)).exit
+      } yield assert(win)(succeeds(equalTo(Chunk.empty))) &&
+        assert(lose)(dies(equalTo(first)))
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -29,6 +29,13 @@ import scala.annotation.tailrec
 sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
+   * Shuts down the queue with the specified cause. Pending and future
+   * operations will fail with the winning cause and the winning caller
+   * receives the values that were still buffered in the queue.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]]
+
+  /**
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
@@ -142,7 +149,7 @@ object Queue extends QueuePlatformSpecific {
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
-      new AtomicBoolean(false),
+      new AtomicReference[Cause[Nothing]](null),
       strategy
     )
   }
@@ -151,26 +158,30 @@ object Queue extends QueuePlatformSpecific {
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownCauseRef, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownFlag: AtomicBoolean,
+    shutdownCauseRef: AtomicReference[Cause[Nothing]],
     strategy: Strategy[A]
   ) extends Queue[A] {
+
+    private def shutdownCauseOrNull: Cause[Nothing] =
+      shutdownCauseRef.get()
 
     override def capacity: Int = queue.capacity
 
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null) ZIO.refailCause(cause)
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownCauseRef)
         }
       }
 
@@ -186,14 +197,15 @@ object Queue extends QueuePlatformSpecific {
 
       if (noRemaining) true
       else if (queue.offer(a)) {
-        strategy.unsafeCompleteTakers(queue, takers)
+        strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
         true
       } else false
     }
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null) ZIO.refailCause(cause)
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -207,10 +219,10 @@ object Queue extends QueuePlatformSpecific {
             val surplus = unsafeOfferAll(queue, remaining)
 
             if (surplus.isEmpty) {
-              strategy.unsafeCompleteTakers(queue, takers)
+              strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownCauseRef).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -221,32 +233,48 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null)
+          ZIO.refailCause(cause)
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
-        if (shutdownFlag.compareAndSet(false, true)) {
-          implicit val unsafe: Unsafe = Unsafe
-          shutdownHook.unsafe.succeedUnit
-          val it = unsafePollAll(takers).iterator
-          while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
-          }
-          strategy.shutdown(fiberId)
-        }
-        Exit.unit
+        shutdownCause(Cause.interrupt(fiberId)).unit
       }.uninterruptible
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      ZIO.suspendSucceed {
+        val existing = shutdownCauseOrNull
+        if (existing ne null) {
+          ZIO.refailCause(existing)
+        } else if (shutdownCauseRef.compareAndSet(null, cause)) {
+          implicit val unsafe: Unsafe = Unsafe
+          shutdownHook.unsafe.succeedUnit
+
+          val takerIterator = unsafePollAll(takers).iterator
+          while (takerIterator.hasNext) {
+            takerIterator.next().unsafe.refailCause(cause)
+          }
+
+          val surplus  = strategy.shutdown(cause)
+          val buffered = unsafePollAll(queue)
+
+          Exit.succeed(buffered ++ surplus)
+        } else {
+          ZIO.refailCause(shutdownCauseOrNull)
+        }
+      }.uninterruptible
+
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownCauseOrNull ne null)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          val cause = shutdownCauseOrNull
+          if (cause ne null) ZIO.refailCause(cause)
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -257,7 +285,7 @@ object Queue extends QueuePlatformSpecific {
                 val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe)
 
                 takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers)
+                strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
                 restore(p.await).catchAllCause { c =>
                   val removed = p.unsafe.completeWith(interruptAsNone)(Unsafe)
                   takers.remove(p)
@@ -270,7 +298,7 @@ object Queue extends QueuePlatformSpecific {
                   }
                 }
               case item =>
-                strategy.unsafeOnQueueEmptySpace(queue, takers)
+                strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
                 Exit.succeed(item)
             }
           }
@@ -279,12 +307,13 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null)
+          ZIO.refailCause(cause)
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers)
+            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -294,12 +323,13 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null)
+          ZIO.refailCause(cause)
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers)
+            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -309,13 +339,14 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        val cause = shutdownCauseOrNull
+        if (cause ne null)
+          ZIO.refailCause(cause)
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
             case v =>
-              strategy.unsafeOnQueueEmptySpace(queue, takers)
+              strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
               Exit.succeed(Some(v))
           }
         }
@@ -329,24 +360,26 @@ object Queue extends QueuePlatformSpecific {
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      isShutdown: AtomicBoolean
+      shutdownCause: AtomicReference[Cause[Nothing]]
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
       queue: MutableConcurrentQueue[A],
-      takers: ConcurrentDeque[Promise[Nothing, A]]
+      takers: ConcurrentDeque[Promise[Nothing, A]],
+      shutdownCause: AtomicReference[Cause[Nothing]]
     ): Unit
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A]
 
     @tailrec
     final def unsafeCompleteTakers(
       queue: MutableConcurrentQueue[A],
-      takers: ConcurrentDeque[Promise[Nothing, A]]
+      takers: ConcurrentDeque[Promise[Nothing, A]],
+      shutdownCause: AtomicReference[Cause[Nothing]]
     ): Unit =
-      if (!takers.isEmpty && draining.compareAndSet(false, true)) {
+      if ((shutdownCause.get eq null) && !takers.isEmpty && draining.compareAndSet(false, true)) {
         try {
           var keepPolling      = !queue.isEmpty()
           val empty            = null.asInstanceOf[A]
@@ -373,14 +406,14 @@ object Queue extends QueuePlatformSpecific {
               }
             }
           }
-          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers)
+          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
         } finally {
           draining.set(false)
         }
 
         // We need to check in case someone added a putter or pulled from the queue since our last check
         // while we were still holding the lock
-        if (!queue.isEmpty()) unsafeCompleteTakers(queue, takers)
+        if ((shutdownCause.get eq null) && !queue.isEmpty()) unsafeCompleteTakers(queue, takers, shutdownCause)
       }
   }
 
@@ -401,16 +434,17 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCause: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
 
           ZIO.suspendSucceed {
             unsafeOffer(as, p)
-            unsafeOnQueueEmptySpace(queue, takers)
-            unsafeCompleteTakers(queue, takers)
-            if (isShutdown.get) ZIO.interrupt else p.await
+            unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
+            unsafeCompleteTakers(queue, takers, shutdownCause)
+            val cause = shutdownCause.get
+            if (cause eq null) p.await else ZIO.refailCause(cause)
           }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
         }
 
@@ -427,18 +461,22 @@ object Queue extends QueuePlatformSpecific {
       @tailrec
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]]
+        takers: ConcurrentDeque[Promise[Nothing, A]],
+        shutdownCause: AtomicReference[Cause[Nothing]]
       ): Unit = {
         val putters0 = putters
-        if (!putters0.isEmpty && notifying.compareAndSet(false, true)) {
+        if ((shutdownCause.get eq null) && !putters0.isEmpty && notifying.compareAndSet(false, true)) {
           var keepPolling = !queue.isFull()
 
           try {
-            while (keepPolling) {
+            while (keepPolling && (shutdownCause.get eq null)) {
               val putter = putters0.poll()
               if (putter eq null) {
                 keepPolling = false
-                unsafeCompleteTakers(queue, takers)
+                unsafeCompleteTakers(queue, takers, shutdownCause)
+              } else if (shutdownCause.get ne null) {
+                putters0.addFirst(putter)
+                keepPolling = false
               } else {
                 val offered = queue.offer(putter._1)
                 if (offered && putter._3)
@@ -447,7 +485,7 @@ object Queue extends QueuePlatformSpecific {
                   putters0.addFirst(putter)
                 }
                 if (!offered || queue.isFull()) {
-                  unsafeCompleteTakers(queue, takers)
+                  unsafeCompleteTakers(queue, takers, shutdownCause)
                   keepPolling = !queue.isFull()
                 }
               }
@@ -458,19 +496,22 @@ object Queue extends QueuePlatformSpecific {
 
           // We need to check in case someone added a putter or pulled from the queue since our last check
           // while we were still holding the lock
-          if (!queue.isFull()) unsafeOnQueueEmptySpace(queue, takers)
+          if ((shutdownCause.get eq null) && !queue.isFull()) unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
         }
       }
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = {
+        val items = ChunkBuilder.make[A](putters.size())
         var next = putters.poll()
         while (next ne null) {
-          val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          val (value, promise, isLast) = next
+          items.addOne(value)
+          if (isLast) promise.unsafe.refailCause(cause)
           next = putters.poll()
         }
+        items.result()
       }
     }
 
@@ -480,17 +521,18 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCause: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]]
+        takers: ConcurrentDeque[Promise[Nothing, A]],
+        shutdownCause: AtomicReference[Cause[Nothing]]
       ): Unit = ()
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = Chunk.empty
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -498,7 +540,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        isShutdown: AtomicBoolean
+        shutdownCause: AtomicReference[Cause[Nothing]]
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {
@@ -519,19 +561,20 @@ object Queue extends QueuePlatformSpecific {
 
         ZIO.succeed {
           unsafeSlidingOffer(as)
-          unsafeCompleteTakers(queue, takers)
+          unsafeCompleteTakers(queue, takers, shutdownCause)
           true
         }
       }
 
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]]
+        takers: ConcurrentDeque[Promise[Nothing, A]],
+        shutdownCause: AtomicReference[Cause[Nothing]]
       ): Unit = ()
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = Chunk.empty
     }
   }
 

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -30,8 +30,8 @@ sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal
 
   /**
    * Shuts down the queue with the specified cause. Pending and future
-   * operations will fail with the winning cause and the winning caller
-   * receives the values that were still buffered in the queue.
+   * operations will fail with the winning cause and the winning caller receives
+   * the values that were still buffered in the queue.
    */
   def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]]
 
@@ -49,6 +49,7 @@ sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal
 }
 
 object Queue extends QueuePlatformSpecific {
+  private val DefaultShutdown = new AnyRef
   private val interruptAsNone = ZIO.interruptAs(FiberId.None)(Trace.empty)
 
   private[zio] abstract class Internal[A] extends Queue[A]
@@ -149,7 +150,7 @@ object Queue extends QueuePlatformSpecific {
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
-      new AtomicReference[Cause[Nothing]](null),
+      new AtomicReference[AnyRef](null),
       strategy
     )
   }
@@ -158,30 +159,40 @@ object Queue extends QueuePlatformSpecific {
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownCauseRef: AtomicReference[Cause[Nothing]],
+    shutdownState: AtomicReference[AnyRef],
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownCauseRef, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownState, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownCauseRef: AtomicReference[Cause[Nothing]],
+    shutdownState: AtomicReference[AnyRef],
     strategy: Strategy[A]
   ) extends Queue[A] {
 
+    private def shutdownEffect(state: AnyRef)(implicit trace: Trace): UIO[Nothing] =
+      if (state eq DefaultShutdown) ZIO.interrupt
+      else ZIO.refailCause(state.asInstanceOf[Cause[Nothing]])
+
     private def shutdownCauseOrNull: Cause[Nothing] =
-      shutdownCauseRef.get()
+      shutdownState.get() match {
+        case null | DefaultShutdown => null
+        case cause                  => cause.asInstanceOf[Cause[Nothing]]
+      }
+
+    private def shutdownStateOrNull: AnyRef =
+      shutdownState.get()
 
     override def capacity: Int = queue.capacity
 
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null) ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null) shutdownEffect(state)
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownCauseRef)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownState)
         }
       }
 
@@ -197,15 +208,15 @@ object Queue extends QueuePlatformSpecific {
 
       if (noRemaining) true
       else if (queue.offer(a)) {
-        strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
+        strategy.unsafeCompleteTakers(queue, takers, shutdownState)
         true
       } else false
     }
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null) ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null) shutdownEffect(state)
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -219,10 +230,10 @@ object Queue extends QueuePlatformSpecific {
             val surplus = unsafeOfferAll(queue, remaining)
 
             if (surplus.isEmpty) {
-              strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
+              strategy.unsafeCompleteTakers(queue, takers, shutdownState)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownCauseRef).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownState).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -233,24 +244,39 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null)
-          ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null)
+          shutdownEffect(state)
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
-        shutdownCause(Cause.interrupt(fiberId)).unit
+        if (shutdownState.compareAndSet(null, DefaultShutdown)) {
+          implicit val unsafe: Unsafe = Unsafe
+          shutdownHook.unsafe.succeedUnit
+
+          val takerIterator = unsafePollAll(takers).iterator
+          while (takerIterator.hasNext) {
+            takerIterator.next().unsafe.interruptAs(fiberId)
+          }
+
+          strategy.shutdown(Cause.interrupt(fiberId))
+          Exit.unit
+        } else {
+          val state = shutdownStateOrNull
+          if (state eq DefaultShutdown) Exit.unit
+          else shutdownEffect(state)
+        }
       }.uninterruptible
 
     override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        val existing = shutdownCauseOrNull
+        val existing = shutdownStateOrNull
         if (existing ne null) {
-          ZIO.refailCause(existing)
-        } else if (shutdownCauseRef.compareAndSet(null, cause)) {
+          shutdownEffect(existing)
+        } else if (shutdownState.compareAndSet(null, cause)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
 
@@ -264,17 +290,17 @@ object Queue extends QueuePlatformSpecific {
 
           Exit.succeed(buffered ++ surplus)
         } else {
-          ZIO.refailCause(shutdownCauseOrNull)
+          shutdownEffect(shutdownStateOrNull)
         }
       }.uninterruptible
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownCauseOrNull ne null)
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownStateOrNull ne null)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          val cause = shutdownCauseOrNull
-          if (cause ne null) ZIO.refailCause(cause)
+          val state = shutdownStateOrNull
+          if (state ne null) shutdownEffect(state)
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -285,7 +311,7 @@ object Queue extends QueuePlatformSpecific {
                 val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe)
 
                 takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers, shutdownCauseRef)
+                strategy.unsafeCompleteTakers(queue, takers, shutdownState)
                 restore(p.await).catchAllCause { c =>
                   val removed = p.unsafe.completeWith(interruptAsNone)(Unsafe)
                   takers.remove(p)
@@ -298,7 +324,7 @@ object Queue extends QueuePlatformSpecific {
                   }
                 }
               case item =>
-                strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
+                strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
                 Exit.succeed(item)
             }
           }
@@ -307,13 +333,13 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null)
-          ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null)
+          shutdownEffect(state)
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
+            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -323,13 +349,13 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null)
-          ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null)
+          shutdownEffect(state)
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
+            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -339,14 +365,14 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        val cause = shutdownCauseOrNull
-        if (cause ne null)
-          ZIO.refailCause(cause)
+        val state = shutdownStateOrNull
+        if (state ne null)
+          shutdownEffect(state)
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
             case v =>
-              strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownCauseRef)
+              strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
               Exit.succeed(Some(v))
           }
         }
@@ -360,13 +386,13 @@ object Queue extends QueuePlatformSpecific {
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownCause: AtomicReference[Cause[Nothing]]
+      shutdownState: AtomicReference[AnyRef]
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownCause: AtomicReference[Cause[Nothing]]
+      shutdownState: AtomicReference[AnyRef]
     ): Unit
 
     def surplusSize: Int
@@ -377,9 +403,9 @@ object Queue extends QueuePlatformSpecific {
     final def unsafeCompleteTakers(
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownCause: AtomicReference[Cause[Nothing]]
+      shutdownState: AtomicReference[AnyRef]
     ): Unit =
-      if ((shutdownCause.get eq null) && !takers.isEmpty && draining.compareAndSet(false, true)) {
+      if ((shutdownState.get eq null) && !takers.isEmpty && draining.compareAndSet(false, true)) {
         try {
           var keepPolling      = !queue.isEmpty()
           val empty            = null.asInstanceOf[A]
@@ -406,14 +432,14 @@ object Queue extends QueuePlatformSpecific {
               }
             }
           }
-          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
+          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers, shutdownState)
         } finally {
           draining.set(false)
         }
 
         // We need to check in case someone added a putter or pulled from the queue since our last check
         // while we were still holding the lock
-        if ((shutdownCause.get eq null) && !queue.isEmpty()) unsafeCompleteTakers(queue, takers, shutdownCause)
+        if ((shutdownState.get eq null) && !queue.isEmpty()) unsafeCompleteTakers(queue, takers, shutdownState)
       }
   }
 
@@ -434,17 +460,20 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
 
           ZIO.suspendSucceed {
             unsafeOffer(as, p)
-            unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
-            unsafeCompleteTakers(queue, takers, shutdownCause)
-            val cause = shutdownCause.get
-            if (cause eq null) p.await else ZIO.refailCause(cause)
+            unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+            unsafeCompleteTakers(queue, takers, shutdownState)
+            shutdownState.get() match {
+              case null            => p.await
+              case DefaultShutdown => ZIO.interrupt
+              case cause           => ZIO.refailCause(cause.asInstanceOf[Cause[Nothing]])
+            }
           }.onInterrupt(ZIO.succeed(unsafeRemove(p)))
         }
 
@@ -462,19 +491,19 @@ object Queue extends QueuePlatformSpecific {
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       ): Unit = {
         val putters0 = putters
-        if ((shutdownCause.get eq null) && !putters0.isEmpty && notifying.compareAndSet(false, true)) {
+        if ((shutdownState.get eq null) && !putters0.isEmpty && notifying.compareAndSet(false, true)) {
           var keepPolling = !queue.isFull()
 
           try {
-            while (keepPolling && (shutdownCause.get eq null)) {
+            while (keepPolling && (shutdownState.get eq null)) {
               val putter = putters0.poll()
               if (putter eq null) {
                 keepPolling = false
-                unsafeCompleteTakers(queue, takers, shutdownCause)
-              } else if (shutdownCause.get ne null) {
+                unsafeCompleteTakers(queue, takers, shutdownState)
+              } else if (shutdownState.get ne null) {
                 putters0.addFirst(putter)
                 keepPolling = false
               } else {
@@ -485,7 +514,7 @@ object Queue extends QueuePlatformSpecific {
                   putters0.addFirst(putter)
                 }
                 if (!offered || queue.isFull()) {
-                  unsafeCompleteTakers(queue, takers, shutdownCause)
+                  unsafeCompleteTakers(queue, takers, shutdownState)
                   keepPolling = !queue.isFull()
                 }
               }
@@ -496,7 +525,7 @@ object Queue extends QueuePlatformSpecific {
 
           // We need to check in case someone added a putter or pulled from the queue since our last check
           // while we were still holding the lock
-          if ((shutdownCause.get eq null) && !queue.isFull()) unsafeOnQueueEmptySpace(queue, takers, shutdownCause)
+          if ((shutdownState.get eq null) && !queue.isFull()) unsafeOnQueueEmptySpace(queue, takers, shutdownState)
         }
       }
 
@@ -504,7 +533,7 @@ object Queue extends QueuePlatformSpecific {
 
       def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = {
         val items = ChunkBuilder.make[A](putters.size())
-        var next = putters.poll()
+        var next  = putters.poll()
         while (next ne null) {
           val (value, promise, isLast) = next
           items.addOne(value)
@@ -521,13 +550,13 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       ): Unit = ()
 
       def surplusSize: Int = 0
@@ -540,7 +569,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {
@@ -561,7 +590,7 @@ object Queue extends QueuePlatformSpecific {
 
         ZIO.succeed {
           unsafeSlidingOffer(as)
-          unsafeCompleteTakers(queue, takers, shutdownCause)
+          unsafeCompleteTakers(queue, takers, shutdownState)
           true
         }
       }
@@ -569,7 +598,7 @@ object Queue extends QueuePlatformSpecific {
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownCause: AtomicReference[Cause[Nothing]]
+        shutdownState: AtomicReference[AnyRef]
       ): Unit = ()
 
       def surplusSize: Int = 0

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -33,7 +33,11 @@ sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal
    * operations will fail with the winning cause and the winning caller receives
    * the values that were still buffered in the queue.
    */
-  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]]
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+    this match {
+      case support: Queue.ShutdownSupport[A @unchecked] => support.shutdownCauseNow(cause)
+      case _                                            => shutdown.as(Chunk.empty)
+    }
 
   /**
    * Checks whether the queue is currently empty.
@@ -53,6 +57,9 @@ object Queue extends QueuePlatformSpecific {
   private val interruptAsNone = ZIO.interruptAs(FiberId.None)(Trace.empty)
 
   private[zio] abstract class Internal[A] extends Queue[A]
+  private[zio] trait ShutdownSupport[A] {
+    def shutdownCauseNow(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]]
+  }
 
   /**
    * Makes a new bounded queue. When the capacity of the queue is reached, any
@@ -145,12 +152,15 @@ object Queue extends QueuePlatformSpecific {
     strategy: Strategy[A],
     fiberId: FiberId
   )(implicit unsafe: Unsafe): Queue[A] = {
-    val p = Promise.unsafe.make[Nothing, Unit](fiberId)
+    val p             = Promise.unsafe.make[Nothing, Unit](fiberId)
+    val shutdownFlag  = new AtomicBoolean(false)
+    val shutdownState = new AtomicReference[AnyRef](null)
+    strategy.unsafeSetShutdownState(shutdownFlag, shutdownState)
     unsafeCreate(
       queue,
       new ConcurrentDeque[Promise[Nothing, A]],
       p,
-      new AtomicReference[AnyRef](null),
+      shutdownFlag,
       strategy
     )
   }
@@ -159,17 +169,20 @@ object Queue extends QueuePlatformSpecific {
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownState: AtomicReference[AnyRef],
+    shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownState, strategy)
+  ): Queue[A] = new QueueImpl[A](queue, takers, shutdownHook, shutdownFlag, strategy)
 
   private final class QueueImpl[A](
     queue: MutableConcurrentQueue[A],
     takers: ConcurrentDeque[Promise[Nothing, A]],
     shutdownHook: Promise[Nothing, Unit],
-    shutdownState: AtomicReference[AnyRef],
+    shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
-  ) extends Queue[A] {
+  ) extends Queue[A]
+      with ShutdownSupport[A] {
+
+    private[this] val shutdownState = strategy.shutdownStateRef
 
     private def shutdownEffect(state: AnyRef)(implicit trace: Trace): UIO[Nothing] =
       if (state eq DefaultShutdown) ZIO.interrupt
@@ -192,7 +205,7 @@ object Queue extends QueuePlatformSpecific {
         if (state ne null) shutdownEffect(state)
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownState)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
         }
       }
 
@@ -208,7 +221,7 @@ object Queue extends QueuePlatformSpecific {
 
       if (noRemaining) true
       else if (queue.offer(a)) {
-        strategy.unsafeCompleteTakers(queue, takers, shutdownState)
+        strategy.unsafeCompleteTakers(queue, takers)
         true
       } else false
     }
@@ -230,10 +243,10 @@ object Queue extends QueuePlatformSpecific {
             val surplus = unsafeOfferAll(queue, remaining)
 
             if (surplus.isEmpty) {
-              strategy.unsafeCompleteTakers(queue, takers, shutdownState)
+              strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownState).map { offered =>
+              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
                 if (offered) Chunk.empty else surplus
               }
           }
@@ -253,7 +266,7 @@ object Queue extends QueuePlatformSpecific {
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
       ZIO.fiberIdWith { fiberId =>
-        if (shutdownState.compareAndSet(null, DefaultShutdown)) {
+        if (shutdownFlag.compareAndSet(false, true) && shutdownState.compareAndSet(null, DefaultShutdown)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
 
@@ -262,7 +275,7 @@ object Queue extends QueuePlatformSpecific {
             takerIterator.next().unsafe.interruptAs(fiberId)
           }
 
-          strategy.shutdown(Cause.interrupt(fiberId))
+          strategy.shutdown(fiberId)
           Exit.unit
         } else {
           val state = shutdownStateOrNull
@@ -271,12 +284,12 @@ object Queue extends QueuePlatformSpecific {
         }
       }.uninterruptible
 
-    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+    override def shutdownCauseNow(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
         val existing = shutdownStateOrNull
         if (existing ne null) {
           shutdownEffect(existing)
-        } else if (shutdownState.compareAndSet(null, cause)) {
+        } else if (shutdownFlag.compareAndSet(false, true) && shutdownState.compareAndSet(null, cause)) {
           implicit val unsafe: Unsafe = Unsafe
           shutdownHook.unsafe.succeedUnit
 
@@ -285,7 +298,7 @@ object Queue extends QueuePlatformSpecific {
             takerIterator.next().unsafe.refailCause(cause)
           }
 
-          val surplus  = strategy.shutdown(cause)
+          val surplus  = strategy.shutdownWithCause(cause)
           val buffered = unsafePollAll(queue)
 
           Exit.succeed(buffered ++ surplus)
@@ -311,7 +324,7 @@ object Queue extends QueuePlatformSpecific {
                 val p = Promise.unsafe.make[Nothing, A](fiberId)(Unsafe)
 
                 takers.offer(p)
-                strategy.unsafeCompleteTakers(queue, takers, shutdownState)
+                strategy.unsafeCompleteTakers(queue, takers)
                 restore(p.await).catchAllCause { c =>
                   val removed = p.unsafe.completeWith(interruptAsNone)(Unsafe)
                   takers.remove(p)
@@ -324,7 +337,7 @@ object Queue extends QueuePlatformSpecific {
                   }
                 }
               case item =>
-                strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+                strategy.unsafeOnQueueEmptySpace(queue, takers)
                 Exit.succeed(item)
             }
           }
@@ -339,7 +352,7 @@ object Queue extends QueuePlatformSpecific {
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+            strategy.unsafeOnQueueEmptySpace(queue, takers)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -355,7 +368,7 @@ object Queue extends QueuePlatformSpecific {
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
-            strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+            strategy.unsafeOnQueueEmptySpace(queue, takers)
             Exit.succeed(as)
           } else {
             Exit.emptyChunk
@@ -372,7 +385,7 @@ object Queue extends QueuePlatformSpecific {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
             case v =>
-              strategy.unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+              strategy.unsafeOnQueueEmptySpace(queue, takers)
               Exit.succeed(Some(v))
           }
         }
@@ -380,32 +393,47 @@ object Queue extends QueuePlatformSpecific {
   }
 
   private sealed abstract class Strategy[A] {
-    private[this] val draining = new AtomicBoolean(false)
+    private[this] val draining                               = new AtomicBoolean(false)
+    private[this] var isShutdown: AtomicBoolean              = _
+    private[this] var shutdownState: AtomicReference[AnyRef] = _
+
+    final def unsafeSetShutdownState(
+      shutdownFlag: AtomicBoolean,
+      state: AtomicReference[AnyRef]
+    ): Unit = {
+      isShutdown = shutdownFlag
+      shutdownState = state
+    }
+
+    final def shutdownStateOrNull: AnyRef =
+      if (shutdownState eq null) null else shutdownState.get()
+
+    final def shutdownStateRef: AtomicReference[AnyRef] = shutdownState
 
     def handleSurplus(
       as: Iterable[A],
       queue: MutableConcurrentQueue[A],
       takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownState: AtomicReference[AnyRef]
+      isShutdown: AtomicBoolean
     )(implicit trace: Trace): UIO[Boolean]
 
     def unsafeOnQueueEmptySpace(
       queue: MutableConcurrentQueue[A],
-      takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownState: AtomicReference[AnyRef]
+      takers: ConcurrentDeque[Promise[Nothing, A]]
     ): Unit
 
     def surplusSize: Int
 
-    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A]
+    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+
+    def shutdownWithCause(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = Chunk.empty
 
     @tailrec
     final def unsafeCompleteTakers(
       queue: MutableConcurrentQueue[A],
-      takers: ConcurrentDeque[Promise[Nothing, A]],
-      shutdownState: AtomicReference[AnyRef]
+      takers: ConcurrentDeque[Promise[Nothing, A]]
     ): Unit =
-      if ((shutdownState.get eq null) && !takers.isEmpty && draining.compareAndSet(false, true)) {
+      if (!isShutdown.get && !takers.isEmpty && draining.compareAndSet(false, true)) {
         try {
           var keepPolling      = !queue.isEmpty()
           val empty            = null.asInstanceOf[A]
@@ -432,14 +460,14 @@ object Queue extends QueuePlatformSpecific {
               }
             }
           }
-          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+          if (notifyEmptySpace) unsafeOnQueueEmptySpace(queue, takers)
         } finally {
           draining.set(false)
         }
 
         // We need to check in case someone added a putter or pulled from the queue since our last check
         // while we were still holding the lock
-        if ((shutdownState.get eq null) && !queue.isEmpty()) unsafeCompleteTakers(queue, takers, shutdownState)
+        if (!isShutdown.get && !queue.isEmpty()) unsafeCompleteTakers(queue, takers)
       }
   }
 
@@ -460,16 +488,16 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] =
         ZIO.fiberIdWith { fiberId =>
           val p = Promise.unsafe.make[Nothing, Boolean](fiberId)(Unsafe.unsafe)
 
           ZIO.suspendSucceed {
             unsafeOffer(as, p)
-            unsafeOnQueueEmptySpace(queue, takers, shutdownState)
-            unsafeCompleteTakers(queue, takers, shutdownState)
-            shutdownState.get() match {
+            unsafeOnQueueEmptySpace(queue, takers)
+            unsafeCompleteTakers(queue, takers)
+            shutdownStateOrNull match {
               case null            => p.await
               case DefaultShutdown => ZIO.interrupt
               case cause           => ZIO.refailCause(cause.asInstanceOf[Cause[Nothing]])
@@ -490,20 +518,19 @@ object Queue extends QueuePlatformSpecific {
       @tailrec
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        takers: ConcurrentDeque[Promise[Nothing, A]]
       ): Unit = {
         val putters0 = putters
-        if ((shutdownState.get eq null) && !putters0.isEmpty && notifying.compareAndSet(false, true)) {
+        if ((shutdownStateOrNull eq null) && !putters0.isEmpty && notifying.compareAndSet(false, true)) {
           var keepPolling = !queue.isFull()
 
           try {
-            while (keepPolling && (shutdownState.get eq null)) {
+            while (keepPolling && (shutdownStateOrNull eq null)) {
               val putter = putters0.poll()
               if (putter eq null) {
                 keepPolling = false
-                unsafeCompleteTakers(queue, takers, shutdownState)
-              } else if (shutdownState.get ne null) {
+                unsafeCompleteTakers(queue, takers)
+              } else if (shutdownStateOrNull ne null) {
                 putters0.addFirst(putter)
                 keepPolling = false
               } else {
@@ -514,7 +541,7 @@ object Queue extends QueuePlatformSpecific {
                   putters0.addFirst(putter)
                 }
                 if (!offered || queue.isFull()) {
-                  unsafeCompleteTakers(queue, takers, shutdownState)
+                  unsafeCompleteTakers(queue, takers)
                   keepPolling = !queue.isFull()
                 }
               }
@@ -525,13 +552,22 @@ object Queue extends QueuePlatformSpecific {
 
           // We need to check in case someone added a putter or pulled from the queue since our last check
           // while we were still holding the lock
-          if ((shutdownState.get eq null) && !queue.isFull()) unsafeOnQueueEmptySpace(queue, takers, shutdownState)
+          if ((shutdownStateOrNull eq null) && !queue.isFull()) unsafeOnQueueEmptySpace(queue, takers)
         }
       }
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = {
+      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+        var next = putters.poll()
+        while (next ne null) {
+          val (_, promise, isLast) = next
+          if (isLast) promise.unsafe.interruptAs(fiberId)
+          next = putters.poll()
+        }
+      }
+
+      override def shutdownWithCause(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = {
         val items = ChunkBuilder.make[A](putters.size())
         var next  = putters.poll()
         while (next ne null) {
@@ -550,18 +586,17 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] = Exit.`false`
 
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        takers: ConcurrentDeque[Promise[Nothing, A]]
       ): Unit = ()
 
       def surplusSize: Int = 0
 
-      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = Chunk.empty
+      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -569,7 +604,7 @@ object Queue extends QueuePlatformSpecific {
         as: Iterable[A],
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        isShutdown: AtomicBoolean
       )(implicit trace: Trace): UIO[Boolean] = {
         def unsafeSlidingOffer(as: Iterable[A]): Unit =
           if (!as.isEmpty && queue.capacity > 0) {
@@ -590,20 +625,19 @@ object Queue extends QueuePlatformSpecific {
 
         ZIO.succeed {
           unsafeSlidingOffer(as)
-          unsafeCompleteTakers(queue, takers, shutdownState)
+          unsafeCompleteTakers(queue, takers)
           true
         }
       }
 
       def unsafeOnQueueEmptySpace(
         queue: MutableConcurrentQueue[A],
-        takers: ConcurrentDeque[Promise[Nothing, A]],
-        shutdownState: AtomicReference[AnyRef]
+        takers: ConcurrentDeque[Promise[Nothing, A]]
       ): Unit = ()
 
       def surplusSize: Int = 0
 
-      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Chunk[A] = Chunk.empty
+      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -847,6 +847,9 @@ object ZSinkSpec extends ZIOBaseSpec {
 
             override def shutdown(implicit trace: Trace): UIO[Unit] = ZIO.succeed(this.isShutDown = true)
 
+            override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+              q.shutdownCause(cause) <* ZIO.succeed(this.isShutDown = true)
+
             override def size(implicit trace: Trace): UIO[Int] = q.size
 
             override def take(implicit trace: Trace): ZIO[Any, Nothing, A] = q.take

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -5873,6 +5873,14 @@ object ZStreamSpec extends ZIOBaseSpec {
                           .take(3)
                           .runCollect
             } yield result)(forall(hasSize(isLessThanEqualTo(2))))
+          },
+          test("fails with queue shutdownCause") {
+            val boom = new RuntimeException("boom")
+            assertZIO(for {
+              queue <- Queue.unbounded[Int]
+              _     <- queue.shutdownCause(Cause.die(boom))
+              exit  <- ZStream.fromQueue(queue).runCollect.exit
+            } yield exit)(dies(equalTo(boom)))
           }
         ),
         test("fromTQueue") {


### PR DESCRIPTION
This adds a compatibility-preserving `shutdownCause` API to `Queue`.

What changed:
- add `Queue.shutdownCause(cause: Cause[Nothing]): UIO[Chunk[A]]`
- keep `shutdown` behavior as the interrupt-based shorthand by delegating to `shutdownCause`
- store the first winning shutdown cause and fail pending/future queue operations with it
- return buffered and back-pressured items to the winning shutdown caller in queue order
- preserve `ZStream.fromQueue` behavior for normal shutdown while surfacing non-interrupt shutdown causes

Tests:
- `coreTestsJVM/testOnly zio.QueueSpec`
- `streamsTestsJVM/testOnly zio.stream.ZSinkSpec -- -t "fromQueueWithShutdown"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "fromQueue"`

Closes #9844.