### PR TITLE
docs: fix list spacing and grammar in coding-guidelines and contributing pages

### DIFF
--- a/docs/coding-guidelines.md
+++ b/docs/coding-guidelines.md
@@ -4,153 +4,89 @@ slug: coding-guidelines
 title: "Coding Guidelines"
 ---
 
-These are coding guidelines strictly for ZIO contributors for ZIO projects and 
-not general conventions to be applied by the Scala community at large.
+These are coding guidelines strictly for ZIO contributors working on ZIO projects and not general conventions to be applied by the Scala community at large.
 
-Additionally, bear in mind that, although we try to enforce these rules to the 
-best of our ability, both via automated rules (scalafmt) and strict reviewing 
-processes, it is both possible to find existing code that does not comply to 
-these rules. If that is the case, we would be extremely grateful if you could 
-make a contribution, by providing a fix to said issue.
+Additionally, bear in mind that, although we try to enforce these rules to the best of our ability, both via automated rules (scalafmt) and strict reviewing processes, it is still possible to find existing code that does not comply with these rules. If that is the case, we would be extremely grateful if you could make a contribution by providing a fix for the issue.
 
-Last, but not least, these rules are continuously evolving and as such, 
-refer to them once in a while when in doubt.
+Last, but not least, these rules are continuously evolving and, as such, refer to them once in a while when in doubt.
 
 ### Defining classes and traits
 
-1. Value classes must be final and extend `AnyVal`. 
-This is done to avoid allocating runtime objects; 
+1. Value classes must be final and extend `AnyVal`. This is done to avoid allocating runtime objects.
+2. Method extension classes must be final and extend `AnyVal`.
+3. Avoid overloading standard interfaces. When creating services, avoid using the same names as well-known standard interfaces. Example: Instead of having a service `Random` with methods `nextLong(n)` and `nextInt(n)`, consider choosing something like `nextLongBounded(n)` and `nextIntBounded(n)`.
+4. Sealed traits that are ADTs (algebraic data types) should extend `Product` and `Serializable`. This is done to help the compiler infer types.
+5. Regular traits and sealed traits that do not form ADTs should extend `Serializable` but not `Product`.
+6. Traits should always extend `Serializable` (e.g. `ZIO`).
 
-2. Method extension classes must be final and extend `AnyVal`;
+### Final and private modifiers
 
-3. Avoid overloading standard interfaces. When creating services avoid using the same names as well known standard interfaces.
-Example: Instead of having a service `Random` with methods `nextLong(n)` and `nextInt(n)` consider choosing something like 
-`nextLongBounded(n)` and `nextIntBounded(n)`.
-
-4. Sealed traits that are ADTs (Algebraic data types) should extend `Product` and `Serializable`. 
-This is done to help the compiler infer types;
-
-5. Regular traits and sealed trait that do not form ADTs should extend `Serializable` but not `Product`;
-
-6. Traits should always extend `Serializable`. (e.g. `ZIO`).
-
-### Final and private modifiers 
-
-1. All methods on classes / traits are declared `final`, by default;
-
-2. No methods on objects declared `final`, because they are `final` by default;
-
-3. No methods on final classes declared `final`, because they are `final` by default;
-
-4. All classes inside objects should be defined `final`, because otherwise they could still be extended;
-
-5. In general, classes that are not case classes have their constructors & constructor parameters private. 
-   Typically, it is not good practice to expose constructors and constructor parameters but exceptions apply (i.e. `Assertion` and `TestAnnotation`);
-
-6. All `vals` declared `final`, even in objects or `final classes`, if they are constant expressions and without type annotations;
-
+1. All methods on classes / traits are declared `final`, by default.
+2. No methods on objects are declared `final`, because they are `final` by default.
+3. No methods on final classes are declared `final`, because they are `final` by default.
+4. All classes inside objects should be defined `final`, because otherwise they could still be extended.
+5. In general, classes that are not case classes have their constructors and constructor parameters private. Typically, it is not good practice to expose constructors and constructor parameters, but exceptions apply (i.e. `Assertion` and `TestAnnotation`).
+6. All `vals` are declared `final`, even in objects or `final` classes, if they are constant expressions and without type annotations.
 7. Package-private `vals` and methods should be declared `final`.
 
 ### Refactoring
 
