### PR TITLE
Optimize test environment FiberRef lifecycle

### DIFF
--- a/benchmarks/src/main/scala/zio/test/TestEnvironmentFiberIdLayerBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/test/TestEnvironmentFiberIdLayerBenchmark.scala
@@ -1,0 +1,43 @@
+package zio.test
+
+import org.openjdk.jmh.annotations.{Scope => JmhScope, _}
+import zio.BenchmarkUtil.unsafeRun
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.TimeUnit
+
+@State(JmhScope.Benchmark)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@Fork(3)
+class TestEnvironmentFiberIdLayerBenchmark {
+
+  @Param(Array("10000"))
+  var environmentCount: Int = _
+
+  private implicit val trace: Trace = Trace.empty
+
+  private var separate: UIO[Unit] = _
+  private var fused: UIO[Unit]    = _
+
+  @Setup
+  def setup(): Unit = {
+    val fiberIdGenerator =
+      ZLayer.scoped(FiberRef.currentFiberIdGenerator.locallyScoped(FiberId.Gen.Monotonic))
+    val separateLayer = liveEnvironment >>> (TestEnvironment.live <*> fiberIdGenerator)
+
+    separate = ZIO.loopDiscard(0)(_ < environmentCount, _ + 1)(_ => ZIO.unit.provideLayer(separateLayer))
+    fused = ZIO.loopDiscard(0)(_ < environmentCount, _ + 1)(_ => ZIO.unit.provideLayer(testEnvironment))
+  }
+
+  @Benchmark
+  def separateFiberIdLayer(): Unit =
+    unsafeRun(separate)
+
+  @Benchmark
+  def fusedFiberIdInstallation(): Unit =
+    unsafeRun(fused)
+}

--- a/test-tests/shared/src/test/scala/zio/test/EnvironmentSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/EnvironmentSpec.scala
@@ -72,22 +72,26 @@ object EnvironmentSpec extends ZIOBaseSpec {
       val layer = liveEnvironment >>> TestEnvironment.live
       val acquire =
         (for {
-          environment     <- ZIO.environment[TestEnvironment]
-          testServices    <- TestServices.currentServices.get
-          defaultServices <- DefaultServices.currentServices.get
+          environment      <- ZIO.environment[TestEnvironment]
+          testServices     <- TestServices.currentServices.get
+          defaultServices  <- DefaultServices.currentServices.get
+          fiberIdGenerator <- FiberRef.currentFiberIdGenerator.get
         } yield (
           environment,
           testServices,
-          defaultServices
+          defaultServices,
+          fiberIdGenerator
         )).provideLayer(layer)
 
       for {
-        testServicesBefore    <- TestServices.currentServices.get
-        defaultServicesBefore <- DefaultServices.currentServices.get
-        first                 <- acquire
-        second                <- acquire
-        testServicesAfter     <- TestServices.currentServices.get
-        defaultServicesAfter  <- DefaultServices.currentServices.get
+        testServicesBefore     <- TestServices.currentServices.get
+        defaultServicesBefore  <- DefaultServices.currentServices.get
+        fiberIdGeneratorBefore <- FiberRef.currentFiberIdGenerator.get
+        first                  <- acquire
+        second                 <- acquire
+        testServicesAfter      <- TestServices.currentServices.get
+        defaultServicesAfter   <- DefaultServices.currentServices.get
+        fiberIdGeneratorAfter  <- FiberRef.currentFiberIdGenerator.get
       } yield assertTrue(
         first._1.get[Annotations] eq first._2.get[Annotations],
         first._1.get[Live] eq first._2.get[Live],
@@ -101,8 +105,23 @@ object EnvironmentSpec extends ZIOBaseSpec {
         first._3.get[Clock] ne second._3.get[Clock],
         first._1.get[TestConfig] eq second._1.get[TestConfig],
         testServicesBefore eq testServicesAfter,
-        defaultServicesBefore eq defaultServicesAfter
+        defaultServicesBefore eq defaultServicesAfter,
+        fiberIdGeneratorBefore eq first._4,
+        fiberIdGeneratorBefore eq fiberIdGeneratorAfter
       )
+    },
+    test("testEnvironment installs and restores the monotonic FiberId generator") {
+      FiberRef.currentFiberIdGenerator.locally(FiberId.Gen.Live) {
+        for {
+          before <- FiberRef.currentFiberIdGenerator.get
+          inside <- FiberRef.currentFiberIdGenerator.get.provideLayer(testEnvironment)
+          after  <- FiberRef.currentFiberIdGenerator.get
+        } yield assertTrue(
+          before eq FiberId.Gen.Live,
+          inside eq FiberId.Gen.Monotonic,
+          after eq FiberId.Gen.Live
+        )
+      }
     }
   )
 }

