### PR TITLE
Optimize test environment construction

### DIFF
--- a/benchmarks/src/main/scala/zio/test/TestEnvironmentBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/TestEnvironmentBenchmark.scala
@@ -1,0 +1,33 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.TimeUnit
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+class TestEnvironmentBenchmark {
+
+  @Param(Array("100", "1000", "10000"))
+  var environmentCount: Int = _
+
+  private var acquireAndRelease: UIO[Unit] = _
+
+  @Setup
+  def setup(): Unit = {
+    implicit val trace: Trace = Trace.empty
+
+    acquireAndRelease = ZIO.loopDiscard(0)(_ < environmentCount, _ + 1)(_ => ZIO.unit.provideLayer(testEnvironment))
+  }
+
+  @Benchmark
+  def construct(): Unit =
+    unsafeRun(acquireAndRelease)
+}

--- a/benchmarks/src/main/scala/zio/test/TestExecutionBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/TestExecutionBenchmark.scala
@@ -1,0 +1,81 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.nowarn
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+class TestExecutionBenchmark {
+
+  @Param(Array("100", "1000", "10000"))
+  var leafCount: Int = _
+
+  @Param(Array("baseline", "optimized"))
+  var implementation: String = _
+
+  private var execution: UIO[Summary] = _
+
+  @Setup
+  def setup(): Unit = {
+    implicit val trace: Trace = Trace.empty
+
+    val leaves =
+      Chunk.fromArray(
+        Array.tabulate(leafCount) { index =>
+          Spec.labeled(
+            s"leaf-$index",
+            Spec.test(ZIO.succeed(TestSuccess.Succeeded()), TestAnnotationMap.empty)
+          )
+        }
+      )
+    val spec = TestAspect.fibers(
+      TestAspect.timeoutWarning(60.seconds)(Spec.labeled("trivial", Spec.multiple(leaves)))
+    ): @nowarn("cat=deprecation")
+    val freshLayer =
+      if (implementation == "baseline") {
+        val sizedLive  = Sized.live(100)(Trace.empty)
+        val configLive = TestConfig.live(100, 100, 200, 1000)(Trace.empty)
+        val testFiberRefGen =
+          ZLayer.scoped(FiberRef.currentFiberIdGenerator.locallyScoped(FiberId.Gen.Monotonic))
+        val baselineTestEnvironment =
+          liveEnvironment >>> (
+            Annotations.live <*>
+              Live.default <*>
+              sizedLive <*>
+              ((Live.default <*> Annotations.live) >>> TestClock.default) <*>
+              configLive <*>
+              ((Live.default <*> Annotations.live) >>> TestConsole.debug) <*>
+              TestRandom.deterministic <*>
+              TestSystem.default <*>
+              testFiberRefGen
+          )
+        baselineTestEnvironment
+      } else testEnvironment
+    val executor =
+      TestExecutor.default[Any, Nothing](
+        ZLayer.empty,
+        freshLayer <*> Scope.default,
+        ZLayer.fromZIO(
+          ExecutionEventSink.ExecutionEventSinkLive(new TestOutput {
+            def print(executionEvent: ExecutionEvent): UIO[Unit] = ZIO.unit
+          })
+        ),
+        ZTestEventHandler.silent
+      )
+
+    execution = executor.run("zio.test.TestExecutionBenchmark", spec, ExecutionStrategy.Sequential)
+  }
+
+  @Benchmark
+  def runTrivialLeaves(): Unit =
+    unsafeRun(execution)
+}

