### PR TITLE
Improve ZScheduler external submit draining

### DIFF
--- a/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
+++ b/benchmarks/src/main/scala/zio/internal/ZSchedulerBenchmarks.scala
@@ -7,7 +7,8 @@ import org.openjdk.jmh.annotations.{Scope => JScope, _}
 import zio._
 import zio.BenchmarkUtil._
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 @State(JScope.Thread)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -43,6 +44,12 @@ class ZSchedulerBenchmarks {
   val fixedThreadPool: zio.Executor = fixedThreadPoolExecutor()
   val zScheduler: zio.Executor      = zio.Executor.makeDefault()
 
+  @Param(Array("8192"))
+  var externalSubmitTasks: Int = _
+
+  @Param(Array("8", "32"))
+  var externalSubmitters: Int = _
+
   @Benchmark
   def catsRuntimeChainedFork(): Int =
     catsChainedFork(catsRuntime)
@@ -76,6 +83,10 @@ class ZSchedulerBenchmarks {
     zioYieldMany(fixedThreadPool)
 
   @Benchmark
+  def zioFixedThreadPoolExternalSubmitBurst(): Int =
+    externalSubmitBurst(fixedThreadPool)
+
+  @Benchmark
   def zioSchedulerChainedFork(): Int =
     zioChainedFork(zScheduler)
 
@@ -90,6 +101,10 @@ class ZSchedulerBenchmarks {
   @Benchmark
   def zioSchedulerYieldMany(): Int =
     zioYieldMany(zScheduler)
+
+  @Benchmark
+  def zioSchedulerExternalSubmitBurst(): Int =
+    externalSubmitBurst(zScheduler)
 
   def catsChainedFork(runtime: IORuntime): Int = {
 
@@ -215,5 +230,65 @@ class ZSchedulerBenchmarks {
     } yield 0
 
     unsafeRun(io.onExecutor(executor))
+  }
+
+  def externalSubmitBurst(executor: zio.Executor): Int = {
+    val ready     = new CountDownLatch(externalSubmitters)
+    val start     = new CountDownLatch(1)
+    val done      = new CountDownLatch(externalSubmitTasks)
+    val submitted = new AtomicInteger(0)
+    val failure   = new AtomicReference[Throwable](null)
+
+    val producers = new Array[Thread](externalSubmitters)
+
+    var i = 0
+    while (i < externalSubmitters) {
+      val thread = new Thread(
+        new Runnable {
+          def run(): Unit =
+            try {
+              ready.countDown()
+              start.await()
+
+              var loop = true
+              while (loop) {
+                val n = submitted.getAndIncrement()
+                if (n >= externalSubmitTasks) loop = false
+                else {
+                  val runnable = new Runnable {
+                    def run(): Unit =
+                      done.countDown()
+                  }
+                  Unsafe.unsafe { implicit unsafe =>
+                    if (!executor.submit(runnable)) {
+                      failure.compareAndSet(null, new RuntimeException("executor rejected benchmark task"))
+                    }
+                  }
+                }
+              }
+            } catch {
+              case t: Throwable => failure.compareAndSet(null, t)
+            }
+        },
+        s"zio-external-submit-benchmark-$i"
+      )
+      thread.setDaemon(true)
+      producers(i) = thread
+      i += 1
+    }
+
+    producers.foreach(_.start())
+    ready.await()
+    start.countDown()
+    producers.foreach(_.join())
+
+    val error = failure.get()
+    if (error ne null) throw error
+
+    if (!done.await(30, TimeUnit.SECONDS)) {
+      throw new RuntimeException(s"timed out waiting for ${done.getCount()} externally submitted tasks")
+    }
+
+    externalSubmitTasks
   }
 }

--- a/core-tests/jvm-native/src/test/scala/zio/ZSchedulerSpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/ZSchedulerSpec.scala
@@ -1,0 +1,106 @@
+package zio
+
+import zio.test.Assertion._
+import zio.test.TestAspect.timeout
+import zio.test._
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{CountDownLatch, TimeUnit}
+import scala.concurrent.blocking
+
+object ZSchedulerSpec extends ZIOBaseSpec {
+
+  def spec = suite("ZSchedulerSpec")(
+    test("external submissions complete after worker saturation") {
+      assertZIO(ZIO.attemptBlocking(runExternalSubmissionStress(useBlockingOccupiers = false)))(isTrue)
+    } @@ timeout(15.seconds),
+    test("external submissions complete after blocking worker replacement") {
+      assertZIO(ZIO.attemptBlocking(runExternalSubmissionStress(useBlockingOccupiers = true)))(isTrue)
+    } @@ timeout(15.seconds)
+  )
+
+  private def runExternalSubmissionStress(useBlockingOccupiers: Boolean): Boolean = {
+    val executor       = Executor.makeDefault()
+    val workers        = java.lang.Runtime.getRuntime.availableProcessors()
+    val submitters     = math.min(workers * 2, 32)
+    val tasks          = 4096
+    val occupied       = new CountDownLatch(workers)
+    val releaseWorkers = new CountDownLatch(1)
+    val ready          = new CountDownLatch(submitters)
+    val start          = new CountDownLatch(1)
+    val done           = new CountDownLatch(tasks)
+    val submitted      = new AtomicInteger(0)
+    val failure        = new AtomicReference[Throwable](null)
+
+    def recordFailure(t: Throwable): Unit =
+      if (failure.compareAndSet(null, t)) ()
+
+    Unsafe.unsafe { implicit unsafe =>
+      var i = 0
+      while (i < workers) {
+        executor.submit(new Runnable {
+          def run(): Unit = {
+            occupied.countDown()
+            if (useBlockingOccupiers) {
+              val _ = blocking(releaseWorkers.await(10, TimeUnit.SECONDS))
+            } else {
+              val _ = releaseWorkers.await(10, TimeUnit.SECONDS)
+            }
+          }
+        })
+        i += 1
+      }
+
+      if (!occupied.await(10, TimeUnit.SECONDS)) {
+        releaseWorkers.countDown()
+        false
+      } else {
+        val producerThreads = new Array[Thread](submitters)
+
+        var j = 0
+        while (j < submitters) {
+          val thread = new Thread(
+            new Runnable {
+              def run(): Unit =
+                try {
+                  ready.countDown()
+                  start.await()
+
+                  var loop = true
+                  while (loop) {
+                    val n = submitted.getAndIncrement()
+                    if (n >= tasks) {
+                      loop = false
+                    } else if (
+                      !executor.submit(new Runnable {
+                        def run(): Unit =
+                          done.countDown()
+                      })
+                    ) {
+                      recordFailure(new RuntimeException("executor rejected stress task"))
+                    }
+                  }
+                } catch {
+                  case t: Throwable => recordFailure(t)
+                }
+            }
+          )
+          thread.setDaemon(true)
+          producerThreads(j) = thread
+          j += 1
+        }
+
+        producerThreads.foreach(_.start())
+        ready.await(10, TimeUnit.SECONDS)
+        start.countDown()
+        producerThreads.foreach(_.join(10000))
+        releaseWorkers.countDown()
+
+        val error = failure.get()
+        if (error ne null) throw error
+
+        done.await(10, TimeUnit.SECONDS)
+      }
+    }
+  }
+}

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -206,6 +206,27 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     }
   }
 
