### PR TITLE
Add Queue.shutdownCause

### DIFF
--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -516,6 +516,54 @@ object QueueSpec extends ZIOBaseSpec {
         res    <- queue.size.sandbox.either
       } yield assert(res)(isLeft(equalTo(Cause.interrupt(selfId))))
     },
+    test("shutdownCause returns queued items and fails future interactions with cause") {
+      val boom  = new RuntimeException("boom")
+      val cause = Cause.die(boom)
+
+      for {
+        queue   <- Queue.bounded[Int](3)
+        _       <- queue.offerAll(List(1, 2))
+        drained <- queue.shutdownCause(cause)
+        offer   <- queue.offer(3).sandbox.either
+        take    <- queue.take.sandbox.either
+        size    <- queue.size.sandbox.either
+      } yield assert(drained)(equalTo(Chunk(1, 2))) &&
+        assert(offer)(isLeft(equalTo(cause))) &&
+        assert(take)(isLeft(equalTo(cause))) &&
+        assert(size)(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause fails blocked takers and back-pressured offerers with cause") {
+      val boom  = new RuntimeException("boom")
+      val cause = Cause.die(boom)
+
+      for {
+        takeQueue <- Queue.bounded[Int](1)
+        taker     <- takeQueue.take.fork
+        _         <- waitForSize(takeQueue, -1)
+        _         <- takeQueue.shutdownCause(cause)
+        take      <- taker.join.sandbox.either
+
+        offerQueue <- Queue.bounded[Int](1)
+        _          <- offerQueue.offer(1)
+        putter     <- offerQueue.offer(2).fork
+        _          <- waitForSize(offerQueue, 2)
+        _          <- offerQueue.shutdownCause(cause)
+        offer      <- putter.join.sandbox.either
+      } yield assert(take)(isLeft(equalTo(cause))) &&
+        assert(offer)(isLeft(equalTo(cause)))
+    },
+    test("shutdownCause is atomic") {
+      val winner = Cause.die(new RuntimeException("winner"))
+      val loser  = Cause.die(new RuntimeException("loser"))
+
+      for {
+        queue    <- Queue.bounded[Int](1)
+        _        <- queue.shutdownCause(winner)
+        shutdown <- queue.shutdownCause(loser).sandbox.either
+        take     <- queue.take.sandbox.either
+      } yield assert(shutdown)(isLeft(equalTo(winner))) &&
+        assert(take)(isLeft(equalTo(winner)))
+    },
     test("back-pressured offer completes after take") {
       for {
         queue <- Queue.bounded[Int](2)

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -29,6 +29,17 @@ import scala.annotation.tailrec
 sealed abstract class Queue[A] extends Dequeue.Internal[A] with Enqueue.Internal[A] {
 
   /**
+   * Shuts down the queue with the specified cause and returns the elements that
+   * were buffered in the queue at the time of shutdown.
+   *
+   * Future calls to `offer*`, `take*`, and `size` will fail with the cause that
+   * first shut down the queue. If multiple fibers call `shutdownCause`
+   * concurrently, one wins and other callers fail with the winner's cause.
+   */
+  def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+    shutdown.as(Chunk.empty)
+
+  /**
    * Checks whether the queue is currently empty.
    */
   override final def isEmpty(implicit trace: Trace): UIO[Boolean] =
@@ -162,15 +173,22 @@ object Queue extends QueuePlatformSpecific {
     shutdownFlag: AtomicBoolean,
     strategy: Strategy[A]
   ) extends Queue[A] {
+    private[this] val shutdownCauseRef = new AtomicReference[Cause[Nothing]](null)
 
     override def capacity: Int = queue.capacity
 
+    private def failShutdown[B]: UIO[B] =
+      Exit.failCause(shutdownCauseRef.get)
+
+    private def failShutdownIfNeeded[B](cause: Cause[Nothing]): UIO[B] =
+      if (shutdownCauseRef.get ne null) failShutdown else Exit.failCause(cause)
+
     override def offer(a: A)(implicit trace: Trace): UIO[Boolean] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownCauseRef.get ne null) failShutdown
         else {
           if (tryOffer(a)) Exit.`true`
-          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag)
+          else strategy.handleSurplus(Chunk.single(a), queue, takers, shutdownFlag).catchAllCause(failShutdownIfNeeded)
         }
       }
 
@@ -193,7 +211,7 @@ object Queue extends QueuePlatformSpecific {
 
     override def offerAll[A1 <: A](as: Iterable[A1])(implicit trace: Trace): UIO[Chunk[A1]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get) ZIO.interrupt
+        if (shutdownCauseRef.get ne null) failShutdown
         else {
           val pTakers                = if (queue.isEmpty()) unsafePollN(takers, as.size) else Chunk.empty
           val (forTakers, remaining) = as.splitAt(pTakers.size)
@@ -210,9 +228,12 @@ object Queue extends QueuePlatformSpecific {
               strategy.unsafeCompleteTakers(queue, takers)
               Exit.emptyChunk
             } else
-              strategy.handleSurplus(surplus, queue, takers, shutdownFlag).map { offered =>
-                if (offered) Chunk.empty else surplus
-              }
+              strategy
+                .handleSurplus(surplus, queue, takers, shutdownFlag)
+                .catchAllCause(failShutdownIfNeeded)
+                .map { offered =>
+                  if (offered) Chunk.empty else surplus
+                }
           }
         }
       }
@@ -221,32 +242,46 @@ object Queue extends QueuePlatformSpecific {
 
     override def size(implicit trace: Trace): UIO[Int] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCauseRef.get ne null)
+          failShutdown
         else
           Exit.succeed(queue.size() - takers.size() + strategy.surplusSize)
       }
 
     override def shutdown(implicit trace: Trace): UIO[Unit] =
