### PR TITLE
fix(streams): Fix ZChannel.mergeAllWith deadlock on partial take of async streams

### DIFF
--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1840,43 +1840,25 @@ object ZStreamSpec extends ZIOBaseSpec {
             } yield assertTrue(exit.isInterrupted)
           },
           test("does not deadlock when a partial take interrupts async inner streams") {
-            // Regression for the same defect #10272 fixed in mapOutZIOPar, which was never applied
-            // to mergeAllWith (the flatMapPar path): outgoing.shutdown is bound only to the scope
-            // via addFinalizer, but the coordinator cannot let the scope close while producers are
-            // blocked offering into the full bounded `outgoing` queue. An early take(n) stops the
-            // consumer, the queue fills and never drains, and teardown deadlocks.
-            //
-            // Reproduces specifically when the interrupted producers are parked in an async region
-            // whose canceler is a pure Exit value, which leaves interruption disabled after the
-            // interrupt is delivered (see #11115), so the producer keeps running and never releases
-            // its offer. `asyncInterrupt(..., Left(Exit.unit))` is the minimal form of that; it is
-            // what ZIO.fromFuture arms for a non-cancelable Future. Plain ZIO.async and
-            // scheduler-based async (e.g. ZIO.sleep) drain fine.
+            // Needs a pure Exit canceler, which leaves interruption disabled once delivered (#11115),
+            // so the interrupted producer keeps running and never releases its offer.
             def asyncForever: ZStream[Any, Nothing, Int] =
               ZStream.repeatZIOChunk {
                 ZIO.asyncInterrupt[Any, Nothing, Chunk[Int]] { k =>
-                  // Completed from another thread, so the fiber really parks in the async region.
-                  // Calling `k` synchronously here would not reproduce: the effect finishes without
-                  // ever suspending, so there is no parked interrupt to lose.
                   ExecutionContext.global.execute(() => k(Exit.succeed(Chunk(1, 2, 3, 4))))
                   Left(Exit.unit)
                 }
               }
 
-            def once: ZIO[Any, Nothing, Long] =
-              ZStream
-                .fromIterable(0 until 10)
-                .map(_ => asyncForever)
-                .flatMapPar(256)(identity)
-                .take(6)
-                .runCount
-
-            // Repeated: whether a given producer is parked in the async region at the moment the
-            // take(n) interrupts it is a race, so one iteration hangs only ~1 time in 8. Thirty in
-            // sequence makes hitting it exceedingly likely — measured 40/40 batches hanging before
-            // the fix, and 100/100 passing after it.
-            ZIO.foreach(1 to 30)(_ => once).as(assertCompletes)
-          } @@ exceptJS(nonFlaky) @@ TestAspect.timeout(20.seconds)
+            ZStream
+              .fromIterable(0 until 10)
+              .map(_ => asyncForever)
+              .flatMapPar(256)(identity)
+              .take(6)
+              .runDrain
+              .as(assertCompletes)
+            // nonFlaky is load-bearing: without the fix, a single run only deadlocks ~8% of the time.
+          } @@ TestAspect.timeout(20.seconds) @@ exceptJS(nonFlaky(300))
         ),
         suite("flatMapParSwitch")(
           test("guarantee ordering no parallelism") {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1846,18 +1846,24 @@ object ZStreamSpec extends ZIOBaseSpec {
             // blocked offering into the full bounded `outgoing` queue. An early take(n) stops the
             // consumer, the queue fills and never drains, and teardown deadlocks.
             //
-            // Reproduces specifically when the interrupted producers are parked in an interruptible
-            // async region that has a registered canceler (ZIO.asyncInterrupt with a Left canceler,
-            // as ZIO.fromFuture uses). Plain ZIO.async and scheduler-based async (e.g. ZIO.sleep)
-            // drain fine. fromFuture is the common real-world source, so it is used here.
-            implicit val ec: ExecutionContext = ExecutionContext.global
-
-            def asyncForever: ZStream[Any, Throwable, Int] =
+            // Reproduces specifically when the interrupted producers are parked in an async region
+            // whose canceler is a pure Exit value, which leaves interruption disabled after the
+            // interrupt is delivered (see #11115), so the producer keeps running and never releases
+            // its offer. `asyncInterrupt(..., Left(Exit.unit))` is the minimal form of that; it is
+            // what ZIO.fromFuture arms for a non-cancelable Future. Plain ZIO.async and
+            // scheduler-based async (e.g. ZIO.sleep) drain fine.
+            def asyncForever: ZStream[Any, Nothing, Int] =
               ZStream.repeatZIOChunk {
-                ZIO.fromFuture(_ => scala.concurrent.Future(Chunk(1, 2, 3, 4)))
+                ZIO.asyncInterrupt[Any, Nothing, Chunk[Int]] { k =>
+                  // Completed from another thread, so the fiber really parks in the async region.
+                  // Calling `k` synchronously here would not reproduce: the effect finishes without
+                  // ever suspending, so there is no parked interrupt to lose.
+                  ExecutionContext.global.execute(() => k(Exit.succeed(Chunk(1, 2, 3, 4))))
+                  Left(Exit.unit)
+                }
               }
 
-            def once: ZIO[Any, Throwable, Long] =
+            def once: ZIO[Any, Nothing, Long] =
               ZStream
                 .fromIterable(0 until 10)
                 .map(_ => asyncForever)
@@ -1865,13 +1871,12 @@ object ZStreamSpec extends ZIOBaseSpec {
                 .take(6)
                 .runCount
 
-            for {
-              // forkDaemon so the timeout can fail the test cleanly if `once` deadlocks, rather than
-              // the test fiber awaiting a stuck child while it unwinds.
-              fiber <- ZIO.foreach(1 to 30)(_ => once).forkDaemon
-              exit  <- fiber.await.timeout(20.seconds)
-            } yield assertTrue(exit.exists(_.isSuccess))
-          } @@ withLiveClock @@ exceptJS(nonFlaky)
+            // Repeated: whether a given producer is parked in the async region at the moment the
+            // take(n) interrupts it is a race, so one iteration hangs only ~1 time in 8. Thirty in
+            // sequence makes hitting it exceedingly likely — measured 40/40 batches hanging before
+            // the fix, and 100/100 passing after it.
+            ZIO.foreach(1 to 30)(_ => once).as(assertCompletes)
+          } @@ exceptJS(nonFlaky) @@ TestAspect.timeout(20.seconds)
         ),
         suite("flatMapParSwitch")(
           test("guarantee ordering no parallelism") {

--- a/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
+++ b/streams-tests/shared/src/test/scala/zio/stream/ZStreamSpec.scala
@@ -1838,7 +1838,40 @@ object ZStreamSpec extends ZIOBaseSpec {
             for {
               exit <- stream.runDrain.exit
             } yield assertTrue(exit.isInterrupted)
-          }
+          },
+          test("does not deadlock when a partial take interrupts async inner streams") {
+            // Regression for the same defect #10272 fixed in mapOutZIOPar, which was never applied
+            // to mergeAllWith (the flatMapPar path): outgoing.shutdown is bound only to the scope
+            // via addFinalizer, but the coordinator cannot let the scope close while producers are
+            // blocked offering into the full bounded `outgoing` queue. An early take(n) stops the
+            // consumer, the queue fills and never drains, and teardown deadlocks.
+            //
+            // Reproduces specifically when the interrupted producers are parked in an interruptible
+            // async region that has a registered canceler (ZIO.asyncInterrupt with a Left canceler,
+            // as ZIO.fromFuture uses). Plain ZIO.async and scheduler-based async (e.g. ZIO.sleep)
+            // drain fine. fromFuture is the common real-world source, so it is used here.
+            implicit val ec: ExecutionContext = ExecutionContext.global
+
+            def asyncForever: ZStream[Any, Throwable, Int] =
+              ZStream.repeatZIOChunk {
+                ZIO.fromFuture(_ => scala.concurrent.Future(Chunk(1, 2, 3, 4)))
+              }
+
+            def once: ZIO[Any, Throwable, Long] =
+              ZStream
+                .fromIterable(0 until 10)
+                .map(_ => asyncForever)
+                .flatMapPar(256)(identity)
+                .take(6)
+                .runCount
+
+            for {
+              // forkDaemon so the timeout can fail the test cleanly if `once` deadlocks, rather than
+              // the test fiber awaiting a stuck child while it unwinds.
+              fiber <- ZIO.foreach(1 to 30)(_ => once).forkDaemon
+              exit  <- fiber.await.timeout(20.seconds)
+            } yield assertTrue(exit.exists(_.isSuccess))
+          } @@ withLiveClock @@ exceptJS(nonFlaky)
         ),
         suite("flatMapParSwitch")(
           test("guarantee ordering no parallelism") {

--- a/streams/shared/src/main/scala/zio/stream/ZChannel.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZChannel.scala
@@ -2125,7 +2125,7 @@ object ZChannel {
               }
             }
 
-          consumer.embedInput(input)
+          consumer.embedInput(input).ensuring(outgoing.shutdown)
         }
       }
     }