-1. If a class has all its members `final`, the class should be declared `final` and `final` member annotations should be removed except constant expressions;
-
-2. All type annotations should use the least powerful type alias. This means, that, let us say, a `ZIO` effect that has 
-   no dependencies but throws an arbitrary error, should be defined as `IO`.
+1. If a class has all its members `final`, the class should be declared `final` and the `final` member annotations should be removed, except for constant expressions.
+2. All type annotations should use the least powerful type alias. This means that, for example, a `ZIO` effect that has no dependencies but throws an arbitrary error should be defined as `IO`.
 3. Use `def` in place of `val` for an abstract data member to avoid `NullPointerException` risk.
 
 ### Understanding naming of parameters or values
 
-ZIO code often uses the following naming conventions, and you might be asked to change method parameters to follow these conventions. This guide can help you understand where the names come from. 
-Naming expectations can be helpful in understanding the role of certain parameters without even glancing at its type signature when reading code or class/method signatures.
+ZIO code often uses the following naming conventions, and you might be asked to change method parameters to follow these conventions. This guide can help you understand where the names come from. Naming expectations can be helpful in understanding the role of certain parameters without even glancing at their type signatures when reading code or class/method signatures.
 
-1. Partial functions have a shortened name `pf`;
-
-2. In ZIO implicit parameters are often used as compiler evidences;
-   These evidences help you, as a developer, prove something to the compiler (at compile time), and they have the ability to add constraints to a method;
-   They are typically called `ev` if there is only one. Or `ev1`, `ev2`... if more than one;
-   
-3. Promises are called `p` (unless in its own class methods, in that case it is called `that`, like point 8 defines);
-
-4. Functions are called `fn`, `fn1`, unless they bear specific meaning: `use`, `release`;
-
-5. ZIO effects are called `f`, unless they bear specific meaning like partially providing environment: `r0`;
-
-6. Iterable are called `in`;
-
-7. When a parameter type equals own (in a method of a trait) call it `that`;
-
-8. Be mindful of using by-name parameters. Mind the `Function[0]` extra allocation and loss of clean syntax when invoking the method.
-   Loss of syntax means that instead of being able to do something like `f.flatMap(ZIO.success)` you require to explicitly do `f.flatMap(ZIO.success(_))`;
-   
-9. Fold or fold variants initial values are called `zero`.
+1. Partial functions have a shortened name `pf`.
+2. In ZIO, implicit parameters are often used as compiler evidences. These evidences help you, as a developer, prove something to the compiler (at compile time), and they have the ability to add constraints to a method. They are typically called `ev` if there is only one, or `ev1`, `ev2`, ... if there is more than one.
+3. Promises are called `p` (unless in their own class methods, in which case they are called `that`, as point 7 defines).
+4. Functions are called `fn`, `fn1`, unless they bear specific meaning: `use`, `release`.
+5. ZIO effects are called `f`, unless they bear specific meaning like partially providing an environment: `r0`.
+6. Iterables are called `in`.
+7. When a parameter type equals its own (in a method of a trait), call it `that`.
+8. Be mindful of using by-name parameters. Mind the `Function[0]` extra allocation and loss of clean syntax when invoking the method. Loss of syntax means that instead of being able to do something like `f.flatMap(ZIO.success)` you are required to explicitly do `f.flatMap(ZIO.success(_))`.
+9. Fold or fold-variant initial values are called `zero`.
 
 ### Understanding naming of methods
 
-ZIO goes to great lengths to define method names that are intuitive to the library user. Naming is hard!!! 
-This section will attempt to provide some guidelines and examples to document, guide and explain naming of methods in ZIO.
+ZIO goes to great lengths to define method names that are intuitive to the library user. Naming is hard! This section will attempt to provide some guidelines and examples to document, guide, and explain the naming of methods in ZIO.
 
