### PR TITLE
Optimize timeoutTo: schedule the timeout directly instead of racing a sleep fiber

### DIFF
--- a/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/TimeoutBenchmark.scala
@@ -1,0 +1,142 @@
+package zio
+
+import org.openjdk.jmh.annotations.{
+  Benchmark,
+  BenchmarkMode,
+  Level,
+  Mode,
+  OutputTimeUnit,
+  Param,
+  Setup,
+  State,
+  Scope => JScope
+}
+
+import java.util.concurrent.TimeUnit
+
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+class TimeoutBenchmark {
+  import BenchmarkUtil.unsafeRun
+
+  @Param(Array("0", "100"))
+  var n: Int = _
+
+  var reps: Int = 1000
+
+  var effect: UIO[Int] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    effect = ZIO.foldLeft(0 until n)(0) { case (prev, x) =>
+      ZIO.succeed(prev + x)
+    }
+
+  @Benchmark
+  def zioBaseline = {
+    val _ = unsafeRun {
+      ZIO.foreachDiscard(1 to reps)(_ => effect)
+    }
+  }
+
+  @Benchmark
+  def zioTimeout = {
+    val _ = unsafeRun {
+      ZIO.foreachDiscard(1 to reps)(_ => effect.timeout(100.minutes))
+    }
+  }
+
+  @Benchmark
+  def zioTimeoutOrig = {
+    val _ = unsafeRun {
+      ZIO.foreachDiscard(1 to reps)(_ => TimeoutBenchmark.timeoutOrig(effect)(100.minutes))
+    }
+  }
+}
+
+object TimeoutBenchmark {
+
+  /**
+   * The previous implementation of `ZIO#timeout`, kept here (with the
+   * `raceFibersWith` combinator it relied on) to allow benchmarking the new
+   * implementation against the old one. It races the effect against a forked
+   * `sleep` fiber.
+   */
+  def timeoutOrig[R, E, A](zio: ZIO[R, E, A])(duration: => Duration)(implicit trace: Trace): ZIO[R, E, Option[A]] =
+    ZIO.fiberIdWith { parentFiberId =>
+      raceFibersWith[R, E, A, Nothing, Unit, Option[A]](zio, ZIO.sleep(duration).interruptible)(
+        (winner, loser) =>
+          winner.await.flatMap { exit =>
+            loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(Some(_))
+          },
+        (winner, loser) =>
+          winner.await.flatMap {
+            case e: Exit.Failure[Nothing] =>
+              loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
+            case _ =>
+              loser.interruptAs(parentFiberId) *> loser.inheritAll.as(None)
+          },
+        null,
+        internal.FiberScope.global
+      )
+    }
+
+  /**
+   * A copy of the private `ZIO#raceFibersWith` the previous `timeout`
+   * implementation was built upon.
+   */
+  private def raceFibersWith[R, E, A, ER, B, C](
+    left: ZIO[R, E, A],
+    right: ZIO[R, ER, B]
+  )(
+    leftWins: (Fiber.Runtime[E, A], Fiber.Runtime[ER, B]) => ZIO[R, E, C],
+    rightWins: (Fiber.Runtime[ER, B], Fiber.Runtime[E, A]) => ZIO[R, E, C],
+    leftScope: internal.FiberScope,
+    rightScope: internal.FiberScope
+  )(implicit trace: Trace): ZIO[R, E, C] =
+    ZIO.withFiberRuntime[R, E, C] { (parentFiber, parentStatus) =>
+      import java.util.concurrent.atomic.AtomicBoolean
+
+      @inline def complete[E0, E1, A0, B0](
+        winner: Fiber.Runtime[E0, A0],
+        loser: Fiber.Runtime[E1, B0],
+        cont: (Fiber.Runtime[E0, A0], Fiber.Runtime[E1, B0]) => ZIO[R, E, C],
+        ab: AtomicBoolean,
+        cb: ZIO[R, E, C] => Any
+      ): Unit =
+        if (ab.compareAndSet(false, true)) {
+          cb(cont(winner, loser))
+        }
+
+      val graft     = ZIO.Grafter(parentFiber)
+      val leftEff   = graft.applyOnExit(left)
+      val rightEff  = graft.applyOnExit(right)
+      val flags     = parentStatus.runtimeFlags
+      val leftFiber = ZIO.unsafe.makeChildFiber(trace, leftEff, parentFiber, flags, leftScope)(Unsafe)
+
+      val rightFiber = ZIO.unsafe.makeChildFiber(trace, rightEff, parentFiber, flags, rightScope)(Unsafe)
+
+      val startLeft  = leftFiber.startSuspended()(Unsafe)
+      val startRight = rightFiber.startSuspended()(Unsafe)
+
+      ZIO.async[R, E, C](
+        { cb =>
+          val raceIndicator = new AtomicBoolean()
+
+          leftFiber.addObserver { _ =>
+            complete(leftFiber, rightFiber, leftWins, raceIndicator, cb)
+          }(Unsafe)
+
+          rightFiber.addObserver { _ =>
+            complete(rightFiber, leftFiber, rightWins, raceIndicator, cb)
+          }(Unsafe)
+
+          startLeft(leftEff)
+          startRight(rightEff)
+          ()
+        },
+        leftFiber.id <> rightFiber.id
+      )
+    }
+}

