### PR TITLE
Restore zio-constraintless in website deps

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -31,6 +31,7 @@
     "@zio.dev/zio-cache": "0.2.8",
     "@zio.dev/zio-cli": "0.7.4",
     "@zio.dev/zio-config": "4.0.6",
+    "@zio.dev/zio-constraintless": "0.3.5",
     "@zio.dev/zio-direct": "1.0.0-RC7",
     "@zio.dev/zio-dynamodb": "1.0.0-RC24",
     "@zio.dev/zio-ftp": "0.5.2",


### PR DESCRIPTION
## Summary
- `@zio.dev/zio-constraintless` was removed from `website/package.json` in bca1d73 (#9547, "Documentation: Remove Deprecated Projects"), swept in alongside genuinely dead projects (`zio-actors`, `zio-flow`, `zio-webhooks`, `zio-insight`, etc).
- `zio-constraintless` is actively maintained (see [zio/zio-constraintless](https://github.com/zio/zio-constraintless)), and its docs package is still published to npm (`@zio.dev/zio-constraintless`, currently `0.3.5`).
- Its removal broke https://zio.dev/zio-constraintless (currently 404).
- Re-add the dependency at its current published version to restore the page.

## Test plan
- [ ] After merge, confirm `website/build-website` picks up the package and https://zio.dev/zio-constraintless resolves.