-1. All operators that return effects should be lazy in all parameters that are not lambdas. Strict parameters are a source of bugs when users inadvertently call side effecting code
-   in arguments to these parameters. Preventing these bugs is the responsibility of the effect system and lazy parameters allow the runtime to properly manage these side effects.
-   There are two exceptions. First, strict parameters should be used when by name parameters would cause duplicate method signatures due to type erasure. Second, operators on high
-   performance concurrent data structures such as `Ref`, `Queue`, and `Hub` should be strict in their parameters.
-
-2. Methods that have the form of `List#zip` are called `zip`, and have an alias called `<*>`. The parallel version, if applicable, has the name `zipPar`, with an alias called `<&>`;
-
-3. Avoid the use of `effect` in constructors as this pushes responsibility on users to identify what code is or is not side effecting whereas the effect system should handle this
-   correctly regardless. Instead prefer more specific names such as `succeed`, `attempt`, or `suspend`.
-
-4. The dual of zip, which is trying either a left or right side, producing an Either of the result, should be called `orElseEither`, with alias `<+>`. 
-   The simplified variant where both left and right have the same type should be called `orElse`, with alias `<>`;
-    
-5. Constructors for a data type `X` that are based on another data type `Y` should be placed in the companion object `X` and named `fromY`. 
-   For example, `ZIO.fromOption`, `ZStream.fromEffect`;
-   
+1. All operators that return effects should be lazy in all parameters that are not lambdas. Strict parameters are a source of bugs when users inadvertently call side-effecting code in arguments to these parameters. Preventing these bugs is the responsibility of the effect system, and lazy parameters allow the runtime to properly manage these side effects. There are two exceptions. First, strict parameters should be used when by-name parameters would cause duplicate method signatures due to type erasure. Second, operators on high-performance concurrent data structures such as `Ref`, `Queue`, and `Hub` should be strict in their parameters.
+2. Methods that have the form of `List#zip` are called `zip`, and have an alias called `<*>`. The parallel version, if applicable, has the name `zipPar`, with an alias called `<&>`.
+3. Avoid the use of `effect` in constructors, as this pushes responsibility onto users to identify what code is or is not side-effecting, whereas the effect system should handle this correctly regardless. Instead, prefer more specific names such as `succeed`, `attempt`, or `suspend`.
+4. The dual of zip, which is trying either a left or right side, producing an `Either` of the result, should be called `orElseEither`, with alias `<+>`. The simplified variant where both left and right have the same type should be called `orElse`, with alias `<>`.
+5. Constructors for a data type `X` that are based on another data type `Y` should be placed in the companion object `X` and named `fromY`. For example, `ZIO.fromOption`, `ZStream.fromEffect`.
 6. Parallel versions of methods should be named the same, but with a `Par` suffix.
-
 7. `foreach` should be used for operators that effectually iterate over a collection. For example, `ZIO.foreach`.
+8. Variants of operators that accept arguments or return results in the context of an effect type should be suffixed by the name of the effect type, for example `mapZIO` or `mapSTM`. The `M` suffix should not be used, as it is not idiomatic Scala and does not specify what effect type is involved.
+9. Use the `Discard` suffix for variants of methods that discard their results. For example, `foreachDiscard`. The `_` suffix should not be used, as it is not idiomatic Scala and does not describe what it does.
+10. Methods that are necessarily side-effecting should be prefixed with `unsafe`, for example `unsafeRun`. This does not apply to methods on internal data types that are inherently imperative in nature, for example `MutableConcurrentQueue`.
 
-8. Variants of operators that accept arguments or return results in the context of an effect type should be suffixed by the name of the effect type, for example `mapZIO` or
-   `mapSTM`. The `M` suffix should not be used as it is not idiomatic Scala and does not specify what effect type is involved.
-
-9. Use the `Discard` suffix for variants of methods that discard their results. For example, `foreachDiscard`. The `_` suffix should not be used as it is not idiomatic Scala and
-   does not describe what it does.
-
-10. Methods that are necessarily side effecting should be prefixed with `unsafe`, for example `unsafeRun`. This does not apply to methods on internal data types that are inherently imperative in nature, for example `MutableConcurrentQueue`.
-   
 ### Type annotations
 
-ZIO goes to great lengths to take advantage of the scala compiler in varied ways. Type variance is one of them. 
-The following rules are good to have in mind when adding new `types`, `traits` or `classes` that have either covariant or contravariant types.
+ZIO goes to great lengths to take advantage of the Scala compiler in varied ways. Type variance is one of them. The following rules are good to have in mind when adding new `types`, `traits`, or `classes` that have either covariant or contravariant types.
 
