### PR TITLE
Fix Gen runCollectN resampling

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/GenSpec.scala
@@ -701,6 +701,17 @@ object GenSpec extends ZIOBaseSpec {
         assert(a)(hasSize(equalTo(100))) &&
         assert(b)(hasSize(equalTo(100)))
     },
+    test("runCollectN resamples a random generator followed by an infinite deterministic generator") {
+      val infinite = new Iterable[Int] {
+        override def iterator: Iterator[Int] = Iterator.iterate(0)(_ + 1)
+      }
+      val gen = for {
+        id <- Gen.uuid
+        _  <- Gen.fromIterable(infinite)
+      } yield id
+
+      assertZIO(gen.runCollectN(20).map(_.distinct.length))(isGreaterThan(1))
+    },
     test("runHead") {
       assertZIO(Gen.int(-10, 10).runHead)(isSome(isWithin(-10, 10)))
     },

--- a/test/shared/src/main/scala/zio/test/Gen.scala
+++ b/test/shared/src/main/scala/zio/test/Gen.scala
@@ -154,7 +154,7 @@ final case class Gen[-R, +A](sample: ZStream[R, Nothing, Sample[R, A]]) { self =
    * in a list.
    */
   def runCollectN(n: Int)(implicit trace: Trace): ZIO[R, Nothing, List[A]] =
-    sample.map(_.value).forever.take(n.toLong).runCollect.map(_.toList)
+    ZIO.collectAll(List.fill(n)(sample.map(_.value).runHead.map(_.toList))).map(_.flatten)
 
   /**
    * Runs the generator returning the first value of the generator.


### PR DESCRIPTION
/claim #9101

## Summary
- Makes `Gen.runCollectN` run the generator once per requested value and collect the head from each run.
- Adds a regression for `Gen.uuid` followed by an infinite deterministic `Gen.fromIterable`, matching the order-dependent behavior from #9101.
- Keeps `runCollect` unchanged for deterministic enumeration while making `runCollectN` resample random parts even when a later generator has an infinite sample stream.

## Root Cause
`runCollectN` previously used `sample.map(_.value).forever.take(n)`. If `flatMap` produced an infinite inner deterministic sample stream, that stream never completed, so `forever` never restarted the outer random generator and all collected values reused the same outer sample.

## Validation
- `sbt 'testTestsJVM/testOnly zio.test.GenSpec -- -t "runCollectN resamples"'`
- `sbt 'testTestsJVM/testOnly zio.test.GenSpec'`
- `sbt fmtCheck`
- `sbt '++2.12.21 testTestsJVM/testOnly zio.test.GenSpec -- -t "runCollectN resamples"'`
- `sbt '++3.3.7 testTestsJVM/testOnly zio.test.GenSpec -- -t "runCollectN resamples"'`


## Demo Video
- Short proof video: https://github.com/SadmanPinon/bounty-proof-assets/blob/main/demos/zio-9101-demo.mp4