### PR TITLE
Guard ZScheduler worker unparking with CAS

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -445,14 +445,27 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     }
 
   private def maybeUnparkWorker(currentState: Int): Unit = {
-    val currentSearching = currentState & 0xffff
-    val currentActive    = (currentState & 0xffff0000) >> 16
-    if (currentActive != poolSize && currentSearching == 0) {
-      val worker = idle.poll()
-      if (worker ne null) {
-        state.getAndAdd(0x10001)
-        worker.active = true
-        LockSupport.unpark(worker)
+    var stateSnapshot = currentState
+    var loop          = true
+    while (loop) {
+      val currentSearching = stateSnapshot & 0xffff
+      val currentActive    = (stateSnapshot & 0xffff0000) >> 16
+      if (currentActive != poolSize && currentSearching == 0) {
+        val worker = idle.poll()
+        if (worker ne null) {
+          if (state.compareAndSet(stateSnapshot, stateSnapshot + 0x10001)) {
+            worker.active = true
+            LockSupport.unpark(worker)
+            loop = false
+          } else {
+            idle.offer(worker)
+            stateSnapshot = state.get
+          }
+        } else {
+          loop = false
+        }
+      } else {
+        loop = false
       }
     }
   }


### PR DESCRIPTION
Refs #9878
/claim #9878

## Summary
- make `maybeUnparkWorker` reserve the active/searching state transition with `compareAndSet` before waking a parked worker
- requeue the polled idle worker if another caller wins the state race
- avoid multiple concurrent submitters unparking workers from the same stale `currentSearching == 0` snapshot

## Validation
- `git diff --check`

I was not able to run the ZIO test or benchmark suite in this workspace because `sbt` / `scala-cli` are not installed here.