### PR TITLE
ci: auto-approve and auto-merge bot dependency PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,11 +1,14 @@
-name: Auto-approve Renovate's PRs
+name: Auto-approve bot dependency PRs
 
 on: pull_request_target
 
+permissions:
+  pull-requests: write
+
 jobs:
-  auto-approve-renovate-prs:
+  auto-approve-bot-prs:
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]'
+    if: github.actor == 'renovate[bot]' || github.actor == 'app/zio-scala-steward'
     steps:
       - name: Git Checkout
         uses: actions/checkout@v6.0.3

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -10,11 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'renovate[bot]' || github.actor == 'app/zio-scala-steward'
     steps:
-      - name: Git Checkout
-        uses: actions/checkout@v6.0.3
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
       - name: Approve PR
         run: gh pr review --approve ${{ github.event.number }}
         env:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,11 +4,6 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
-    inputs:
-      actor_filter:
-        description: 'Bot actor to process (leave blank for both)'
-        required: false
-        default: ''
 
 permissions:
   contents: write
@@ -32,6 +27,7 @@ jobs:
       - name: Backfill auto-merge for existing bot PRs
         if: github.event_name == 'workflow_dispatch'
         run: |
+          set -euo pipefail
           for actor in "app/zio-scala-steward" "renovate[bot]"; do
             gh pr list \
               --author "$actor" \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,45 @@
+name: Auto-merge bot dependency PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      actor_filter:
+        description: 'Bot actor to process (leave blank for both)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'app/zio-scala-steward'
+    steps:
+      - name: Enable auto-merge for bot PR
+        if: github.event_name == 'pull_request_target'
+        run: gh pr merge --auto --squash ${{ github.event.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+
+      - name: Backfill auto-merge for existing bot PRs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          for actor in "app/zio-scala-steward" "renovate[bot]"; do
+            gh pr list \
+              --author "$actor" \
+              --state open \
+              --json number \
+              --jq '.[].number' | \
+            xargs -I{} gh pr merge --auto --squash {}
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Extends `auto-approve.yml` to cover `app/zio-scala-steward` PRs (previously only `renovate[bot]`)
- Adds new `auto-merge.yml` that enables GitHub native auto-merge on bot PRs once all required CI checks pass
- Includes `workflow_dispatch` trigger for backfilling auto-merge on existing open bot PRs

## How it works

On each bot PR opened/updated, the workflow calls `gh pr merge --auto --squash`. GitHub queues the merge and fires it automatically once all required status checks pass. No polling required.

## Backfill

After merging, trigger `auto-merge.yml` manually via Actions → workflow_dispatch to enable auto-merge on all currently open bot PRs.

## Prerequisites (repo settings to verify)

- [ ] Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests" is **enabled**
- [ ] Branch protection on `series/2.x` has required status checks configured (so auto-merge waits for CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)