### PR TITLE
Fix ZPipeline.fromFunction dropping environment updates on the upstream

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZPipelineSpec.scala
@@ -311,6 +311,32 @@ object ZPipelineSpec extends ZIOBaseSpec {
           .runCollect
           .map(assert(_)(equalTo(Chunk.range(1, 21))))
       },
+      test("fromFunction propagates provideSomeEnvironment to the upstream") {
+        for {
+          ref <- Ref.make(0)
+          _ <- ZStream
+                 .serviceWithZIO[Int](i => ref.set(i))
+                 .via(ZPipeline.fromFunction { (s: ZStream[Any, Nothing, Unit]) =>
+                   s.provideSomeEnvironment[Int](_.update(_ => 2))
+                 })
+                 .provideEnvironment(ZEnvironment(1))
+                 .runDrain
+          result <- ref.get
+        } yield assert(result)(equalTo(2))
+      },
+      test("fromFunction propagates provideSomeEnvironment to a layer-provided upstream") {
+        for {
+          ref <- Ref.make(0)
+          _ <- ZStream
+                 .serviceWithZIO[Int](i => ref.set(i))
+                 .via(ZPipeline.fromFunction { (s: ZStream[Any, Nothing, Unit]) =>
+                   s.provideSomeEnvironment[Int](_.update(_ => 2))
+                 })
+                 .runDrain
+                 .provideLayer(ZLayer.succeed(1))
+          result <- ref.get
+        } yield assert(result)(equalTo(2))
+      },
       suite("mapEitherChunk")(
         test("with empty chunk") {
           val chunk = Chunk.empty[Int]

--- a/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
+++ b/streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala
@@ -247,18 +247,46 @@ private[stream] final class ChannelExecutor[Env, InErr, InElem, InDone, OutErr, 
               }
 
             case ZChannel.DeferedUpstream(mkChannel) =>
-              val inpAsChannel: ZChannel[Env, Any, Any, Any, Any, Any, Any] = execToPullingChannel(input)
+              // The environment the upstream executor captured from the enclosing pipe.
+              val inputProvidedEnv = input.providedEnv
 
-              // when input's provided env is null, we have to explicitly provide it with the 'outer' env
-              // otherwise any env provided by downstream will override the 'correct' env when the input channel executes effects.
               val nextChannel: Channel[Env] =
-                if (null ne input.providedEnv)
-                  mkChannel(inpAsChannel.asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]])
-                else
+                if (null ne inputProvidedEnv) {
+                  // Clear the captured environment so the upstream's effects become "raw".
+                  // Otherwise they are already provided with `inputProvidedEnv`, which shadows
+                  // any environment transformation a pipeline applies to the upstream (e.g. via
+                  // `provideSomeEnvironment`), silently making it a no-op.
+                  input.providedEnv = null
+                  val inpAsChannel = execToPullingChannel(input)
+                  // Provide the upstream by overlaying the environment produced by the pipeline
+                  // (`pe`) on top of the captured base. This lets a pipeline transform the
+                  // upstream's environment, while still preserving the services the upstream
+                  // received from the enclosing scope that the pipeline does not itself provide.
+                  mkChannel(ZChannel.environmentWithChannel[Any] { pe =>
+                    inpAsChannel
+                      .asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]]
+                      .provideEnvironment(inputProvidedEnv.unionAll(pe))
+                  })
+                } else {
+                  val inpAsChannel = execToPullingChannel(input)
+                  // When input's provided env is null, we still have to explicitly provide the
+                  // upstream with the 'outer' env; otherwise any env provided by downstream would
+                  // override the 'correct' env when the input channel executes effects.
+                  // We read the outer env (`env`) as the base, but overlay the environment the
+                  // pipeline produces (`pe`, read at the point the upstream is used inside
+                  // `mkChannel`) on top of it via `unionAll`. This mirrors the non-null branch:
+                  // it lets a pipeline transform the upstream's environment while preserving the
+                  // services the upstream received from the enclosing scope that the pipeline does
+                  // not itself provide (env-neutral pipelines reduce to providing `env`).
                   ZChannel // TODO: can we eliminate the effect evaluation here? i.e. by usingFiber.currentFiber()
                     .environmentWithChannel[Env] { env =>
-                      mkChannel(inpAsChannel.provideEnvironment(env))
+                      mkChannel(ZChannel.environmentWithChannel[Any] { pe =>
+                        inpAsChannel
+                          .asInstanceOf[ZChannel[Any, Any, Any, Any, Any, Any, Any]]
+                          .provideEnvironment(env.unionAll(pe))
+                      })
                     }
+                }
 
               val previousInput = input
               input = null