-1. Generalized ADTs should always have type annotation. (i.e. `final case class Fail[+E](value: E) extends Cause[E]`);
-   
-2. Type alias should always have type annotation. Much like in Generalized ADTs defining type aliases should carry the type annotations 
-   (i.e. `type IO[+E, +A] = ZIO[Any, E, A]`).
+1. Generalized ADTs should always have type annotations (i.e. `final case class Fail[+E](value: E) extends Cause[E]`).
+2. Type aliases should always have type annotations. Much like in generalized ADTs, defining type aliases should carry the type annotations (i.e. `type IO[+E, +A] = ZIO[Any, E, A]`).
 
 When defining new methods, keep in mind the following rules:
 
 1. Accept the most general type possible. For example, if a method accepts a collection, prefer `Iterable[A]` to `List[A]`.
-2. Return the most specific type possible, e.g., prefer `UIO[Unit]` to `UIO[Any]`.
+2. Return the most specific type possible, e.g. prefer `UIO[Unit]` to `UIO[Any]`.
 
 ### Method alphabetization
 
-In general the following rules should be applied regarding method alphabetization. 
-To fix forward references of values we recommend the programmer to make them lazy (`lazy val`).
-Operators are any methods that only have non-letter characters (i.e. `<*>` , `<>`, `*>`).
+In general, the following rules should be applied regarding method alphabetization. To fix forward references of values, we recommend the programmer make them lazy (`lazy val`). Operators are any methods that only have non-letter characters (i.e. `<*>`, `<>`, `*>`).
 
-1. Public abstract defs / vals listed first, and alphabetized, with operators appearing before names.
-
-2. Public concrete defs / vals listed second, and alphabetized, with operators appearing before names.
-
-3. Private implementation details listed third, and alphabetized, with operators appearing before names.
+1. Public abstract defs / vals are listed first, and alphabetized, with operators appearing before names.
+2. Public concrete defs / vals are listed second, and alphabetized, with operators appearing before names.
+3. Private implementation details are listed third, and alphabetized, with operators appearing before names.
 
 ### Scala documentation
 
-It is strongly recommended to use scala doc links when referring to other members. 
-This both makes it easier for users to navigate the documentation and enforces that the references are accurate.
-A good example of this are `ZIO` type aliases that are extremely pervasive in the codebase: `Task`, `RIO`, `URIO` and `UIO`.
-To make it easy for developers to see the implementation scala doc links are used, for example:
+It is strongly recommended to use Scaladoc links when referring to other members. This both makes it easier for users to navigate the documentation and enforces that the references are accurate. Good examples of this are the `ZIO` type aliases that are extremely pervasive in the codebase: `Task`, `RIO`, `URIO`, and `UIO`. To make it easy for developers to see the implementation, Scaladoc links are used, for example:
 
 ```
   /**
@@ -159,4 +95,3 @@ To make it easy for developers to see the implementation scala doc links are use
   def absolve[R, A](v: RIO[R, Either[Throwable, A]]): RIO[R, A] =
     ZIO.absolve(v)
 ```
-

--- a/docs/contributing-to-documentation.md
+++ b/docs/contributing-to-documentation.md
@@ -10,7 +10,7 @@ keywords:
   - "Microsite"
 ---
 
-The ZIO documentation is provided by a worldwide community, just like the project itself. So if you are reading this page, you can help us to improve the documentation.
+The ZIO documentation is provided by a worldwide community, just like the project itself. So if you are reading this page, you can help us improve the documentation.
 
 Please read the [Contributor Guideline](contributor-guidelines.md) before contributing to documentation.
 
@@ -24,63 +24,53 @@ Please read the [Contributor Guideline](contributor-guidelines.md) before contri
 
 We encourage contributors to use GitHub's editor for making minor changes to existing documents.
 
-1. On each page, there is a button called _Edit this page_, by clicking this button, we will be redirected to the GitHub editor.
+1. On each page, there is a button called _Edit this page_. By clicking this button, we will be redirected to the GitHub editor.
 
-![Edit this page](/img/assets/edit-this-page.png)
+   ![Edit this page](/img/assets/edit-this-page.png)
+2. After editing the page, we can check whether our changes have been formatted correctly by using the _Preview_ tab.
 
