### PR TITLE
Modernize website appearance and chat widget

### DIFF
--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -11,7 +11,7 @@ export default function HomepageCodingAgent() {
       <div className={styles.wideContainer}>
         <div className={styles.singleColumn}>
           <div className={styles.agentContent}>
-            <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent Latest ZIO Knowledge</h2>
+            <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent the Latest ZIO Knowledge</h2>
             <p>
               The <code>zio-knowledge</code> skill teaches your coding agent to fetch live documentation
               from zio.dev before answering any ZIO question — so you always get accurate, up-to-date

--- a/website/src/components/sections/CodingAgent/index.jsx
+++ b/website/src/components/sections/CodingAgent/index.jsx
@@ -11,7 +11,7 @@ export default function HomepageCodingAgent() {
       <div className={styles.wideContainer}>
         <div className={styles.singleColumn}>
           <div className={styles.agentContent}>
-            <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent the Latest ZIO Knowledge</h2>
+            <h2 className={clsx("sectionHeader", "text-4xl", "text-center")}>Teach Your Coding Agent Latest ZIO Knowledge</h2>
             <p>
               The <code>zio-knowledge</code> skill teaches your coding agent to fetch live documentation
               from zio.dev before answering any ZIO question — so you always get accurate, up-to-date

--- a/website/src/components/sections/Ecosystem/index.jsx
+++ b/website/src/components/sections/Ecosystem/index.jsx
@@ -6,13 +6,13 @@ import SectionWrapper from '@site/src/components/ui/SectionWrapper';
 
 import { ecosystemProjects } from './data';
 
-export default function Ecosystem({ title, subtitle, children}) {
+export default function Ecosystem({ eyebrow, title, subtitle, children}) {
   // Separate ZIO HTTP from other projects (featured project)
   const featuredProject = ecosystemProjects.find(p => p.name === 'ZIO HTTP');
   const otherProjects = ecosystemProjects.filter(p => p.name !== 'ZIO HTTP');
 
   return (
-    <SectionWrapper title={title} subtitle={subtitle} >
+    <SectionWrapper eyebrow={eyebrow} title={title} subtitle={subtitle} >
       <div className={styles.wideContainer}>
         {/* Featured project in its own row */}
         {featuredProject && (

--- a/website/src/components/sections/Ecosystem/styles.module.css
+++ b/website/src/components/sections/Ecosystem/styles.module.css
@@ -34,21 +34,41 @@
 
 
 .ecosystemCard {
+  position: relative;
+  overflow: hidden;
   height: 100%;
   padding: 2rem;
-  border-radius: 8px;
+  border-radius: 14px;
   background-color: var(--ifm-card-background-color);
-  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.1);
-  transition: all 0.3s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--ifm-color-emphasis-200);
 }
 
-.ecosystemCard:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
-  border-color: var(--ifm-color-primary-lightest);
+.ecosystemCard::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--gradient-brand);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .ecosystemCard:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 14px 30px var(--brand-shadow);
+    border-color: rgba(220, 38, 38, 0.35);
+  }
+}
+
+.ecosystemCard:hover::before {
+  opacity: 1;
 }
 
 .ecosystemCardHeader {

--- a/website/src/components/sections/Features/index.jsx
+++ b/website/src/components/sections/Features/index.jsx
@@ -7,7 +7,7 @@ import { features } from './data';
 
 export default function Features() {
   return (
-    <SectionWrapper eyebrow="Why ZIO" title="Features">
+    <SectionWrapper title="Features">
       <div className="container grid list-none grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
         {features.map((item, idx) => (
           <div

--- a/website/src/components/sections/Features/index.jsx
+++ b/website/src/components/sections/Features/index.jsx
@@ -7,20 +7,18 @@ import { features } from './data';
 
 export default function Features() {
   return (
-    <SectionWrapper title="Features">
+    <SectionWrapper eyebrow="Why ZIO" title="Features">
       <div className="container grid list-none grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4">
         {features.map((item, idx) => (
-          <div key={`features-${idx}`} className="card">
-            <div className="card__header flex flex-col items-start gap-5">
-              <div className="bg-accent/10 flex h-10 w-10 items-center justify-center rounded-full p-2">
-                <FaCheck className="text-accent" />
-              </div>
-
-              <h2 className="text-xl font-bold">{item.title}</h2>
+          <div
+            key={`features-${idx}`}
+            className="card-modern flex flex-col gap-4 p-6"
+          >
+            <div className="card-icon-tile">
+              <FaCheck />
             </div>
-            <div className="card__body text-zinc-900 dark:text-zinc-400">
-              <p>{item.content}</p>
-            </div>
+            <h2 className="text-xl font-bold">{item.title}</h2>
+            <p className="text-zinc-600 dark:text-zinc-400">{item.content}</p>
           </div>
         ))}
       </div>

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -24,12 +24,11 @@ export default function Hero() {
       <div className="container flex flex-col items-center gap-6 text-center">
         <span className="eyebrow">Purely functional effect system</span>
 
-        <p
-          className="text-primary leading-none font-black tracking-tight"
-          style={{ fontSize: 'clamp(3.5rem, 10vw, 6rem)' }}
-        >
-          {siteConfig.title || 'ZIO'}
-        </p>
+        <img
+          className="h-20 md:h-24"
+          src="/img/navbar_brand2x.png"
+          alt={`${siteConfig.title}`}
+        />
 
         <h1 className="w-full max-w-5xl text-3xl leading-tight font-black tracking-tight md:text-5xl">
           Type-safe, composable asynchronous and{' '}

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -31,9 +31,9 @@ export default function Hero() {
         />
 
         <h1 className="w-full max-w-5xl text-3xl leading-tight font-black tracking-tight md:text-5xl">
-          Type-safe, composable asynchronous and{' '}
-          <span className="gradient-text">concurrent</span> programming for
-          Scala
+          Type-safe, composable{' '}
+          <span className="gradient-text">asynchronous</span> and concurrent
+          programming for Scala
         </h1>
 
         <p className="max-w-2xl text-lg text-zinc-600 dark:text-zinc-400">

--- a/website/src/components/sections/Hero/index.jsx
+++ b/website/src/components/sections/Hero/index.jsx
@@ -1,33 +1,67 @@
 import React from 'react';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Link from '@docusaurus/Link';
-import { FaArrowRight } from 'react-icons/fa6';
+import { FaArrowRight, FaStar } from 'react-icons/fa6';
+
+import RepoStats from '@site/src/components/ui/RepoStats';
 
 export default function Hero() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
 
   return (
-    <section className="flex flex-col gap-24 py-10">
-      <div className="container flex flex-col items-center gap-6">
-        <img
-          className="h-20"
-          src="/img/navbar_brand2x.png"
-          alt={`${siteConfig.title}`}
-        />
+    <section className="relative overflow-hidden py-16 md:py-24">
+      {/* Soft, theme-aware red radial glow behind the hero content. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[420px]"
+        style={{
+          background:
+            'radial-gradient(60% 100% at 50% 0%, rgba(220,38,38,0.14), transparent 70%)',
+        }}
+      />
 
-        <p className="w-full max-w-7xl text-center text-3xl font-black leading-tight md:text-5xl">
-          Type-safe, composable asynchronous and concurrent programming for{' '}
-          <span className="text-primary">Scala</span>
+      <div className="container flex flex-col items-center gap-6 text-center">
+        <span className="eyebrow">Purely functional effect system</span>
+
+        <p
+          className="text-primary leading-none font-black tracking-tight"
+          style={{ fontSize: 'clamp(3.5rem, 10vw, 6rem)' }}
+        >
+          {siteConfig.title || 'ZIO'}
         </p>
 
-        <Link
-          className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2 font-semibold text-white hover:text-white hover:no-underline"
-          to="/overview/getting-started"
-        >
-          <span>Get Started</span>
-          <FaArrowRight />
-        </Link>
+        <h1 className="w-full max-w-5xl text-3xl leading-tight font-black tracking-tight md:text-5xl">
+          Type-safe, composable asynchronous and{' '}
+          <span className="gradient-text">concurrent</span> programming for
+          Scala
+        </h1>
+
+        <p className="max-w-2xl text-lg text-zinc-600 dark:text-zinc-400">
+          Build resilient, high-performance applications with a purely
+          functional effect system — with rich concurrency, resource safety, and
+          testability built in.
+        </p>
+
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <Link
+            className="hover:bg-primary-500 bg-primary flex items-center gap-2 rounded-full px-6 py-2.5 font-semibold text-white transition-colors hover:text-white hover:no-underline"
+            to="/overview/getting-started"
+          >
+            <span>Get Started</span>
+            <FaArrowRight />
+          </Link>
+
+          <Link
+            className="hover:border-primary hover:text-primary flex items-center gap-2 rounded-full border border-zinc-300 px-6 py-2.5 font-semibold text-zinc-800 transition-colors hover:no-underline dark:border-zinc-700 dark:text-zinc-100"
+            href="https://github.com/zio/zio"
+          >
+            <FaStar className="text-accent" />
+            <span>Star on GitHub</span>
+          </Link>
+        </div>
+
+        <RepoStats />
       </div>
     </section>
   );

--- a/website/src/components/sections/Sponsors/index.jsx
+++ b/website/src/components/sections/Sponsors/index.jsx
@@ -7,7 +7,7 @@ import { sponsors } from './data';
 
 export default function Sponsors() {
   return (
-    <SectionWrapper title="Our Sponsors">
+    <SectionWrapper eyebrow="Backed by" title="Our Sponsors">
       <div className="container">
         <div className="mx-auto flex w-full max-w-7xl flex-wrap items-center justify-around gap-12">
           {sponsors.map((sponsor, idx) => (

--- a/website/src/components/ui/RepoStats/data.js
+++ b/website/src/components/ui/RepoStats/data.js
@@ -1,0 +1,10 @@
+// Static fallbacks captured 2026-07-15 from github.com/zio/zio.
+// Stars are refreshed live at runtime (see index.jsx); contributors and the
+// latest version are shown as-is and bumped here when they drift.
+export const repoStats = {
+  owner: 'zio',
+  repo: 'zio',
+  stars: 4396,
+  contributors: '760+',
+  version: 'v2.1.26',
+};

--- a/website/src/components/ui/RepoStats/data.js
+++ b/website/src/components/ui/RepoStats/data.js
@@ -1,6 +1,7 @@
 // Static fallbacks captured 2026-07-15 from github.com/zio/zio.
-// Stars are refreshed live at runtime (see index.jsx); contributors and the
-// latest version are shown as-is and bumped here when they drift.
+// Stars and the latest version are refreshed live at runtime (see index.jsx);
+// these values are only shown if the GitHub API is unreachable. Contributors
+// has no cheap live count, so it stays static and is bumped here when it drifts.
 export const repoStats = {
   owner: 'zio',
   repo: 'zio',

--- a/website/src/components/ui/RepoStats/index.jsx
+++ b/website/src/components/ui/RepoStats/index.jsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { repoStats } from './data';
+
+function formatStars(n) {
+  if (n >= 1000) {
+    return `${(n / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+  }
+  return `${n}`;
+}
+
+/**
+ * Trust badge row for the hero: live star count with a static fallback, plus
+ * static contributor count and latest version. The GitHub call is
+ * unauthenticated and best-effort — any failure (offline, rate limit) silently
+ * keeps the baked-in fallback.
+ */
+export default function RepoStats() {
+  const [stars, setStars] = useState(repoStats.stars);
+
+  useEffect(() => {
+    let active = true;
+    fetch(`https://api.github.com/repos/${repoStats.owner}/${repoStats.repo}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (active && data && typeof data.stargazers_count === 'number') {
+          setStars(data.stargazers_count);
+        }
+      })
+      .catch(() => {
+        /* keep fallback */
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const items = [
+    { value: formatStars(stars), label: 'stars' },
+    { value: repoStats.contributors, label: 'contributors' },
+    { value: repoStats.version, label: 'latest' },
+  ];
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-x-8 gap-y-2 text-sm text-zinc-500 dark:text-zinc-400">
+      {items.map((item) => (
+        <span key={item.label}>
+          <span className="font-bold text-zinc-900 dark:text-zinc-100">
+            {item.value}
+          </span>{' '}
+          {item.label}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/website/src/components/ui/RepoStats/index.jsx
+++ b/website/src/components/ui/RepoStats/index.jsx
@@ -16,10 +16,13 @@ function formatStars(n) {
  */
 export default function RepoStats() {
   const [stars, setStars] = useState(repoStats.stars);
+  const [version, setVersion] = useState(repoStats.version);
 
   useEffect(() => {
     let active = true;
-    fetch(`https://api.github.com/repos/${repoStats.owner}/${repoStats.repo}`)
+    const base = `https://api.github.com/repos/${repoStats.owner}/${repoStats.repo}`;
+
+    fetch(base)
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (active && data && typeof data.stargazers_count === 'number') {
@@ -29,6 +32,18 @@ export default function RepoStats() {
       .catch(() => {
         /* keep fallback */
       });
+
+    fetch(`${base}/releases/latest`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (active && data && data.tag_name) {
+          setVersion(data.tag_name);
+        }
+      })
+      .catch(() => {
+        /* keep fallback */
+      });
+
     return () => {
       active = false;
     };
@@ -37,7 +52,7 @@ export default function RepoStats() {
   const items = [
     { value: formatStars(stars), label: 'stars' },
     { value: repoStats.contributors, label: 'contributors' },
-    { value: repoStats.version, label: 'latest' },
+    { value: version, label: 'latest' },
   ];
 
   return (

--- a/website/src/components/ui/Reveal/index.jsx
+++ b/website/src/components/ui/Reveal/index.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+/**
+ * Wraps children and fades/slides them into view when scrolled near the
+ * viewport. Movement is defined purely in CSS behind a
+ * `prefers-reduced-motion: no-preference` guard, so reduced-motion users and
+ * the no-JS/SSR fallback both see the final state with no animation.
+ */
+export default function Reveal({ children, className, as: Tag = 'div' }) {
+  const ref = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === 'undefined') {
+      setVisible(true);
+      return undefined;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setVisible(true);
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.12, rootMargin: '0px 0px -10% 0px' },
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <Tag
+      ref={ref}
+      className={clsx('reveal', visible && 'reveal--visible', className)}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/website/src/components/ui/SectionWrapper/index.jsx
+++ b/website/src/components/ui/SectionWrapper/index.jsx
@@ -1,19 +1,21 @@
 import React from 'react';
 import styles from './styles.module.css';
 
-export default function SectionWrapper({ title, subtitle, children }) {
+export default function SectionWrapper({ eyebrow, title, subtitle, children }) {
   return (
     <section className="py-10">
       {title ? (
-        <div className="container mb-10">
-          <h2 className="text-center text-4xl font-bold">{title}</h2>
+        <div className="container mb-10 flex flex-col items-center text-center">
+          {eyebrow ? <span className="eyebrow mb-3">{eyebrow}</span> : null}
+          <h2 className="section-title">{title}</h2>
+          <div className="gradient-rule" />
         </div>
       ) : null}
       {subtitle ? (
-          <div className="col col--12 text--center">
-            <p className={styles.subtitle}>{subtitle}</p>
-          </div>
-        ): null}
+        <div className="col col--12 text--center">
+          <p className={styles.subtitle}>{subtitle}</p>
+        </div>
+      ) : null}
       {children}
     </section>
   );

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -194,47 +194,27 @@ button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
-  /* Rest state: a circular chat-bubble icon tucked in the corner. The text
-     label is collapsed (font-size:0) and the width clamped to a circle; hover
-     expands max-width and restores the label to reveal the full "ZIO Chat!". */
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
-  gap: 0.5rem !important;
-  height: 3.5rem !important;
-  min-width: 3.5rem !important;
-  max-width: 3.5rem !important;
-  padding: 0 1rem !important;
-  margin: 0 1rem 1rem 0 !important;
-  overflow: hidden !important;
-  white-space: nowrap !important;
-  font-size: 0 !important;
-  border-radius: 9999px !important;
+  /* Rest state: the full "ZIO Chat!" pill is tucked off the right edge, leaving
+     only a slim gradient sliver peeking to hint at it. Hover / keyboard focus
+     slides it fully into view. */
+  transform: translateX(calc(100% - 16px)) !important;
+  transition: transform 0.3s ease, filter 0.2s ease !important;
+  border-radius: 9999px 0 0 9999px !important;
+  padding: 0.6rem 1.25rem !important;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25) !important;
-  transition: max-width 0.3s ease, filter 0.2s ease !important;
-}
-
-/* White chat-bubble glyph, sized independently of the collapsed label. */
-button.fixed.bg-orange-400::before {
-  content: '';
-  flex: 0 0 auto;
-  width: 1.6rem;
-  height: 1.6rem;
-  background-color: currentColor;
-  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
-  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
 }
 
 button.fixed.bg-orange-400:hover,
 button.fixed.bg-orange-400:focus-visible {
-  max-width: 14rem !important;
-  font-size: 1.25rem !important;
+  transform: translateX(0) !important;
   filter: brightness(0.96);
 }
 
 @media (prefers-reduced-motion: reduce) {
   button.fixed.bg-orange-400 {
     transition: none !important;
+    /* No slide for reduced-motion: show a compact but visible tab. */
+    transform: translateX(calc(100% - 3.25rem)) !important;
   }
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -194,10 +194,24 @@ button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
+  /* Rest state: tuck most of the button off the right edge, leaving a ~48px
+     sliver to catch the eye. Slides fully in on hover/focus. */
+  transform: translateX(calc(100% - 48px)) !important;
+  transition: transform 0.28s ease, filter 0.2s ease !important;
+  border-top-left-radius: 0.5rem !important;
+  border-bottom-left-radius: 0.5rem !important;
 }
 
-button.fixed.bg-orange-400:hover {
-  filter: brightness(0.94);
+button.fixed.bg-orange-400:hover,
+button.fixed.bg-orange-400:focus-visible {
+  transform: translateX(0) !important;
+  filter: brightness(0.96);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button.fixed.bg-orange-400 {
+    transition: none !important;
+  }
 }
 
 /* ── Footer link hover ────────────────────────────────────────────────── */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -193,31 +193,38 @@ a {
 button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
-  color: #ffffff !important;
   /* Crisp-style launcher: a round chat-bubble button pinned bottom-right,
-     always visible, with a gentle scale on hover. The text label is kept in the
-     DOM for screen readers but hidden visually (font-size:0). */
-  display: inline-flex !important;
-  align-items: center !important;
-  justify-content: center !important;
+     always visible, with a gentle scale on hover. The "ZIO Chat!" text stays in
+     the DOM for screen readers but is fully hidden: transparent, zero font-size,
+     indented and clipped. The icon is drawn as an absolutely-centered ::before
+     so the hidden text can't affect it. */
+  position: fixed !important;
+  color: transparent !important;
   width: 3.75rem !important;
   height: 3.75rem !important;
   min-width: 3.75rem !important;
   padding: 0 !important;
   margin: 0 1.25rem 1.25rem 0 !important;
   font-size: 0 !important;
+  line-height: 0 !important;
+  text-indent: -9999px !important;
+  overflow: hidden !important;
   border-radius: 9999px !important;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28) !important;
   transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease !important;
 }
 
-/* White chat-bubble glyph. */
+/* White chat-bubble glyph, absolutely centered regardless of the hidden text. */
 button.fixed.bg-orange-400::before {
   content: '';
-  flex: 0 0 auto;
-  width: 1.6rem;
-  height: 1.6rem;
-  background-color: currentColor;
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
+  width: 1.6rem !important;
+  height: 1.6rem !important;
+  text-indent: 0 !important;
+  background-color: #ffffff !important;
   -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -189,6 +189,16 @@ a {
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+/* ── ByteBrain chat toggle: match brand red instead of default orange ─── */
+button.fixed.bg-orange-400 {
+  background-color: #dc2626 !important;
+  color: #ffffff !important;
+}
+
+button.fixed.bg-orange-400:hover {
+  background-color: #c82020 !important;
+}
+
 /* ── Footer link hover ────────────────────────────────────────────────── */
 .footer__link-item:hover {
   color: #e14747;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -70,8 +70,165 @@
   --ifm-color-primary-lightest: #e76969;
 }
 
+:root {
+  --gradient-brand: linear-gradient(90deg, #dc2626, #f59e0b);
+  --brand-shadow: rgba(220, 38, 38, 0.12);
+}
+
 a {
   font-weight: 500;
+}
+
+/* ── Modern refresh: shared brand primitives ───────────────────────────── */
+
+/* Small uppercase eyebrow label above section titles / hero. */
+.eyebrow {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: #dc2626;
+  background: rgba(220, 38, 38, 0.1);
+  padding: 0.28rem 0.85rem;
+  border-radius: 999px;
+}
+
+[data-theme='dark'] .eyebrow {
+  color: #f87171;
+  background: rgba(220, 38, 38, 0.16);
+}
+
+/* Red→amber clipped text for keyword emphasis in headings. */
+.gradient-text {
+  background: var(--gradient-brand);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+/* Short gradient bar under section titles. */
+.gradient-rule {
+  width: 48px;
+  height: 3px;
+  border-radius: 2px;
+  background: var(--gradient-brand);
+  margin: 0.85rem auto 0;
+}
+
+/* Tightened, heavier heading treatment for homepage sections. */
+.section-title {
+  font-size: 2.25rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  margin: 0.5rem 0 0;
+}
+
+/* ── Modern card ──────────────────────────────────────────────────────── */
+/* Reusable across Features / Ecosystem / CodingAgent cards. */
+.card-modern {
+  position: relative;
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  background: var(--ifm-card-background-color, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.card-modern::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--gradient-brand);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+[data-theme='dark'] .card-modern {
+  border-color: var(--ifm-color-emphasis-300);
+  background: var(--ifm-background-color);
+}
+
+/* Gradient-tinted rounded icon tile inside cards. */
+.card-icon-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.8rem;
+  color: #dc2626;
+  background: linear-gradient(135deg, rgba(220, 38, 38, 0.12), rgba(245, 158, 11, 0.12));
+}
+
+[data-theme='dark'] .card-icon-tile {
+  color: #f87171;
+}
+
+/* ── Navbar: sticky translucent + blur ────────────────────────────────── */
+.navbar {
+  backdrop-filter: saturate(180%) blur(10px);
+  -webkit-backdrop-filter: saturate(180%) blur(10px);
+  border-bottom: 1px solid var(--color-gray-200, rgba(0, 0, 0, 0.08));
+}
+
+:root {
+  --ifm-navbar-background-color: rgba(246, 246, 246, 0.8);
+}
+
+[data-theme='dark'] {
+  --ifm-navbar-background-color: rgba(15, 15, 15, 0.8);
+}
+
+[data-theme='dark'] .navbar {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* ── Footer link hover ────────────────────────────────────────────────── */
+.footer__link-item:hover {
+  color: #e14747;
+  text-decoration: none;
+}
+
+/* ── Motion: scroll reveal + reduced-motion guard ─────────────────────── */
+.reveal {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+    will-change: opacity, transform;
+  }
+
+  .reveal.reveal--visible {
+    opacity: 1;
+    transform: none;
+  }
+
+  .card-modern:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 14px 30px var(--brand-shadow);
+    border-color: rgba(220, 38, 38, 0.35);
+  }
+
+  .card-modern:hover::before {
+    opacity: 1;
+  }
+}
+
+/* Reduced-motion / no-JS: cards still get a static hover accent. */
+@media (prefers-reduced-motion: reduce) {
+  .card-modern:hover {
+    border-color: rgba(220, 38, 38, 0.35);
+  }
 }
 
 .header-github-link:hover {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -194,17 +194,21 @@ button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
-  /* Rest state: tuck most of the button off the right edge, leaving a ~48px
-     sliver to catch the eye. Slides fully in on hover/focus. */
-  transform: translateX(calc(100% - 48px)) !important;
-  transition: transform 0.28s ease, filter 0.2s ease !important;
+  /* Rest state: clip the button's width from the left so only the trailing
+     "Chat!" shows; the pinned right edge keeps it hugging the corner. Hover
+     expands to full width, revealing "ZIO Chat!". */
+  max-width: 4.75rem !important;
+  overflow: hidden !important;
+  white-space: nowrap !important;
+  text-align: right !important;
+  transition: max-width 0.28s ease, filter 0.2s ease !important;
   border-top-left-radius: 0.5rem !important;
   border-bottom-left-radius: 0.5rem !important;
 }
 
 button.fixed.bg-orange-400:hover,
 button.fixed.bg-orange-400:focus-visible {
-  transform: translateX(0) !important;
+  max-width: 14rem !important;
   filter: brightness(0.96);
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -194,21 +194,41 @@ button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
-  /* Rest state: clip the button's width from the left so only the trailing
-     "Chat!" shows; the pinned right edge keeps it hugging the corner. Hover
-     expands to full width, revealing "ZIO Chat!". */
-  max-width: 4.75rem !important;
+  /* Rest state: a circular chat-bubble icon tucked in the corner. The text
+     label is collapsed (font-size:0) and the width clamped to a circle; hover
+     expands max-width and restores the label to reveal the full "ZIO Chat!". */
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 0.5rem !important;
+  height: 3.5rem !important;
+  min-width: 3.5rem !important;
+  max-width: 3.5rem !important;
+  padding: 0 1rem !important;
+  margin: 0 1rem 1rem 0 !important;
   overflow: hidden !important;
   white-space: nowrap !important;
-  text-align: right !important;
-  transition: max-width 0.28s ease, filter 0.2s ease !important;
-  border-top-left-radius: 0.5rem !important;
-  border-bottom-left-radius: 0.5rem !important;
+  font-size: 0 !important;
+  border-radius: 9999px !important;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25) !important;
+  transition: max-width 0.3s ease, filter 0.2s ease !important;
+}
+
+/* White chat-bubble glyph, sized independently of the collapsed label. */
+button.fixed.bg-orange-400::before {
+  content: '';
+  flex: 0 0 auto;
+  width: 1.6rem;
+  height: 1.6rem;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
 }
 
 button.fixed.bg-orange-400:hover,
 button.fixed.bg-orange-400:focus-visible {
   max-width: 14rem !important;
+  font-size: 1.25rem !important;
   filter: brightness(0.96);
 }
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -191,12 +191,13 @@ a {
 
 /* ── ByteBrain chat toggle: match brand red instead of default orange ─── */
 button.fixed.bg-orange-400 {
-  background-color: #dc2626 !important;
+  background-color: transparent !important;
+  background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
 }
 
 button.fixed.bg-orange-400:hover {
-  background-color: #c82020 !important;
+  filter: brightness(0.94);
 }
 
 /* ── Footer link hover ────────────────────────────────────────────────── */

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -246,6 +246,95 @@ button.fixed.bg-orange-400:focus-visible {
   }
 }
 
+/* ── ByteBrain chat window: brand-consistent + modern ────────────────────
+   The library ships a blue/black themed popup. These scoped overrides (under
+   the .zio-chat wrapper so they never leak to bg-blue/bg-black elsewhere)
+   retheme it to the red/amber system, theme-aware. */
+
+/* Popup panel (flex-col rounded-md bg-gray-100). */
+.zio-chat .rounded-md.bg-gray-100 {
+  background: #ffffff !important;
+  border: 1px solid var(--ifm-color-emphasis-200) !important;
+  border-radius: 16px !important;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.22) !important;
+}
+
+[data-theme='dark'] .zio-chat .rounded-md.bg-gray-100 {
+  background: #181818 !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+/* Assistant/bot message bubbles (bg-blue-600) → neutral readable surface with
+   a red accent edge. White-on-gradient was too low-contrast to read. */
+.zio-chat .bg-blue-600 {
+  background: #f4f4f5 !important;
+  color: #1a1a1a !important;
+  border-left: 3px solid #dc2626 !important;
+}
+
+.zio-chat .bg-blue-600 * {
+  color: #1a1a1a !important;
+}
+
+.zio-chat .bg-blue-600 a {
+  color: #dc2626 !important;
+}
+
+[data-theme='dark'] .zio-chat .bg-blue-600 {
+  background: #242526 !important;
+  color: #ececec !important;
+}
+
+[data-theme='dark'] .zio-chat .bg-blue-600 *:not(a) {
+  color: #ececec !important;
+}
+
+[data-theme='dark'] .zio-chat .bg-blue-600 a {
+  color: #f87171 !important;
+}
+
+/* User message bubbles (bg-blue-500) → brand red, white text. */
+.zio-chat .bg-blue-500 {
+  background: #dc2626 !important;
+  color: #ffffff !important;
+}
+
+.zio-chat .bg-blue-500 * {
+  color: #ffffff !important;
+}
+
+/* Bot message bubbles (bg-gray-300 / text-gray-600). */
+.zio-chat .bg-gray-300 {
+  background: #f1f1f1 !important;
+}
+
+.zio-chat .text-gray-600 {
+  color: #333333 !important;
+}
+
+[data-theme='dark'] .zio-chat .bg-gray-300 {
+  background: #242526 !important;
+}
+
+[data-theme='dark'] .zio-chat .text-gray-600 {
+  color: #e5e5e5 !important;
+}
+
+/* Send button (bg-black / hover:bg-gray-900) → brand red. */
+.zio-chat .bg-black {
+  background: #dc2626 !important;
+  border-radius: 10px !important;
+}
+
+.zio-chat .bg-black:hover {
+  background: #b91c1c !important;
+}
+
+/* Header links. */
+.zio-chat a.text-white:hover {
+  color: #0f0f0f !important;
+}
+
 /* ── Footer link hover ────────────────────────────────────────────────── */
 .footer__link-item:hover {
   color: #e14747;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -194,27 +194,48 @@ button.fixed.bg-orange-400 {
   background-color: transparent !important;
   background-image: var(--gradient-brand) !important;
   color: #ffffff !important;
-  /* Rest state: the full "ZIO Chat!" pill is tucked off the right edge, leaving
-     only a slim gradient sliver peeking to hint at it. Hover / keyboard focus
-     slides it fully into view. */
-  transform: translateX(calc(100% - 16px)) !important;
-  transition: transform 0.3s ease, filter 0.2s ease !important;
-  border-radius: 9999px 0 0 9999px !important;
-  padding: 0.6rem 1.25rem !important;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25) !important;
+  /* Crisp-style launcher: a round chat-bubble button pinned bottom-right,
+     always visible, with a gentle scale on hover. The text label is kept in the
+     DOM for screen readers but hidden visually (font-size:0). */
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 3.75rem !important;
+  height: 3.75rem !important;
+  min-width: 3.75rem !important;
+  padding: 0 !important;
+  margin: 0 1.25rem 1.25rem 0 !important;
+  font-size: 0 !important;
+  border-radius: 9999px !important;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28) !important;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease !important;
+}
+
+/* White chat-bubble glyph. */
+button.fixed.bg-orange-400::before {
+  content: '';
+  flex: 0 0 auto;
+  width: 1.6rem;
+  height: 1.6rem;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M4 2h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H8l-6 5V4a2 2 0 0 1 2-2z'/%3E%3C/svg%3E") center / contain no-repeat;
 }
 
 button.fixed.bg-orange-400:hover,
 button.fixed.bg-orange-400:focus-visible {
-  transform: translateX(0) !important;
-  filter: brightness(0.96);
+  transform: scale(1.06) !important;
+  box-shadow: 0 12px 30px rgba(220, 38, 38, 0.35) !important;
+  filter: brightness(0.97);
 }
 
 @media (prefers-reduced-motion: reduce) {
   button.fixed.bg-orange-400 {
     transition: none !important;
-    /* No slide for reduced-motion: show a compact but visible tab. */
-    transform: translateX(calc(100% - 3.25rem)) !important;
+  }
+  button.fixed.bg-orange-400:hover,
+  button.fixed.bg-orange-400:focus-visible {
+    transform: none !important;
   }
 }
 

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -31,7 +31,6 @@ export default function WelcomePage() {
         </Reveal>
         <Reveal>
           <Ecosystem
-            eyebrow="Libraries"
             title="Ecosystem"
             subtitle="A rich ecosystem of libraries built on ZIO to solve real-world problems"
           />

--- a/website/src/pages/index.jsx
+++ b/website/src/pages/index.jsx
@@ -8,6 +8,7 @@ import Ecosystem from '@site/src/components/sections/Ecosystem';
 import CodingAgent from '@site/src/components/sections/CodingAgent';
 import Sponsors from '@site/src/components/sections/Sponsors';
 import Zionomicon from '@site/src/components/sections/Zionomicon';
+import Reveal from '@site/src/components/ui/Reveal';
 
 // Construct the home page from all components
 export default function WelcomePage() {
@@ -22,11 +23,25 @@ export default function WelcomePage() {
       <Hero />
 
       <main>
-        <CodingAgent />
-        <Features />
-        <Ecosystem title = "Ecosystem" subtitle="A rich ecosystem of libraries built on ZIO to solve real-world problems"/>
-        <Zionomicon />
-        <Sponsors />
+        <Reveal>
+          <CodingAgent />
+        </Reveal>
+        <Reveal>
+          <Features />
+        </Reveal>
+        <Reveal>
+          <Ecosystem
+            eyebrow="Libraries"
+            title="Ecosystem"
+            subtitle="A rich ecosystem of libraries built on ZIO to solve real-world problems"
+          />
+        </Reveal>
+        <Reveal>
+          <Zionomicon />
+        </Reveal>
+        <Reveal>
+          <Sponsors />
+        </Reveal>
       </main>
     </Layout>
   );

--- a/website/src/theme/Footer/index.js
+++ b/website/src/theme/Footer/index.js
@@ -1,16 +1,18 @@
-import React from "react";
-import Footer from "@theme-original/Footer";
-import { ChatApp } from "@bytebrain.ai/bytebrain-ui";
+import React from 'react';
+import Footer from '@theme-original/Footer';
+import { ChatApp } from '@bytebrain.ai/bytebrain-ui';
 
 export default function FooterWrapper(props) {
   return (
     <>
       <Footer {...props} />
-      <ChatApp
-        websocketHost="chat.zio.dev"
-        websocketPort="80"
-        websocketEndpoint="/chat"
-      />
+      <div className="zio-chat">
+        <ChatApp
+          websocketHost="chat.zio.dev"
+          websocketPort="80"
+          websocketEndpoint="/chat"
+        />
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## What

Evolutionary refresh of the ZIO website's homepage and global chrome, keeping the existing red/amber brand identity, plus a full retheme of the ByteBrain chat widget.

### Homepage & chrome
- **Hero**: eyebrow label, gradient keyword ("asynchronous"), dual CTAs (Get Started + Star on GitHub), soft radial glow, and a GitHub stats badge row. Uses the original ZIO logo image.
- **RepoStats** (new): live star count and latest release version fetched from the GitHub API at runtime, with static fallbacks when the API is unreachable; contributors static.
- **Shared brand primitives** in `custom.css`: gradient token, `.eyebrow`, `.gradient-text`, `.gradient-rule`, `.section-title`, `.card-modern` + gradient icon tile.
- **Modern cards** (hover lift + gradient accent bar) on Features and Ecosystem; refined section headers.
- **Sticky translucent navbar** with backdrop blur; footer link hover.
- **Reveal** (new): tasteful scroll-reveal motion, gated behind `prefers-reduced-motion` and SSR-safe.

### Chat widget (ByteBrain)
- Launcher restyled as a Crisp-style round, icon-only gradient bubble pinned bottom-right with a gentle hover scale; label hidden visually but kept in the DOM for screen readers.
- Chat window rethemed to the brand palette, theme-aware: neutral readable assistant bubbles with a red accent edge, red user bubbles, red send button, modern white/dark panel. All overrides scoped under a `.zio-chat` wrapper so nothing leaks to other blue/black elements.

## Notes
- Pure CSS + Tailwind v4 utilities + two small React components (`Reveal`, `RepoStats`). No new heavy dependencies.
- Both light and dark themes styled. Docs pages only inherit the global chrome/token changes.

## Verification
- `yarn build` completes clean (pre-existing broken-link warnings in ecosystem docs are unrelated).
- Local preview checked in light/dark: hero, card hover, scroll reveals, navbar blur, chat launcher, and rethemed chat window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)