### PR DESCRIPTION
## What

`ZChannel.mergeAllWith` binds `outgoing.shutdown` only to the scope via
`addFinalizer` (ZChannel.scala:2087). When downstream stops early
(e.g. `flatMapPar(...).take(n)`) over async inner streams, scope teardown can
deadlock: a producer fiber ends up parked on a bounded-queue `offer` that is
never completed, and scope close waits on that producer forever.

This is the same defect #10272 fixed for `mapOutZIOPar` (#10195, #10088), which
was never applied to `mergeAllWith`. This applies the same remedy: attach
`outgoing.shutdown` to the consumer channel's own termination via `.ensuring`
(ZChannel.scala:2128), so downstream completion shuts the queue immediately,
independent of scope-finalizer ordering. `Queue.shutdown` completes the parked
offer's promise directly rather than relying on interrupting the offering fiber,
so it frees the producer even while interruption is masked; teardown then
proceeds.

## Underlying runtime cause

The deadlock is only reachable because interruption is disabled but not
re-enabled when a fiber is interrupted while parked in an `asyncInterrupt` with a
pure (`Exit.unit`) canceler. That lost-interrupt behavior is a deeper runtime
issue, reported separately in #11115. This PR fixes the stream-level symptom.

## Testing

Adds a regression test in the `flatMapPar` suite that reproduces the hang
(partial `take` over async inner streams) and passes with the fix.
