### PR TITLE
Optimize test logger and supervisor allocations

### DIFF
--- a/benchmarks/src/main/scala/zio/test/TestFiberSupervisorBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/TestFiberSupervisorBenchmark.scala
@@ -1,0 +1,51 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.immutable.SortedSet
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@Fork(3)
+class TestFiberSupervisorBenchmark {
+
+  @Param(Array("10000"))
+  var leafCount: Int = _
+
+  private implicit val trace: Trace = Trace.empty
+
+  private var previous: UIO[Unit] = _
+  private var current: UIO[Unit]  = _
+
+  @Setup
+  def setup(): Unit = {
+    previous = ZIO.loopDiscard(0)(_ < leafCount, _ + 1) { _ =>
+      ZIO.suspendSucceed {
+        val ref = new AtomicReference(SortedSet.empty[Fiber.Runtime[Any, Any]])
+        Supervisor.fibersIn(ref).flatMap(ZIO.unit.supervised(_))
+      }
+    }
+    current = ZIO.loopDiscard(0)(_ < leafCount, _ + 1) { _ =>
+      ZIO.suspendSucceed {
+        val ref = new AtomicReference(SortedSet.empty[Fiber.Runtime[Any, Any]])
+        ZIO.unit.supervised(Supervisor.unsafe.fibersIn(ref))
+      }
+    }
+  }
+
+  @Benchmark
+  def effectfulConstruction(): Unit =
+    unsafeRun(previous)
+
+  @Benchmark
+  def directConstruction(): Unit =
+    unsafeRun(current)
+}

--- a/benchmarks/src/main/scala/zio/test/ZTestLoggerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/ZTestLoggerBenchmark.scala
@@ -1,0 +1,85 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+
+import java.util.concurrent.{CountDownLatch, Executors, TimeUnit}
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+class ZTestLoggerBenchmark {
+
+  @Param(Array("100", "1000", "10000"))
+  var messageCount: Int = _
+
+  private val workerCount = 16
+  private val message     = () => "entry"
+
+  private var executor                          = Executors.newFixedThreadPool(workerCount)
+  private var logger: ZTestLogger[String, Unit] = _
+  private var start: CountDownLatch             = _
+  private var done: CountDownLatch              = _
+  private var workers: Array[Runnable]          = _
+
+  @Setup(Level.Trial)
+  def setupWorkers(): Unit = {
+    val quotient  = messageCount / workerCount
+    val remainder = messageCount % workerCount
+
+    workers = Array.tabulate(workerCount) { worker =>
+      val count = quotient + (if (worker < remainder) 1 else 0)
+      new Runnable {
+        def run(): Unit = {
+          val currentLogger = logger
+          val currentStart  = start
+          val currentDone   = done
+          try {
+            currentStart.await()
+            var i = 0
+            while (i < count) {
+              currentLogger(
+                Trace.empty,
+                FiberId.None,
+                LogLevel.Info,
+                message,
+                Cause.empty,
+                FiberRefs.empty,
+                Nil,
+                Map.empty
+              )
+              i += 1
+            }
+          } finally currentDone.countDown()
+        }
+      }
+    }
+  }
+
+  @Setup(Level.Invocation)
+  def setupInvocation(): Unit = {
+    logger = ZTestLogger.unsafe.make()(Unsafe).asInstanceOf[ZTestLogger[String, Unit]]
+    start = new CountDownLatch(1)
+    done = new CountDownLatch(workerCount)
+  }
+
+  @TearDown(Level.Trial)
+  def shutdownWorkers(): Unit =
+    executor.shutdown()
+
+  @Benchmark
+  def logConcurrently(): Int = {
+    var i = 0
+    while (i < workers.length) {
+      executor.execute(workers(i))
+      i += 1
+    }
+    start.countDown()
+    done.await()
+    unsafeRun(logger.logOutput).size
+  }
+}

--- a/benchmarks/src/main/scala/zio/test/ZTestLoggerConstructionBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/ZTestLoggerConstructionBenchmark.scala
@@ -1,0 +1,32 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.TimeUnit
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@Fork(3)
+class ZTestLoggerConstructionBenchmark {
+
+  @Param(Array("10000"))
+  var loggerCount: Int = _
+
+  private implicit val trace: Trace = Trace.empty
+
+  private var construct: UIO[Unit] = _
+
+  @Setup
+  def setup(): Unit =
+    construct = ZIO.loopDiscard(0)(_ < loggerCount, _ + 1)(_ => ZTestLogger.locally(ZIO.unit))
+
+  @Benchmark
+  def constructLoggers(): Unit =
+    unsafeRun(construct)
+}

--- a/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/LoggingSpec.scala
@@ -14,6 +14,9 @@ object LoggingSpec extends ZIOBaseSpec {
           assertTrue(output(0).message() == "It's alive!") &&
           assertTrue(output(0).logLevel == LogLevel.Info)
       },
