### PR TITLE
Correctly skip months with less days specified in `Schedule.dayOfMonth`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -477,6 +477,60 @@ object ScheduleSpec extends ZIOBaseSpec {
           equalTo(List(expected))
         }
       },
+      test("does not skip skip February for 29 days") {
+        def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
+          in._1.map(t => t._1.withNano(0))
+
+        val originOffset = OffsetDateTime
+          .now()
+          .withYear(2020)
+          .withMonth(1)
+          .withDayOfMonth(31)
+          .truncatedTo(ChronoUnit.DAYS)
+
+        val input = List(originOffset).map((_, ()))
+
+        assertZIO(runManually(Schedule.dayOfMonth(29), input).map(toOffsetDateTime)) {
+          val expected = originOffset.withMonth(2).withDayOfMonth(29)
+          equalTo(List(expected))
+        }
+      },
+      test("skips non-leap February for 29 days #1") {
+        def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
+          in._1.map(t => t._1.withNano(0))
+
+        val originOffset = OffsetDateTime
+          .now()
+          .withYear(2021)
+          .withMonth(2)
+          .withDayOfMonth(28)
+          .truncatedTo(ChronoUnit.DAYS)
+
+        val input = List(originOffset).map((_, ()))
+
+        assertZIO(runManually(Schedule.dayOfMonth(29), input).map(toOffsetDateTime)) {
+          val expected = originOffset.withMonth(3).withDayOfMonth(29)
+          equalTo(List(expected))
+        }
+      },
+      test("skips non-leap February for 29 days #2") {
+        def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
+          in._1.map(t => t._1.withNano(0))
+
+        val originOffset = OffsetDateTime
+          .now()
+          .withYear(2021)
+          .withMonth(1)
+          .withDayOfMonth(31)
+          .truncatedTo(ChronoUnit.DAYS)
+
+        val input = List(originOffset).map((_, ()))
+
+        assertZIO(runManually(Schedule.dayOfMonth(29), input).map(toOffsetDateTime)) {
+          val expected = originOffset.withMonth(3).withDayOfMonth(29)
+          equalTo(List(expected))
+        }
+      },
       test("throw IllegalArgumentException on invalid `day` argument of `dayOfMonth`") {
         val input = List(OffsetDateTime.now())
         for {

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -441,7 +441,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           equalTo(List(expectedFirstInTime, expectedSecondInTime, expectedBefore, expectedAfter))
         }
       },
-      test("recur only in months containing valid number of days") {
+      test("skips next month if it does not contain a valid number of days") {
         def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
           in._1.map(t => t._1.withNano(0))
 
@@ -450,6 +450,24 @@ object ScheduleSpec extends ZIOBaseSpec {
           .withYear(2020)
           .withMonth(1)
           .withDayOfMonth(31)
+          .truncatedTo(ChronoUnit.DAYS)
+
+        val input = List(originOffset).map((_, ()))
+
+        assertZIO(runManually(Schedule.dayOfMonth(30), input).map(toOffsetDateTime)) {
+          val expected = originOffset.withMonth(3).withDayOfMonth(30)
+          equalTo(List(expected))
+        }
+      },
+      test("skips this month if it does not contain a valid number of days") {
+        def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
+          in._1.map(t => t._1.withNano(0))
+
+        val originOffset = OffsetDateTime
+          .now()
+          .withYear(2020)
+          .withMonth(2)
+          .withDayOfMonth(20)
           .truncatedTo(ChronoUnit.DAYS)
 
         val input = List(originOffset).map((_, ()))

--- a/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ScheduleSpec.scala
@@ -477,7 +477,7 @@ object ScheduleSpec extends ZIOBaseSpec {
           equalTo(List(expected))
         }
       },
-      test("does not skip skip February for 29 days") {
+      test("does not skip February for 29 days") {
         def toOffsetDateTime[T](in: (List[(OffsetDateTime, T)], Option[T])): List[OffsetDateTime] =
           in._1.map(t => t._1.withNano(0))
 

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1882,15 +1882,23 @@ object Schedule {
     now.`with`(temporalAdjuster)
   }
 
-  private def nextDayOfMonth(now: OffsetDateTime, day: Int, initial: Boolean): OffsetDateTime =
-    if (now.getDayOfMonth == day && initial) now
-    else if (now.getDayOfMonth < day) now.`with`(DAY_OF_MONTH, day.toLong)
+  private def nextDayOfMonth(now: OffsetDateTime, day: Int, initial: Boolean): OffsetDateTime = {
+    val dayOfMonth = now.getDayOfMonth
+    if (dayOfMonth == day && initial) now
+    else if (
+      dayOfMonth < day
+      && day <= now.getMonth.maxLength()
+    ) now.`with`(DAY_OF_MONTH, day.toLong)
     else findNextMonth(now, day, 1)
+  }
 
+  @tailrec
   private def findNextMonth(now: OffsetDateTime, day: Int, months: Int): OffsetDateTime =
-    if (now.`with`(DAY_OF_MONTH, day.toLong).plusMonths(months.toLong).getDayOfMonth == day)
-      now.`with`(DAY_OF_MONTH, day.toLong).plusMonths(months.toLong)
-    else findNextMonth(now, day, months + 1)
+    if (day <= now.getMonth.plus(months.toLong).maxLength()) {
+      val next = now.plusMonths(months.toLong).`with`(DAY_OF_MONTH, day.toLong)
+      if (next.getDayOfMonth == day) next
+      else findNextMonth(now, day, months + 1)
+    } else findNextMonth(now, day, months + 1)
 
   private def nextHour(now: OffsetDateTime, hour: Int, initial: Boolean): OffsetDateTime =
     if (now.getHour == hour && initial) now

--- a/core/shared/src/main/scala/zio/Schedule.scala
+++ b/core/shared/src/main/scala/zio/Schedule.scala
@@ -1887,18 +1887,27 @@ object Schedule {
     if (dayOfMonth == day && initial) now
     else if (
       dayOfMonth < day
-      && day <= now.getMonth.maxLength()
+      && day <= maxDays(now)
     ) now.`with`(DAY_OF_MONTH, day.toLong)
     else findNextMonth(now, day, 1)
   }
 
   @tailrec
-  private def findNextMonth(now: OffsetDateTime, day: Int, months: Int): OffsetDateTime =
-    if (day <= now.getMonth.plus(months.toLong).maxLength()) {
-      val next = now.plusMonths(months.toLong).`with`(DAY_OF_MONTH, day.toLong)
+  private def findNextMonth(now: OffsetDateTime, day: Int, months: Int): OffsetDateTime = {
+    val nextMonth = now.plusMonths(months.toLong)
+    if (day <= maxDays(nextMonth)) {
+      val next = nextMonth.`with`(DAY_OF_MONTH, day.toLong)
       if (next.getDayOfMonth == day) next
       else findNextMonth(now, day, months + 1)
     } else findNextMonth(now, day, months + 1)
+  }
+
+  private def maxDays(now: OffsetDateTime): Int =
+    if (
+      now.getMonthValue == 2
+      && now.toLocalDate.isLeapYear
+    ) 29
+    else now.getMonth.minLength()
 
   private def nextHour(now: OffsetDateTime, hour: Int, initial: Boolean): OffsetDateTime =
     if (now.getHour == hour && initial) now


### PR DESCRIPTION
/fixes #10883