### PR TITLE
Optimize ZIO.timeoutTo by scheduling the deadline on the clock's scheduler

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,140 @@
+package zio
+
+import org.openjdk.jmh.annotations.{
+  Benchmark,
+  BenchmarkMode,
+  Level,
+  Mode,
+  OutputTimeUnit,
+  Param,
+  Setup,
+  State,
+  Scope => JScope
+}
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TimeoutBenchmark {
+  import BenchmarkUtil.unsafeRun
+
+  @Param(Array("0", "100", "10000"))
+  var n: Int = _
+
+  var effect: UIO[Int] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    effect = ZIO.foldLeft(0 until n)(0) { case (prev, x) =>
+      ZIO.succeed(prev + x)
+    }
+
+  @Benchmark
+  def zioBaseline = {
+    val _ = unsafeRun {
+      effect
+    }
+  }
+
+  @Benchmark
+  def zioTimeout = {
+    val _ = unsafeRun {
+      effect.timeout(100.minutes)
+    }
+  }
+
+  @Benchmark
+  def zioTimeoutOrig = {
+    val _ = unsafeRun {
+      TimeoutBenchmark.timeoutOrig(effect)(100.minutes)
+    }
+  }
+}
+
+object TimeoutBenchmark {
+
+  /**
+   * The previous implementation of `ZIO#timeout`, kept here (with the
+   * `raceFibersWith` combinator it relied on) to allow benchmarking the new
+   * implementation against the old one. It races the effect against a forked
+   * `sleep` fiber.
+   */
+  def timeoutOrig[R, E, A](zio: ZIO[R, E, A])(duration: => Duration)(implicit trace: Trace): ZIO[R, E, Option[A]] =
+    ZIO.fiberIdWith { parentFiberId =>
+      raceFibersWith[R, E, A, Nothing, Unit, Option[A]](zio, ZIO.sleep(duration).interruptible)(
+        (winner, loser) =>
+          winner.await.flatMap { exit =>
+            loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(Some(_))
+          },
+        (winner, loser) =>
+          winner.await.flatMap {
+            case e: Exit.Failure[Nothing] =>
+              loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
+            case _ =>
+              loser.interruptAs(parentFiberId) *> loser.inheritAll.as(None)
+          },
+        null,
+        internal.FiberScope.global
+      )
+    }
+
+  /**
+   * A copy of the private `ZIO#raceFibersWith` the previous `timeout`
+   * implementation was built upon.
+   */
+  private def raceFibersWith[R, E, A, ER, B, C](
+    left: ZIO[R, E, A],
+    right: ZIO[R, ER, B]
+  )(
+    leftWins: (Fiber.Runtime[E, A], Fiber.Runtime[ER, B]) => ZIO[R, E, C],
+    rightWins: (Fiber.Runtime[ER, B], Fiber.Runtime[E, A]) => ZIO[R, E, C],
+    leftScope: internal.FiberScope,
+    rightScope: internal.FiberScope
+  )(implicit trace: Trace): ZIO[R, E, C] =
+    ZIO.withFiberRuntime[R, E, C] { (parentFiber, parentStatus) =>
+      import java.util.concurrent.atomic.AtomicBoolean
+
+      @inline def complete[E0, E1, A0, B0](
+        winner: Fiber.Runtime[E0, A0],
+        loser: Fiber.Runtime[E1, B0],
+        cont: (Fiber.Runtime[E0, A0], Fiber.Runtime[E1, B0]) => ZIO[R, E, C],
+        ab: AtomicBoolean,
+        cb: ZIO[R, E, C] => Any
+      ): Unit =
+        if (ab.compareAndSet(false, true)) {
+          cb(cont(winner, loser))
+        }
+
+      val graft     = ZIO.Grafter(parentFiber)
+      val leftEff   = graft.applyOnExit(left)
+      val rightEff  = graft.applyOnExit(right)
+      val flags     = parentStatus.runtimeFlags
+      val leftFiber = ZIO.unsafe.makeChildFiber(trace, leftEff, parentFiber, flags, leftScope)(Unsafe)
+
+      val rightFiber = ZIO.unsafe.makeChildFiber(trace, rightEff, parentFiber, flags, rightScope)(Unsafe)
+
+      val startLeft  = leftFiber.startSuspended()(Unsafe)
+      val startRight = rightFiber.startSuspended()(Unsafe)
+
+      ZIO.async[R, E, C](
+        { cb =>
+          val raceIndicator = new AtomicBoolean()
+
+          leftFiber.addObserver { _ =>
+            complete(leftFiber, rightFiber, leftWins, raceIndicator, cb)
+          }(Unsafe)
+
+          rightFiber.addObserver { _ =>
+            complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
+          }(Unsafe)
+
+          startLeft(leftEff)
+          startRight(rightEff)
+          ()
+        },
+        leftFiber.id <> rightFiber.id
+      )
+    }
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3269,6 +3269,29 @@ object ZIOSpec extends ZIOBaseSpec {
       test("timeout of terminate") {
         val io: ZIO[Any, Nothing, Option[Int]] = ZIO.die(ExampleError).timeout(1.hour)
         assertZIO(Live.live(io).exit)(dies(equalTo(ExampleError)))
+      },
+      test("timeout elapses when the test clock is adjusted") {
+        for {
+          fiber  <- ZIO.never.timeout(10.seconds).fork
+          _      <- TestClock.adjust(10.seconds)
+          result <- fiber.join
+        } yield assert(result)(isNone)
+      },
+      test("timeout inherits fiber refs of the effect") {
+        for {
+          fiberRef <- FiberRef.make(0)
+          result   <- (fiberRef.set(42) *> ZIO.succeed("ok")).timeout(1.second)
+          value    <- fiberRef.get
+        } yield assert(result)(isSome(equalTo("ok"))) && assert(value)(equalTo(42))
+      },
+      test("timeout inherits fiber refs of the effect when the timeout elapses") {
+        for {
+          fiberRef <- FiberRef.make(0)
+          fiber    <- (fiberRef.set(42) *> ZIO.never).timeoutTo(0)(_ => 1)(1.second).fork
+          _        <- TestClock.adjust(1.second)
+          result   <- fiber.join
+          value    <- fiberRef.get
+        } yield assert(result)(equalTo(0)) && assert(value)(equalTo(42))
       }
     ),
     suite("RTS option tests")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5667,22 +5667,56 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
+      ZIO.clockWith(_.scheduler).flatMap { scheduler =>
+        ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
+          import java.util.concurrent.atomic.AtomicBoolean
+
+          // Indicates which side of the race completed first, the effect or
+          // the timeout, ensuring that only one of them resumes the parent
+          // fiber:
+          val raceIndicator = new AtomicBoolean(false)
+
+          val graft    = ZIO.Grafter(parentFiber)
+          val childEff = graft.applyOnExit(self)
+
+          val childFiber =
+            ZIO.unsafe.makeChildFiber(trace, childEff, parentFiber, parentStatus.runtimeFlags, null)(Unsafe)
+          val startChild = childFiber.startSuspended()(Unsafe)
+
+          ZIO.asyncInterrupt[R, E, B1](
+            { cb =>
+              // Instead of racing the effect against a forked `sleep` fiber we
+              // schedule the timeout directly on the clock's scheduler,
+              // eliminating one fiber fork, one interruption and one join:
+              val cancelTimeout = scheduler.schedule(
+                () =>
+                  if (raceIndicator.compareAndSet(false, true)) {
+                    // The timeout elapsed before the effect completed.
+                    // Interrupt the effect and await its interruption before
+                    // producing the default value, so that this method does
+                    // not return until the underlying effect is actually
+                    // interrupted:
+                    cb(childFiber.interruptAs(parentFiber.id) *> childFiber.inheritAll.as(b()))
+                  },
+                duration
+              )(Unsafe)
+
+              childFiber.addObserver { exit =>
+                if (raceIndicator.compareAndSet(false, true)) {
+                  // The effect completed before the timeout elapsed. Cancel
+                  // the scheduled timeout and resume with the effect's result:
+                  cancelTimeout()
+                  cb(childFiber.inheritAll *> exit.mapExit(f))
+                }
+              }(Unsafe)
+
+              startChild(childEff)
+
+              Left(ZIO.succeed(cancelTimeout()))
             },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+            childFiber.id
+          )
+        }
       }
   }
 

