### PR TITLE
docs(zlayer): document resources that can outlive their layer via fromZIO/apply

### DIFF
--- a/docs/reference/contextual/zlayer.md
+++ b/docs/reference/contextual/zlayer.md
@@ -127,6 +127,113 @@ object CLive {
 }
 ```
 
+### Avoiding Accidental Scope Leaks
+
+`ZLayer.apply`/`ZLayer.fromZIO` accept any `ZIO[R, E, A]`, including an effect whose `R` contains `Scope`. This means a resourceful effect can end up in them by mistake, and instead of the resource being released when the layer finishes constructing, the `Scope` requirement leaks into the layer's own `RIn`.
+
+#### Passing a Resourceful Effect to `ZLayer.fromZIO`
+
+For example, suppose we build a `Connection` using `ZIO.acquireRelease`, which produces a `ZIO[Scope, E, A]`, and pass it directly to `ZLayer.fromZIO`:
+
+```scala mdoc:compile-only
+import zio._
+
+trait Connection {
+  def close: UIO[Unit]
+}
+
+object Connection {
+  def open: ZIO[Any, Throwable, Connection] = ???
+}
+
+val acquireConnection: ZIO[Scope, Throwable, Connection] =
+  ZIO.acquireRelease(Connection.open)(_.close)
+
+val leaky: ZLayer[Scope, Throwable, Connection] =
+  ZLayer.fromZIO(acquireConnection)
+```
+
+This compiles, and `leaky` ends up with type `ZLayer[Scope, Throwable, Connection]`: the `Scope` was never closed by the layer itself, it was pushed into `RIn` instead. Providing this layer now requires supplying a `Scope` from somewhere, and the connection stays open for as long as that `Scope` stays open, not just for as long as the layer's own construction takes:
+
+```scala mdoc:compile-only
+import zio._
+
+trait Connection {
+  def close: UIO[Unit]
+}
+
+object Connection {
+  def open: ZIO[Any, Throwable, Connection] = ???
+}
+
+val acquireConnection: ZIO[Scope, Throwable, Connection] =
+  ZIO.acquireRelease(Connection.open)(_.close)
+
+val leaky: ZLayer[Scope, Throwable, Connection] =
+  ZLayer.fromZIO(acquireConnection)
+
+val program: ZIO[Connection, Throwable, Unit] = ZIO.unit
+
+val runnable: ZIO[Any, Throwable, Unit] =
+  program.provide(leaky, Scope.default)
+```
+
+Here `Scope.default` lives for the entire remaining execution of `runnable`, so the connection is held open for the whole program instead of being closed right after `program` is done with it. The fix is to build the layer with `ZLayer.scoped` instead of `ZLayer.fromZIO`, which consumes the `Scope` internally and ties the release to the layer's own lifetime:
+
+```scala mdoc:compile-only
+import zio._
+
+trait Connection {
+  def close: UIO[Unit]
+}
+
+object Connection {
+  def open: ZIO[Any, Throwable, Connection] = ???
+}
+
+val connectionLayer: ZLayer[Any, Throwable, Connection] =
+  ZLayer.scoped {
+    ZIO.acquireRelease(Connection.open)(_.close)
+  }
+
+val program: ZIO[Connection, Throwable, Unit] = ZIO.unit
+
+val runnable: ZIO[Any, Throwable, Unit] =
+  program.provide(connectionLayer)
+```
+
+`connectionLayer` no longer requires a `Scope` in `RIn`, and `runnable` closes the connection as soon as `program` finishes with it.
+
+:::note[Current Behavior]
+`ZLayer.fromZIO` and `ZLayer.apply` do not currently require evidence that `R` excludes `Scope`, so the compiler does not flag the pattern above. Prefer `ZLayer.scoped` whenever the effect you give to a layer constructor requires a `Scope`.
+:::
+
+#### Extending a Layer's Scope on Purpose
+
+Sometimes a layer's resource is meant to outlive the scope in which it was built, for example when it should be shared for the entire remaining lifetime of an application rather than closed as soon as it is constructed. `ZLayer#extendScope` exists for this: it takes a layer built with `ZLayer.scoped` and returns a new layer that ties the resource's release to an outer `Scope` supplied by the caller, instead of releasing it when construction completes:
+
+```scala mdoc:compile-only
+import zio._
+
+trait Connection {
+  def close: UIO[Unit]
+}
+
+object Connection {
+  def open: ZIO[Any, Throwable, Connection] = ???
+}
+
+val connectionLayer: ZLayer[Any, Throwable, Connection] =
+  ZLayer.scoped {
+    ZIO.acquireRelease(Connection.open)(_.close)
+  }
+
+val extendedLayer: ZLayer[Scope, Throwable, Connection] =
+  connectionLayer.extendScope
+```
+
+`extendedLayer` has the same `Scope` requirement in `RIn` as the leaky layer earlier in this section, but here it is intentional: calling `ZLayer#extendScope` documents in the code itself that the resource's lifetime is meant to extend beyond this layer's own construction, rather than being an accidental side effect of using `ZLayer.fromZIO` on a resourceful effect.
+
 ### From Functions
 
 A `ZLayer[R, E, A]` can be thought of as a function from `R` to `A`. So we can convert functions to the `ZLayer` using the `ZLayer.fromFunction` constructor.

