### PR TITLE
docs(website): make left sidebar hideable

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -46,6 +46,7 @@ const config = {
     },
     docs: {
       sidebar: {
+        hideable: true,
         autoCollapseCategories: true,
       },
     },


### PR DESCRIPTION
## Summary
- Enable Docusaurus' built-in sidebar collapse via `themeConfig.docs.sidebar.hideable: true` in `website/docusaurus.config.js`, letting readers hide/show the left docs sidebar.

## Test plan
- [ ] `sbt "docs/mdoc; docs/unidoc"` then `yarn start` in `website/` and verify collapse/expand button works on a docs page