### PR TITLE
make Cause.Unified more consistent by fixing className and printStackTrace

### DIFF
--- a/core-tests/shared/src/test/scala/zio/UnifiedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/UnifiedSpec.scala
@@ -1,7 +1,8 @@
 package zio
 
 import zio.test.Assertion.equalTo
-import zio.test.assert
+import zio.test.TestAspect.jvmOnly
+import zio.test.{TestVersion, assert}
 
 object UnifiedSpec extends ZIOBaseSpec {
 
@@ -17,12 +18,19 @@ object UnifiedSpec extends ZIOBaseSpec {
         val boom = generateRuntimeBoom
         // TODO - is it ok to use `exceptionHasTrace` from another test suite, which under the hood calls `printStackTrace`?
         assert(boom)(zio.StackTracesSpec.exceptionHasTrace {
-          """java.lang.RuntimeException: boom
-            |	at zio.UnifiedSpec$.generateRuntimeBoom
-            |	at zio.UnifiedSpec$.$anonfun$spec
-            |""".stripMargin
+          if (TestVersion.isScala2)
+            """java.lang.RuntimeException: boom
+              |	at zio.UnifiedSpec$.generateRuntimeBoom
+              |	at zio.UnifiedSpec$.$anonfun$spec
+              |""".stripMargin
+          else
+            """java.lang.RuntimeException: boom
+              |	at zio.UnifiedSpec$.generateRuntimeBoom
+              |	at zio.UnifiedSpec$.spec$$anonfun
+              |	at zio.test.TestConstructor$.apply$$anonfun$1$$anonfun
+              |""".stripMargin
         })
-      }
+      } @@ jvmOnly
     )
   )
 

--- a/core-tests/shared/src/test/scala/zio/UnifiedSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/UnifiedSpec.scala
@@ -1,0 +1,36 @@
+package zio
+
+import zio.test.Assertion.equalTo
+import zio.test.assert
+
+object UnifiedSpec extends ZIOBaseSpec {
+
+  def spec = suite("UnifiedSpec")(
+    suite("toThrowable")(
+      test("preserves original exception type") {
+        val t1 = unifiedThrowable(new RuntimeException("foo"))
+        val t2 = unifiedThrowable(new IllegalArgumentException("bar"))
+        assert(t1.toString)(equalTo("java.lang.RuntimeException: foo")) &&
+        assert(t2.toString)(equalTo("java.lang.IllegalArgumentException: bar"))
+      },
+      test("preserves stack trace in `printStackTrace`") {
+        val boom = generateRuntimeBoom
+        // TODO - is it ok to use `exceptionHasTrace` from another test suite, which under the hood calls `printStackTrace`?
+        assert(boom)(zio.StackTracesSpec.exceptionHasTrace {
+          """java.lang.RuntimeException: boom
+            |	at zio.UnifiedSpec$.generateRuntimeBoom
+            |	at zio.UnifiedSpec$.$anonfun$spec
+            |""".stripMargin
+        })
+      }
+    )
+  )
+
+  def unifiedThrowable(defect: Throwable): Throwable =
+    Cause.die(defect).unified.head.toThrowable
+
+  def generateRuntimeBoom: Throwable = {
+    val defect = new RuntimeException("boom")
+    unifiedThrowable(defect)
+  }
+}

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -19,7 +19,7 @@ package zio
 import zio.Cause.Both
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
-import java.io.PrintWriter
+import java.io.{PrintStream, PrintWriter}
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.runtime.AbstractFunction2
@@ -895,9 +895,24 @@ object Cause extends Serializable {
   final case class Unified(fiberId: FiberId, className: String, message: String, trace: Chunk[StackTraceElement]) {
     def toThrowable: Throwable =
       new Throwable(null, null, false, false) {
+        // TODO - does this need an `implicit unsafe`?
+        // TODO - final private vs private final - see both used
+        private[zio] final def prettyPrintWith(append: String => Unit): Unit = {
+          append(toString)
+          trace.foreach(trace => append(s"\tat $trace"))
+        }
+
+        // TODO - should we override `toString`, so it carries the name of the exception, rather than `zio.Cause$Unified$$anon$3`?
+        // TODO - `FiberFailure` includes the full stack trace in the `toString`. do we want to follow that pattern, or the more typical "toString is class + message"?
+        override final def toString: String = s"$className: $message"
+
         override final def getMessage(): String = message
 
         override final def getStackTrace(): Array[StackTraceElement] = trace.toArray
+
+        override final def printStackTrace(s: PrintStream): Unit = prettyPrintWith(s.println)
+
+        override final def printStackTrace(s: PrintWriter): Unit = prettyPrintWith(s.println)
       }
   }
 

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -895,24 +895,23 @@ object Cause extends Serializable {
   final case class Unified(fiberId: FiberId, className: String, message: String, trace: Chunk[StackTraceElement]) {
     def toThrowable: Throwable =
       new Throwable(null, null, false, false) {
-        // TODO - does this need an `implicit unsafe`?
-        // TODO - final private vs private final - see both used
-        private[zio] final def prettyPrintWith(append: String => Unit): Unit = {
+        private final def prettyPrintWith(append: String => Unit)(implicit unsafe: Unsafe): Unit = {
           append(toString)
-          trace.foreach(trace => append(s"\tat $trace"))
+          // default JVM stack trace depth is 1024 frames
+          trace.take(1024).foreach(trace => append(s"\tat $trace"))
         }
 
         // TODO - should we override `toString`, so it carries the name of the exception, rather than `zio.Cause$Unified$$anon$3`?
         // TODO - `FiberFailure` includes the full stack trace in the `toString`. do we want to follow that pattern, or the more typical "toString is class + message"?
         override final def toString: String = s"$className: $message"
 
-        override final def getMessage(): String = message
+        override final def getMessage: String = message
 
-        override final def getStackTrace(): Array[StackTraceElement] = trace.toArray
+        override final def getStackTrace: Array[StackTraceElement] = trace.toArray
 
-        override final def printStackTrace(s: PrintStream): Unit = prettyPrintWith(s.println)
+        override final def printStackTrace(s: PrintStream): Unit = prettyPrintWith(s.println)(Unsafe.unsafe)
 
-        override final def printStackTrace(s: PrintWriter): Unit = prettyPrintWith(s.println)
+        override final def printStackTrace(s: PrintWriter): Unit = prettyPrintWith(s.println)(Unsafe.unsafe)
       }
   }
 


### PR DESCRIPTION
fixes #11094 

this updates `Unified` to:
- report the underlying exception class name in the `toString` and `printStackTrace`, as opposed to the previous `zio.Cause$Unified$$anon$3` it would report regardless of the actual exception
- fix `printStackTrace` to actually print the stack trace

I made no changes to `getCause` since it seems unified exceptions never have a direct cause (instead, it's one exception in a list of causes)