-      ZIO.fiberIdWith { fiberId =>
-        if (shutdownFlag.compareAndSet(false, true)) {
+      ZIO.fiberIdWith(fiberId => shutdownCauseInternal(Cause.interrupt(fiberId), failIfAlreadyShutdown = false).unit)
+
+    override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+      shutdownCauseInternal(cause, failIfAlreadyShutdown = true)
+
+    private def shutdownCauseInternal(cause: Cause[Nothing], failIfAlreadyShutdown: Boolean)(implicit
+      trace: Trace
+    ): UIO[Chunk[A]] =
+      ZIO.suspendSucceed {
+        if (shutdownCauseRef.compareAndSet(null, cause)) {
           implicit val unsafe: Unsafe = Unsafe
+          shutdownFlag.set(true)
           shutdownHook.unsafe.succeedUnit
-          val it = unsafePollAll(takers).iterator
+          val queued = unsafePollAll(queue)
+          val it     = unsafePollAll(takers).iterator
           while (it.hasNext) {
-            it.next().unsafe.interruptAs(fiberId)
+            it.next().unsafe.done(Exit.failCause(cause))
           }
-          strategy.shutdown(fiberId)
+          strategy.shutdown(cause)
+          Exit.succeed(queued)
+        } else if (failIfAlreadyShutdown) {
+          failShutdown
+        } else {
+          Exit.emptyChunk
         }
-        Exit.unit
       }.uninterruptible
 
-    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownFlag.get)
+    override def isShutdown(implicit trace: Trace): UIO[Boolean] = ZIO.succeed(shutdownCauseRef.get ne null)
 
     override def take(implicit trace: Trace): UIO[A] =
       ZIO.uninterruptibleMask { restore =>
         ZIO.fiberIdWith { fiberId =>
-          if (shutdownFlag.get) ZIO.interrupt
+          if (shutdownCauseRef.get ne null) failShutdown
           else {
             queue.poll(null.asInstanceOf[A]) match {
               case null =>
@@ -279,8 +314,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeAll(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCauseRef.get ne null)
+          failShutdown
         else {
           val as = unsafePollAll(queue)
           if (!as.isEmpty) {
@@ -294,8 +329,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def takeUpTo(max: Int)(implicit trace: Trace): UIO[Chunk[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCauseRef.get ne null)
+          failShutdown
         else {
           val as = unsafePollN(queue, max)
           if (!as.isEmpty) {
@@ -309,8 +344,8 @@ object Queue extends QueuePlatformSpecific {
 
     override def poll(implicit trace: Trace): UIO[Option[A]] =
       ZIO.suspendSucceed {
-        if (shutdownFlag.get)
-          ZIO.interrupt
+        if (shutdownCauseRef.get ne null)
+          failShutdown
         else {
           queue.poll(null.asInstanceOf[A]) match {
             case null => Exit.none
@@ -339,7 +374,7 @@ object Queue extends QueuePlatformSpecific {
 
     def surplusSize: Int
 
-    def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit
+    def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit
 
     @tailrec
     final def unsafeCompleteTakers(
@@ -464,11 +499,11 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = putters.size()
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = {
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = {
         var next = putters.poll()
         while (next ne null) {
           val (_, promise, isLast) = next
-          if (isLast) promise.unsafe.interruptAs(fiberId)
+          if (isLast) promise.unsafe.done(Exit.failCause(cause))
           next = putters.poll()
         }
       }
@@ -490,7 +525,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
 
     final case class Sliding[A]() extends Strategy[A] {
@@ -531,7 +566,7 @@ object Queue extends QueuePlatformSpecific {
 
       def surplusSize: Int = 0
 
-      def shutdown(fiberId: FiberId)(implicit trace: Trace, unsafe: Unsafe): Unit = ()
+      def shutdown(cause: Cause[Nothing])(implicit trace: Trace, unsafe: Unsafe): Unit = ()
     }
   }
 

--- a/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZSinkSpec.scala
@@ -847,6 +847,9 @@ object ZSinkSpec extends ZIOBaseSpec {
 
             override def shutdown(implicit trace: Trace): UIO[Unit] = ZIO.succeed(this.isShutDown = true)
 
+            override def shutdownCause(cause: Cause[Nothing])(implicit trace: Trace): UIO[Chunk[A]] =
+              ZIO.succeed(this.isShutDown = true) *> q.shutdownCause(cause)
+
             override def size(implicit trace: Trace): UIO[Int] = q.size
 
             override def take(implicit trace: Trace): ZIO[Any, Nothing, A] = q.take


### PR DESCRIPTION
/claim #9844

Closes #9844.

This adds `Queue.shutdownCause(Cause[Nothing])`, following the non-source-breaking direction discussed on the issue: callers can shut a queue down with a concrete defect/interruption cause, retrieve buffered elements, and have pending/future queue operations fail with the winning shutdown cause.

Implementation notes:
- Stores the first shutdown cause atomically.
- Preserves existing `shutdown` behavior as interruption-based and idempotent.
- Completes blocked takers and back-pressured offerers with the shutdown cause.
- Returns elements buffered in the underlying queue when `shutdownCause` wins.

Verification:
- `/tmp/sbt-extras fmt`
- `/tmp/sbt-extras "coreTestsJVM/testOnly zio.QueueSpec"` -> 93 tests passed, 0 failed.
- `/tmp/sbt-extras 'set ThisBuild / previousStableVersion := Some("2.1.26"); mimaChecks'`
- `/tmp/sbt-extras 'coreTestsJVM/testOnly zio.QueueSpec -- -t shutdownCause'` -> 3 focused shutdownCause tests passed.