--- a/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -17,7 +17,9 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Duration, Scheduler, Trace, UIO, Unsafe, ZIO}
+import zio.{Cause, Duration, FiberId, Scheduler, Trace, UIO, Unsafe, ZIO}
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
 
@@ -25,9 +27,27 @@ private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
     ZIO.runtime[Any].map { runtime =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
+          // The cancelled flag is flipped by whichever of the forked fiber or
+          // the cancel token runs first. This allows cancellation to be
+          // performed synchronously, without blocking the calling thread
+          // waiting for the fiber to be interrupted, which is impossible on
+          // Scala.js and would otherwise hang when this scheduler is used
+          // from within an uninterruptible region (the runtime captured above
+          // inherits the interruptibility of the fiber that created it, hence
+          // the `.interruptible` below):
+          val cancelled = new AtomicBoolean(false)
           val fiber =
-            runtime.unsafe.fork(sleep(duration) *> ZIO.succeed(runnable.run()))
-          () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
+            runtime.unsafe.fork(
+              (sleep(duration) *> ZIO.suspendSucceed {
+                if (cancelled.compareAndSet(false, true)) ZIO.succeed(runnable.run())
+                else ZIO.unit
+              }).interruptible
+            )
+          () =>
+            if (cancelled.compareAndSet(false, true)) {
+              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))(unsafe)
+              true
+            } else false
         }
       }
     }

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -17,11 +17,11 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Duration, Scheduler, Trace, UIO, Unsafe, ZIO}
+import zio.{Cause, Duration, FiberId, Scheduler, Trace, UIO, Unsafe, ZIO}
 
 import java.time.Instant
 import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.{Collections, List}
 import scala.annotation.tailrec
 