+  private[this] def pollGlobalAndBatch(worker: ZScheduler.Worker, random: ThreadLocalRandom): Runnable = {
+    val runnable = globalQueue.poll(random)
+
+    if (runnable ne null) {
+      var i    = 0
+      var loop = true
+      while (i < 16 && loop) {
+        val next = globalQueue.poll(random)
+        if (next eq null) {
+          loop = false
+        } else if (!worker.localQueue.offer(next)) {
+          globalQueue.offer(next, random)
+          loop = false
+        }
+        i += 1
+      }
+    }
+
+    runnable
+  }
+
   private[this] def isBlocking(worker: ZScheduler.Worker, runnable: Runnable): Boolean =
     if (autoBlocking && runnable.isInstanceOf[FiberRunnable]) {
       val fiberRunnable = runnable.asInstanceOf[FiberRunnable]
@@ -307,14 +328,14 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
             nextRunnable = null
           } else {
             if ((currentOpCount & 63) == 0) {
-              runnable = globalQueue.poll(random)
+              runnable = pollGlobalAndBatch(self, random)
               if (runnable eq null) {
                 runnable = localQueue.poll(null)
               }
             } else {
               runnable = localQueue.poll(null)
               if (runnable eq null) {
-                runnable = globalQueue.poll(random)
+                runnable = pollGlobalAndBatch(self, random)
               }
             }
             if (runnable eq null) {
@@ -356,7 +377,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
                   i += 1
                 }
                 if (runnable eq null) {
-                  runnable = globalQueue.poll(random)
+                  runnable = pollGlobalAndBatch(self, random)
                 }
               }
             }


### PR DESCRIPTION
/claim #9356

Draft PR for issue #9356. This is intentionally narrower than previous direct least-loaded/external-placement attempts: external submissions still enter the global queue, and workers that successfully poll global work opportunistically batch a small number of additional global tasks into their local queue. It keeps submit placement, blocking-worker replacement, work stealing, and global fallback behavior intact.

Changes:
- Add bounded global-queue batch draining in ZScheduler workers.
- Add an external-submit JMH benchmark for fixed thread pool vs ZScheduler.
- Add JVM/native stress coverage for saturated external submissions and blocking worker replacement.

Validation on JDK 21 after rebasing onto current series/2.x:
- `++2.13; coreJVM/Compile/compile; benchmarks/Compile/compile; coreTestsJVM/testOnly *.ZSchedulerSpec` completed successfully. The sbt summary says no tests to run, but `core-tests/jvm/target/test-reports-zio/output.json` records both ZSchedulerSpec cases as Success.
- `++2.13; coreJVM/scalafmtCheck; coreTestsJVM/scalafmtCheck; benchmarks/scalafmtCheck` passed.
- `git diff --check` passed.
- JMH smoke: `benchmarks/jmh:run -i 1 -wi 0 -f1 -t1 zio.internal.ZSchedulerBenchmarks.*ExternalSubmitBurst` completed; ZScheduler external-submit throughput was 578.212 ops/s with 8 submitters and 471.601 ops/s with 32 submitters on this machine.

Keeping this draft until broader CI/maintainer feedback confirms whether this narrower batch-drain approach is worth pursuing.