### PR TITLE
fix(ci): include dependabot[bot] in auto-approve/auto-merge workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'renovate[bot]' ||
-      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Approve PR
         if: github.event_name == 'pull_request_target'
@@ -27,7 +28,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "zio-scala-steward[bot]" "renovate[bot]"; do
+          for actor in "zio-scala-steward[bot]" "renovate[bot]" "dependabot[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,7 +15,8 @@ jobs:
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.user.login == 'renovate[bot]' ||
-      github.event.pull_request.user.login == 'zio-scala-steward[bot]'
+      github.event.pull_request.user.login == 'zio-scala-steward[bot]' ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Enable auto-merge for bot PR
         if: github.event_name == 'pull_request_target'
@@ -28,7 +29,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           set -euo pipefail
-          for actor in "zio-scala-steward[bot]" "renovate[bot]"; do
+          for actor in "zio-scala-steward[bot]" "renovate[bot]" "dependabot[bot]"; do
             gh pr list \
               --author "$actor" \
               --state open \


### PR DESCRIPTION
## Summary
- PR #11112 (`scala-steward-action` bump) never got auto-approved or auto-merged even though it's a bot dependency PR.
- Root cause: `auto-approve.yml` and `auto-merge.yml` gate on `github.event.pull_request.user.login` matching `renovate[bot]` or `zio-scala-steward[bot]` only. Dependabot owns the `github-actions` ecosystem per `.github/dependabot.yml`, but `dependabot[bot]` was missing from the allowlist (both the `if:` condition and the `workflow_dispatch` backfill loop).

## Changes
- Add `dependabot[bot]` to the actor allowlist in both workflows' `if:` condition and backfill loop.

## Test plan
- [ ] Confirm `auto-approve.yml` / `auto-merge.yml` trigger and succeed on the next `dependabot[bot]`-authored PR (e.g. re-run via `workflow_dispatch` against #11112).