@@ -31,9 +31,26 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
     (ZIO.executor <*> ZIO.runtime[Any]).map { case (executor, runtime) =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
+          // The cancelled flag is flipped by whichever of the forked fiber or
+          // the cancel token runs first. This allows cancellation to be
+          // performed synchronously, without blocking the calling thread
+          // waiting for the fiber to be interrupted, which would otherwise
+          // hang when this scheduler is used from within an uninterruptible
+          // region (the runtime captured above inherits the interruptibility
+          // of the fiber that created it, hence the `.interruptible` below):
+          val cancelled = new AtomicBoolean(false)
           val fiber =
-            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())))
-          () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
+            runtime.unsafe.fork(
+              (sleep(duration) *> ZIO.suspendSucceed {
+                if (cancelled.compareAndSet(false, true)) ZIO.succeed(runnable.run())
+                else ZIO.unit
+              }).interruptible
+            )
+          () =>
+            if (cancelled.compareAndSet(false, true)) {
+              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))(unsafe)
+              true
+            } else false
         }
 
         def asScheduledExecutorService: ScheduledExecutorService = {


### PR DESCRIPTION
/claim #9211
Closes #9211

## Summary

`ZIO.timeoutTo` (and therefore `timeout`, `timeoutFail`, `timeoutFailCause`, `timeoutOption`, ...) delegated to `raceFibersWith` against a forked `ZIO.sleep(duration)` fiber, paying for **two fiber forks, an interruption and a join** on every timeout — including the common case where the effect completes long before the deadline. This PR schedules the deadline directly on the ambient `Clock`'s `Scheduler` and races it against a single child fiber running the effect:

- a single `AtomicBoolean` decides the race; whichever of the child fiber's observer and the scheduled task fires first resumes the parent (both paths are idempotent);
- **effect wins** → the scheduled task is cancelled synchronously, fiber refs are inherited, and the result is mapped with `f`;
- **timeout wins** → the effect is interrupted *as the parent fiber* and its interruption is awaited before producing `b()`, preserving the documented "will not itself return until the underlying effect is actually interrupted" semantics;
- **parent interrupted while waiting** → the registered canceler cancels the scheduled task, while the child is interrupted through the usual parent/child machinery and awaited on the parent's exit.

Preserved semantics: `inheritAll` on both paths, interruption as the parent fiber id, `Grafter.applyOnExit` transfer of the effect's children, supervision, `TestClock` compatibility (timeouts are driven by `TestClock.adjust`), and behavior inside uninterruptible regions.

## Relation to #9261 / #9266

This revives the direction explored by @eyalfa in #9261 (and the follow-up #9266, both closed unmerged), rebuilt from scratch against current `series/2.x` with a substantially simpler coordination scheme — one `AtomicBoolean` instead of the three-state bypass machine reviewers found hard to follow — and fixes the two issues that surfaced in that review:

1. **Uninterruptible window.** #9261 resumed the parent with `ZIO.left(b()).ensuring(fib.interrupt *> fib.inheritAll)`, so the parent could not respond to interrupts while awaiting the loser's interruption. Here the post-timeout continuation (`childFiber.interruptAs(parent.id) *> childFiber.inheritAll.as(b())`) runs in the ordinary interruptible region, exactly like the previous `raceFibersWith`-based implementation.
2. **TestClock scheduler cancellation hang.** Cancelling a task scheduled on `TestClock`'s scheduler blocked the caller until the forked sleep fiber finished being interrupted; that fiber inherits its interruptibility from the fiber that created the scheduler (through `ZIO.runtime`), so cancelling from within an uninterruptible region hung forever — and blocking is impossible on Scala.js altogether. `TestClock`'s scheduler now uses a purely synchronous, non-blocking cancellation scheme (an `AtomicBoolean` flipped by whichever of the task and the cancel token runs first, with `.interruptible` on the forked effect).

## Benchmarks

A new `zio.TimeoutBenchmark` (JMH) compares the baseline effect, the new `timeout`, and a self-contained copy of the previous implementation (`zioTimeoutOrig`). Fresh numbers on a quiet machine will be posted as a comment; on eyalfa's original measurements this approach eliminated ~90% of the overhead for fast effects and ~2x for effects with real work.

## Verification

- `coreTestsJVM/testOnly *.ZIOSpec` — 575 tests passed (including 3 new regression tests: timeout firing under `TestClock.adjust`, fiber-ref inheritance on both the effect-wins and timeout-wins paths)
- `testTestsJVM/test` — 920 tests passed (covers the `TestClock` scheduler change)
- `streamsTestsJVM/testOnly *.ZStreamSpec -- -t timeout` — passed
- `coreTestsJS/testOnly *.ZIOSpec -- -t timeout` — passed (Scala.js, covers the JS `TestClock` scheduler change)
- `scalafmtCheckAll` — clean

## Disclosure

This change was developed with assistance from an AI coding agent (design review, implementation and verification); it is submitted under the contributor's own account and responsibility.