--- a/test/shared/src/main/scala/zio/test/package.scala
+++ b/test/shared/src/main/scala/zio/test/package.scala
@@ -59,7 +59,17 @@ package object test extends CompileVariants {
 
     val any: ZLayer[TestEnvironment, Nothing, TestEnvironment] =
       ZLayer.environment[TestEnvironment](Tracer.newTrace)
-    val live: ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] = {
+
+    val live: ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] =
+      make(installMonotonicFiberIds = false)
+
+    private[test] val liveWithMonotonicFiberIds
+      : ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] =
+      make(installMonotonicFiberIds = true)
+
+    private def make(
+      installMonotonicFiberIds: Boolean
+    ): ZLayer[Clock with Console with System with Random, Nothing, TestEnvironment] = {
       implicit val trace = Tracer.newTrace
       ZLayer.scopedEnvironment {
         ZIO.environmentWithZIO[Scope with Clock with Console with System with Random] { liveEnvironment =>
@@ -72,26 +82,42 @@ package object test extends CompileVariants {
             TestConsole.unsafe.make(TestConsole.DefaultData, true, live, annotations)(Unsafe)
           val testRandom = TestRandom.unsafe.make(TestRandom.DefaultData)(Unsafe)
           val testSystem = TestSystem.unsafe.make(TestSystem.DefaultData)(Unsafe)
+          val environment =
+            ZEnvironment[Annotations, Live, Sized, TestConfig](annotations, live, sized, defaultTestConfig)
 
-          for {
-            testServices    <- TestServices.currentServices.get
-            defaultServices <- DefaultServices.currentServices.get
-            _               <- scope.addFinalizer(TestClock.unsafe.close(testClock))
-            _ <- TestServices.currentServices.locallyScoped(
-                   testServices
-                     .add[Annotations](annotations)
-                     .add[Live](live)
-                     .add[Sized](sized)
-                     .add[TestConfig](defaultTestConfig)
-                 )
-            _ <- DefaultServices.currentServices.locallyScoped(
-                   defaultServices
-                     .add[TestClock](testClock)
-                     .add[TestConsole](testConsole)
-                     .add[TestRandom](testRandom)
-                     .add[TestSystem](testSystem)
-                 )
-          } yield ZEnvironment[Annotations, Live, Sized, TestConfig](annotations, live, sized, defaultTestConfig)
+          ZIO.withFiberRuntime[Any, Nothing, ZEnvironment[TestEnvironment]] { (fiber, _) =>
+            val testServices     = fiber.getFiberRef(TestServices.currentServices)
+            val defaultServices  = fiber.getFiberRef(DefaultServices.currentServices)
+            val fiberIdGenerator = fiber.getFiberRef(FiberRef.currentFiberIdGenerator)
+            val testServices1 =
+              testServices
+                .add[Annotations](annotations)
+                .add[Live](live)
+                .add[Sized](sized)
+                .add[TestConfig](defaultTestConfig)
+            val defaultServices1 =
+              defaultServices
+                .add[TestClock](testClock)
+                .add[TestConsole](testConsole)
+                .add[TestRandom](testRandom)
+                .add[TestSystem](testSystem)
+
+            val finalizer = ZIO.withFiberRuntime[Any, Nothing, Unit] { (fiber, _) =>
+              if (installMonotonicFiberIds)
+                fiber.setFiberRef(FiberRef.currentFiberIdGenerator, fiberIdGenerator)
+              fiber.setFiberRef(DefaultServices.currentServices, defaultServices)
+              fiber.setFiberRef(TestServices.currentServices, testServices)
+              TestClock.unsafe.close(testClock)
+            }
+
+            scope.addFinalizer(finalizer).map { _ =>
+              fiber.setFiberRef(TestServices.currentServices, testServices1)
+              fiber.setFiberRef(DefaultServices.currentServices, defaultServices1)
+              if (installMonotonicFiberIds)
+                fiber.setFiberRef(FiberRef.currentFiberIdGenerator, FiberId.Gen.Monotonic)
+              environment
+            }
+          }
         }
       }
     }
@@ -109,14 +135,9 @@ package object test extends CompileVariants {
     )
   }
 
-  private val testFiberRefGen: ULayer[Unit] = {
-    implicit val trace = Trace.empty
-    ZLayer.scoped(FiberRef.currentFiberIdGenerator.locallyScoped(FiberId.Gen.Monotonic))
-  }
-
   val testEnvironment: ZLayer[Any, Nothing, TestEnvironment] = {
     implicit val trace = Tracer.newTrace
-    liveEnvironment >>> (TestEnvironment.live <*> testFiberRefGen)
+    liveEnvironment >>> TestEnvironment.liveWithMonotonicFiberIds
   }
 
   /**


### PR DESCRIPTION
The canonical test environment composes TestEnvironment.live with a second scoped layer whose only purpose is installing the monotonic FiberId generator. Environment acquisition also reads and installs test services, default services, and FiberId through independent effects and scoped lifecycles, creating duplicate memo entries, continuations, and finalizers for every test leaf.

Add a package-private TestEnvironment path that folds monotonic FiberId installation into the existing layer. Read all current FiberRef values in one runtime callback, install replacements after registering one finalizer, and restore them in reverse order before TestClock cleanup. Public TestEnvironment.live continues to preserve the caller FiberId generator.

| Benchmark | Median before | Median after | Speedup | Allocation before | Allocation after | Reduction |
| :--- | ---: | ---: | ---: | ---: | ---: | ---: |
| 10,000 test leaves | 215.947 ms | 173.285 ms | 1.25x | 943,727,303 B/op | 773,670,694 B/op | 18.0% |