### PR TITLE
docs: Add zio-knowledge skill section to homepage and getting-started guide

### DIFF
--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -5,6 +5,24 @@ sidebar_label: "Getting Started"
 slug: "getting-started"
 ---
 
+## Teach Your Coding Agent Latest ZIO Knowledge
+
+The `zio-knowledge` skill teaches Claude Code to fetch live documentation from zio.dev before answering any ZIO question — so you always get accurate, up-to-date answers, not guesses from stale training data.
+
+**To install the skill:**
+
+```bash
+npx skills add zio/zio-skills --skill zio-knowledge
+```
+
+**This skill covers:**
+- ZIO ecosystem modules like Core, Streams, Test, STM, Config, Schema, JSON, Kafka, and more
+- Fetches current related docs from zio.dev on ZIO related development questions
+
+---
+
+## Installation
+
 Include ZIO in your project by adding the following to your `build.sbt` file:
 
 ```scala mdoc:passthrough

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -7,19 +7,11 @@ slug: "getting-started"
 
 ## Teach Your Coding Agent Latest ZIO Knowledge
 
-The `zio-knowledge` skill teaches your coding agent to fetch live documentation from zio.dev before answering any ZIO question — so you always get accurate, up-to-date answers, not guesses from stale training data.
-
-**To install the skill:**
+The `zio-knowledge` skill teaches your coding agent to fetch live documentation from zio.dev before answering any ZIO question — so you always get accurate, up-to-date answers, not guesses from stale training data:
 
 ```bash
 npx skills add zio/zio-skills --skill zio-knowledge
 ```
-
-**This skill covers:**
-- ZIO ecosystem modules like Core, Streams, Test, STM, Config, Schema, JSON, Kafka, and more
-- Fetches current related docs from zio.dev on ZIO related development questions
-
----
 
 ## Installation
 

--- a/docs/overview/index.md
+++ b/docs/overview/index.md
@@ -7,7 +7,7 @@ slug: "getting-started"
 
 ## Teach Your Coding Agent Latest ZIO Knowledge
 
-The `zio-knowledge` skill teaches Claude Code to fetch live documentation from zio.dev before answering any ZIO question — so you always get accurate, up-to-date answers, not guesses from stale training data.
+The `zio-knowledge` skill teaches your coding agent to fetch live documentation from zio.dev before answering any ZIO question — so you always get accurate, up-to-date answers, not guesses from stale training data.
 
 **To install the skill:**
 

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
-import { FaArrowRight } from 'react-icons/fa6';
 import styles from './styles.module.css';
 
 export default function HomepageCodingAgent() {
@@ -11,40 +9,27 @@ export default function HomepageCodingAgent() {
   return (
     <section className={styles.codingAgent}>
       <div className={styles.wideContainer}>
-        <div className="row">
-          <div className="col col--6">
-            <div className={styles.agentContent}>
-              <h2 className={clsx("sectionHeader", "text-4xl")}>Teach Your AI Coding Agent ZIO</h2>
-              <p className={styles.agentSubtitle}>
-                Give your AI assistant always-current ZIO knowledge
-              </p>
-              <p>
-                The <code>zio-knowledge</code> skill teaches Claude Code to fetch live documentation
-                from zio.dev before answering any ZIO question — so you always get accurate, up-to-date
-                answers, not guesses from stale training data.
-              </p>
-              <ul>
-                <li>Covers ZIO core, Streams, Test, STM, Config, Schema, JSON, Kafka, and the full ecosystem</li>
-                <li>Fetches current docs from zio.dev on every question</li>
-                <li>Works seamlessly with Claude Code's slash commands</li>
-              </ul>
-              <div className={styles.buttonContainer}>
-                <Link
-                  className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2 font-semibold text-white hover:text-white hover:no-underline"
-                  to="/overview/getting-started"
-                >
-                  <span>Get Started</span>
-                  <FaArrowRight />
-                </Link>
-              </div>
-            </div>
+        <div className={styles.singleColumn}>
+          <div className={styles.agentContent}>
+            <h2 className={clsx("sectionHeader", "text-4xl")}>Teach Your AI Coding Agent ZIO</h2>
+            <p className={styles.agentSubtitle}>
+              Give your AI assistant always-current ZIO knowledge
+            </p>
+            <p>
+              The <code>zio-knowledge</code> skill teaches Claude Code to fetch live documentation
+              from zio.dev before answering any ZIO question — so you always get accurate, up-to-date
+              answers, not guesses from stale training data.
+            </p>
+            <ul>
+              <li>Covers ZIO core, Streams, Test, STM, Config, Schema, JSON, Kafka, and the full ecosystem</li>
+              <li>Fetches current docs from zio.dev on every question</li>
+              <li>Works seamlessly with Claude Code's slash commands</li>
+            </ul>
           </div>
-          <div className="col col--6">
-            <div className={styles.codeContainer}>
-              <CodeBlock language="bash">
-                {installCommand}
-              </CodeBlock>
-            </div>
+          <div className={styles.codeContainer}>
+            <CodeBlock language="bash">
+              {installCommand}
+            </CodeBlock>
           </div>
         </div>
       </div>

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import clsx from 'clsx';
+import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
+import { FaArrowRight } from 'react-icons/fa6';
 import styles from './styles.module.css';
 
 export default function HomepageCodingAgent() {
@@ -26,6 +28,15 @@ export default function HomepageCodingAgent() {
                 <li>Fetches current docs from zio.dev on every question</li>
                 <li>Works seamlessly with Claude Code's slash commands</li>
               </ul>
+              <div className={styles.buttonContainer}>
+                <Link
+                  className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2 font-semibold text-white hover:text-white hover:no-underline"
+                  to="/overview/getting-started"
+                >
+                  <span>Get Started</span>
+                  <FaArrowRight />
+                </Link>
+              </div>
             </div>
           </div>
           <div className="col col--6">

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import clsx from 'clsx';
+import CodeBlock from '@theme/CodeBlock';
+import styles from './styles.module.css';
+
+export default function HomepageCodingAgent() {
+  const installCommand = `npx skills add zio/zio-skills --skill zio-knowledge`;
+
+  return (
+    <section className={styles.codingAgent}>
+      <div className={styles.wideContainer}>
+        <div className="row">
+          <div className="col col--6">
+            <div className={styles.agentContent}>
+              <h2 className={clsx("sectionHeader", "text-4xl")}>Teach Your AI Coding Agent ZIO</h2>
+              <p className={styles.agentSubtitle}>
+                Give your AI assistant always-current ZIO knowledge
+              </p>
+              <p>
+                The <code>zio-knowledge</code> skill teaches Claude Code to fetch live documentation
+                from zio.dev before answering any ZIO question — so you always get accurate, up-to-date
+                answers, not guesses from stale training data.
+              </p>
+              <ul>
+                <li>Covers ZIO core, Streams, Test, STM, Config, Schema, JSON, Kafka, and the full ecosystem</li>
+                <li>Fetches current docs from zio.dev on every question</li>
+                <li>Works seamlessly with Claude Code's slash commands</li>
+              </ul>
+            </div>
+          </div>
+          <div className="col col--6">
+            <div className={styles.codeContainer}>
+              <CodeBlock language="bash">
+                {installCommand}
+              </CodeBlock>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -13,7 +13,7 @@ export default function HomepageCodingAgent() {
           <div className={styles.agentContent}>
             <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent Latest ZIO Knowledge</h2>
             <p>
-              The <code>zio-knowledge</code> skill teaches Claude Code to fetch live documentation
+              The <code>zio-knowledge</code> skill teaches your coding agent to fetch live documentation
               from zio.dev before answering any ZIO question — so you always get accurate, up-to-date
               answers, not guesses from stale training data.
             </p>

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -1,48 +1,29 @@
-import React, { useState } from 'react';
+import React from 'react';
 import clsx from 'clsx';
-import { FaCheck, FaCopy } from 'react-icons/fa6';
 import CodeBlock from '@theme/CodeBlock';
 import styles from './styles.module.css';
 
 export default function HomepageCodingAgent() {
   const installCommand = `npx skills add zio/zio-skills --skill zio-knowledge`;
-  const [copied, setCopied] = useState(false);
-
-  const handleCopyCommand = () => {
-    navigator.clipboard.writeText(installCommand);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
 
   return (
     <section className={styles.codingAgent}>
       <div className={styles.wideContainer}>
         <div className={styles.singleColumn}>
           <div className={styles.agentContent}>
-            <h2 className={clsx("sectionHeader", "text-4xl")}>Teach Your AI Coding Agent ZIO</h2>
-            <p className={styles.agentSubtitle}>
-              Give your AI assistant always-current ZIO knowledge
-            </p>
+            <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent Latest ZIO Knowledge</h2>
             <p>
               The <code>zio-knowledge</code> skill teaches Claude Code to fetch live documentation
               from zio.dev before answering any ZIO question — so you always get accurate, up-to-date
               answers, not guesses from stale training data.
             </p>
             <ul>
-              <li>Covers ZIO core, Streams, Test, STM, Config, Schema, JSON, Kafka, and the full ecosystem</li>
-              <li>Fetches current docs from zio.dev on every question</li>
-              <li>Works seamlessly with Claude Code's slash commands</li>
+              <li>Covers ZIO ecosystem modules like Core, Streams, Test, STM, Config, Schema, JSON, Kafka, and more</li>
+              <li>Fetches current related docs from zio.dev on ZIO related development questions</li>
             </ul>
           </div>
           <div className={styles.codeContainer}>
             <div className={styles.codeWrapper}>
-              <button
-                className={clsx(styles.copyButton, { [styles.copied]: copied })}
-                onClick={handleCopyCommand}
-                title="Copy installation command to clipboard"
-              >
-                {copied ? <FaCheck className={styles.icon} /> : <FaCopy className={styles.icon} />}
-              </button>
               <CodeBlock language="bash">
                 {installCommand}
               </CodeBlock>

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -1,10 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
+import { FaCheck, FaCopy } from 'react-icons/fa6';
 import CodeBlock from '@theme/CodeBlock';
 import styles from './styles.module.css';
 
 export default function HomepageCodingAgent() {
   const installCommand = `npx skills add zio/zio-skills --skill zio-knowledge`;
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyCommand = () => {
+    navigator.clipboard.writeText(installCommand);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <section className={styles.codingAgent}>
@@ -27,9 +35,18 @@ export default function HomepageCodingAgent() {
             </ul>
           </div>
           <div className={styles.codeContainer}>
-            <CodeBlock language="bash">
-              {installCommand}
-            </CodeBlock>
+            <div className={styles.codeWrapper}>
+              <button
+                className={clsx(styles.copyButton, { [styles.copied]: copied })}
+                onClick={handleCopyCommand}
+                title="Copy installation command to clipboard"
+              >
+                {copied ? <FaCheck className={styles.icon} /> : <FaCopy className={styles.icon} />}
+              </button>
+              <CodeBlock language="bash">
+                {installCommand}
+              </CodeBlock>
+            </div>
           </div>
         </div>
       </div>

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -16,7 +16,7 @@
 .singleColumn {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 0.5rem;
   max-width: 900px;
   margin: 0 auto;
 }
@@ -54,7 +54,7 @@
 .codeWrapper {
   position: relative;
   width: 100%;
-  max-width: 550px;
+  max-width: 520px;
   margin: 0 auto;
 }
 

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -13,8 +13,16 @@
   max-width: 1400px;
 }
 
+.singleColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
 .agentContent {
-  padding: 2rem;
+  padding: 0;
 }
 
 .agentSubtitle {
@@ -39,7 +47,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 3rem;
+  padding: 0;
 }
 
 .codeContainer :global(.codeBlockContainer) {
@@ -56,25 +64,15 @@
 
 /* Responsive styles */
 @media (max-width: 996px) {
-  .codingAgent .row {
-    flex-direction: column;
+  .singleColumn {
+    max-width: 100%;
   }
 
   .agentContent {
-    padding: 2rem 1rem;
-    text-align: center;
-  }
-
-  .agentContent ul {
-    display: inline-block;
-    text-align: left;
+    padding: 0;
   }
 
   .codeContainer {
-    padding: 2rem 1rem;
-  }
-
-  .buttonContainer {
-    text-align: center;
+    padding: 0;
   }
 }

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -39,13 +39,18 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 2rem;
+  padding: 3rem;
 }
 
 .codeContainer :global(.codeBlockContainer) {
   width: 100%;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 8px;
+}
+
+.codeContainer :global(.codeBlockContainer code) {
+  font-size: 1.1rem;
+  line-height: 1.8;
 }
 
 /* Responsive styles */

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -1,0 +1,74 @@
+.codingAgent {
+  display: flex;
+  align-items: center;
+  padding: 4rem 0;
+  width: 100%;
+  background-color: var(--ifm-color-emphasis-0);
+}
+
+.wideContainer {
+  margin: 0 auto;
+  padding: 0 var(--ifm-spacing-horizontal);
+  width: 100%;
+  max-width: 1400px;
+}
+
+.agentContent {
+  padding: 2rem;
+}
+
+.agentSubtitle {
+  font-size: 1.2rem;
+  color: var(--ifm-color-primary);
+  margin-bottom: 1.5rem;
+}
+
+.agentContent ul {
+  margin-bottom: 2rem;
+}
+
+.agentContent li {
+  margin-bottom: 0.5rem;
+}
+
+.buttonContainer {
+  margin-top: 2rem;
+}
+
+.codeContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+}
+
+.codeContainer :global(.codeBlockContainer) {
+  width: 100%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  border-radius: 8px;
+}
+
+/* Responsive styles */
+@media (max-width: 996px) {
+  .codingAgent .row {
+    flex-direction: column;
+  }
+
+  .agentContent {
+    padding: 2rem 1rem;
+    text-align: center;
+  }
+
+  .agentContent ul {
+    display: inline-block;
+    text-align: left;
+  }
+
+  .codeContainer {
+    padding: 2rem 1rem;
+  }
+
+  .buttonContainer {
+    text-align: center;
+  }
+}

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -44,13 +44,14 @@
 
 .codeContainer :global(.codeBlockContainer) {
   width: 100%;
+  padding: 2rem !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 8px;
 }
 
 .codeContainer :global(.codeBlockContainer code) {
-  font-size: 1.1rem;
-  line-height: 1.8;
+  font-size: 1.4rem;
+  line-height: 2;
 }
 
 /* Responsive styles */

--- a/website/src/components/sections/CodingAgent/styles.module.css
+++ b/website/src/components/sections/CodingAgent/styles.module.css
@@ -46,20 +46,64 @@
 .codeContainer {
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   padding: 0;
+  width: 100%;
+}
+
+.codeWrapper {
+  position: relative;
+  width: 100%;
+  max-width: 550px;
+  margin: 0 auto;
+}
+
+.copyButton {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  z-index: 100;
+  padding: 0.6rem;
+  background-color: #9ca3af;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.copyButton .icon {
+  font-size: 1.1rem;
+}
+
+.copyButton:hover {
+  background-color: #6b7280;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.copyButton:active {
+  transform: translateY(0);
+}
+
+.copyButton.copied {
+  background-color: #6b7280;
 }
 
 .codeContainer :global(.codeBlockContainer) {
   width: 100%;
-  padding: 2rem !important;
+  padding: 3rem !important;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   border-radius: 8px;
 }
 
 .codeContainer :global(.codeBlockContainer code) {
-  font-size: 1.4rem;
-  line-height: 2;
+  font-size: 1.7rem;
+  line-height: 2.2;
+  font-weight: 500;
 }
 
 /* Responsive styles */

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Link from '@docusaurus/Link';
+import { FaArrowRight } from 'react-icons/fa6';
 
 export default function Hero() {
   const context = useDocusaurusContext();
@@ -18,6 +20,14 @@ export default function Hero() {
           Type-safe, composable asynchronous and concurrent programming for{' '}
           <span className="text-primary">Scala</span>
         </p>
+
+        <Link
+          className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2 font-semibold text-white hover:text-white hover:no-underline"
+          to="/overview/getting-started"
+        >
+          <span>Get Started</span>
+          <FaArrowRight />
+        </Link>
       </div>
     </section>
   );

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import Link from '@docusaurus/Link';
-import { FaArrowRight } from 'react-icons/fa6';
 
 export default function Hero() {
   const context = useDocusaurusContext();
@@ -20,14 +18,6 @@ export default function Hero() {
           Type-safe, composable asynchronous and concurrent programming for{' '}
           <span className="text-primary">Scala</span>
         </p>
-
-        <Link
-          className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2 font-semibold text-white hover:text-white hover:no-underline"
-          to="/overview/getting-started"
-        >
-          <span>Get Started</span>
-          <FaArrowRight />
-        </Link>
       </div>
     </section>
   );

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -3,8 +3,6 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
 import { FaArrowRight } from 'react-icons/fa6';
 
-import EmbeddedVideo from '@site/src/components/EmbeddedVideo';
-
 export default function Hero() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
@@ -30,13 +28,6 @@ export default function Hero() {
           <span>Get Started</span>
           <FaArrowRight />
         </Link>
-      </div>
-
-      <div className="container">
-        <EmbeddedVideo
-          className="mx-auto w-full max-w-7xl"
-          video="XUwynbWUlhg"
-        />
       </div>
     </section>
   );

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -5,6 +5,7 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Hero from '@site/src/components/sections/Hero';
 import Features from '@site/src/components/sections/Features';
 import Ecosystem from '@site/src/components/sections/Ecosystem';
+import CodingAgent from '@site/src/components/sections/CodingAgent';
 import Sponsors from '@site/src/components/sections/Sponsors';
 import Zionomicon from '@site/src/components/sections/Zionomicon';
 
@@ -21,6 +22,7 @@ export default function WelcomePage() {
       <Hero />
 
       <main>
+        <CodingAgent />
         <Features />
         <Ecosystem title = "Ecosystem" subtitle="A rich ecosystem of libraries built on ZIO to solve real-world problems"/>
         <Zionomicon />


### PR DESCRIPTION
## Summary
Adds a prominent section to the zio.dev homepage teaching users about the `zio-knowledge` Claude Code skill, which allows coding agents to fetch live ZIO documentation instead of relying on stale training data.

### Changes
- Created new CodingAgent section component with installation instructions
- Added similar documentation to the getting-started guide
- Updated homepage to showcase the skill integration
- Ensured responsive design and consistent styling

### Benefits
- Drives adoption of the zio-skills plugin
- Signals ZIO as "AI-native" with first-class coding agent support
- Helps developers get more accurate ZIO answers from AI tools

🤖 Generated with Claude Code