+      test("log output is isolated between tests") {
+        ZTestLogger.logOutput.map(output => assertTrue(output.isEmpty))
+      },
       test("change log level in region") {
         for {
           _      <- LogLevel.Warning(ZIO.log("It's alive!"))
@@ -81,6 +84,14 @@ object LoggingSpec extends ZIOBaseSpec {
           } yield assertTrue(output.length == 1) &&
             assertTrue(output(0).context.get(ref).contains(value))
         )
+      },
+      test("concurrent log messages are retained") {
+        val messages = 0 until 1000
+        for {
+          _      <- ZIO.foreachParDiscard(messages)(message => ZIO.log(message.toString))
+          output <- ZTestLogger.logOutput
+        } yield assertTrue(output.length == messages.length) &&
+          assertTrue(output.map(_.message()).toSet == messages.map(_.toString).toSet)
       }
     ) @@ TestAspect.silentLogging
 }

--- a/core/shared/src/main/scala/zio/Supervisor.scala
+++ b/core/shared/src/main/scala/zio/Supervisor.scala
@@ -96,8 +96,30 @@ object Supervisor {
   def fibersIn(
     ref: AtomicReference[SortedSet[Fiber.Runtime[Any, Any]]]
   )(implicit trace: Trace): UIO[Supervisor[SortedSet[Fiber.Runtime[Any, Any]]]] =
-    ZIO.succeed {
+    ZIO.succeed(unsafe.fibersIn(ref))
 
+  /**
+   * A supervisor that doesn't do anything in response to supervision events.
+   */
+  val none: Supervisor[Unit] = new ConstSupervisor(_ => ZIO.unit)
+
+  private class ConstSupervisor[A](value0: Trace => UIO[A]) extends Supervisor[A] {
+    def value(implicit trace: Trace): UIO[A] = value0(trace)
+
+    def onStart[R, E, A](
+      environment: ZEnvironment[R],
+      effect: ZIO[R, E, A],
+      parent: Option[Fiber.Runtime[Any, Any]],
+      fiber: Fiber.Runtime[E, A]
+    )(implicit unsafe: Unsafe): Unit = ()
+
+    def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
+  }
+
+  private[zio] object unsafe {
+    def fibersIn(
+      ref: AtomicReference[SortedSet[Fiber.Runtime[Any, Any]]]
+    ): Supervisor[SortedSet[Fiber.Runtime[Any, Any]]] =
       new Supervisor[SortedSet[Fiber.Runtime[Any, Any]]] {
         def value(implicit trace: Trace): UIO[SortedSet[Fiber.Runtime[Any, Any]]] =
           ZIO.succeed(ref.get)
@@ -123,27 +145,7 @@ object Supervisor {
           }
         }
       }
-    }
 
-  /**
-   * A supervisor that doesn't do anything in response to supervision events.
-   */
-  val none: Supervisor[Unit] = new ConstSupervisor(_ => ZIO.unit)
-
-  private class ConstSupervisor[A](value0: Trace => UIO[A]) extends Supervisor[A] {
-    def value(implicit trace: Trace): UIO[A] = value0(trace)
-
-    def onStart[R, E, A](
-      environment: ZEnvironment[R],
-      effect: ZIO[R, E, A],
-      parent: Option[Fiber.Runtime[Any, Any]],
-      fiber: Fiber.Runtime[E, A]
-    )(implicit unsafe: Unsafe): Unit = ()
-
-    def onEnd[R, E, A](value: Exit[E, A], fiber: Fiber.Runtime[E, A])(implicit unsafe: Unsafe): Unit = ()
-  }
-
-  private[zio] object unsafe {
     def track(weak: Boolean)(implicit unsafe: Unsafe): Supervisor[Chunk[Fiber.Runtime[Any, Any]]] = {
       val set: java.util.Set[Fiber.Runtime[Any, Any]] =
         if (weak) Platform.newWeakSet[Fiber.Runtime[Any, Any]]()

--- a/test/shared/src/main/scala/zio/test/TestAspect.scala
+++ b/test/shared/src/main/scala/zio/test/TestAspect.scala
@@ -589,8 +589,8 @@ object TestAspect extends TimeoutVariants {
             Annotations.annotate(TestAnnotation.fibers, Left(n))
           case _ => Exit.unit
         }
-        ZIO.acquireReleaseWith(acquire)(_ => release) {
-          Supervisor.fibersIn(_).flatMap(test.supervised(_))
+        ZIO.acquireReleaseWith(acquire)(_ => release) { ref =>
+          test.supervised(Supervisor.unsafe.fibersIn(ref))
         }
       }
     }

--- a/test/shared/src/main/scala/zio/test/TestExecutor.scala
+++ b/test/shared/src/main/scala/zio/test/TestExecutor.scala
@@ -139,7 +139,7 @@ object TestExecutor {
                         )
                       )
                     start  <- ClockLive.currentTime(TimeUnit.MILLISECONDS)
-                    result <- Live.withLive(test)(ZIO.identityFn).either
+                    result <- test.either
                   } yield {
                     val end = ClockLive.unsafe.currentTime(TimeUnit.MILLISECONDS)(Unsafe)
                     ExecutionEvent
@@ -163,9 +163,13 @@ object TestExecutor {
               }
 
             val scopedSpec =
-              (spec @@ TestAspect.aroundTest(
-                ZTestLogger.default.build.as(ZIO.successFn[TestSuccess])
-              )).annotated
+              spec
+                .transform[R with TestEnvironment with Scope, E] {
+                  case Spec.TestCase(test, annotations) =>
+                    Spec.TestCase(Annotations.withAnnotation(ZTestLogger.locally(test)), annotations)
+                  case specCase =>
+                    specCase
+                }
                 .provideSomeLayer[R](freshLayerPerSpec)
                 .provideLayerShared(sharedSpecLayer.tapErrorCause { e =>
                   processEvent(

--- a/test/shared/src/main/scala/zio/test/ZTestLogger.scala
+++ b/test/shared/src/main/scala/zio/test/ZTestLogger.scala
@@ -2,7 +2,7 @@ package zio.test
 
 import zio._
 
-import scala.annotation.tailrec
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * A `ZTestLogger` is an implementation of a `ZLogger` that writes all log
@@ -52,6 +52,9 @@ object ZTestLogger {
         .getOrElse(ZIO.dieMessage("Defect: ZTestLogger is missing"))
     }
 
+  private[test] def locally[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+    FiberRef.currentLoggers.locallyWith(_ + unsafe.make()(Unsafe))(zio)
+
   /**
    * A log entry captures all of the contents of a log message as a data
    * structure.
@@ -74,32 +77,35 @@ object ZTestLogger {
    * Constructs a `ZTestLogger`.
    */
   private def make: UIO[ZLogger[String, Unit]] =
-    ZIO.succeed {
+    ZIO.succeed(unsafe.make()(Unsafe))
 
-      val _logOutput = new java.util.concurrent.atomic.AtomicReference[Chunk[LogEntry]](Chunk.empty)
+  private[test] object unsafe {
+    def make()(implicit unsafe: Unsafe): ZLogger[String, Unit] =
+      new TestLogger
 
-      new ZTestLogger[String, Unit] {
-        @tailrec
-        def apply(
-          trace: Trace,
-          fiberId: FiberId,
-          logLevel: LogLevel,
-          message: () => String,
-          cause: Cause[Any],
-          context: FiberRefs,
-          spans: List[LogSpan],
-          annotations: Map[String, String]
-        ): Unit = {
-          val newEntry = LogEntry(trace, fiberId, logLevel, message, cause, context, spans, annotations)
+    private final class TestLogger
+        extends AtomicReference[Chunk[LogEntry]](Chunk.empty)
+        with ZTestLogger[String, Unit] {
+      def apply(
+        trace: Trace,
+        fiberId: FiberId,
+        logLevel: LogLevel,
+        message: () => String,
+        cause: Cause[Any],
+        context: FiberRefs,
+        spans: List[LogSpan],
+        annotations: Map[String, String]
+      ): Unit = {
+        val newEntry = LogEntry(trace, fiberId, logLevel, message, cause, context, spans, annotations)
 
-          val oldState = _logOutput.get
-
-          if (!_logOutput.compareAndSet(oldState, oldState :+ newEntry))
-            apply(trace, fiberId, logLevel, message, cause, context, spans, annotations)
-          else ()
+        var updated = false
+        while (!updated) {
+          val oldState = get
+          updated = compareAndSet(oldState, oldState :+ newEntry)
         }
-        val logOutput: UIO[Chunk[LogEntry]] =
-          ZIO.succeed(_logOutput.get)
       }
+      val logOutput: UIO[Chunk[LogEntry]] =
+        ZIO.succeed(get)
     }
+  }
 }


### PR DESCRIPTION
Per-test execution allocates a logger and fiber supervisor for every leaf. The logger also stores its state in a separate AtomicReference and previously rebuilt LogEntry values after failed CAS attempts. Each leaf additionally runs through an identity Live.withLive wrapper.

Fuse logger and annotation setup, construct the logger inside the existing FiberRef suspension, and store logging state directly in the logger. Hoist LogEntry construction out of the CAS retry loop, remove redundant live-service restoration, and construct internal test fiber supervisors directly.

Add JMH benchmarks for logger construction, concurrent logging, identity Live wrappers, and supervisor construction. Reuse the parent PR end-to-end benchmark to measure the complete effect on test execution.

| Benchmark | Median before | Median after | Speedup | Allocation before | Allocation after | Reduction |
| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
| 10,000 test leaves | 245.230 ms | 225.027 ms | 1.09x | 1,040,858,735 B/op | 943,818,594 B/op | 9.3% |
| 10,000 logger constructions | 2.619 ms | 2.488 ms | 1.05x | 6,725,352 B/op | 6,565,352 B/op | 2.4% |
| 10,000 supervisor constructions | 6.274 ms | 2.908 ms | 2.16x | 8,165,352 B/op | 7,365,352 B/op | 9.8% |
| 10,000 concurrent log entries | 4.184 ms | 3.910 ms | 1.07x | 39,567,374 B/op | 38,351,896 B/op | 3.1% |