--- a/docs/reference/contextual/zlayer.md
+++ b/docs/reference/contextual/zlayer.md
@@ -127,9 +127,9 @@ object CLive {
 }
 ```
 
-### Avoiding Accidental Scope Leaks
+### Avoiding Resources That Outlive Their Intended Scope
 
-`ZLayer.apply`/`ZLayer.fromZIO` accept any `ZIO[R, E, A]`, including an effect whose `R` contains `Scope`. This means a resourceful effect can end up in them by mistake, and instead of the resource being released when the layer finishes constructing, the `Scope` requirement leaks into the layer's own `RIn`.
+`ZLayer.apply`/`ZLayer.fromZIO` accept any `ZIO[R, E, A]`, including an effect whose `R` contains `Scope`. This means a resourceful effect can end up in them by mistake, and instead of the resource being released when the layer finishes constructing, its `Scope` requirement surfaces in the layer's own `RIn`, letting the resource outlive the layer's construction.
 
 #### Passing a Resourceful Effect to `ZLayer.fromZIO`
 
@@ -149,11 +149,11 @@ object Connection {
 val acquireConnection: ZIO[Scope, Throwable, Connection] =
   ZIO.acquireRelease(Connection.open)(_.close)
 
-val leaky: ZLayer[Scope, Throwable, Connection] =
+val outlivingLayer: ZLayer[Scope, Throwable, Connection] =
   ZLayer.fromZIO(acquireConnection)
 ```
 
-This compiles, and `leaky` ends up with type `ZLayer[Scope, Throwable, Connection]`: the `Scope` was never closed by the layer itself, it was pushed into `RIn` instead. Providing this layer now requires supplying a `Scope` from somewhere, and the connection stays open for as long as that `Scope` stays open, not just for as long as the layer's own construction takes:
+This compiles, and `outlivingLayer` ends up with type `ZLayer[Scope, Throwable, Connection]`: the `Scope` was never closed by the layer itself, so the connection can outlive the layer's own construction. Providing this layer now requires supplying a `Scope` from somewhere, and the connection stays open for as long as that `Scope` stays open, not just for as long as the layer's own construction takes:
 
 ```scala mdoc:compile-only
 import zio._
@@ -169,16 +169,16 @@ object Connection {
 val acquireConnection: ZIO[Scope, Throwable, Connection] =
   ZIO.acquireRelease(Connection.open)(_.close)
 
-val leaky: ZLayer[Scope, Throwable, Connection] =
+val outlivingLayer: ZLayer[Scope, Throwable, Connection] =
   ZLayer.fromZIO(acquireConnection)
 
 val program: ZIO[Connection, Throwable, Unit] = ZIO.unit
 
 val runnable: ZIO[Any, Throwable, Unit] =
-  program.provide(leaky, Scope.default)
+  program.provide(outlivingLayer, Scope.default)
 ```
 
-Here `Scope.default` lives for the entire remaining execution of `runnable`, so the connection is held open for the whole program instead of being closed right after `program` is done with it. The fix is to build the layer with `ZLayer.scoped` instead of `ZLayer.fromZIO`, which consumes the `Scope` internally and ties the release to the layer's own lifetime:
+Here `Scope.default` lives for the entire remaining execution of `runnable`, so the connection outlives `program` and stays open for the whole remaining execution instead of closing right after `program` is done with it. The fix is to build the layer with `ZLayer.scoped` instead of `ZLayer.fromZIO`, which consumes the `Scope` internally and ties the release to the layer's own lifetime:
 
 ```scala mdoc:compile-only
 import zio._
@@ -202,10 +202,10 @@ val runnable: ZIO[Any, Throwable, Unit] =
   program.provide(connectionLayer)
 ```
 
-`connectionLayer` no longer requires a `Scope` in `RIn`, and `runnable` closes the connection as soon as `program` finishes with it.
+`connectionLayer` no longer requires a `Scope` in `RIn`, and `runnable` closes the connection as soon as `program` finishes with it, so nothing outlives its intended scope.
 
 :::note[Current Behavior]
-`ZLayer.fromZIO` and `ZLayer.apply` do not currently require evidence that `R` excludes `Scope`, so the compiler does not flag the pattern above. Prefer `ZLayer.scoped` whenever the effect you give to a layer constructor requires a `Scope`.
+`ZLayer.fromZIO` and `ZLayer.apply` do not currently require evidence that `R` excludes `Scope`, so the compiler does not flag an effect whose resource can outlive the layer's construction. Prefer `ZLayer.scoped` whenever the effect you give to a layer constructor requires a `Scope`.
 :::
 
 #### Extending a Layer's Scope on Purpose
