### PR TITLE
Fix ZStream buffer(1) backpressure

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -607,7 +607,26 @@ object ZStreamSpec extends ZIOBaseSpec {
               _  <- latch.await
               l2 <- ref.get
             } yield assert(l1.toList)(equalTo((1 to 2).toList)) && assert(l2.reverse)(equalTo((1 to 4).toList))
-          }
+          },
+          test("buffer(1) evaluates at most one element ahead of the consumer") {
+            for {
+              evaluated       <- Ref.make(Vector.empty[Int])
+              consumerStarted <- Promise.make[Nothing, Unit]
+              secondEvaluated <- Promise.make[Nothing, Unit]
+              releaseConsumer <- Promise.make[Nothing, Unit]
+              fiber <- ZStream
+                         .fromIterator(Iterator.from(1))
+                         .mapZIO(n => evaluated.update(_ :+ n) *> secondEvaluated.succeed(()).when(n == 2).as(n))
+                         .buffer(1)
+                         .runForeach(_ => consumerStarted.succeed(()) *> releaseConsumer.await)
+                         .fork
+              _      <- consumerStarted.await
+              _      <- secondEvaluated.await
+              _      <- ZIO.yieldNow.repeatN(10)
+              result <- evaluated.get
+              _      <- fiber.interrupt
+            } yield assert(result)(equalTo(Vector(1, 2)))
+          } @@ TestAspect.timeout(5.seconds)
         ),
         suite("bufferChunks")(
           test("maintains elements and ordering")(check(tinyChunkOf(tinyChunkOf(Gen.int))) { chunk =>

--- a/streams/shared/src/main/scala/zio/stream/ZStream.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZStream.scala
@@ -391,23 +391,44 @@ final class ZStream[-R, +E, +A] private (val channel: ZChannel[R, Any, Any, Any,
    *   Prefer capacities that are powers of 2 for better performance.
    */
   def buffer(capacity: => Int)(implicit trace: Trace): ZStream[R, E, A] = {
-    val queue = self.toQueueOfElements(capacity)
+    def process(take: => UIO[Exit[Option[E], A]]): ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] = {
+      lazy val loop: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
+        ZChannel.fromZIO(take).flatMap { (exit: Exit[Option[E], A]) =>
+          exit.foldExit(
+            Cause
+              .flipCauseOption(_)
+              .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
+            value => ZChannel.write(Chunk.single(value)) *> loop
+          )
+        }
+
+      loop
+    }
+
     new ZStream(
       ZChannel.unwrapScoped[R] {
-        queue.map { queue =>
-          lazy val process: ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit] =
-            ZChannel.fromZIO {
-              queue.take
-            }.flatMap { (exit: Exit[Option[E], A]) =>
-              exit.foldExit(
-                Cause
-                  .flipCauseOption(_)
-                  .fold[ZChannel[Any, Any, Any, Any, E, Chunk[A], Unit]](ZChannel.unit)(ZChannel.refailCause),
-                value => ZChannel.write(Chunk.single(value)) *> process
-              )
-            }
+        ZIO.suspendSucceed {
+          val capacity0 = capacity
 
-          process
+          if (capacity0 == 1) {
+            def producer(
+              handoff: ZStream.Handoff[Exit[Option[E], A]]
+            ): ZChannel[R, E, Chunk[A], Any, Nothing, Nothing, Any] =
+              ZChannel.readWithCause[R, E, Chunk[A], Any, Nothing, Nothing, Any](
+                in =>
+                  ZChannel.fromZIO(ZIO.foreachDiscard(in)(a => handoff.offer(Exit.succeed(a)))) *> producer(handoff),
+                cause => ZChannel.fromZIO(handoff.offer(Exit.failCause(cause.map(Some(_))))),
+                _ => ZChannel.fromZIO(handoff.offer(Exit.fail(None)))
+              )
+
+            for {
+              handoff <- ZStream.Handoff.make[Exit[Option[E], A]]
+              channel <- ZIO.scopeWith { scope =>
+                           (self.channel >>> producer(handoff)).runIn(scope).forkIn(scope).as(process(handoff.take))
+                         }
+            } yield channel
+          } else
+            self.toQueueOfElements(if (capacity0 > 1) capacity0 - 1 else capacity0).map(queue => process(queue.take))
         }
       }
     )


### PR DESCRIPTION
Fixes #9810

## Summary
- make `ZStream.buffer` account for the in-flight producer element when sizing its internal queue
- use the existing `Handoff` synchronization path for `buffer(1)` so the producer cannot evaluate a third element while the consumer is still processing the first
- add a regression test that reproduces `buffer(1)` evaluating `Vector(1, 2, 3)` instead of stopping at `Vector(1, 2)`

## Verification
- `sbt 'streamsTestsJVM/testOnly *.ZStreamSpec -- -t "buffer(1) evaluates at most one element ahead of the consumer"'`\n- `sbt 'streamsTestsJVM/testOnly *.ZStreamSpec -- -t "buffer"'`\n- `sbt 'streamsJVM/scalafmtCheck' 'streamsTestsJVM/Test/scalafmtCheck'`