### PR DESCRIPTION
## `ZPipeline.fromFunction` now propagates environment updates to the upstream

Fixes #10726

### Problem

A `ZPipeline` built with `ZPipeline.fromFunction` that applies `provideSomeEnvironment`
to its upstream stream silently drops the environment update. The two snippets below are
expected to behave identically (both should log `2`), but the pipeline version logs `1`:

```scala
// prints 2 (correct)
ZStream
  .serviceWithZIO[Int](i => ZIO.logInfo(i.toString))
  .provideSomeEnvironment[Int](_.update(_ => 2))
  .provideEnvironment(ZEnvironment(1))
  .runDrain

// prints 1 (bug) — the environment update inside the pipeline has no effect
ZStream
  .serviceWithZIO[Int](i => ZIO.logInfo(i.toString))
  .via(ZPipeline.fromFunction { s =>
    s.provideSomeEnvironment[Int](_.update(_ => 2))
  })
  .provideEnvironment(ZEnvironment(1))
  .runDrain
```

The same drop happens when the environment is supplied via a `ZLayer` / the channel's `R`
instead of `.provideEnvironment` on the stream:

```scala
// prints 1 (bug) — same structural cause, environment supplied by a layer
ZStream
  .serviceWithZIO[Int](i => ZIO.logInfo(i.toString))
  .via(ZPipeline.fromFunction { s =>
    s.provideSomeEnvironment[Int](_.update(_ => 2))
  })
  .runDrain
  .provideLayer(ZLayer.succeed(1))
```

### Root cause

`streams/shared/src/main/scala/zio/stream/internal/ChannelExecutor.scala`, the
`ZChannel.DeferedUpstream` handler.

`ZPipeline.fromFunction` compiles to a `ZChannel.DeferedUpstream` node whose `mkChannel`
function receives the upstream as a channel and transforms it. When the pipeline is applied
via a `PipeTo`, the upstream runs in a *separate* `ChannelExecutor` (`input`). The handler
provided the upstream's environment **before** the pipeline's transform ran, so the
upstream's effects were effectively **sealed**: any `provideSomeEnvironment` /
`provideEnvironment` that `mkChannel` wrapped around the upstream became an outer
`provideEnvironment` over an already-provided effect, which is a no-op — so the update from
`1` to `2` was ignored.

This affected **both** ways the environment reaches the upstream:

1. **Captured env** (`input.providedEnv` is non-null) — the environment was captured from the
   enclosing scope by a `Provide` node (e.g. `.provideEnvironment(ZEnvironment(1))` on the
   stream). That executor eagerly provides its captured environment to every effect it runs,
   so the upstream was sealed with it and the pipeline's transform was ignored.
2. **Layer / `R`-supplied env** (`input.providedEnv` is null) — the environment flows through
   the channel's `R` (e.g. `.provideLayer(ZLayer.succeed(1))` at the outer scope). Here the
   handler read the outer env and provided the *whole* env to the upstream up front, again
   sealing it before the pipeline's transform could take effect.

### Fix

