### PR TITLE
chore: restore respectLatest for ZIO docs packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,6 @@
         "@zio.dev/**"
       ],
       "ignoreUnstable": false,
-      "respectLatest": false,
       "enabled": true
     },
     {


### PR DESCRIPTION
## What happened

#11151 set `respectLatest: false` for `@zio.dev/**` so Renovate could see docs prereleases that are published under the `rc` dist-tag rather than `latest`. Renovate ran minutes after the merge and opened two PRs:

- #11154 — `@zio.dev/izumi-reflect` to `2025.12.9-933f52d81e0c` — correct.
- #11153 — `@zio.dev/zio-dynamodb` from `1.0.0-RC24` to **`1.0.0-RC9`** — a downgrade.

With `automerge` and `platformAutomerge` both enabled, #11153 would have merged itself once checks passed.

## Why it produced a downgrade

Removing `respectLatest` removes the dist-tag ceiling, leaving Renovate to rank versions by semver alone. Semver compares alphanumeric prerelease identifiers as strings, not numbers, and these RC identifiers are not zero-padded, so `RC9` outranks `RC27`:

```
$ semver 1.0.0-RC9 1.0.0-RC24 1.0.0-RC26 1.0.0-RC27
1.0.0-RC24
1.0.0-RC26
1.0.0-RC27
1.0.0-RC9      <- semver-greatest
```

Renovate picked the semver maximum, which is genuinely `RC9`. The bot is right; the version scheme is what misleads it. Everything from RC10 onward sorts below RC9.

The ceiling had been shielding the repo from an ordering hazard that was always latent.

## Change

Remove the `respectLatest` override and fix the problem at the source instead. zio/zio-sbt#747 changes `publishToNpm` to publish docs prereleases under the `latest` dist-tag rather than deriving a tag from the prerelease identifier. A dist-tag records what a project last released regardless of how the version string sorts, so `respectLatest` then tracks releases exactly — for every `@zio.dev/*` package at once, with no per-package configuration here.

The glob fix to `matchPackageNames` from #11151 stays. That rule matched nothing before it, and its `ignoreUnstable` and label settings still need to apply.

## Sequencing

Until zio-sbt#747 is released and each project cuts its next docs release, `latest` stays where it is and these packages simply hold at their current pins — the same state as before #11151, minus the downgrade risk. Packages already published under `rc` can be corrected sooner with a one-off registry operation by someone with publish rights, e.g. `npm dist-tag add @zio.dev/zio-dynamodb@1.0.0-RC27 latest`.

#11153 is already closed. #11154 is unaffected by this change and can be merged on its own merits.

## Verification

`renovate-config-validator` passes.
