### PR TITLE
Optimize `Chunk.Tags.fromValue`

### DIFF
--- a/core/jvm-native/src/main/scala/zio/ChunkPlatformSpecific.scala
+++ b/core/jvm-native/src/main/scala/zio/ChunkPlatformSpecific.scala
@@ -18,62 +18,42 @@ package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import scala.reflect.{ClassTag, classTag}
+import scala.reflect.ClassTag
 
 private[zio] trait ChunkPlatformSpecific {
 
   private[zio] object Tags {
-    def fromValue[A](a: A): ClassTag[A] =
-      if (a == null) classTag[AnyRef].asInstanceOf[ClassTag[A]]
+    def fromValue[A](a: A): ClassTag[A] = {
+      if (a == null) ClassTag.AnyRef
       else {
         val c = a.getClass
-        val unboxedClass =
-          if (isBoolean(c)) BooleanClass.asInstanceOf[Class[A]]
-          else if (isByte(c)) ByteClass.asInstanceOf[Class[A]]
-          else if (isShort(c)) ShortClass.asInstanceOf[Class[A]]
-          else if (isInt(c)) IntClass.asInstanceOf[Class[A]]
-          else if (isLong(c)) LongClass.asInstanceOf[Class[A]]
-          else if (isFloat(c)) FloatClass.asInstanceOf[Class[A]]
-          else if (isDouble(c)) DoubleClass.asInstanceOf[Class[A]]
-          else if (isChar(c)) CharClass.asInstanceOf[Class[A]]
-          else null
-
-        if (unboxedClass eq null) classTag[AnyRef].asInstanceOf[ClassTag[A]]
-        else ClassTag(unboxedClass).asInstanceOf[ClassTag[A]]
+        if (isByte(c)) ClassTag.Byte
+        else if (isInt(c)) ClassTag.Int
+        else if (isBoolean(c)) ClassTag.Boolean
+        else if (isChar(c)) ClassTag.Char
+        else if (isShort(c)) ClassTag.Short
+        else if (isLong(c)) ClassTag.Long
+        else if (isFloat(c)) ClassTag.Float
+        else if (isDouble(c)) ClassTag.Double
+        else ClassTag.AnyRef
       }
+    }.asInstanceOf[ClassTag[A]]
 
     private def isBoolean(c: Class[_]): Boolean =
-      c == BooleanClass || c == BooleanClassBox
+      (c eq classOf[Boolean]) || (c eq classOf[java.lang.Boolean])
     private def isByte(c: Class[_]): Boolean =
-      c == ByteClass || c == ByteClassBox
+      (c eq classOf[Byte]) || (c eq classOf[java.lang.Byte])
     private def isShort(c: Class[_]): Boolean =
-      c == ShortClass || c == ShortClassBox
+      (c eq classOf[Short]) || (c eq classOf[java.lang.Short])
     private def isInt(c: Class[_]): Boolean =
-      c == IntClass || c == IntClassBox
+      (c eq classOf[Int]) || (c eq classOf[java.lang.Integer])
     private def isLong(c: Class[_]): Boolean =
-      c == LongClass || c == LongClassBox
+      (c eq classOf[Long]) || (c eq classOf[java.lang.Long])
     private def isFloat(c: Class[_]): Boolean =
-      c == FloatClass || c == FloatClassBox
+      (c eq classOf[Float]) || (c eq classOf[java.lang.Float])
     private def isDouble(c: Class[_]): Boolean =
-      c == DoubleClass || c == DoubleClassBox
+      (c eq classOf[Double]) || (c eq classOf[java.lang.Double])
     private def isChar(c: Class[_]): Boolean =
-      c == CharClass || c == CharClassBox
-
-    private val BooleanClass    = classOf[Boolean]
-    private val BooleanClassBox = classOf[java.lang.Boolean]
-    private val ByteClass       = classOf[Byte]
-    private val ByteClassBox    = classOf[java.lang.Byte]
-    private val ShortClass      = classOf[Short]
-    private val ShortClassBox   = classOf[java.lang.Short]
-    private val IntClass        = classOf[Int]
-    private val IntClassBox     = classOf[java.lang.Integer]
-    private val LongClass       = classOf[Long]
-    private val LongClassBox    = classOf[java.lang.Long]
-    private val FloatClass      = classOf[Float]
-    private val FloatClassBox   = classOf[java.lang.Float]
-    private val DoubleClass     = classOf[Double]
-    private val DoubleClassBox  = classOf[java.lang.Double]
-    private val CharClass       = classOf[Char]
-    private val CharClassBox    = classOf[java.lang.Character]
+      (c eq classOf[Char]) || (c eq classOf[java.lang.Character])
   }
 }


### PR DESCRIPTION
I was working on another issue and I was surprised to see this method taking a disproportional amount of CPU time in some method that created a lot of `Chunk`s. It seems that Chunks have an `implicit val tag` which means we calculate their `ClassTag` whenever we create a new one.

Anyways, this is much faster, and makes the method practically disappear from the profiles