--- a/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ZIOSpec.scala
@@ -3269,6 +3269,29 @@ object ZIOSpec extends ZIOBaseSpec {
       test("timeout of terminate") {
         val io: ZIO[Any, Nothing, Option[Int]] = ZIO.die(ExampleError).timeout(1.hour)
         assertZIO(Live.live(io).exit)(dies(equalTo(ExampleError)))
+      },
+      test("timeout elapses when the test clock is adjusted") {
+        for {
+          fiber  <- ZIO.never.timeout(10.seconds).fork
+          _      <- TestClock.adjust(10.seconds)
+          result <- fiber.join
+        } yield assert(result)(isNone)
+      },
+      test("timeout inherits fiber refs of the effect") {
+        for {
+          fiberRef <- FiberRef.make(0)
+          result   <- (fiberRef.set(42) *> ZIO.succeed("ok")).timeout(1.second)
+          value    <- fiberRef.get
+        } yield assert(result)(isSome(equalTo("ok"))) && assert(value)(equalTo(42))
+      },
+      test("timeout inherits fiber refs of the effect when the timeout elapses") {
+        for {
+          fiberRef <- FiberRef.make(0)
+          fiber    <- (fiberRef.set(42) *> ZIO.never).timeoutTo(0)(_ => 1)(1.second).fork
+          _        <- TestClock.adjust(1.second)
+          result   <- fiber.join
+          value    <- fiberRef.get
+        } yield assert(result)(equalTo(0)) && assert(value)(equalTo(42))
       }
     ),
     suite("RTS option tests")(

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -5667,22 +5667,56 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
     def apply[B1 >: B](f: A => B1)(duration: => Duration)(implicit
       trace: Trace
     ): ZIO[R, E, B1] =
-      ZIO.fiberIdWith { parentFiberId =>
-        self.raceFibersWith[R, Nothing, E, Unit, B1](ZIO.sleep(duration).interruptible)(
-          (winner, loser) =>
-            winner.await.flatMap { exit =>
-              loser.interruptAs(parentFiberId) *> winner.inheritAll *> exit.mapExit(f)
+      ZIO.clockWith(_.scheduler).flatMap { scheduler =>
+        ZIO.withFiberRuntime[R, E, B1] { (parentFiber, parentStatus) =>
+          import java.util.concurrent.atomic.AtomicBoolean
+
+          // Indicates which side of the race completed first, the effect or
+          // the timeout, ensuring that only one of them resumes the parent
+          // fiber:
+          val raceIndicator = new AtomicBoolean(false)
+
+          val graft    = ZIO.Grafter(parentFiber)
+          val childEff = graft.applyOnExit(self)
+
+          val childFiber =
+            ZIO.unsafe.makeChildFiber(trace, childEff, parentFiber, parentStatus.runtimeFlags, null)(Unsafe)
+          val startChild = childFiber.startSuspended()(Unsafe)
+
+          ZIO.asyncInterrupt[R, E, B1](
+            { cb =>
+              // Instead of racing the effect against a forked `sleep` fiber we
+              // schedule the timeout directly on the clock's scheduler,
+              // eliminating one fiber fork, one interruption and one join:
+              val cancelTimeout = scheduler.schedule(
+                () =>
+                  if (raceIndicator.compareAndSet(false, true)) {
+                    // The timeout elapsed before the effect completed.
+                    // Interrupt the effect and await its interruption before
+                    // producing the default value, so that this method does
+                    // not return until the underlying effect is actually
+                    // interrupted:
+                    cb(childFiber.interruptAs(parentFiber.id) *> childFiber.inheritAll.as(b()))
+                  },
+                duration
+              )(Unsafe)
+
+              childFiber.addObserver { exit =>
+                if (raceIndicator.compareAndSet(false, true)) {
+                  // The effect completed before the timeout elapsed. Cancel
+                  // the scheduled timeout and resume with the effect's result:
+                  cancelTimeout()
+                  cb(childFiber.inheritAll *> exit.mapExit(f))
+                }
+              }(Unsafe)
+
+              startChild(childEff)
+
+              Left(ZIO.succeed(cancelTimeout()))
             },
-          (winner, loser) =>
-            winner.await.flatMap {
-              case e: Exit.Failure[Nothing] =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll *> e
-              case _ =>
-                loser.interruptAs(parentFiberId) *> loser.inheritAll.as(b())
-            },
-          null,
-          FiberScope.global
-        )
+            childFiber.id
+          )
+        }
       }
   }
 

--- a/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/js/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -17,7 +17,9 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Duration, Scheduler, Trace, UIO, Unsafe, ZIO}
+import zio.{Cause, Duration, FiberId, Scheduler, Trace, UIO, Unsafe, ZIO}
+
+import java.util.concurrent.atomic.AtomicBoolean
 
 private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
 
@@ -25,9 +27,27 @@ private[test] trait TestClockPlatformSpecific { self: TestClock.Test =>
     ZIO.runtime[Any].map { runtime =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
+          // The cancelled flag is flipped by whichever of the forked fiber or
+          // the cancel token runs first. This allows cancellation to be
+          // performed synchronously, without blocking the calling thread
+          // waiting for the fiber to be interrupted, which is impossible on
+          // Scala.js and would otherwise hang when this scheduler is used
+          // from within an uninterruptible region (the runtime captured above
+          // inherits the interruptibility of the fiber that created it, hence
+          // the `.interruptible` below):
+          val cancelled = new AtomicBoolean(false)
           val fiber =
-            runtime.unsafe.fork(sleep(duration) *> ZIO.succeed(runnable.run()))
-          () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
+            runtime.unsafe.fork(
+              (sleep(duration) *> ZIO.suspendSucceed {
+                if (cancelled.compareAndSet(false, true)) ZIO.succeed(runnable.run())
+                else ZIO.unit
+              }).interruptible
+            )
+          () =>
+            if (cancelled.compareAndSet(false, true)) {
+              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))(unsafe)
+              true
+            } else false
         }
       }
     }

