### PR TITLE
Preserve TMap.takeFirst bucket entries after a match

### DIFF
--- a/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/stm/TMapSpec.scala
@@ -111,6 +111,19 @@ object TMapSpec extends ZIOBaseSpec {
 
         assertZIO(tx.commit)(isNone)
       },
+      test("takeFirst preserves remaining colliding entries") {
+        for {
+          tmap <- TMap
+                    .make(CollidingKey("a") -> 1, CollidingKey("b") -> 2, CollidingKey("c") -> 3)
+                    .commit
+          taken     <- tmap.takeFirst { case (_, value) if value == 2 => value }.commit
+          remaining <- tmap.toList.commit
+          size      <- tmap.size.commit
+        } yield assertTrue(taken == 2, size == 2) &&
+          assert(remaining.map { case (key, value) => key.name -> value })(
+            hasSameElements(List("a" -> 1, "c" -> 3))
+          )
+      },
       test("add many keys with negative hash codes") {
         val expected = (1 to 1000).map(i => HashContainer(-i) -> i).toList
 
@@ -475,5 +488,9 @@ object TMapSpec extends ZIOBaseSpec {
       }
 
     override def toString: String = s"HashContainer($i)"
+  }
+
+  private final case class CollidingKey(name: String) {
+    override def hashCode(): Int = 0
   }
 }

--- a/core/shared/src/main/scala/zio/stm/TMap.scala
+++ b/core/shared/src/main/scala/zio/stm/TMap.scala
@@ -418,6 +418,9 @@ final class TMap[K, V] private (
                 newBucket = pair :: newBucket
               }
             }
+            while (it.hasNext) {
+              newBucket = it.next() :: newBucket
+            }
             buckets.array(i).unsafeSet(journal, newBucket)
           }
 


### PR DESCRIPTION
Fixes #10936

This drains the rest of the matching bucket after takeFirst finds the first selected entry, so non-matching entries that follow the match are preserved instead of being dropped when the bucket is written back.

Validation:
- sbt "coreTestsJVM/testOnly zio.stm.TMapSpec -- -t takeFirst"
- sbt "coreTestsJVM/testOnly zio.stm.TMapSpec"
- sbt scalafmtCheckAll
- git diff --check