### PR TITLE
docs(events): update events page with recent editions

### DIFF
--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -7,34 +7,19 @@ ZIO has a number of events that are organized by the community all around the wo
 
 If you know of an upcoming event related to ZIO, please add it to the list below by submitting a pull request.
 
-## Upcoming Events
-
-### Zymposiums, Online, Every Friday
-
-Every Friday the [Ziverge](https://ziverge.com/) team hosts a Zymposium, an hour-long ZIO-focused live stream. You can find the recordings of past Zymposiums on the [Ziverge YouTube channel](https://www.youtube.com/playlist?list=PLvdARMfvom9C8ss18he1P5vOcogawm5uC).
-
-### ZIO World 2023, Lisbon, Portugal, April 21
-
-The [third edition](https://zioworld.com) of ZIO World brings together ZIO users and contributors worldwide to showcase the power, performance, and productivity of ZIO 2.0 and its broad-based maturing ecosystem. Discover how ZIO 2.0 and a stunning ecosystem of ZIO 2 libraries will give you a competitive edge, making your team more productive and happier than ever before.
-
-### Functional Scala 2023, London, Uk, NOV 30 – DEC 1
-
-[Functional Scala 2023](https://www.functionalscala.com/) is a two-day conference in London with excellent speakers from around the world who are passionate about Scala.
-
-### ZIO Hackathons
+## ZIO Hackathons
 
 ZIO Hackathons are designed to bring together many core contributors to ZIO from all around the world, as well as current ZIO users, future ZIO users and contributors, and contributors to other libraries for async and concurrent programming in the broader functional Scala ecosystem.
 
 The goal of the hackathon is to work on ZIO and related libraries, improve the ecosystem, and have fun. We will have a number of ZIO core contributors present to help with questions and to work on ZIO. So by attending a ZIO Hackathon, you will have the opportunity to pair with other ZIO contributors and to learn from them.
-
-- [ZIO Hackathon, Colorado, USA (in-person & online), 13 September 2023](https://www.eventbrite.com/e/zio-hackathon-colorado-usa-in-person-online-tickets-540880276467)
-- [ZIO Hackathon, Inverness, Scotland (in-person and online), 27-28 July 2023](https://www.eventbrite.com/e/zio-hackathon-scotland-in-person-and-online-tickets-539525153257)
 
 ## Past Events
 
 The followings are recordings of past ZIO events.
 
 ### Zymposiums
+
+Every Friday the [Ziverge](https://ziverge.com/) team hosts a Zymposium, an hour-long ZIO-focused live stream. You can find the recordings of past Zymposiums on the [Ziverge YouTube channel](https://www.youtube.com/playlist?list=PLvdARMfvom9C8ss18he1P5vOcogawm5uC).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9C8ss18he1P5vOcogawm5uC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
@@ -46,6 +31,10 @@ The followings are recordings of past ZIO events.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CK_nXP41eioIXZLHvME5gB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
+### ZIO World 2023
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 ### Functional Scala 2021
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COGPlva4OnTkFEXzXhhqNH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
@@ -53,3 +42,11 @@ The followings are recordings of past ZIO events.
 ### Functional Scala 2022
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9A0L97KNywK1lWEeHYDLX0P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### Functional Scala 2023
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DCDLfWzukYMiY9nY4nrNDz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### Functional Scala 2024
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -25,28 +25,42 @@ Every Friday the [Ziverge](https://ziverge.com/) team hosts a Zymposium, an hour
 
 ### Functional Scala 2024
 
+You can find the recordings on the [Functional Scala 2024 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js).
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### Functional Scala 2023
+
+You can find the recordings on the [Functional Scala 2023 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9DCDLfWzukYMiY9nY4nrNDz).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DCDLfWzukYMiY9nY4nrNDz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### ZIO World 2023
 
+You can find the recordings on the [ZIO World 2023 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3).
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### Functional Scala 2022
+
+You can find the recordings on the [Functional Scala 2022 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9A0L97KNywK1lWEeHYDLX0P).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9A0L97KNywK1lWEeHYDLX0P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### ZIO World 2022
 
+You can find the recordings on the [ZIO World 2022 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9CK_nXP41eioIXZLHvME5gB).
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CK_nXP41eioIXZLHvME5gB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### Functional Scala 2021
 
+You can find the recordings on the [Functional Scala 2021 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9COGPlva4OnTkFEXzXhhqNH).
+
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COGPlva4OnTkFEXzXhhqNH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### ZIO World 2021
+
+You can find the recordings on the [ZIO World 2021 playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9COFgVauwWQ9PsCBOsDmHJm).
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COFgVauwWQ9PsCBOsDmHJm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/events/index.md
+++ b/docs/events/index.md
@@ -23,30 +23,30 @@ Every Friday the [Ziverge](https://ziverge.com/) team hosts a Zymposium, an hour
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9C8ss18he1P5vOcogawm5uC" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-### ZIO World 2021
+### Functional Scala 2024
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COFgVauwWQ9PsCBOsDmHJm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-### ZIO World 2022
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CK_nXP41eioIXZLHvME5gB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-### ZIO World 2023
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-### Functional Scala 2021
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COGPlva4OnTkFEXzXhhqNH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
-### Functional Scala 2022
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9A0L97KNywK1lWEeHYDLX0P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
 ### Functional Scala 2023
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DCDLfWzukYMiY9nY4nrNDz" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
-### Functional Scala 2024
+### ZIO World 2023
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### Functional Scala 2022
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9A0L97KNywK1lWEeHYDLX0P" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### ZIO World 2022
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9CK_nXP41eioIXZLHvME5gB" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### Functional Scala 2021
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COGPlva4OnTkFEXzXhhqNH" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
+### ZIO World 2021
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/videoseries?list=PLvdARMfvom9COFgVauwWQ9PsCBOsDmHJm" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>


### PR DESCRIPTION
## Motivation

The [ZIO Events](https://zio.dev/events/) page was frozen at May 2024. Every entry under **Upcoming Events** (ZIO World 2023, Functional Scala 2023, ZIO Hackathons) was already long past, and several past events with public recordings were never listed.

## Changes

- Remove the stale **Upcoming Events** section — all its entries were 2023 dates.
- Fold **Zymposiums** into Past Events (weekly, ongoing) and keep **ZIO Hackathons** as an evergreen, dateless section.
- Add recordings for previously-undocumented past events:
  - **ZIO World 2023** — [playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9DaohnWcFxBllxkDoBCymx3)
  - **Functional Scala 2023** — [playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9DCDLfWzukYMiY9nY4nrNDz)
  - **Functional Scala 2024** — [playlist](https://www.youtube.com/playlist?list=PLvdARMfvom9CuM40p_Yr3UAtlADSKC2Js)

Latest confirmed editions: Functional Scala = 2024 (online), ZIO World = 2023. No newer editions exist to add.

Docs-only change (single `.md` file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)