### PR TITLE
Improve fiber mailbox hot path

### DIFF
--- a/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/BroadFlatMapBenchmark.scala
@@ -60,6 +60,8 @@ class BroadFlatMapBenchmark {
   def zioBroadFlatMap(): BigInt = zioBroadFlatMap(BenchmarkUtil)
 
   private[this] def zioBroadFlatMap(runtime: Runtime[Any]): BigInt = {
+    implicit val trace: Trace = Trace.empty
+
     def fib(n: Int): UIO[BigInt] =
       if (n <= 1) ZIO.succeed[BigInt](n)
       else

--- a/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/NarrowFlatMapBenchmark.scala
@@ -92,6 +92,8 @@ class NarrowFlatMapBenchmark {
   def zioNarrowFlatMap(): Int = zioNarrowFlatMap(BenchmarkUtil)
 
   private[this] def zioNarrowFlatMap(runtime: Runtime[Any]): Int = {
+    implicit val trace: Trace = Trace.empty
+
     def loop(i: Int): UIO[Int] =
       if (i < size) ZIO.succeed[Int](i + 1).flatMap(loop)
       else ZIO.succeed(i)

--- a/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/internal/FiberMailboxBenchmark.scala
@@ -1,0 +1,135 @@
+package zio.internal
+
+import org.openjdk.jmh.annotations._
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.TimeUnit
+
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Array(Mode.AverageTime))
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+@State(Scope.Thread)
+private[this] class FiberMailboxBenchmark {
+  private[this] val Ops = 1024
+
+  private[this] val message = FiberMessage.resumeUnit
+
+  private[this] var fiberMailbox = null.asInstanceOf[FiberMailbox]
+  private[this] var linkedQueue  = null.asInstanceOf[ConcurrentLinkedQueue[FiberMessage]]
+
+  @volatile
+  private[this] var noUnrolling = true
+
+  @Setup(Level.Invocation)
+  def setup(): Unit = {
+    fiberMailbox = new FiberMailbox()
+    linkedQueue = new ConcurrentLinkedQueue[FiberMessage]()
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def fiberMailboxEmptyPoll(): Unit = {
+    val mailbox = fiberMailbox
+    var i       = 0
+    while (i < Ops && noUnrolling) {
+      mailbox.poll()
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def linkedQueueEmptyPoll(): Unit = {
+    val queue = linkedQueue
+    var i     = 0
+    while (i < Ops && noUnrolling) {
+      queue.poll()
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def fiberMailboxSingleAddPoll(): Unit = {
+    val mailbox = fiberMailbox
+    var i       = 0
+    while (i < Ops && noUnrolling) {
+      mailbox.add(message)
+      if (mailbox.poll() eq null) throw new AssertionError("missing mailbox message")
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def linkedQueueSingleAddPoll(): Unit = {
+    val queue = linkedQueue
+    var i     = 0
+    while (i < Ops && noUnrolling) {
+      queue.add(message)
+      if (queue.poll() eq null) throw new AssertionError("missing queue message")
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def fiberMailboxBurst4(): Unit = {
+    val mailbox = fiberMailbox
+    var i       = 0
+    while (i < Ops && noUnrolling) {
+      mailbox.add(message)
+      mailbox.add(message)
+      mailbox.add(message)
+      mailbox.add(message)
+      mailbox.poll()
+      mailbox.poll()
+      mailbox.poll()
+      mailbox.poll()
+      i += 4
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def linkedQueueBurst4(): Unit = {
+    val queue = linkedQueue
+    var i     = 0
+    while (i < Ops && noUnrolling) {
+      queue.add(message)
+      queue.add(message)
+      queue.add(message)
+      queue.add(message)
+      queue.poll()
+      queue.poll()
+      queue.poll()
+      queue.poll()
+      i += 4
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def fiberMailboxIsEmpty(): Unit = {
+    val mailbox = fiberMailbox
+    var i       = 0
+    while (i < Ops && noUnrolling) {
+      mailbox.isEmpty
+      i += 1
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(1024)
+  def linkedQueueIsEmpty(): Unit = {
+    val queue = linkedQueue
+    var i     = 0
+    while (i < Ops && noUnrolling) {
+      queue.isEmpty
+      i += 1
+    }
+  }
+}

--- a/core-tests/jvm-native/src/test/scala/zio/internal/FiberMailboxConcurrencySpec.scala
+++ b/core-tests/jvm-native/src/test/scala/zio/internal/FiberMailboxConcurrencySpec.scala
@@ -1,0 +1,124 @@
+package zio.internal
+
+import zio._
+import zio.test._
+import zio.test.Assertion._
+
+import java.util.IdentityHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
+object FiberMailboxConcurrencySpec extends ZIOBaseSpec {
+
+  private def message(n: Int): FiberMessage =
+    FiberMessage.Resume(ZIO.succeed(n))
+
+  def spec = suite("FiberMailboxConcurrencySpec")(
+    test("does not lose or duplicate messages from multiple writers") {
+      val mailbox       = new FiberMailbox()
+      val writers       = 4
+      val perWriter     = 1000
+      val totalMessages = writers * perWriter
+      val messages      = Array.tabulate(totalMessages)(message)
+      val start         = new CountDownLatch(1)
+      val done          = new CountDownLatch(writers)
+      val failure       = new AtomicReference[Throwable]()
+
+      val threads =
+        (0 until writers).map { writer =>
+          new Thread(
+            () =>
+              try {
+                start.await()
+                var i   = writer * perWriter
+                val end = i + perWriter
+                while (i < end) {
+                  mailbox.add(messages(i))
+                  i += 1
+                }
+              } catch {
+                case t: Throwable =>
+                  failure.compareAndSet(null, t)
+                  ()
+              } finally done.countDown(),
+            s"fiber-mailbox-writer-$writer"
+          )
+        }
+
+      threads.foreach(_.start())
+      start.countDown()
+      done.await()
+
+      val seen = new IdentityHashMap[FiberMessage, java.lang.Boolean]()
+      var next = mailbox.poll()
+      while (next ne null) {
+        seen.put(next, java.lang.Boolean.TRUE)
+        next = mailbox.poll()
+      }
+
+      assert(failure.get())(isNull) &&
+      assertTrue(seen.size() == totalMessages, messages.forall(seen.containsKey), mailbox.isEmpty)
+    },
+    test("single reader can poll while writers are adding") {
+      val mailbox       = new FiberMailbox()
+      val writers       = 4
+      val perWriter     = 1000
+      val totalMessages = writers * perWriter
+      val messages      = Array.tabulate(totalMessages)(message)
+      val start         = new CountDownLatch(1)
+      val done          = new CountDownLatch(writers)
+      val readerDone    = new CountDownLatch(1)
+      val failure       = new AtomicReference[Throwable]()
+      val seen          = new IdentityHashMap[FiberMessage, java.lang.Boolean]()
+
+      val reader = new Thread(
+        () =>
+          try {
+            start.await()
+            while (done.getCount() > 0 || !mailbox.isEmpty) {
+              val next = mailbox.poll()
+              if (next ne null) {
+                if (seen.put(next, java.lang.Boolean.TRUE) ne null)
+                  throw new AssertionError("duplicate mailbox message")
+              } else Thread.`yield`()
+            }
+          } catch {
+            case t: Throwable =>
+              failure.compareAndSet(null, t)
+              ()
+          } finally readerDone.countDown(),
+        "fiber-mailbox-reader"
+      )
+
+      val threads =
+        (0 until writers).map { writer =>
+          new Thread(
+            () =>
+              try {
+                start.await()
+                var i   = writer * perWriter
+                val end = i + perWriter
+                while (i < end) {
+                  mailbox.add(messages(i))
+                  i += 1
+                }
+              } catch {
+                case t: Throwable =>
+                  failure.compareAndSet(null, t)
+                  ()
+              } finally done.countDown(),
+            s"fiber-mailbox-writer-$writer"
+          )
+        }
+
+      reader.start()
+      threads.foreach(_.start())
+      start.countDown()
+      done.await()
+      readerDone.await()
+
+      assert(failure.get())(isNull) &&
+      assertTrue(seen.size() == totalMessages, messages.forall(seen.containsKey), mailbox.isEmpty)
+    }
+  ) @@ TestAspect.nonFlaky
+}

--- a/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/FiberMailboxSpec.scala
@@ -1,0 +1,72 @@
+package zio.internal
+
+import zio._
+import zio.test._
+
+object FiberMailboxSpec extends ZIOBaseSpec {
+
+  private def message(n: Int): FiberMessage =
+    FiberMessage.Resume(ZIO.succeed(n))
+
+  def spec = suite("FiberMailboxSpec")(
+    test("starts empty") {
+      val mailbox = new FiberMailbox()
+      val polled  = mailbox.poll()
+
+      assertTrue(mailbox.isEmpty, polled == null)
+    },
+    test("uses the single message fast path") {
+      val mailbox = new FiberMailbox()
+      val first   = message(1)
+
+      mailbox.add(first)
+
+      val nonEmptyBeforePoll = !mailbox.isEmpty
+      val firstPolled        = mailbox.poll()
+      val nextPolled         = mailbox.poll()
+
+      assertTrue(nonEmptyBeforePoll, firstPolled eq first, mailbox.isEmpty, nextPolled == null)
+    },
+    test("promotes to FIFO queue when multiple messages are waiting") {
+      val mailbox = new FiberMailbox()
+      val first   = message(1)
+      val second  = message(2)
+      val third   = message(3)
+
+      mailbox.add(first)
+      mailbox.add(second)
+      mailbox.add(third)
+
+      val firstPolled  = mailbox.poll()
+      val secondPolled = mailbox.poll()
+      val thirdPolled  = mailbox.poll()
+      val nextPolled   = mailbox.poll()
+
+      assertTrue(
+        firstPolled eq first,
+        secondPolled eq second,
+        thirdPolled eq third,
+        nextPolled == null,
+        mailbox.isEmpty
+      )
+    },
+    test("reuses the promoted queue after it has drained") {
+      val mailbox = new FiberMailbox()
+      val first   = message(1)
+      val second  = message(2)
+      val third   = message(3)
+
+      mailbox.add(first)
+      mailbox.add(second)
+      val firstPolled   = mailbox.poll()
+      val secondPolled  = mailbox.poll()
+      val emptyAfterTwo = mailbox.isEmpty
+
+      mailbox.add(third)
+      val thirdPolled     = mailbox.poll()
+      val emptyAfterThree = mailbox.isEmpty
+
+      assertTrue(firstPolled eq first, secondPolled eq second, emptyAfterTwo, thirdPolled eq third, emptyAfterThree)
+    }
+  )
+}

--- a/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberMailbox.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicReference
+import scala.annotation.tailrec
+
+/**
+ * A specialized mailbox for fiber messages.
+ *
+ * Most fiber mailboxes contain at most one message, so the empty/single-message
+ * states avoid the node allocation and traversal cost of a linked queue. When a
+ * second message arrives before the first is drained, the mailbox promotes once
+ * to a ConcurrentLinkedQueue and keeps using it for the rest of the fiber's
+ * lifetime, preserving FIFO ordering and the same MPSC safety profile as the
+ * previous implementation.
+ */
+private[zio] final class FiberMailbox extends Serializable {
+  private[this] val state = new AtomicReference[AnyRef]()
+
+  @tailrec
+  final def add(message: FiberMessage): Unit = {
+    assert(message ne null)
+
+    val current = state.get()
+
+    if (current eq null) {
+      if (!state.compareAndSet(null, message.asInstanceOf[AnyRef])) add(message)
+    } else if (current.isInstanceOf[ConcurrentLinkedQueue[_]]) {
+      current.asInstanceOf[ConcurrentLinkedQueue[FiberMessage]].add(message)
+      ()
+    } else {
+      val queue = new ConcurrentLinkedQueue[FiberMessage]()
+      queue.add(current.asInstanceOf[FiberMessage])
+      queue.add(message)
+
+      if (!state.compareAndSet(current, queue)) add(message)
+    }
+  }
+
+  @tailrec
+  final def poll(): FiberMessage = {
+    val current = state.get()
+
+    if (current eq null) null
+    else if (current.isInstanceOf[ConcurrentLinkedQueue[_]]) {
+      current.asInstanceOf[ConcurrentLinkedQueue[FiberMessage]].poll()
+    } else if (state.compareAndSet(current, null)) {
+      current.asInstanceOf[FiberMessage]
+    } else poll()
+  }
+
+  final def isEmpty: Boolean = {
+    val current = state.get()
+
+    (current eq null) || (
+      current.isInstanceOf[ConcurrentLinkedQueue[_]] &&
+        current.asInstanceOf[ConcurrentLinkedQueue[FiberMessage]].isEmpty
+    )
+  }
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -22,7 +22,6 @@ import zio.internal.SpecializationHelpers.SpecializeInt
 import zio.metrics.{Metric, MetricLabel}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.{Set => JavaSet}
 import scala.annotation.tailrec
@@ -42,7 +41,7 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
   private var _blockingOn     = FiberRuntime.notBlockingOn
   private var _asyncContWith  = null.asInstanceOf[AsyncContWith]
   private val running         = new AtomicBoolean(false)
-  private val inbox           = new ConcurrentLinkedQueue[FiberMessage]()
+  private val inbox           = new FiberMailbox()
   private var _children       = null.asInstanceOf[JavaSet[Fiber.Runtime[_, _]]]
   private var observers       = Nil: List[Exit[E, A] => Unit]
   private var runningExecutor = null.asInstanceOf[Executor]


### PR DESCRIPTION
Fixes #8807

/claim #8807

This replaces the fiber inbox `ConcurrentLinkedQueue` with a small shared mailbox tuned for the common empty/single-message path. It keeps the behavior conservative: once a second message is waiting it promotes to `ConcurrentLinkedQueue` and never demotes again, so FIFO ordering stays simple and the implementation keeps the same MPSC safety profile as the previous queue-based inbox.

What changed:

- Added `FiberMailbox` with empty, single-message, and promoted-queue states.
- Switched `FiberRuntime` to use the mailbox while preserving the existing `add` / `poll` / `isEmpty` call shape.
- Added shared FIFO/fast-path tests and JVM/Native concurrent writer/reader stress coverage.
- Added a focused JMH benchmark comparing the mailbox to `ConcurrentLinkedQueue` for the hot operations.
- Added `Trace.empty` to the existing narrow/broad flatMap benchmarks to reduce trace overhead noise, as suggested in the issue thread.

Quick local JMH sanity run, JDK 21.0.9, lower is better:

```text
sbt "benchmarks/jmh:run zio.internal.FiberMailboxBenchmark -wi 1 -i 3 -f 1"

Benchmark                                        Score   Units   CLQ score   Change
FiberMailboxBenchmark.fiberMailboxEmptyPoll      0.703  ns/op     1.220     42.4% lower
FiberMailboxBenchmark.fiberMailboxIsEmpty        0.705  ns/op     1.256     43.9% lower
FiberMailboxBenchmark.fiberMailboxSingleAddPoll 16.207  ns/op    21.059     23.0% lower
FiberMailboxBenchmark.fiberMailboxBurst4        13.855  ns/op    16.444     15.7% lower
```

Validation run locally:

```text
sbt "++2.13; coreTestsJVM/testOnly zio.internal.FiberMailboxSpec zio.internal.FiberMailboxConcurrencySpec; benchmarks/Compile/compile"
sbt "++2.13; scalafmtSbtCheck; coreJVM/scalafmtCheck; coreTestsJVM/scalafmtCheck; benchmarks/scalafmtCheck"
sbt "coreTestsJS/Test/scalafmtCheck" "coreTestsJVM/Test/scalafmtCheck" "coreTestsNative/Test/scalafmtCheck"
sbt "++2.13; coreJS/Compile/compile; coreNative/Compile/compile; coreTestsJS/Test/compile; coreTestsNative/Test/compile"
sbt "benchmarks/jmh:run zio.internal.FiberMailboxBenchmark -wi 1 -i 3 -f 1"
```

Payment method: Algora payout to GitHub user `@jamilahmadzai`.
