### PR TITLE
fix(website): theme-aware, on-brand, dismissable announcement bar

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -23,9 +23,9 @@ const config = {
       id: 'announcementBar',
       content:
         '📚 <b>ZIONOMICON</b>, updated for ZIO 2.1, is out now! Grab <a href="https://zionomicon.com" target="_blank">your free copy</a> and level up your ZIO skills 🚀',
-      backgroundColor: 'rgb(190, 105, 255)',
-      textColor: 'rgba(220, 173, 240, 1)',
-      isCloseable: false,
+      backgroundColor: '#ececec',
+      textColor: '#1a1a1a',
+      isCloseable: true,
     },
     image: 'https://zio.dev/img/zio.png',
     algolia: {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -90,18 +90,48 @@ a {
   background: url("data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='white' d='M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12'/%3E%3C/svg%3E") no-repeat;
 }
 
-div[class^='announcementBar'] {
+/* Announcement bar: matches navbar surfaces, red CTA accent, theme-aware.
+   Target the stable Docusaurus class (`theme-announcement-bar`) rather than the
+   hashed `announcementBar_xxxx` class, which is order-dependent and unreliable. */
+.theme-announcement-bar {
   padding: 25px;
   font-size: 20px;
-  background:
-    /* Horizontal lines */
-    linear-gradient(90deg,
-      rgba(74, 43, 123, .9) 15px,
-      transparent 100%) center,
+  background: #ececec;
+  color: #1a1a1a;
+  border-bottom: 1px solid var(--color-gray-200, rgba(0, 0, 0, .1));
+}
 
-    /* Vertical lines */
-    linear-gradient(rgba(74, 43, 123, .9) 15px,
-      transparent 98%) center,
-    #6a0dad;
-  background-size: 16px 16px;
+.theme-announcement-bar a {
+  color: #dc2626 !important;
+  text-decoration: none;
+}
+
+.theme-announcement-bar a:hover {
+  text-decoration: underline;
+}
+
+[data-theme='dark'] .theme-announcement-bar {
+  background: #1c1c1c !important;
+  color: #f0f0f0 !important;
+  border-bottom: 1px solid rgba(255, 255, 255, .1);
+}
+
+[data-theme='dark'] .theme-announcement-bar a {
+  color: #e14747 !important;
+}
+
+/* Center the dismiss (×) button vertically: default `align-self: stretch`
+   collapses its icon to the top given the bar's large vertical padding. */
+.theme-announcement-bar .close {
+  align-self: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: auto;
+  padding: 0 20px;
+}
+
+.theme-announcement-bar .close svg {
+  width: 16px;
+  height: 16px;
 }


### PR DESCRIPTION
## Problem

The website announcement bar (Zionomicon promo) had several issues:

1. **Not theme-sensitive** — rendered an identical hardcoded purple gradient in both light and dark mode.
2. **Off-brand** — purple clashed with the ZIO red brand and the navbar surfaces.
3. **Broken selector** — the CSS targeted `div[class^='announcementBar']`, which never matched because Docusaurus prepends the stable `theme-announcement-bar` class.
4. **Not dismissable** — `isCloseable: false`.

## Changes

- **Stable selector**: target `.theme-announcement-bar` instead of the order-dependent hashed class.
- **Theme-aware + on-brand**: bar background matches navbar surfaces with a subtle offset so it reads as a distinct banner — `#ececec` (light) / `#1c1c1c` (dark) — with a red CTA link (`#dc2626` / `#e14747`). Dark overrides use `!important` to beat the inline colors Docusaurus injects from config.
- **Dismissable**: `isCloseable: true` — users can dismiss the bar; dismissal persists via `localStorage` (keyed by the bar `id`).
- **Centered × button**: the dismiss button otherwise collapsed to the top due to the bar's large vertical padding.

## Screenshots

**Light mode**

![Announcement bar in light mode](https://raw.githubusercontent.com/khajavi/zio/pr-assets/docs-assets/announce-bar-light.png)

**Dark mode**

![Announcement bar in dark mode](https://raw.githubusercontent.com/khajavi/zio/pr-assets/docs-assets/announce-bar-dark.png)

## Verification

Verified headless (Chromium) in both light and dark mode:

| | Light | Dark |
|---|---|---|
| background | `#ececec` | `#1c1c1c` |
| text | `#1a1a1a` | `#f0f0f0` |
| CTA link | `#dc2626` | `#e14747` |

- Dismiss button renders right-aligned and vertically centered.
- Clicking it removes the bar and it stays gone after reload (localStorage persistence confirmed).

> Note: bumping the bar `id` in config re-shows it after the promo text changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)