### PR TITLE
ci: fix auto-approve and auto-merge workflow issues

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -2,6 +2,7 @@ name: Auto-approve bot dependency PRs
 
 on:
   pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -12,14 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.actor == 'renovate[bot]' ||
-      github.actor == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'app/zio-scala-steward'
     steps:
       - name: Approve PR
         if: github.event_name == 'pull_request_target'
         run: gh pr review --approve ${{ github.event.number }}
         env:
           GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GH_REPO: ${{ github.repository }}
 
       - name: Backfill auto-approve for existing bot PRs
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      github.actor == 'renovate[bot]' ||
-      github.actor == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'renovate[bot]' ||
+      github.event.pull_request.user.login == 'app/zio-scala-steward'
     steps:
       - name: Enable auto-merge for bot PR
         if: github.event_name == 'pull_request_target'


### PR DESCRIPTION
## Summary

Fixes a bug where `gh pr review --approve` fails with `fatal: not a git repository` because `GH_REPO` was missing from the approve step — `gh` tried to detect the repo from git context with no checkout.

Also applies two improvements identified during zio-http review:

- **Add `GH_REPO`** to the approve step so `gh` resolves the repo deterministically without requiring a checkout
- **Scope `pull_request_target` to `types`** — avoids unnecessary runs on `closed`, `labeled`, `edited`, etc.
- **Use `github.event.pull_request.user.login`** instead of `github.actor` — actor can be wrong for `ready_for_review` events (triggered by whoever clicked the button, not the PR author)

🤖 Generated with [Claude Code](https://claude.com/claude-code)