--- a/test-tests/shared/src/test/scala/zio/test/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/EnvironmentSpec.scala
@@ -67,6 +67,42 @@ object EnvironmentSpec extends ZIOBaseSpec {
       for {
         _ <- TestClock.timeZone
       } yield assertCompletes
-    } @@ withLiveClock
+    } @@ withLiveClock,
+    test("TestEnvironment.live installs fresh services and restores the previous services") {
+      val layer = liveEnvironment >>> TestEnvironment.live
+      val acquire =
+        (for {
+          environment     <- ZIO.environment[TestEnvironment]
+          testServices    <- TestServices.currentServices.get
+          defaultServices <- DefaultServices.currentServices.get
+        } yield (
+          environment,
+          testServices,
+          defaultServices
+        )).provideLayer(layer)
+
+      for {
+        testServicesBefore    <- TestServices.currentServices.get
+        defaultServicesBefore <- DefaultServices.currentServices.get
+        first                 <- acquire
+        second                <- acquire
+        testServicesAfter     <- TestServices.currentServices.get
+        defaultServicesAfter  <- DefaultServices.currentServices.get
+      } yield assertTrue(
+        first._1.get[Annotations] eq first._2.get[Annotations],
+        first._1.get[Live] eq first._2.get[Live],
+        first._1.get[Sized] eq first._2.get[Sized],
+        first._1.get[TestConfig] eq first._2.get[TestConfig],
+        first._3.get[Clock].isInstanceOf[TestClock],
+        first._3.get[Console].isInstanceOf[TestConsole],
+        first._3.get[Random].isInstanceOf[TestRandom],
+        first._3.get[System].isInstanceOf[TestSystem],
+        first._1.get[Annotations] ne second._1.get[Annotations],
+        first._3.get[Clock] ne second._3.get[Clock],
+        first._1.get[TestConfig] eq second._1.get[TestConfig],
+        testServicesBefore eq testServicesAfter,
+        defaultServicesBefore eq defaultServicesAfter
+      )
+    }
   )
 }

