### PR TITLE
Optimize timeoutTo scheduling overhead

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,31 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Warmup(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 3)
+@Fork(1)
+class TimeoutBenchmark {
+
+  @Param(Array("0", "1000"))
+  var size: Int = _
+
+  private def effect: UIO[Int] =
+    ZIO.foldLeft(0 until size)(0) { case (total, value) =>
+      ZIO.succeed(total + value)
+    }
+
+  @Benchmark
+  def baseline(): Int =
+    unsafeRun(effect)
+
+  @Benchmark
+  def timeout(): Option[Int] =
+    unsafeRun(effect.timeout(100.minutes))
+}

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -23,7 +23,7 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.io.IOException
 import java.util.concurrent.ConcurrentLinkedQueue
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.function.IntFunction
 import scala.annotation.implicitNotFound
 import scala.collection.mutable.ListBuffer
@@ -5667,23 +5667,92 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
-            },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+      ZIO.clockWith(_.scheduler).flatMap { scheduler =>
+        ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
+          ZIO.uninterruptibleMask { restore =>
+            import TimeoutTo._
+
+            val effect = ZIO.Grafter(parentFiber).applyOnExit(self)
+            val fiber =
+              ZIO.unsafe.makeChildFiber(trace, effect, parentFiber, parentStatus.runtimeFlags, null)(Unsafe)
+            val state    = new AtomicReference[State[E, A]](Registering)
+            val callback = new AtomicReference[ZIO[R, E, B1] => Unit](null)
+
+            def timeoutResult: ZIO[R, E, B1] =
+              fiber.interruptAs(parentFiber.id) *> fiber.inheritAll.as(b())
+
+            @annotation.tailrec
+            def complete(next: State[E, A], result: => ZIO[R, E, B1]): Unit =
+              state.get() match {
+                case Registering =>
+                  if (!state.compareAndSet(Registering, next)) complete(next, result)
+                case Registered =>
+                  if (state.compareAndSet(Registered, next)) callback.get()(result)
+                  else complete(next, result)
+                case _ => ()
+              }
+
+            val cancelTimeout = scheduler.schedule(
+              () => complete(TimedOut, timeoutResult),
+              duration
+            )(Unsafe)
+
+            def effectResult(exit: Exit[E, A]): ZIO[R, E, B1] =
+              ZIO.succeed(cancelTimeout()) *> fiber.inheritAll *> exit.mapExit(f)
+
+            val canceler: URIO[R, Any] =
+              ZIO.succeed(state.set(Cancelled)) *> ZIO.succeed(cancelTimeout())
+
+            fiber.addObserver { exit =>
+              complete(Completed(exit), effectResult(exit))
+            }(Unsafe)
+
+            fiber.startSuspended()(Unsafe)
+            state.get() match {
+              case TimedOut => ()
+              case _        => fiber.start(effect)
+            }
+
+            val awaitResult =
+              ZIO.asyncInterruptUnsafe[R, E, B1](
+                _ =>
+                  cb => {
+                    callback.set(cb)
+
+                    @annotation.tailrec
+                    def register(): Either[URIO[R, Any], ZIO[R, E, B1]] =
+                      state.get() match {
+                        case Completed(exit) => Right(effectResult(exit))
+                        case TimedOut        => Right(timeoutResult)
+                        case Registering =>
+                          if (state.compareAndSet(Registering, Registered)) Left(canceler)
+                          else register()
+                        case Registered | Cancelled => Left(canceler)
+                      }
+
+                    register()
+                  },
+                fiber.id
+              )
+
+            state.get() match {
+              case Completed(exit) => effectResult(exit)
+              case TimedOut        => timeoutResult
+              case Registering | Registered | Cancelled =>
+                restore(awaitResult).onInterrupt(canceler)
+            }
+          }
+        }
       }
+  }
+
+  private object TimeoutTo {
+    sealed trait State[+E, +A]
+    case object Registering                              extends State[Nothing, Nothing]
+    case object Registered                               extends State[Nothing, Nothing]
+    case object TimedOut                                 extends State[Nothing, Nothing]
+    case object Cancelled                                extends State[Nothing, Nothing]
+    final case class Completed[+E, +A](exit: Exit[E, A]) extends State[E, A]
   }
 
   final class Acquire[-R, +E, +A](private val acquire: () => ZIO[R, E, A]) extends AnyVal {

--- a/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -26,8 +26,12 @@ private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
-            runtime.unsafe.fork(sleep(duration) *> ZIO.succeed(runnable.run()))
-          () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
+            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible)
+          () => {
+            val pending = fiber.unsafe.poll.isEmpty
+            fiber.unsafe.interrupt(zio.Cause.interrupt(zio.FiberId.None))
+            pending
+          }
         }
       }
     }

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -32,7 +32,7 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
           val fiber =
-            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())))
+            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())).interruptible)
           () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
         }
 


### PR DESCRIPTION
/claim #9211

Fixes #9211

## Summary

- Replace the two-fiber `timeoutTo` race with one child fiber plus `Clock.scheduler`.
- Preserve synchronous completion with an atomic coordination state while protecting child initialization from parent interruption, including the #10255 regression.
- Make `TestClock` timer fibers interruptible and make Scala.js cancellation non-blocking.
- Add a JMH benchmark for timeout overhead.

## Benchmark

Command used on both `origin/series/2.x` (`94366d2ac`) and this branch:

```bash
benchmarks/Jmh/run -wi 1 -i 2 -f 1 -w 1s -r 1s -p size=0,1000 .*TimeoutBenchmark.*
```

| Benchmark | size | Upstream ops/s | This PR ops/s | Improvement |
| --- | ---: | ---: | ---: | ---: |
| `TimeoutBenchmark.timeout` | 0 | 29,596.333 | 1,170,788.898 | 39.6x |
| `TimeoutBenchmark.timeout` | 1000 | 6,325.023 | 68,296.838 | 10.8x |

For context, the corresponding no-timeout baseline was 9,153,340 ops/s upstream and 10,230,211 ops/s on this branch at size 0.

## Testing

- `fmt`
- `fmtCheck`
- `coreTestsJVM/testOnly *.ZIOSpec` (`572` passed)
- `coreTestsJVM/testOnly *.FiberRefSpec` (`49` passed)
- `coreTestsJS/testOnly *.ZIOSpec` (`562` passed, `10` platform-ignored)
- `coreTestsJS/testOnly *.FiberRefSpec` (`49` passed)
- `benchmarks/Test/compile`