### PR TITLE
docs: Document Exit.none public value

### DIFF
--- a/docs/reference/core/exit.md
+++ b/docs/reference/core/exit.md
@@ -38,3 +38,22 @@ val result: ZIO[Any, IOException, Unit] =
     }
   } yield ()
 ```
+
+## Pre-constructed Exit Values
+
+ZIO provides several pre-constructed `Exit` values for common cases:
+
+- `Exit.unit` — A success exit with a `Unit` value
+- `Exit.none` — A success exit with a `None` value (type: `Exit[Nothing, Option[Nothing]]`)
+
+These values are useful when you need to return a pre-made exit without constructing it manually:
+
+```scala mdoc:silent
+import zio._
+
+// Using Exit.unit for effects that only care about success or failure
+val unitExit: Exit[String, Unit] = Exit.unit
+
+// Using Exit.none for optional values
+val noneExit: Exit[String, Option[Nothing]] = Exit.none
+```


### PR DESCRIPTION
## Summary

Adds documentation for the newly public `Exit.none` pre-constructed value in the Exit reference page. Also documents `Exit.unit` for completeness since it's a related public value.

## Related PR

Addresses documentation for PR #10838 (Make Exit.none public)

## Changes

- Added "Pre-constructed Exit Values" section to `docs/reference/core/exit.md`
- Documented `Exit.unit` and `Exit.none` values with examples
- All Scala code formatted with `sbt scalafmtAll`
- Lint checks pass with `sbt "++2.13; check"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)