--- a/test/shared/src/main/scala/zio/test/Annotations.scala
+++ b/test/shared/src/main/scala/zio/test/Annotations.scala
@@ -31,6 +31,11 @@ object Annotations {
 
   implicit val tag: Tag[Annotations] = Tag(EnvironmentTag.tagFromTagMacro[Annotations])
 
+  private[test] object unsafe {
+    def make()(implicit unsafe: Unsafe): Annotations =
+      Test(Ref.unsafe.make(TestAnnotationMap.empty))
+  }
+
   final case class Test(ref: Ref.Atomic[TestAnnotationMap]) extends Annotations {
     def annotate[V](key: TestAnnotation[V], value: V)(implicit trace: Trace): UIO[Unit] =
       ref.update(_.annotate(key, value))
@@ -83,8 +88,7 @@ object Annotations {
   val live: ULayer[Annotations] = {
     implicit val trace = Tracer.newTrace
     ZLayer.scoped {
-      val ref         = Unsafe.unsafe(Ref.unsafe.make(TestAnnotationMap.empty)(_))
-      val annotations = Test(ref)
+      val annotations = unsafe.make()(Unsafe)
       withAnnotationsScoped(annotations).as(annotations)
     }
   }

--- a/test/shared/src/main/scala/zio/test/Sized.scala
+++ b/test/shared/src/main/scala/zio/test/Sized.scala
@@ -14,6 +14,11 @@ object Sized {
 
   implicit val tag: Tag[Sized] = Tag(EnvironmentTag.tagFromTagMacro[Sized])
 
+  private[test] object unsafe {
+    def make(size: Int)(implicit unsafe: Unsafe): Sized =
+      Test(FiberRef.unsafe.make(size))
+  }
+
   final case class Test(fiberRef: FiberRef[Int]) extends Sized {
     def size(implicit trace: Trace): UIO[Int] =
       fiberRef.get
@@ -34,13 +39,12 @@ object Sized {
 
   def live(size: Int)(implicit trace: Trace): Layer[Nothing, Sized] =
     ZLayer.scoped {
-      val fiberRef = FiberRef.unsafe.make(size)(Unsafe)
-      val sized    = Test(fiberRef)
+      val sized = unsafe.make(size)(Unsafe)
       withSizedScoped(sized).as(sized)
     }
 
   private[test] val initial: Sized =
-    Test(FiberRef.unsafe.make(100)(Unsafe.unsafe))
+    unsafe.make(100)(Unsafe.unsafe)
 
   def size(implicit trace: Trace): UIO[Int] =
     sizedWith(_.size)

--- a/test/shared/src/main/scala/zio/test/TestClock.scala
+++ b/test/shared/src/main/scala/zio/test/TestClock.scala
@@ -99,6 +99,20 @@ trait TestClock extends Clock with Restorable {
 
 object TestClock extends Serializable {
 
+  implicit val tag: Tag[TestClock] = Tag(EnvironmentTag.tagFromTagMacro[TestClock])
+
+  private[test] object unsafe {
+    def make(data: Data, live: Live, annotations: Annotations)(implicit unsafe: Unsafe): Test = {
+      val warningState          = Ref.Synchronized.unsafe.make(WarningData.start)
+      val suspendedWarningState = Ref.Synchronized.unsafe.make(SuspendedWarningData.start)
+      val clockState            = Ref.unsafe.make(data)
+      Test(clockState, live, annotations, warningState, suspendedWarningState)
+    }
+
+    def close(test: Test)(implicit trace: Trace): UIO[Unit] =
+      test.warningDone *> test.suspendedWarningDone
+  }
+
   final case class Test(
     clockState: Ref.Atomic[TestClock.Data],
     live: Live,
@@ -438,22 +452,20 @@ object TestClock extends Serializable {
   ): ZLayer[Annotations with Live, Nothing, TestClock] =
     ZLayer.scoped {
       ZIO.environmentWithZIO { env =>
-        val live                  = env.get[Live]
-        val annotations           = env.get[Annotations]
-        val scope                 = env.getScope
-        val warningState          = Ref.Synchronized.unsafe.make(WarningData.start)(Unsafe)
-        val suspendedWarningState = Ref.Synchronized.unsafe.make(SuspendedWarningData.start)(Unsafe)
-        val clockState            = Ref.unsafe.make(data)(Unsafe)
-        val test                  = Test(clockState, live, annotations, warningState, suspendedWarningState)
-        ZIO.withClockScoped(test) *> scope.addFinalizer(test.warningDone *> test.suspendedWarningDone).as(test)
+        val scope = env.getScope
+        val test  = unsafe.make(data, env.get[Live], env.get[Annotations])(Unsafe)
+        ZIO.withClockScoped(test) *> scope.addFinalizer(unsafe.close(test)).as(test)
       }
     }
 
   val any: ZLayer[TestClock, Nothing, TestClock] =
     ZLayer.environment[TestClock](Tracer.newTrace)
 
+  private[test] val DefaultData: Data =
+    Data(Instant.EPOCH, Nil, ZoneId.of("UTC"))
+
   val default: ZLayer[Live with Annotations, Nothing, TestClock] =
-    live(Data(Instant.EPOCH, Nil, ZoneId.of("UTC")))(Tracer.newTrace)
+    live(DefaultData)(Tracer.newTrace)
 
   /**
    * Accesses a `TestClock` instance in the environment and increments the time

--- a/test/shared/src/main/scala/zio/test/TestConsole.scala
+++ b/test/shared/src/main/scala/zio/test/TestConsole.scala
@@ -72,6 +72,13 @@ trait TestConsole extends Console with Restorable {
 
 object TestConsole extends Serializable {
 
+  implicit val tag: Tag[TestConsole] = Tag(EnvironmentTag.tagFromTagMacro[TestConsole])
+
+  private[test] object unsafe {
+    def make(data: Data, debug: Boolean, live: Live, annotations: Annotations)(implicit unsafe: Unsafe): Test =
+      Test(Ref.unsafe.make(data), live, annotations, FiberRef.unsafe.make(debug))
+  }
+
   case class Test(
     consoleState: Ref.Atomic[TestConsole.Data],
     live: Live,
@@ -228,11 +235,7 @@ object TestConsole extends Serializable {
   ): ZLayer[Live with Annotations, Nothing, TestConsole] =
     ZLayer.scoped {
       ZIO.environmentWithZIO[Live & Annotations] { env =>
-        val live        = env.get[Live]
-        val annotations = env.get[Annotations]
-        val ref         = Ref.unsafe.make(data)(Unsafe)
-        val debugRef    = FiberRef.unsafe.make(debug)(Unsafe)
-        val test        = Test(ref, live, annotations, debugRef)
+        val test = unsafe.make(data, debug, env.get[Live], env.get[Annotations])(Unsafe)
         ZIO.withConsoleScoped(test).as(test)
       }
     }
@@ -240,8 +243,11 @@ object TestConsole extends Serializable {
   val any: ZLayer[TestConsole, Nothing, TestConsole] =
     ZLayer.environment[TestConsole](Tracer.newTrace)
 
+  private[test] val DefaultData: Data =
+    Data(Nil, Vector())
+
   val debug: ZLayer[Live with Annotations, Nothing, TestConsole] =
-    make(Data(Nil, Vector()), true)(Tracer.newTrace)
+    make(DefaultData, true)(Tracer.newTrace)
 
   val silent: ZLayer[Live with Annotations, Nothing, TestConsole] =
     make(Data(Nil, Vector()), false)(Tracer.newTrace)

--- a/test/shared/src/main/scala/zio/test/TestRandom.scala
+++ b/test/shared/src/main/scala/zio/test/TestRandom.scala
@@ -93,6 +93,13 @@ trait TestRandom extends Random with Restorable {
 
 object TestRandom extends Serializable {
 
+  implicit val tag: Tag[TestRandom] = Tag(EnvironmentTag.tagFromTagMacro[TestRandom])
+
+  private[test] object unsafe {
+    def make(data: Data)(implicit unsafe: Unsafe): Test =
+      Test(Ref.unsafe.make(data), Ref.unsafe.make(Buffer()))
+  }
+
   /**
    * Adapted from @gzmo work in Scala.js
    * (https://github.com/scala-js/scala-js/pull/780)
@@ -790,9 +797,7 @@ object TestRandom extends Serializable {
   def make(data: Data): Layer[Nothing, TestRandom] = {
     implicit val trace = Tracer.newTrace
     ZLayer.scoped {
-      val data0  = Ref.unsafe.make(data)(Unsafe)
-      val buffer = Ref.unsafe.make(Buffer())(Unsafe)
-      val test   = Test(data0, buffer)
+      val test = unsafe.make(data)(Unsafe)
       ZIO.withRandomScoped(test).as(test)
     }
   }
@@ -820,9 +825,7 @@ object TestRandom extends Serializable {
    * This can be useful for mixing in with implementations of other interfaces.
    */
   def makeTest(data: Data)(implicit trace: Trace): UIO[Test] = ZIO.succeedUnsafe { implicit unsafe =>
-    val data0  = Ref.unsafe.make(data)
-    val buffer = Ref.unsafe.make(Buffer())
-    Test(data0, buffer)
+    TestRandom.unsafe.make(data)
   }
 
   /**

--- a/test/shared/src/main/scala/zio/test/TestSystem.scala
+++ b/test/shared/src/main/scala/zio/test/TestSystem.scala
@@ -16,7 +16,7 @@
 
 package zio.test
 
-import zio.{IO, Layer, Ref, System, Trace, UIO, URIO, Unsafe, ZIO, ZLayer}
+import zio.{EnvironmentTag, IO, Layer, Ref, System, Tag, Trace, UIO, URIO, Unsafe, ZIO, ZLayer}
 import zio.internal.stacktracer.Tracer
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
@@ -46,6 +46,13 @@ trait TestSystem extends System with Restorable {
 }
 
 object TestSystem extends Serializable {
+
+  implicit val tag: Tag[TestSystem] = Tag(EnvironmentTag.tagFromTagMacro[TestSystem])
+
+  private[test] object unsafe {
+    def make(data: Data)(implicit unsafe: Unsafe): TestSystem =
+      Test(Ref.unsafe.make(data))
+  }
 
   final case class Test(systemState: Ref.Atomic[TestSystem.Data]) extends TestSystem {
 
@@ -195,8 +202,7 @@ object TestSystem extends Serializable {
   def live(data: Data): Layer[Nothing, TestSystem] = {
     implicit val trace: Trace = Tracer.newTrace
     ZLayer.scoped {
-      val ref  = Ref.unsafe.make(data)(Unsafe)
-      val test = Test(ref)
+      val test = unsafe.make(data)(Unsafe)
       ZIO.withSystemScoped(test).as(test)
     }
   }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -54,20 +54,46 @@ package object test extends CompileVariants {
   object TestEnvironment {
     private val sizedLive  = Sized.live(100)(Trace.empty)
     private val configLive = TestConfig.live(100, 100, 200, 1000)(Trace.empty)
+    private val defaultTestConfig =
+      TestConfig.TestV2(100, 100, 200, 1000, ZIOAspect.identity)
 
     val any: ZLayer[TestEnvironment, Nothing, TestEnvironment] =
       ZLayer.environment[TestEnvironment](Tracer.newTrace)
     val live: ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] = {
       implicit val trace = Tracer.newTrace
-      Annotations.live <*>
-        Live.default <*>
-        sizedLive <*>
-        ((Live.default <*> Annotations.live) >>> TestClock.default) <*>
-        configLive <*>
-        ((Live.default <*> Annotations.live) >>> TestConsole.debug) <*>
-        TestRandom.deterministic <*>
-        TestSystem.default
+      ZLayer.scopedEnvironment {
+        ZIO.environmentWithZIO[Scope with Clock with Console with System with Random] { liveEnvironment =>
+          val scope       = liveEnvironment.getScope
+          val annotations = Annotations.unsafe.make()(Unsafe)
+          val live        = Live.Test(liveEnvironment)
+          val sized       = Sized.unsafe.make(100)(Unsafe)
+          val testClock   = TestClock.unsafe.make(TestClock.DefaultData, live, annotations)(Unsafe)
+          val testConsole =
+            TestConsole.unsafe.make(TestConsole.DefaultData, true, live, annotations)(Unsafe)
+          val testRandom = TestRandom.unsafe.make(TestRandom.DefaultData)(Unsafe)
+          val testSystem = TestSystem.unsafe.make(TestSystem.DefaultData)(Unsafe)
 
+          for {
+            testServices    <- TestServices.currentServices.get
+            defaultServices <- DefaultServices.currentServices.get
+            _               <- scope.addFinalizer(TestClock.unsafe.close(testClock))
+            _ <- TestServices.currentServices.locallyScoped(
+                   testServices
+                     .add[Annotations](annotations)
+                     .add[Live](live)
+                     .add[Sized](sized)
+                     .add[TestConfig](defaultTestConfig)
+                 )
+            _ <- DefaultServices.currentServices.locallyScoped(
+                   defaultServices
+                     .add[TestClock](testClock)
+                     .add[TestConsole](testConsole)
+                     .add[TestRandom](testRandom)
+                     .add[TestSystem](testSystem)
+                 )
+          } yield ZEnvironment[Annotations, Live, Sized, TestConfig](annotations, live, sized, defaultTestConfig)
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fresh TestEnvironment construction dominates allocation for trivial tests and substantially limits execution performance. The existing path evaluates eight independently scoped layers for every leaf, creating memo-map entries, child scopes, intermediate environments, and separate FiberRef updates.

Construct the mutable test services through package-private unsafe.make helpers and install the complete test and default service environments in one scoped layer. This preserves fresh mutable state, scoped restoration, and TestClock cleanup. Reuse the immutable default TestConfig and cache public companion tags for TestClock, TestConsole, TestRandom, and TestSystem.

Add JMH benchmarks for environment construction and end-to-end test execution.

| Benchmark | Median before | Median after | Speedup | Allocation before | Allocation after | Reduction |
| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
| 10,000 test leaves | 528.392 ms | 250.214 ms | 2.11x | 2,348,652,329 B/op | 1,047,226,342 B/op | 55.4% |
| 10,000 acquisitions | 354.672 ms | 81.991 ms | 4.33x | 1,737,029,304 B/op | 466,642,398 B/op | 73.1% |