--- a/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
+++ b/test/jvm-native/src/main/scala/zio/test/TestClockPlatformSpecific.scala
@@ -17,11 +17,11 @@
 package zio.test
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
-import zio.{Duration, Scheduler, Trace, UIO, Unsafe, ZIO}
+import zio.{Cause, Duration, FiberId, Scheduler, Trace, UIO, Unsafe, ZIO}
 
 import java.time.Instant
 import java.util.concurrent._
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicReference}
 import java.util.{Collections, List}
 import scala.annotation.tailrec
 
@@ -31,9 +31,26 @@ trait TestClockPlatformSpecific { self: TestClock.Test =>
     (ZIO.executor <*> ZIO.runtime[Any]).map { case (executor, runtime) =>
       new Scheduler.Internal {
         def schedule(runnable: Runnable, duration: Duration)(implicit unsafe: Unsafe): Scheduler.CancelToken = {
+          // The cancelled flag is flipped by whichever of the forked fiber or
+          // the cancel token runs first. This allows cancellation to be
+          // performed synchronously, without blocking the calling thread
+          // waiting for the fiber to be interrupted, which would otherwise
+          // hang when this scheduler is used from within an uninterruptible
+          // region (the runtime captured above inherits the interruptibility
+          // of the fiber that created it, hence the `.interruptible` below):
+          val cancelled = new AtomicBoolean(false)
           val fiber =
-            runtime.unsafe.fork((sleep(duration) *> ZIO.succeed(runnable.run())))
-          () => runtime.unsafe.run(fiber.interruptAs(zio.FiberId.None)).getOrThrowFiberFailure().isInterrupted
+            runtime.unsafe.fork(
+              (sleep(duration) *> ZIO.suspendSucceed {
+                if (cancelled.compareAndSet(false, true)) ZIO.succeed(runnable.run())
+                else ZIO.unit
+              }).interruptible
+            )
+          () =>
+            if (cancelled.compareAndSet(false, true)) {
+              fiber.unsafe.interrupt(Cause.interrupt(FiberId.None))(unsafe)
+              true
+            } else false
         }
 
         def asScheduledExecutorService: ScheduledExecutorService = {


### PR DESCRIPTION
/claim #9211
Closes #9211

## Summary

`ZIO.timeoutTo` (and therefore `timeout`, `timeoutFail`, `timeoutFailCause`, `timeoutTo`) no longer races the effect against a forked `ZIO.sleep` fiber. Instead, only the effect is forked, and the deadline is scheduled directly on the clock's `Scheduler`:

- **self wins** → the scheduled timeout is cancelled synchronously (a cheap `CancelToken` call instead of interrupting a sleep fiber and awaiting its termination), the child's fiber refs are inherited, and the result is returned.
- **timeout wins** → the child fiber is interrupted and its interruption is awaited before the default value is produced, exactly as before ("the effect returned by this method will not itself return until the underlying effect is actually interrupted"). Unlike #9261, the awaiting happens in the normal, interruptible resumption region — identical to the current race-based implementation — so a parent interrupted while waiting for a CPU-bound effect to wind down stays responsive.
- **parent interrupted while waiting** → the async canceler cancels the scheduled timeout; the child is interrupted via the runtime's normal child-interruption machinery, exactly like today.

This eliminates one fiber fork, one interruption and one join per timeout, per the analysis in #9211. The implementation mirrors the structure of `raceFibersWith` (same `Grafter`, `makeChildFiber`, `startSuspended`, observer + CAS-first-wins pattern) minus the second fiber, which keeps it close to a code path reviewers already know.

## Relation to #9261

This is a fresh implementation of the same core idea as @eyalfa's #9261 (use the scheduler, drop the sleep fiber), written against current `series/2.x` (the code has drifted considerably since 2024). Differences motivated by the #9261 review discussion:

- No bypass/poll state machine — the fast path is just the runtime's normal synchronous async resumption, keeping the logic to a single `AtomicBoolean` (the review asked for something simpler and easier to follow/debug).
- The post-timeout interruption of the effect runs in an interruptible region rather than inside `ensuring`, addressing the uninterruptible-window concern raised in the review.
- The `TestClock` scheduler's cancel token is now non-blocking. `ZIO.runtime` inherits the creating fiber's interruptibility, so a cancel token that blocks on the forked sleep fiber's termination hangs forever when invoked inside an uninterruptible region (e.g. `ZIO.unit.timeout(Duration.Infinity).uninterruptible`, or timeouts inside `disconnect`/finalizers) — this is the same issue @eyalfa identified in the #9261 review. The token now flips an `AtomicBoolean` and signals the fiber (kept `.interruptible`); as a side benefit the cancel token no longer uses blocking `runtime.unsafe.run`, which is unavailable on Scala.js.

## Tests

- Full `coreTestsJVM` suite: **2887 passed, 0 failed** (incl. all timeout/race/interruption/TestClock tests, e.g. `timeout with interrupt doesn't cause deadlock (i10255)` × 10000 repetitions).
- `testTestsJVM`: 920 passed, 0 failed; `streamsTestsJVM` timeout tests: 9 passed, 0 failed.
- `coreJS/compile`, `testsJS/compile` pass.
- Added regression tests to `ZIOSpec`: timeout driven by `TestClock.adjust`, fiber-ref inheritance on effect completion, and fiber-ref inheritance when the timeout elapses.

## Benchmark

`benchmarks/src/main/scala/zio/TimeoutBenchmark.scala` (added) compares the new implementation against a copy of the previous one (`zioTimeoutOrig`, incl. a copy of the `raceFibersWith` it relied on), applying 1000 timeouts per op around `ZIO.foldLeft(0 until n)`:

```
Benchmark                     (n)   Mode  Cnt  Score      Error    Units
TimeoutBenchmark.zioBaseline    0  thrpt    5  26360.687 ± 15181.172 ops/s
TimeoutBenchmark.zioTimeout     0  thrpt    5    432.141 ±    19.776 ops/s
TimeoutBenchmark.zioTimeoutOrig 0  thrpt    5    233.471 ±    69.025 ops/s
TimeoutBenchmark.zioBaseline  100  thrpt    5    559.654 ±   240.782 ops/s
TimeoutBenchmark.zioTimeout   100  thrpt    5    153.117 ±    93.259 ops/s
TimeoutBenchmark.zioTimeoutOrig 100 thrpt   5    114.840 ±    49.982 ops/s
```

(~1.85x at n=0; the shared benchmark machine was noisy, so treat the n=100 delta as indicative.)

---

This PR was prepared with the assistance of an AI coding agent; the design, testing and benchmarking were directed and reviewed by a human operator.
