### PR TITLE
fix(test): eliminate race in TestClockSpecJVM scheduler tests

### DIFF
--- a/test-tests/jvm-native/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
+++ b/test-tests/jvm-native/src/test/scala/zio/test/environment/TestClockSpecJVM.scala
@@ -3,7 +3,7 @@ package zio.test.environment
 import zio._
 import zio.test.Assertion._
 import zio.test.TestAspect.{nonFlaky, timeout, parallelN}
-import zio.test.{TestClock, ZIOBaseSpec, assert, assertCompletes}
+import zio.test.{Live, TestClock, ZIOBaseSpec, assert, assertCompletes}
 
 import java.util.concurrent.TimeUnit
 
@@ -36,6 +36,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    )
                  }
             _      <- TestClock.adjust(25.seconds)
+            _      <- Live.live(ref.get.repeatUntil(_.size >= 5).timeout(10.seconds))
             values <- ref.get
           } yield assert(values.reverse)(equalTo(List(5L, 10L, 15L, 20L, 25L)))
         },
@@ -63,6 +64,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    )
                  }
             _      <- TestClock.adjust(28.seconds)
+            _      <- Live.live(ref.get.repeatUntil(_.size >= 5).timeout(10.seconds))
             values <- ref.get
           } yield assert(values.reverse)(equalTo(List(8L, 13L, 18L, 23L, 28L)))
         },
@@ -90,6 +92,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
                    )
                  }
             _      <- TestClock.adjust(33.seconds)
+            _      <- Live.live(ref.get.repeatUntil(_.size >= 5).timeout(10.seconds))
             values <- ref.get
           } yield assert(values.reverse)(equalTo(List(5L, 12L, 19L, 26L, 33L)))
         },
@@ -122,6 +125,7 @@ object TestClockSpecJVM extends ZIOBaseSpec {
             _      <- TestClock.adjust(4.seconds)
             _      <- ZIO.succeed(future.cancel(false))
             _      <- TestClock.adjust(11.seconds)
+            _      <- Live.live(ref.get.repeatUntil(_.size >= 1).timeout(10.seconds))
             values <- ref.get
           } yield assert(values.reverse)(equalTo(List(5L)))
         }


### PR DESCRIPTION
## Summary

`testJvms (17)` failed intermittently on unrelated PRs (e.g. #11161, run [32793328637](https://github.com/zio/zio/actions/runs/32793328637/job/97639366263)) with `TestClockSpecJVM` reporting a missing final tick, e.g.:

```
values.reverse did not satisfy equalTo(List(8L, 13L, 18L, 23L, 28L))
values.reverse = List(8, 13, 18, 23)
```

Root cause: `TestClock.adjust` returns once it has processed the sleeps it knows about, but `Clock.scheduler.asScheduledExecutorService`'s `scheduleAtFixedRate`/`scheduleWithFixedDelay` bridge (`TestClockPlatformSpecific.scala`) hops through an extra `executor.submitOrThrow` before the task's `Runnable.run()` writes its result and re-registers the next tick. That hop is asynchronous and not awaited by `adjust`, so the last scheduled tick can still be in flight when the test reads the result `Ref` right after `adjust` returns. The suite is already wrapped in `@@ nonFlaky(10)`, which raises confidence but doesn't close the race — it just makes it rarer.

## Fix

Poll the result `Ref` on the live (real) clock until it reaches the expected size, bounded by a timeout, instead of asserting immediately after `adjust`. Applied to all four `asScheduledExecutorService` tests in `TestClockSpecJVM`.

## Test plan

- [x] `sbt "testTestsJVM/testOnly zio.test.environment.TestClockSpecJVM"` — 4 consecutive local runs, 0 failures (each test already repeats 10x via `nonFlaky(10)`, so 40 executions per test with no flake)
- [x] `sbt scalafmtAll` — only this file changed
