### PR TITLE
Fix ZStream buffer(1) overproducing elements

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,6 +607,37 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
+          },
+          test("buffer(1) does not evaluate more than one element ahead") {
+            for {
+              produced <- Ref.make(List.empty[Int])
+              next     <- Ref.make(0)
+              second   <- Promise.make[Nothing, Unit]
+              third    <- Promise.make[Nothing, Unit]
+              stream = ZStream
+                         .repeatZIO {
+                           next.updateAndGet(_ + 1).tap { n =>
+                             produced.update(n :: _) *>
+                               second.succeed(()).when(n == 2) *>
+                               third.succeed(()).when(n == 3)
+                           }
+                         }
+                         .take(3)
+                         .buffer(1)
+              result <- ZIO.scoped {
+                          stream.toPull.flatMap { pull =>
+                            for {
+                              first        <- pull
+                              _            <- second.await
+                              _            <- ZIO.yieldNow.repeatN(10)
+                              thirdStarted <- third.isDone
+                              values       <- produced.get
+                            } yield assert(first)(equalTo(Chunk.single(1))) &&
+                              assert(values.reverse)(equalTo(List(1, 2))) &&
+                              assertTrue(!thirdStarted)
+                          }
+                        }
+            } yield result
           }
         ),
         suite("bufferChunks")(

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,10 +391,14 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
+        for {
+          capacity <- ZIO.succeed(capacity)
+          queue    <- ZIO.acquireRelease(Queue.bounded[Exit[Option[E], A]](capacity))(_.shutdown)
+          permits  <- Semaphore.make(capacity.toLong)
+          _        <- self.runIntoQueueElementsScoped(queue, permits).forkScoped
+        } yield {
           lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
             ZChannel.fromZIO {
               queue.take
@@ -403,7 +407,7 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
                 Cause
                   .flipCauseOption(_)
                   .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
+                value => ZChannel.fromZIO(permits.release) *> ZChannel.write(Chunk.single(value)) *> process
               )
             }
 
@@ -2976,6 +2980,23 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
       )
 
     (self.channel >>> writer).drain.runScoped.unit
+  }
+
+  private def runIntoQueueElementsScoped(
+    queue: => Enqueue[Exit[Option[E], A]],
+    permits: => Semaphore
+  )(implicit trace: Trace): ZIO[R with Scope, Nothing, Unit] = {
+    lazy val writer: ZChannel[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any] =
+      ZChannel.fromZIO(permits.acquire) *>
+        ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Exit[Option[E], A], Any](
+          in =>
+            if (in.isEmpty) ZChannel.fromZIO(permits.release) *> writer
+            else ZChannel.fromZIO(queue.offer(Exit.succeed(in(0)))) *> writer,
+          err => ZChannel.fromZIO(queue.offer(Exit.failCause(err.map(Some(_))))),
+          _ => ZChannel.fromZIO(queue.offer(Exit.fail(None)))
+        )
+
+    (self.rechunk(1).channel >>> writer).drain.runScoped.unit
   }
 
   /**


### PR DESCRIPTION
Fixes #9810.

This updates `ZStream#buffer` so the upstream producer acquires a capacity permit before evaluating each next element and releases it only after the downstream consumer takes that element. That keeps `buffer(1)` from evaluating a second queued element plus one in-flight element ahead of the consumer.

Also adds a regression test that waits until the second element is produced, yields several times, and asserts the third element has not started before another downstream pull.

Validation:
- `git diff --check` passes
- Not run: Scala/ZIO test suite locally, because this environment does not have a Java runtime or sbt installed.

/claim #9810