### PR TITLE
Fix ZStream.buffer(1) evaluating two elements ahead

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,32 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("does not evaluate more than capacity elements ahead") {
+            for {
+              secondStarted <- Promise.make[Nothing, Unit]
+              thirdStarted  <- Promise.make[Nothing, Unit]
+              result <- ZIO.scoped {
+                          val stream =
+                            ZStream
+                              .fromIterable(1 to 3)
+                              .mapZIO { n =>
+                                ZIO.when(n == 2)(secondStarted.succeedUnit) *>
+                                  ZIO.when(n == 3)(thirdStarted.succeedUnit) *>
+                                  ZIO.succeed(n)
+                              }
+                              .buffer(1)
+
+                          stream.toPull.flatMap { pull =>
+                            for {
+                              first <- pull
+                              _     <- secondStarted.await
+                              _     <- ZIO.yieldNow.repeatN(10)
+                              third <- thirdStarted.poll
+                            } yield assert(first)(equalTo(Chunk.single(1))) && assert(third)(isNone)
+                          }
+                        }
+            } yield result
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,10 +391,40 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def producer(
+      queue: Queue[Exit[Option[E], A]],
+      permits: Queue[Unit]
+    ): ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] = {
+      lazy val loop: ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+        ZChannel.fromZIO(permits.take) *>
+          ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+            in =>
+              if (in.isEmpty)
+                ZChannel.fromZIO(permits.offer(()).unit) *> loop
+              else
+                ZChannel.fromZIO(queue.offerAll(in.map(Exit.succeed(_))).unit) *> loop,
+            err =>
+              ZChannel.fromZIO {
+                permits.offer(()) *> queue.offer(Exit.failCause(err.map(Some(_)))).unit
+              },
+            _ =>
+              ZChannel.fromZIO {
+                permits.offer(()) *> queue.offer(Exit.fail(None)).unit
+              }
+          )
+
+      loop
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          requestedCapacity <- ZIO.succeed(capacity)
+          queue             <- ZIO.acquireRelease(Queue.bounded[Exit[Option[E], A]](requestedCapacity))(_.shutdown)
+          permits           <- ZIO.acquireRelease(Queue.bounded[Unit](requestedCapacity))(_.shutdown)
+          _                 <- permits.offerAll(Chunk.fill(requestedCapacity)(())).unit
+          _                 <- (self.rechunk(1).channel >>> producer(queue, permits)).runScoped.forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
               queue.take
@@ -403,7 +433,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.fromZIO(permits.offer(()).unit) *> ZChannel.write(Chunk.single(value)) *> process
               )
             }
 


### PR DESCRIPTION
Fixes #9810
/claim #9810

### Summary
- gate `ZStream#buffer` upstream pulls with a permit queue so upstream acquires buffer capacity before pulling/evaluating the next element
- preserve element-level buffering by rechunking to size 1 and releasing a permit when downstream takes a queued element
- add a regression test showing `buffer(1)` does not evaluate a third element while the second element is still buffered

### Validation
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "does not evaluate more than capacity elements ahead"`
- `streamsTestsJVM/testOnly zio.stream.ZStreamSpec -- -t "buffer"`
- `streamsJVM/scalafmtCheck`
- `streamsTestsJVM/scalafmtCheck`
