### PR TITLE
chore: let Renovate update ZIO ecosystem docs packages past the npm latest tag

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,9 +27,10 @@
         "documentation"
       ],
       "matchPackageNames": [
-        "^@zio\\.dev\\/.*"
+        "@zio.dev/**"
       ],
       "ignoreUnstable": false,
+      "respectLatest": false,
       "enabled": true
     },
     {


### PR DESCRIPTION
## Problem

`website/package.json` pins 33 `@zio.dev/*` docs packages, and Renovate keeps them current. But it can only ever reach the version tagged `latest` on npm, so any package whose releases go out under a different dist-tag is frozen. Today that means:

| package | pinned here | npm `latest` | npm `rc` |
| --- | --- | --- | --- |
| `@zio.dev/zio-dynamodb` | 1.0.0-RC24 | 1.0.0-RC24 | **1.0.0-RC27** |
| `@zio.dev/zio-telemetry` | 3.1.19 | 3.1.19 | **4.0.0-RC12** |

Across all 33 pins, 30 match `latest` exactly and not one tracks an `rc` tag — the ceiling is consistent and mechanical, not a coincidence of timing.

Two separate causes.

### 1. The package filter matches nothing

```json
"matchPackageNames": ["^@zio\\.dev\\/.*"]
```

Renovate treats a string in `matchPackageNames` as a regex **only when it is wrapped in slashes** — `"/^@zio\\.dev\\//"`. Anything else is parsed as a minimatch glob, and in glob syntax `^` is a literal caret character. No package on npm begins with a caret, so this rule has been matching zero packages and everything inside it — `ignoreUnstable: false`, the `dependencies` / `documentation` labels — has never applied.

This is a silent failure: `renovate-config-validator` accepts the current file without complaint (I checked), because the value is a well-formed string. It just never matches.

### 2. `respectLatest` caps updates at the `latest` tag

`respectLatest` defaults to `true` for npm: *"Upgrades versions up to the latest tag in the npm registry."* zio-sbt publishes prereleases under the `rc` tag, which leaves `latest` pointing at whatever was last released as stable — RC24 for zio-dynamodb, from December 2025. RC25, RC26 and RC27 are all above the ceiling.

Fixing only the first cause would not produce an update for zio-dynamodb, since the version it is pinned to is already a prerelease; `respectLatest` is the operative blocker there.

## Change

```diff
       "matchPackageNames": [
-        "^@zio\\.dev\\/.*"
+        "@zio.dev/**"
       ],
       "ignoreUnstable": false,
+      "respectLatest": false,
```

The glob form is used rather than the slash-wrapped regex because it reads more clearly and is what the Renovate docs recommend for scope matching.

## Effect

Renovate should now propose, for `@zio.dev/*` packages only:

- `@zio.dev/zio-dynamodb` → `1.0.0-RC27`
- `@zio.dev/zio-telemetry` → `4.0.0-RC12`

Worth a conscious decision before merging: the zio-telemetry bump is a major-version move onto a prerelease line (`3.1.19` → `4.0.0-RC12`). That is the intended behaviour of the rule as written in its own description ("including pre-releases"), but it has never actually happened before, so it is new in practice. If the docs site should stay on telemetry 3.x, that is better expressed as a targeted `allowedVersions` rule than by leaving the ecosystem-wide rule broken.

Nothing outside `@zio.dev/*` is affected — the rule is scoped, and no defaults change globally.

## Not addressed here

The second `packageRules` entry has the same unwrapped-regex bug:

```json
"matchPackageNames": ["^(?!@zio\\.dev\\/)"]
```

A negative lookahead is regex syntax and meaningless as a glob, so "Disable patch updates for non-ZIO npm packages" is not in effect either. Fixing it (`["**", "!@zio.dev/**"]`) would start suppressing patch PRs for 27 other packages — a real behaviour change for unrelated dependencies, so I left it out of this PR rather than bundling it in. Happy to follow up separately if that rule is still wanted.

Separately, and outside this repo: the release-triggered `repository_dispatch` path is also broken. zio-dynamodb's "Notify Docs Release" job POSTs to `/repos/zio/zio/dispatches` and currently gets `401 Bad credentials` (its `PAT_TOKEN` needs rotating), and the payload version comes from `npm view <pkg> version`, which resolves the `latest` tag and would therefore report the already-pinned version. This PR makes Renovate able to do the job on its own regardless.
