### PR TITLE
ci: fix auto-approve/merge for zio-scala-steward bot

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,46 @@
+# Auto-Approve and Auto-Merge Workflows
+
+This directory contains workflows that automatically approve and merge dependency update PRs from automation bots.
+
+## Overview
+
+- **`auto-approve.yml`**: Automatically approves PRs from dependency bots
+- **`auto-merge.yml`**: Enables GitHub's auto-merge feature (squash strategy) on bot PRs
+- **`scala-steward.yml`**: Runs Scala Steward to generate dependency update PRs
+
+## Manual Backfill / Force Re-trigger
+
+If PRs are not being auto-approved or auto-merged (e.g., due to a workflow bug or missed events), manually trigger the backfill logic:
+
+### Method 1: GitHub Web UI
+1. Go to **Actions** → **Auto-approve bot dependency PRs** (or **Auto-merge bot dependency PRs**)
+2. Click **Run workflow** → **Run workflow** button
+3. Select branch: `series/2.x` (or your target branch)
+4. Click **Run workflow**
+
+### Method 2: GitHub CLI
+
+```bash
+# Re-approve all open bot PRs on a branch
+gh workflow run auto-approve.yml --repo zio/zio --ref series/2.x
+
+# Re-enable auto-merge on all open bot PRs on a branch
+gh workflow run auto-merge.yml --repo zio/zio --ref series/2.x
+```
+
+The `workflow_dispatch` triggers will iterate over all currently open PRs from both bots and apply the approvals/merges.
+
+## How It Works
+
+### Auto-Approve Workflow
+
+1. **Trigger**: `pull_request_target` (new/updated/reopened/ready-for-review bot PRs) or `workflow_dispatch` (manual)
+2. **Condition**: Checks if PR author is `renovate[bot]` or `zio-scala-steward[bot]`
+3. **Action**: Runs `gh pr review --approve` to approve the PR
+
+### Auto-Merge Workflow
+
+1. **Trigger**: `pull_request_target` (new/updated/reopened/ready-for-review bot PRs) or `workflow_dispatch` (manual)
+2. **Condition**: Checks if PR author is `renovate[bot]` or `zio-scala-steward[bot]`
+3. **Action**: Runs `gh pr merge --auto --squash` to enable squash auto-merge
+

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'renovate[bot]' ||
-      github.event.pull_request.user.login == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
     steps:
       - name: Approve PR
         if: github.event_name == 'pull_request_target'
@@ -27,7 +27,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "app/zio-scala-steward" "renovate[bot]"; do
+          for actor in "zio-scala-steward[bot]" "renovate[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,7 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'renovate[bot]' ||
-      github.event.pull_request.user.login == 'app/zio-scala-steward'
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
     steps:
       - name: Enable auto-merge for bot PR
         if: github.event_name == 'pull_request_target'
@@ -28,7 +28,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "app/zio-scala-steward" "renovate[bot]"; do
+          for actor in "zio-scala-steward[bot]" "renovate[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \


### PR DESCRIPTION
## Summary
Fix auto-approve and auto-merge workflows to use the correct GitHub App bot login format.

The workflows were checking for `'app/zio-scala-steward'` (GraphQL format), but the GitHub Actions `pull_request_target` event payload contains `'zio-scala-steward[bot]'` (REST API format). This caused all Scala Steward PRs to be skipped.

## Changes
- Updated both `auto-approve.yml` and `auto-merge.yml` to use `'zio-scala-steward[bot]'`
- Updated backfill loops to use the correct bot login format

## Test Plan
- PR #11013 should now be auto-approved and auto-merge enabled after triggering the workflow
- New Scala Steward PRs will show `success` (not `skipped`) on auto-approve/merge checks

🤖 Generated with Claude Code