@@ -232,7 +232,7 @@ val extendedLayer: ZLayer[Scope, Throwable, Connection] =
   connectionLayer.extendScope
 ```
 
-`extendedLayer` has the same `Scope` requirement in `RIn` as the leaky layer earlier in this section, but here it is intentional: calling `ZLayer#extendScope` documents in the code itself that the resource's lifetime is meant to extend beyond this layer's own construction, rather than being an accidental side effect of using `ZLayer.fromZIO` on a resourceful effect.
+`extendedLayer` has the same `Scope` requirement in `RIn` as `outlivingLayer` earlier in this section, but here it is intentional: calling `ZLayer#extendScope` documents in the code itself that the resource's lifetime is meant to extend beyond this layer's own construction, rather than being an accidental side effect of using `ZLayer.fromZIO` on a resourceful effect.
 
 `Spec#provideLayerShared` in ZIO Test builds on exactly this pattern to share one expensive layer across every test in a suite: it acquires the layer once using `ZLayer#extendScope`, ties the layer's release to the scope of the whole suite, and reuses the already-built environment for each test underneath instead of rebuilding the layer per test. The same technique applies outside of testing whenever several independent operations should share one resource. In the following example, two queries reuse the same `Database` connection, and the connection closes only once, after both queries finish, because `ZIO.scoped` supplies the outer `Scope` that `ZLayer#extendScope` extends into:
 

--- a/docs/reference/contextual/zlayer.md
+++ b/docs/reference/contextual/zlayer.md
@@ -234,6 +234,31 @@ val extendedLayer: ZLayer[Scope, Throwable, Connection] =
 
 `extendedLayer` has the same `Scope` requirement in `RIn` as the leaky layer earlier in this section, but here it is intentional: calling `ZLayer#extendScope` documents in the code itself that the resource's lifetime is meant to extend beyond this layer's own construction, rather than being an accidental side effect of using `ZLayer.fromZIO` on a resourceful effect.
 
+`Spec#provideLayerShared` in ZIO Test builds on exactly this pattern to share one expensive layer across every test in a suite: it acquires the layer once using `ZLayer#extendScope`, ties the layer's release to the scope of the whole suite, and reuses the already-built environment for each test underneath instead of rebuilding the layer per test. The same technique applies outside of testing whenever several independent operations should share one resource. In the following example, two queries reuse the same `Database` connection, and the connection closes only once, after both queries finish, because `ZIO.scoped` supplies the outer `Scope` that `ZLayer#extendScope` extends into:
+
+```scala mdoc:compile-only
+import zio._
+
+trait Database {
+  def query(sql: String): Task[Int]
+}
+
+object Database {
+  def connect: ZIO[Scope, Throwable, Database] = ???
+}
+
+val sharedDatabase: ZLayer[Any, Throwable, Database] =
+  ZLayer.scoped(Database.connect)
+
+val program: ZIO[Any, Throwable, (Int, Int)] =
+  ZIO.scoped {
+    sharedDatabase.extendScope.build.flatMap { env =>
+      val db = env.get[Database]
+      db.query("SELECT 1").zip(db.query("SELECT 2"))
+    }
+  }
+```
+
 ### From Functions
 
 A `ZLayer[R, E, A]` can be thought of as a function from `R` to `A`. So we can convert functions to the `ZLayer` using the `ZLayer.fromFunction` constructor.


### PR DESCRIPTION
## Summary
- `ZLayer.fromZIO`/`ZLayer.apply` accept a `Scope`-requiring effect without any compile-time check, letting its `Scope` requirement surface in the layer's `RIn` instead of being released when the layer finishes constructing — so the resource can outlive the layer's own construction.
- Adds a new "Avoiding Resources That Outlive Their Intended Scope" subsection to `docs/reference/contextual/zlayer.md`, right after the existing `ZLayer.fromZIO` introduction, documenting the current (permissive) behavior and the `ZLayer.scoped` fix.
- Also documents `ZLayer#extendScope` as the deliberate, sanctioned mechanism for intentionally letting a layer's resource outlive its construction, to distinguish it from the accidental case, plus a use case grounded in ZIO Test's `Spec#provideLayerShared`.

Prompted by a discussion in the ZIO Discord about whether `ZLayer.fromZIO`/`apply` should require `zio.HasNoScope[R]` (as `zio-http`'s `Server.serve`/`install` already do). This PR only documents current behavior; it does not change any code.

## Test plan
- [x] `sbt "docs/mdoc --in docs/reference/contextual/zlayer.md"` — 0 errors
- [x] `docs-mdoc-conventions` checker — no new violations
- [x] `docs-writing-style` checker — no new violations