-2. After editing the page we can check whether our changes have been formatted correctly or not by using the _Preview_ tab.
+   ![GitHub Editor](/img/assets/github-editor.png)
+3. We can scroll to the bottom of the page, write a title and description of the work, and then propose the changes by clicking on _Propose changes_.
 
-![GitHub Editor](/img/assets/github-editor.png)
+   ![Propose changes](/img/assets/propose-changes.png)
+4. Our browser will be redirected to a new page titled _Comparing changes_ after clicking the _Propose changes_ button. We can compare our proposed changes and then create a pull request by clicking the _Create pull request_ button.
 
-3. We can scroll to the bottom of the page and write a title and description of the work, and then propose the changes by clicking on _Propose changes_.
+   ![Open a pull request](/img/assets/comparing-changes.png)
+5. On the new page, we can edit the title and description of our pull request and finally click _Create pull request_.
 
-![Propose changes](/img/assets/propose-changes.png)
-
-4. Our browser will be redirected to a new page titled _Comparing changes_ after clicking the _Propose changes_ button. We can compare our changes proposal and then create a pull request by clicking the _Create pull request_ button.
-
-![Open a pull request](/img/assets/comparing-changes.png)
-
-5. On the new page, we can edit the title and description of our pull request on the new page and finally click _Create pull request_.
-
-![Open a pull request](/img/assets/open-a-pull-request.png)
-
+   ![Open a pull request](/img/assets/open-a-pull-request.png)
 6. A pull request has been created. Eventually, our work will be reviewed by the rest of the team.
 
 ## Editing Documentation Locally
 
