### PR TITLE
Reduce local scheduler wakeups

### DIFF
--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -148,13 +148,18 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     if (isBlocking(worker, runnable)) {
       submitBlocking(runnable)
     } else {
+      var notify = true
       if ((worker eq null) || worker.blocking) {
         globalQueue.offer(runnable)
       } else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
-      } else ()
-      val currentState = state.get
-      maybeUnparkWorker(currentState)
+      } else {
+        notify = worker.localQueue.size() >= ZScheduler.localWakeupThreshold
+      }
+      if (notify) {
+        val currentState = state.get
+        maybeUnparkWorker(currentState)
+      }
       true
     }
   }
@@ -185,6 +190,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
       // We have to yield, add the runnable to the local / global queue so that it can be scheduled accordingly
       else if (!worker.localQueue.offer(runnable)) {
         handleFullWorkerQueue(worker, runnable)
+      } else {
+        notify = worker.localQueue.size() >= ZScheduler.localWakeupThreshold
       }
 
       if (notify) {
@@ -462,7 +469,8 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 }
 
 private object ZScheduler {
-  private val poolSize = java.lang.Runtime.getRuntime.availableProcessors
+  private val poolSize             = java.lang.Runtime.getRuntime.availableProcessors
+  private val localWakeupThreshold = 64
 
   def markCurrentWorkerAsBlocking(): Unit = {
     val worker = workerOrNull()


### PR DESCRIPTION
# ZIO #9878 PR Draft

## Target

- Repository: `zio/zio`
- Base branch: `series/2.x`
- Issue: https://github.com/zio/zio/issues/9878
- Proposed branch: `codex/zscheduler-reduce-local-unpark`

## PR Title

Reduce ZScheduler worker unparks for local queue submissions

## PR Body

Fixes #9878.

This changes `ZScheduler` so submissions from an already-running worker to its own local queue do not immediately call `maybeUnparkWorker` for every runnable. External submissions, blocking-worker submissions, and local queue overflow still notify idle workers immediately. Local worker submissions now wake idle workers only after the local queue reaches a small backlog threshold.

Rationale:

- `maybeUnparkWorker` can reach `LockSupport.unpark`, which is expensive in the scheduler hot path.
- A worker that successfully enqueues into its own local queue can continue draining that queue without waking another worker for every single local submission.
- The threshold preserves parallelism when a local backlog grows, while avoiding excessive park/unpark cycling for small bursts.

Changes:

- Adds `localWakeupThreshold = 64` beside `poolSize`.
- Tracks whether `submit` / `submitAndYield` need to notify after queueing.
- Skips notification for small local-queue submissions.
- Keeps immediate notification for global queue submissions and queue overflow.

## Testing

Not run in this environment: Java, SBT, Git, and GitHub CLI are not available on PATH.

Recommended maintainer-side checks:

```bash
sbt "coreJVM / Test / compile"
sbt "coreJVM / testOnly zio.ZIOSpec"
```

Recommended benchmark validation:

```bash
sbt "benchmarks / Jmh / run .*Scheduler.*"
```

## Risk

This intentionally trades some immediate work sharing for fewer wakeups. The main risk is reduced parallelism for medium-sized local bursts smaller than 64 queued runnables. If maintainers prefer a more conservative threshold, reduce `localWakeupThreshold` to `16` or `32`, or make it dependent on `poolSize`.

## Claim

If submitted through Algora, include:

```text
/claim #9878
```