In the `DeferedUpstream` handler, in **both** branches, defer reading the environment until
the point the upstream is actually used *inside* `mkChannel` (i.e. after the pipeline's
transform), and provide the upstream by overlaying that environment (`pe`) on top of the
appropriate base with `unionAll`:

- **Captured-env branch:** clear `input.providedEnv` so the upstream's effects become "raw",
  then provide `inputProvidedEnv.unionAll(pe)` (base = the captured environment).
- **Null branch:** provide `env.unionAll(pe)` where `env` is the outer downstream env read at
  the `DeferedUpstream` node (base = the outer env). Keeping `env` as the base retains the
  pre-existing "downstream override" protection — the upstream still receives the outer
  services and downstream cannot override them — while `pe` lets the pipeline transform win.

`unionAll` overlays `pe` onto the base (the pipeline wins for shared services), which:

- lets a pipeline **transform** the upstream's environment
  (`{Int:1}.unionAll({Int:2}) == {Int:2}` → both reported cases now print `2`), while
- **preserves** services the upstream received from the enclosing scope that the pipeline
  does not itself provide
  (`{Resource, Scope}.unionAll({Scope:inner}) == {Resource, Scope:inner}` → keeps `Resource`).

For environment-neutral pipelines the overlaid `pe` equals the base, so `unionAll`
short-circuits and behavior is unchanged.

### Tests

Added two regression tests in `ZPipelineSpec` — one per form:

```scala
test("fromFunction propagates provideSomeEnvironment to the upstream") {
  for {
    ref <- Ref.make(0)
    _ <- ZStream
           .serviceWithZIO[Int](i => ref.set(i))
           .via(ZPipeline.fromFunction { (s: ZStream[Any, Nothing, Unit]) =>
             s.provideSomeEnvironment[Int](_.update(_ => 2))
           })
           .provideEnvironment(ZEnvironment(1))
           .runDrain
    result <- ref.get
  } yield assert(result)(equalTo(2))
},
test("fromFunction propagates provideSomeEnvironment to a layer-provided upstream") {
  for {
    ref <- Ref.make(0)
    _ <- ZStream
           .serviceWithZIO[Int](i => ref.set(i))
           .via(ZPipeline.fromFunction { (s: ZStream[Any, Nothing, Unit]) =>
             s.provideSomeEnvironment[Int](_.update(_ => 2))
           })
           .runDrain
           .provideLayer(ZLayer.succeed(1))
    result <- ref.get
  } yield assert(result)(equalTo(2))
}
```

### Verification (before / after)

Command:
`sbt 'streamsTestsJVM/testOnly zio.stream.ZPipelineSpec -- -t "fromFunction propagates provideSomeEnvironment"'`

- **Before the null-branch fix:** the `.provideEnvironment` test passes, the layer-provided
  test FAILS — `1 was not equal to 2` (result = `1`).
- **After the fix:** both PASS — `2 tests passed. 0 tests failed.`

Full suites (Scala 2.13.18, JVM):
`sbt 'streamsTestsJVM/testOnly zio.stream.ZChannelSpec zio.stream.ZStreamSpec zio.stream.ZPipelineSpec zio.stream.ZSinkSpec'`
→ `791 tests passed. 0 tests failed. 1 tests ignored.`

The existing `ZStreamSpec` env-propagation tests (`respects env`, `respects env multiple
levels`) — which assert that a pipeline's `provideEnvironment` does **not** strip services
the upstream received externally, and which exercise the null branch — continue to pass,
confirming the overlay preserves the original "downstream override" protection.

`scalafmtCheck` passes for both changed projects.

### Compatibility

No public API changes; the change is confined to the internal `ChannelExecutor`
`DeferedUpstream` interpreter. Behavior is unchanged for pipelines that do not alter the
upstream's environment (the overlay reduces to the previously-provided environment). It only
changes cases that were previously broken (environment updates applied to the upstream inside
a `fromFunction` pipeline now take effect, whether the environment was supplied by
`.provideEnvironment` or by a layer).