-ZIO contributors are encouraged to use this approach for introducing new documentation pages, or when we have lots of improvements on code snippets since we can compile check all changes locally before committing and sending a pull request to the project:
+ZIO contributors are encouraged to use this approach for introducing new documentation pages, or when we have many improvements to code snippets, since we can compile-check all changes locally before committing and sending a pull request to the project:
 
 1. First, we need to fork and clone the ZIO project on our machine. Follow the [Get The Project](contributor-guidelines#get-the-project) instructions to fork the repository and clone your fork.
+2. The documentation source files can be found in the `docs` directory, and they are all in Markdown format. Now we can begin improving the existing documentation or adding new documentation.
+3. To generate the documentation site from type-checked Markdown files, we can use the following command:
 
-2. The documentation source code can be found in the `docs` directory and they are all in Markdown format. Now we can begin improving the existing documentation or adding new documentation.
+   ```bash
+   sbt docs/mdoc
+   ```
 
-3. To generate documentation site from type-checked markdowns we can use the following command:
+   If one of our code snippets fails to compile, this command will not succeed and will indicate which line of the documentation caused the error.
 
-```bash
-sbt docs/mdoc
-```
+   It is recommended to run this command in the sbt shell with the `--watch` option. This will start a file watcher and live-reload on changes. It is useful when we want to see the intermediate results while we are writing documentation:
 
-If one of our snippet codes fails to compile, this command doesn't succeed and will guide us on which line of the documentation caused this error.
+   ```bash
+   sbt
+   sbt:docs> docs/mdoc --watch
+   ```
+4. Finally, we can serve the microsite locally with the following command:
 
-It is recommended to run this command with sbt shell with the `--watch` option. This will start a file watcher and livereload on changes. It's useful when we want to see the intermediate results while we are writing documentation:
+   ```bash
+   cd website
+   npm install
+   npm run start --watch
+   ```
 
-```bash
-sbt
-sbt:docs> docs/mdoc --watch
-```
-
-4. Finally, by the following command we can serve the microsite locally:
-
-```bash
-cd website
-npm install
-npm run start --watch
-```
-
-It will be served on [localhost](http://127.0.0.1:3000/) address.
-
+   It will be served at the [localhost](http://127.0.0.1:3000/) address.
 5. When we are finished with the documentation, we can commit those changes and [create a pull request](contributor-guidelines.md#create-a-pull-request).
-
 
 ## AI-friendly Markdown Variants
 
@@ -96,14 +86,14 @@ The mirror step exists because `docusaurus-plugin-llms` writes each `.md` at the
 - `reference/schedule/index.md` is rendered at `/reference/schedule/`, so the natural Markdown URL is `/reference/schedule.md`, not `/reference/schedule/index.md`.
 - `reference/core/zio/zio.md` is rendered at `/reference/core/zio/` (Docusaurus's folder-named-doc convention), so the natural Markdown URL is `/reference/core/zio.md`.
 
-The script scans the build output and, for every `<dir>/index.md` or `<dir>/<dir>.md` it finds, creates a sibling `<dir>.md` so appending `.md` to any rendered URL resolves. It never overwrites an existing file, so its output composes cleanly with the llms plugin and with any future upstream fix. Running after `docusaurus build` (rather than as another Docusaurus plugin) avoids racing against the llms plugin — Docusaurus runs plugins' `postBuild` hooks concurrently, so a mirror plugin could walk the build directory before the llms plugin had finished writing its `.md` files. This keeps the solution in one place rather than requiring explicit `slug:` frontmatter on every index and folder-named-doc file across the site and the ~30 ecosystem subprojects synced in from npm.
+The script scans the build output and, for every `<dir>/index.md` or `<dir>/<dir>.md` it finds, creates a sibling `<dir>.md` so that appending `.md` to any rendered URL resolves. It never overwrites an existing file, so its output composes cleanly with the llms plugin and with any future upstream fix. Running after `docusaurus build` (rather than as another Docusaurus plugin) avoids racing against the llms plugin — Docusaurus runs plugins' `postBuild` hooks concurrently, so a mirror plugin could walk the build directory before the llms plugin had finished writing its `.md` files. This keeps the solution in one place rather than requiring explicit `slug:` frontmatter on every index and folder-named-doc file across the site and the ~30 ecosystem subprojects synced in from npm.
 
 ## Giving Feedback
 
-Sometimes we see some problem in the documentation, or we have some idea to make better documentation, but we haven't time or knowledge to do that personally. We can discuss those ideas with the community. There are two ways to do this:
+Sometimes we see a problem in the documentation, or we have an idea to improve it, but we don't have the time or knowledge to do it ourselves. We can discuss those ideas with the community. There are two ways to do this:
 
 1. Using Discord (https://discord.gg/2ccFBr4) is a great way to share our thoughts with others, discuss them, and brainstorm big ideas.
-2. Opening a new issue (https://github.com/zio/zio/issues/new) is appropriate when we have actionable ideas, such as reorganizing a specific page of a documentation, or a problem with the current documentation.
+2. Opening a new issue (https://github.com/zio/zio/issues/new) is appropriate when we have actionable ideas, such as reorganizing a specific documentation page or reporting a problem with the current documentation.
 
 ## See Also
 


### PR DESCRIPTION
## What

Audit of two documentation pages for rendering and grammar issues.

### Coding Guidelines (`/coding-guidelines`)
- Numbered lists were *loose* (blank lines between items), producing large vertical gaps between enumerated items. Converted to tight lists.
- Joined wrapped continuation lines and removed trailing whitespace.
- Grammar fixes: `comply to` -> `comply with`, `it is both possible` -> `it is still possible`, `Type alias should always have type annotation` -> `Type aliases should always have type annotations`, `Iterable are called` -> `Iterables are called`, subject-verb agreement, and `scala`/`scala doc` -> `Scala`/`Scaladoc` casing.
- Fixed an incorrect cross-reference: item 3 referred to "point 8" for the `that` naming rule, which is actually defined in point 7.

### Contributing to Documentation (`/contributing-to-documentation`)
- Step lists interleaved screenshots and code blocks at column 0, which terminated the ordered list so each step restarted a new list. Indented figures and code under their list items so each section renders as one continuous ordered list.
- Grammar fixes: comma splice in the GitHub-editor step, removed duplicated "on the new page" phrase, `changes proposal` -> `proposed changes`, `source code ... they are` -> `source files ... they are`, `compile check` -> `compile-check`, `livereload` -> `live-reload`, and reworded the Giving Feedback section.

## Notes
Only source files under `docs/` are changed; `website/docs/` is generated by `sbt docs/mdoc`. No `mdoc`-tagged code fences in either page, so output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)