### PR TITLE
ci: add workflow_dispatch backfill to auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,6 +1,8 @@
 name: Auto-approve bot dependency PRs
 
-on: pull_request_target
+on:
+  pull_request_target:
+  workflow_dispatch:
 
 permissions:
   pull-requests: write
@@ -8,9 +10,29 @@ permissions:
 jobs:
   auto-approve-bot-prs:
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]' || github.actor == 'app/zio-scala-steward'
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.actor == 'renovate[bot]' ||
+      github.actor == 'app/zio-scala-steward'
     steps:
       - name: Approve PR
+        if: github.event_name == 'pull_request_target'
         run: gh pr review --approve ${{ github.event.number }}
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Backfill auto-approve for existing bot PRs
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          for actor in "app/zio-scala-steward" "renovate[bot]"; do
+            gh pr list \
+              --author "$actor" \
+              --state open \
+              --json number \
+              --jq '.[].number' | \
+            xargs -I{} gh pr review --approve {}
+          done
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to `auto-approve.yml`
- Adds backfill step that approves all currently open bot PRs (`app/zio-scala-steward` + `renovate[bot]`) when triggered manually
- Approving already-approved PRs is idempotent — safe to run multiple times

## Usage

After merging, go to Actions → Auto-approve bot dependency PRs → Run workflow to approve all existing open bot PRs at once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)