### PR TITLE
Preserve defects in ZIO.ignoreLogged

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -1392,6 +1392,17 @@ object ZIOSpec extends ZIOBaseSpec {
         assertZIO(ZIO.die(ExampleError).ignore.exit)(dies(equalTo(ExampleError)))
       } @@ zioTag(errors)
     ),
+    suite("ignoreLogged")(
+      test("return success as Unit") {
+        assertZIO(ZIO.succeed(11).ignoreLogged)(equalTo(()))
+      },
+      test("return failure as Unit") {
+        assertZIO(ZIO.fail(123).ignoreLogged)(equalTo(()))
+      } @@ zioTag(errors),
+      test("not catch throwable") {
+        assertZIO(ZIO.die(ExampleError).ignoreLogged.exit)(dies(equalTo(ExampleError)))
+      } @@ zioTag(errors)
+    ),
     suite("isFailure")(
       test("returns true when the effect is a failure") {
         assertZIO(ZIO.fail("fail").isFailure)(isTrue)

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -927,6 +927,42 @@ object Cause extends Serializable {
       (causeOption, stackless) => causeOption.map(Stackless(_, stackless))
     )
 
+  private sealed trait CauseToStringStep[+E]
+  private final case class Visit[+E](cause: Cause[E])          extends CauseToStringStep[E]
+  private final case class RenderBinary(name: String)          extends CauseToStringStep[Nothing]
+  private final case class RenderStackless(stackless: Boolean) extends CauseToStringStep[Nothing]
+
+  private def causeToString[E](cause: Cause[E]): String = {
+    val visitStack = new mutable.Stack[CauseToStringStep[E]]()
+    val results    = new mutable.Stack[String]()
+
+    visitStack.push(Visit(cause))
+
+    while (visitStack.nonEmpty) {
+      visitStack.pop() match {
+        case RenderBinary(name) =>
+          val right = results.pop()
+          val left  = results.pop()
+          results.push(s"$name($left,$right)")
+        case RenderStackless(stackless) =>
+          results.push(s"Stackless(${results.pop()},$stackless)")
+        case Visit(current) =>
+          current match {
+            case Both(left, right) =>
+              visitStack.push(RenderBinary("Both"), Visit(right), Visit(left))
+            case Then(left, right) =>
+              visitStack.push(RenderBinary("Then"), Visit(right), Visit(left))
+            case Stackless(cause, stackless) =>
+              visitStack.push(RenderStackless(stackless), Visit(cause))
+            case nonCompositeCause =>
+              results.push(nonCompositeCause.toString)
+          }
+      }
+    }
+
+    results.pop()
+  }
+
   /**
    * A Cause that contains one or more sub-causes
    */
@@ -935,50 +971,7 @@ object Cause extends Serializable {
     /**
      * Stack-safe toString for Cause
      */
-    final private def causeToString: String = {
-      // result modifier function (Function0[Unit]) or cause (Cause[E]) to visit
-      val visitStack = new mutable.Stack[Any]()
-      // calculated string results
-      val results = new mutable.Stack[String]()
-
-      def twoArgStr(name: String) = {
-        val right = results.pop()
-        val left  = results.pop()
-        results.push(s"$name($left,$right)")
-      }
-
-      @tailrec
-      def visitRecursive(): String = {
-        def visitCause(current: Cause[E]) =
-          current match {
-            case Both(left, right) =>
-              visitStack.push(() => twoArgStr("Both"), right, left)
-            case Then(left, right) =>
-              visitStack.push(() => twoArgStr("Then"), right, left)
-            case Stackless(cause, stackless) =>
-              visitStack.push(() => results.push(s"Stackless(${results.pop()},$stackless)"), cause)
-            case nonCompositeCause =>
-              results.push(nonCompositeCause.toString)
-          }
-
-        if (visitStack.isEmpty) {
-          results.pop()
-        } else {
-          visitStack.pop() match {
-            case fn: Function0[Unit] =>
-              fn()
-            case cause: Cause[E] =>
-              visitCause(cause)
-          }
-          visitRecursive()
-        }
-      }
-
-      visitStack.push(self)
-      visitRecursive()
-    }
-
-    final override def toString = causeToString
+    final override def toString = Cause.causeToString(self)
   }
 
   case object Empty extends Cause[Nothing] { self =>

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -872,9 +872,13 @@ sealed trait ZIO[-R, +E, +A]
   final def ignoreLogged(implicit trace: Trace): URIO[R, Unit] =
     self.foldCauseZIO(
       cause =>
-        ZIO.logLevel(LogLevel.Debug) {
-          ZIO.logCause("An error was silently ignored because it is not anticipated to be useful", cause)
-        },
+        cause.failureOrCause.fold(
+          _ =>
+            ZIO.logLevel(LogLevel.Debug) {
+              ZIO.logCause("An error was silently ignored because it is not anticipated to be useful", cause)
+            },
+          Exit.failCause
+        ),
       _ => Exit.unit
     )
 


### PR DESCRIPTION
Fixes #10993

This makes ignoreLogged match ignore for non-typed failures. Typed failures are still logged at Debug and ignored, while defects are no longer converted into a successful Unit.

Validation:
- sbt "coreTestsJVM/testOnly zio.ZIOSpec -- -t ignoreLogged"
- sbt "coreTestsJVM/testOnly zio.ZIOSpec -- -t ignore"
- sbt scalafmtCheckAll
- git diff --check