### PR TITLE
docs(guides): add how-to guide for building a TodoMVC app with ZIO on Scala.js

### DIFF
--- a/docs/guides/build-todomvc-with-zio-scalajs.md
+++ b/docs/guides/build-todomvc-with-zio-scalajs.md
@@ -1,0 +1,338 @@
+---
+id: build-todomvc-with-zio-scalajs
+title: "Build a TodoMVC Application with ZIO on Scala.js"
+description: "Create a browser-based TodoMVC app with ZIO state management, eliminating callback spaghetti and enforcing type safety."
+keywords:
+  - "Scala.js Browser Apps"
+  - "State Management"
+  - "DOM Event Handling"
+  - "Ref"
+  - "ZIOAppDefault"
+---
+
+## Introduction
+
+By the end of this guide, you will have a working TodoMVC application running in the browser with full type safety, atomic state mutations, and composable event handling. The approach eliminates imperative DOM manipulation scattered across event callbacks and replaces it with structured ZIO effects: define your state as a `Ref`, render UI from that state, and wire event handlers to state mutations. This makes your application's behavior obvious and prevents entire classes of bugs that plague callback-heavy code.
+
+## The Problem
+
+Building interactive browser apps with Scala.js often devolves into imperative JavaScript patterns — mutating global state in event callbacks, manually calling render functions after every change, and struggling to keep the DOM in sync with your actual data.
+
+Consider building a todo list without a structured approach: you maintain a mutable list, attach click handlers to buttons, and call a render function from each handler. If you forget to re-render after an update, the UI lies. If two handlers run concurrently, they corrupt the list. You end up with race conditions and scattered `render()` calls that must stay in sync by hand.
+
+Here's what that looks like today:
+
+```scala mdoc:compile-only
+// Global mutable state — unsafe in async context
+var todos: scala.collection.mutable.ListBuffer[String] = scala.collection.mutable.ListBuffer()
+
+// Event handler 1: scattered across the page, manual render call
+def addTodoHandler(title: String): Unit = {
+  if (title.nonEmpty) {
+    todos += title  // UNSAFE: no atomicity, other handlers might interleave
+    // Manually re-render — easy to forget, hard to scale
+    val html = todos.map(t => s"<li>$t</li>").mkString("\n")
+    println(html)  // In real code: render to DOM
+  }
+}
+
+// Event handler 2: doing the same thing differently
+def deleteTodoHandler(index: Int): Unit = {
+  todos.remove(index)  // Order matters; list shifted, indices invalidated
+  
+  // Re-render again, same code, manually
+  val html = todos.map(t => s"<li>$t</li>").mkString("\n")
+  println(html)  // In real code: render to DOM
+}
+
+// Concurrent execution: both handlers run "simultaneously" (async callbacks)
+// If deleteTodoHandler runs between the read and write in addTodoHandler,
+// the mutations interleave and state corruption occurs.
+addTodoHandler("Learn ZIO")
+deleteTodoHandler(0)
+addTodoHandler("Build an app")
+println(s"Final state: $todos")  // Unpredictable order; may lose todos
+```
+
+The pain is obvious: mutable state shared across multiple callbacks, duplicated render logic in each handler, no atomicity guarantees, and the DOM can fall out of sync with data at any point.
+
+## Prerequisites
+
+Add the ZIO library and Scala.js DOM bindings to your project:
+
+```scala
+libraryDependencies ++= Seq(
+  "dev.zio"        %%% "zio"           % "@VERSION@",
+  "org.scala-js"   %%% "scalajs-dom"   % "2.8.1"
+)
+```
+
+Ensure you have the Scala.js sbt plugins in `project/plugins.sbt`:
+
+```scala
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")
+```
+
+Configure your `build.sbt` to enable Scala.js compilation and the browser entry point (covered in the first capability section).
+
+You already understand ZIO basics on the JVM — effects, `Ref`, `for` comprehensions — and want to apply them to the browser. You have a passing familiarity with DOM APIs and HTML.
+
+## The Core Model
+
+Define the types your TodoMVC application will work with:
+
+```scala mdoc:silent
+final case class Todo(
+  id: String,
+  title: String,
+  done: Boolean
+)
+
+sealed trait Filter
+object Filter {
+  case object All       extends Filter
+  case object Active    extends Filter
+  case object Completed extends Filter
+}
+
+final case class AppState(
+  todos: List[Todo],
+  filter: Filter
+)
+```
+
+`AppState` holds the complete UI state: the list of todos (each with a unique `id`, `title`, and `done` flag) and the currently selected filter. All mutations flow through a `Ref[AppState]`, ensuring atomicity and type safety.
+
+## Set Up Scala.js with ZIO
+
+Scala.js requires explicit sbt configuration to cross-compile your code to JavaScript and set up a browser entry point. Your build needs the plugins loaded, and your code module must enable the main initializer so the browser can run your ZIO app.
+
+Define a cross-project that compiles to both JVM and JS (in `build.sbt`):
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
+```
+
+The key flag `scalaJSUseMainModuleInitializer := true` tells the Scala.js compiler to generate a `main()` function that runs immediately in the browser, starting your ZIO runtime.
+
+Confirm compilation succeeds:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+You should see no errors and a compiled JS file at `examples/js/target/scala-2.13/examples-fastopt/main.js`. Open the HTML file (`index.html`, provided in the example) in a browser and check the DevTools console for output.
+
+## Create the Entry Point
+
+On the JVM, ZIO apps extend `ZIOAppDefault` and implement `run: ZIO[ZIOAppArgs with Scope, Any, Any]`. On Scala.js, the same trait works, but the runtime and constraints differ: there are no threads, no blocking I/O, and the effect system is purely asynchronous. You must never return from `run` until your app is ready to shut down — typically, this means calling `ZIO.never` to block forever.
+
+Implement the entry point and wire up state and handlers:
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala
+```
+
+The `for` comprehension initializes a `Ref[AppState]`, renders the initial state to the DOM, wires all event handlers, and then calls `ZIO.never` to keep the application alive. When the browser closes the tab or navigates away, the app terminates naturally.
+
+Compile and check the browser console: you should see the startup message.
+
+## Model State with Ref
+
+All state mutations happen through a single `Ref[AppState]`. Each event handler reads the current state, computes an update, and atomically swaps the old state for the new one. `Ref.modify` ensures that the read-modify-write cycle is atomic — no interleaving race conditions.
+
+Define the core state mutation functions:
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala
+```
+
+Each function takes the `Ref`, reads it, transforms the state, and returns both the result (usually the new state for re-rendering) and the updated state. Because these operations happen inside `Ref.modify`, they are atomic: no concurrent handler can see a partially updated state.
+
+Test by adding multiple todos in rapid succession in the browser — no race conditions, all todos appear, and the state remains consistent.
+
+## Render UI Components
+
+Rendering must be composable: separate functions for the todo list, footer counts, and filter buttons. Each takes the current `AppState` and mutates the DOM to match. Rather than a single monolithic render, break it into concerns, so updating one piece (like filter buttons) doesn't require touching the others.
+
+Define rendering functions:
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala
+```
+
+Call `Render.main(container, state)` after any state change to update the entire UI. The individual render functions are small and easy to reason about — each one knows exactly which DOM elements it owns and how to update them based on the current `AppState`.
+
+Confirm: add a todo, toggle its done flag, delete it, click filter buttons — the UI updates correctly each time.
+
+## Wire Event Handlers
+
+DOM event listeners are synchronous callbacks that expect a return type of `Unit`. ZIO effects are async. The bridge is to fork the effect onto the ZIO runtime from within the callback, so the event handler returns immediately and the effect runs without blocking the browser.
+
+Implement all event handlers:
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
+```
+
+Each handler uses the `onEvent` helper to fork a ZIO effect. Inside the effect, you read the DOM (input values, element attributes), mutate the state via `Ref.modify`, and clean up (clear input, etc.). This example shows the core pattern of state mutation. The complete pattern — including DOM re-rendering after each state change — is shown in the "Putting It Together" section.
+
+In the full TodoMVC app, each state mutation is immediately followed by a call to `Render.main()` to update the DOM. This keeps the UI in sync with your state changes and prevents stale data from appearing on screen.
+
+## Putting It Together
+
+Here is the complete TodoMVC application combining all capabilities:
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala
+```
+
+This single file defines the domain types, the main entry point, rendering logic, state mutations, and all event handlers. It is self-contained and ready to compile and run in the browser.
+
+## Running the Examples
+
+Clone the ZIO repository and navigate to the examples directory:
+
+```bash
+git clone https://github.com/zio/zio.git
+cd zio/examples
+```
+
+<details open><summary>Step 5: Set Up Scala.js with ZIO</summary>
+
+This step configures sbt to cross-compile your code to JavaScript and sets up the browser entry point.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Expected output:
+- Compilation succeeds with no errors.
+- `examples/js/target/scala-2.13/examples-fastopt/main.js` is generated.
+- Opening `index.html` in a browser shows no JavaScript errors in the console.
+
+</details>
+
+<details><summary>Step 6: Create the Entry Point</summary>
+
+This step implements `ZIOAppDefault` for the browser and wires the state and handlers.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Expected output:
+- Compilation succeeds.
+- Browser DevTools console shows startup messages: `TodoMVC starting...` and `TodoMVC ready!`
+
+</details>
+
+<details><summary>Step 7: Model State with Ref</summary>
+
+This step implements atomic state mutations using `Ref.modify`.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Expected output:
+- Compilation succeeds.
+- State functions are available for handlers to call.
+- Rapid state mutations (e.g., clicking "Add" multiple times quickly) produce no race conditions.
+
+</details>
+
+<details><summary>Step 8: Render UI Components</summary>
+
+This step implements composable rendering functions that update the DOM based on state changes.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Expected output:
+- Compilation succeeds.
+- Opening `index.html` shows the initial empty todo list.
+- The footer and filter buttons are rendered with correct styling.
+
+</details>
+
+<details><summary>Step 9: Wire Event Handlers</summary>
+
+This step connects DOM event listeners to state mutations and rendering.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Expected output:
+- Compilation succeeds.
+- All DOM event listeners are attached without errors.
+- DevTools console shows no "event handler" errors (unless intentionally testing error cases).
+
+</details>
+
+<details><summary>Complete TodoMVC Application</summary>
+
+This is the full, integrated TodoMVC application combining all steps.
+
+```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala:show-line-numbers
+```
+
+Run:
+
+```bash
+sbt examplesJS/fastLinkJS
+```
+
+Then serve the HTML file with a local web server:
+
+```bash
+python3 -m http.server 8080
+```
+
+Open `http://localhost:8080` in your browser.
+
+Expected output:
+- Compilation succeeds.
+- Browser shows an interactive todo list.
+- Adding text and clicking "Add" creates a todo.
+- Clicking the checkbox toggles the todo's done state (strikethrough appears).
+- Clicking the × button deletes the todo.
+- Filter buttons highlight the active filter and update the visible list.
+- "Clear completed" removes all done todos.
+- Console shows no errors.
+
+</details>
+
+## Going Further
+
+This guide covered the core: setting up Scala.js, modeling state with `Ref`, rendering, and wiring event handlers. For more:
+
+- **ZIO reference**: Read about [`Ref`](../reference/concurrency/ref.md) for other atomic operations and state management patterns.
+- **Scala.js FFI**: Explore [Scala.js external method definitions](https://www.scala-js.org/doc/interoperability/calling-javascript.html) to call JavaScript libraries and use native APIs.
+- **ZIO-based frontend frameworks**: Investigate [`ZIO-themed UI libraries`](https://zio.dev/ecosystem) for higher-level abstractions (e.g., composable components, routing, middleware).
+- **Asynchronous patterns**: Deepen your understanding of how `Runtime.default.unsafe.fork` works and when to use `ZIO.never` vs. explicit shutdown.
+
+</content>
+</invoke>

--- a/docs/guides/build-todomvc-with-zio-scalajs.md
+++ b/docs/guides/build-todomvc-with-zio-scalajs.md
@@ -58,20 +58,22 @@ The pain is obvious: mutable state shared across multiple callbacks, duplicated 
 
 ## Prerequisites
 
-Add the ZIO library and Scala.js DOM bindings to your project:
+Add the ZIO library and Scala.js DOM bindings to your project. ZIO's runtime uses `java.time` and `java.util.UUID` internally, neither of which Scala.js implements out of the box, so both polyfills are required — without them the linker fails with "Referring to non-existent class" errors and produces no output:
 
 ```scala
 libraryDependencies ++= Seq(
-  "dev.zio"        %%% "zio"           % "@VERSION@",
-  "org.scala-js"   %%% "scalajs-dom"   % "2.8.1"
+  "dev.zio"            %%% "zio"                       % "@VERSION@",
+  "org.scala-js"       %%% "scalajs-dom"                % "2.8.1",
+  "io.github.cquiroz"  %%% "scala-java-time"            % "2.2.0",
+  "io.github.cquiroz"  %%% "scala-java-time-tzdb"       % "2.2.0",
+  "org.scala-js"       %%% "scalajs-java-securerandom"  % "1.0.0"
 )
 ```
 
-Ensure you have the Scala.js sbt plugins in `project/plugins.sbt`:
+Ensure you have the Scala.js sbt plugin in `project/plugins.sbt`:
 
 ```scala
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")
 ```
 
 Configure your `build.sbt` to enable Scala.js compilation and the browser entry point (covered in the first capability section).
@@ -106,22 +108,39 @@ final case class AppState(
 
 ## Set Up Scala.js with ZIO
 
-Scala.js requires explicit sbt configuration to cross-compile your code to JavaScript and set up a browser entry point. Your build needs the plugins loaded, and your code module must enable the main initializer so the browser can run your ZIO app.
+Scala.js requires explicit sbt configuration to compile your code to JavaScript and set up a browser entry point. Create a new, empty directory for this project — do not add it inside an existing checkout. Your build needs the plugin loaded, and your project must enable the main initializer so the browser can run your ZIO app.
 
-Define a cross-project that compiles to both JVM and JS (in `build.sbt`):
+Define the project (in `build.sbt`):
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
 ```
 
-The key flag `scalaJSUseMainModuleInitializer := true` tells the Scala.js compiler to generate a `main()` function that runs immediately in the browser, starting your ZIO runtime.
+The key flag `scalaJSUseMainModuleInitializer := true` tells the Scala.js compiler to generate a `main()` function that runs immediately in the browser, starting your ZIO runtime. It resolves automatically only when your project has exactly one `ZIOAppDefault` object — keep a single `src/main/scala/Main.scala` file and replace its content as you progress through this guide, rather than accumulating multiple entry-point objects side by side.
 
-Confirm compilation succeeds:
+There's nothing to compile yet — `scalaJSUseMainModuleInitializer` requires a real entry point to link against, so the first build happens once you've added `Main.scala` in the next section.
 
-```bash
-sbt examplesJS/fastLinkJS
+Create `index.html` at your project root now — every element ID it defines (`app`, `todoInput`, `addTodo`, `todoList`, `footer`, `filters`) is one the app code looks up directly, so the skeleton must be in place before the app's first render:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>ZIO TodoMVC</title>
+  </head>
+  <body>
+    <div id="app">
+      <h1>todos</h1>
+      <input id="todoInput" placeholder="What needs to be done?" />
+      <button id="addTodo">Add</button>
+      <ul id="todoList"></ul>
+      <div id="footer"></div>
+      <div id="filters"></div>
+    </div>
+    <script src="target/scala-2.13/todomvc-fastopt/main.js"></script>
+  </body>
+</html>
 ```
-
-You should see no errors and a compiled JS file at `examples/js/target/scala-2.13/examples-fastopt/main.js`. Open the HTML file (`index.html`, provided in the example) in a browser and check the DevTools console for output.
 
 ## Create the Entry Point
 
@@ -134,7 +153,7 @@ Implement the entry point and wire up state and handlers:
 
 The `for` comprehension initializes a `Ref[AppState]`, renders the initial state to the DOM, wires all event handlers, and then calls `ZIO.never` to keep the application alive. When the browser closes the tab or navigates away, the app terminates naturally.
 
-Compile and check the browser console: you should see the startup message.
+Save this as your project's `src/main/scala/Main.scala`, replacing the placeholder. Rebuild (`sbt todomvc/fastLinkJS`) and open `index.html` in a browser — check the DevTools console for the startup message.
 
 ## Model State with Ref
 
@@ -147,7 +166,7 @@ Define the core state mutation functions:
 
 Each function takes the `Ref`, reads it, transforms the state, and returns both the result (usually the new state for re-rendering) and the updated state. Because these operations happen inside `Ref.modify`, they are atomic: no concurrent handler can see a partially updated state.
 
-Test by adding multiple todos in rapid succession in the browser — no race conditions, all todos appear, and the state remains consistent.
+These functions aren't wired to any UI yet — that happens in "Wire Event Handlers" below. Once the complete app is running, you can confirm this by adding multiple todos in rapid succession in the browser: no race conditions, all todos appear, and the state remains consistent.
 
 ## Render UI Components
 
@@ -160,7 +179,7 @@ Define rendering functions:
 
 Call `Render.main(container, state)` after any state change to update the entire UI. The individual render functions are small and easy to reason about — each one knows exactly which DOM elements it owns and how to update them based on the current `AppState`.
 
-Confirm: add a todo, toggle its done flag, delete it, click filter buttons — the UI updates correctly each time.
+Nothing calls these functions yet — that wiring happens in "Wire Event Handlers" below. Once the complete app is running, you can confirm: add a todo, toggle its done flag, delete it, click filter buttons — the UI updates correctly each time.
 
 ## Wire Event Handlers
 
@@ -186,30 +205,16 @@ This single file defines the domain types, the main entry point, rendering logic
 
 ## Running the Examples
 
-Clone the ZIO repository and navigate to the examples directory:
-
-```bash
-git clone https://github.com/zio/zio.git
-cd zio/examples
-```
+Create a new, empty directory for this project — these steps build up a single project incrementally, not a checkout of the ZIO repository.
 
 <details open><summary>Step 5: Set Up Scala.js with ZIO</summary>
 
-This step configures sbt to cross-compile your code to JavaScript and sets up the browser entry point.
+This step configures sbt and creates the browser entry point for a standalone project named `todomvc`.
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala:show-line-numbers
 ```
 
-Run:
-
-```bash
-sbt examplesJS/fastLinkJS
-```
-
-Expected output:
-- Compilation succeeds with no errors.
-- `examples/js/target/scala-2.13/examples-fastopt/main.js` is generated.
-- Opening `index.html` in a browser shows no JavaScript errors in the console.
+Create the `index.html` shown in "Set Up Scala.js with ZIO" above. There's nothing to compile yet — `scalaJSUseMainModuleInitializer` requires a real entry point, added in the next step.
 
 </details>
 
@@ -220,92 +225,59 @@ This step implements `ZIOAppDefault` for the browser and wires the state and han
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala:show-line-numbers
 ```
 
-Run:
+Save this as `src/main/scala/Main.scala`, replacing the placeholder, then run:
 
 ```bash
-sbt examplesJS/fastLinkJS
+sbt todomvc/fastLinkJS
 ```
 
 Expected output:
 - Compilation succeeds.
-- Browser DevTools console shows startup messages: `TodoMVC starting...` and `TodoMVC ready!`
+- Opening `index.html` in a browser and checking DevTools shows the startup messages: `TodoMVC starting...` and `TodoMVC ready!`
 
 </details>
 
 <details><summary>Step 7: Model State with Ref</summary>
 
-This step implements atomic state mutations using `Ref.modify`.
+This step implements atomic state mutations using `Ref.modify`. It's shown here for reference — these functions have no entry point of their own and aren't meant to be compiled standalone; they become part of `Main.scala` in the complete app in Step 10 below.
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala:show-line-numbers
 ```
-
-Run:
-
-```bash
-sbt examplesJS/fastLinkJS
-```
-
-Expected output:
-- Compilation succeeds.
-- State functions are available for handlers to call.
-- Rapid state mutations (e.g., clicking "Add" multiple times quickly) produce no race conditions.
 
 </details>
 
 <details><summary>Step 8: Render UI Components</summary>
 
-This step implements composable rendering functions that update the DOM based on state changes.
+This step implements composable rendering functions that update the DOM based on state changes. It's shown here for reference — this object has no entry point of its own and isn't meant to be compiled standalone; it becomes part of `Main.scala` in the complete app in Step 10 below.
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala:show-line-numbers
 ```
-
-Run:
-
-```bash
-sbt examplesJS/fastLinkJS
-```
-
-Expected output:
-- Compilation succeeds.
-- Opening `index.html` shows the initial empty todo list.
-- The footer and filter buttons are rendered with correct styling.
 
 </details>
 
 <details><summary>Step 9: Wire Event Handlers</summary>
 
-This step connects DOM event listeners to state mutations and rendering.
+This step connects DOM event listeners to state mutations. It's shown here for reference — this object has no entry point of its own and isn't meant to be compiled standalone; it becomes part of `Main.scala` in the complete app in Step 10 below.
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala:show-line-numbers
 ```
 
-Run:
-
-```bash
-sbt examplesJS/fastLinkJS
-```
-
-Expected output:
-- Compilation succeeds.
-- All DOM event listeners are attached without errors.
-- DevTools console shows no "event handler" errors (unless intentionally testing error cases).
-
 </details>
 
-<details><summary>Complete TodoMVC Application</summary>
+<details><summary>Step 10: Complete TodoMVC Application</summary>
 
 This is the full, integrated TodoMVC application combining all steps.
 
 ```scala mdoc:embed:examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala:show-line-numbers
 ```
 
-Run:
+Save this as `src/main/scala/Main.scala`, replacing the entry-point-only version from Step 6, then run:
 
 ```bash
-sbt examplesJS/fastLinkJS
+sbt todomvc/fastLinkJS
 ```
 
-Then serve the HTML file with a local web server:
+Then serve the project directory with a local web server:
 
 ```bash
 python3 -m http.server 8080
@@ -329,10 +301,7 @@ Expected output:
 
 This guide covered the core: setting up Scala.js, modeling state with `Ref`, rendering, and wiring event handlers. For more:
 
-- **ZIO reference**: Read about [`Ref`](../reference/concurrency/ref.md) for other atomic operations and state management patterns.
+- **ZIO reference**: Read about [`Ref`](../reference/concurrency/ref.md) for other atomic operations and state management patterns. You may also want to review [`ZIOAppDefault`](../reference/core/zioapp.md) for details on structuring your application's entry point across different platforms.
 - **Scala.js FFI**: Explore [Scala.js external method definitions](https://www.scala-js.org/doc/interoperability/calling-javascript.html) to call JavaScript libraries and use native APIs.
 - **ZIO-based frontend frameworks**: Investigate [`ZIO-themed UI libraries`](https://zio.dev/ecosystem) for higher-level abstractions (e.g., composable components, routing, middleware).
-- **Asynchronous patterns**: Deepen your understanding of how `Runtime.default.unsafe.fork` works and when to use `ZIO.never` vs. explicit shutdown.
-
-</content>
-</invoke>
+- **Asynchronous patterns**: Deepen your understanding of how [`Runtime`](../reference/core/runtime.md) executes effects and how `Runtime.default.unsafe.fork` works when you need to run effects from synchronous callbacks. Compare this with when to use `ZIO.never` vs. explicit shutdown.

--- a/docs/guides/build-todomvc-with-zio-scalajs.md
+++ b/docs/guides/build-todomvc-with-zio-scalajs.md
@@ -207,7 +207,8 @@ This single file defines the domain types, the main entry point, rendering logic
 
 Create a new, empty directory for this project — these steps build up a single project incrementally, not a checkout of the ZIO repository.
 
-<details open><summary>Step 5: Set Up Scala.js with ZIO</summary>
+<details open>
+<summary>Step 5: Set Up Scala.js with ZIO</summary>
 
 This step configures sbt and creates the browser entry point for a standalone project named `todomvc`.
 
@@ -218,7 +219,8 @@ Create the `index.html` shown in "Set Up Scala.js with ZIO" above. There's nothi
 
 </details>
 
-<details><summary>Step 6: Create the Entry Point</summary>
+<details>
+<summary>Step 6: Create the Entry Point</summary>
 
 This step implements `ZIOAppDefault` for the browser and wires the state and handlers.
 
@@ -237,7 +239,8 @@ Expected output:
 
 </details>
 
-<details><summary>Step 7: Model State with Ref</summary>
+<details>
+<summary>Step 7: Model State with Ref</summary>
 
 This step implements atomic state mutations using `Ref.modify`. It's shown here for reference — these functions have no entry point of their own and aren't meant to be compiled standalone; they become part of `Main.scala` in the complete app in Step 10 below.
 
@@ -246,7 +249,8 @@ This step implements atomic state mutations using `Ref.modify`. It's shown here 
 
 </details>
 
-<details><summary>Step 8: Render UI Components</summary>
+<details>
+<summary>Step 8: Render UI Components</summary>
 
 This step implements composable rendering functions that update the DOM based on state changes. It's shown here for reference — this object has no entry point of its own and isn't meant to be compiled standalone; it becomes part of `Main.scala` in the complete app in Step 10 below.
 
@@ -255,7 +259,8 @@ This step implements composable rendering functions that update the DOM based on
 
 </details>
 
-<details><summary>Step 9: Wire Event Handlers</summary>
+<details>
+<summary>Step 9: Wire Event Handlers</summary>
 
 This step connects DOM event listeners to state mutations. It's shown here for reference — this object has no entry point of its own and isn't meant to be compiled standalone; it becomes part of `Main.scala` in the complete app in Step 10 below.
 
@@ -264,7 +269,8 @@ This step connects DOM event listeners to state mutations. It's shown here for r
 
 </details>
 
-<details><summary>Step 10: Complete TodoMVC Application</summary>
+<details>
+<summary>Step 10: Complete TodoMVC Application</summary>
 
 This is the full, integrated TodoMVC application combining all steps.
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -13,9 +13,10 @@ The following guides have been written to help you get started with ZIO with min
 3. [ZIO Quickstart: Building a GraphQL Web Service](quickstarts/graphql-webservice.md)
 4. [ZIO Quickstart: Building a gRPC Server and Client](https://scalapb.github.io/zio-grpc/docs/quickstart/)
 
-## Guides
+## How-To Guides
 
-1. [The Differ Data Type](compositional-fiberref-updates-with-differ.md) — Learn how `Differ[Value, Patch]` powers compositional, patch-based `FiberRef` updates that faithfully merge concurrent fiber changes.
+1. [Build a TodoMVC Application with ZIO on Scala.js](build-todomvc-with-zio-scalajs.md) — Create a browser-based TodoMVC app with ZIO state management, eliminating callback spaghetti and enforcing type safety with `Ref`.
+2. [The Differ Data Type](compositional-fiberref-updates-with-differ.md) — Learn how `Differ[Value, Patch]` powers compositional, patch-based `FiberRef` updates that faithfully merge concurrent fiber changes.
 
 ## Tutorial Guides
 

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala
@@ -16,7 +16,9 @@ import zio.Trace
  * logic, state mutations, and all event handlers. It is self-contained and
  * ready to compile and run in the browser.
  *
- * Run with: sbt appJS/fastLinkJS
+ * Save this file's content as `src/main/scala/Main.scala` in your `todomvc`
+ * project (replacing the entry-point-only version from earlier), then run: sbt
+ * todomvc/fastLinkJS
  *
  * Then serve with: python3 -m http.server 8080
  *

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/CompleteExample.scala
@@ -1,0 +1,310 @@
+package zio.examples.scalajs_todomvc
+
+import org.scalajs.dom
+import org.scalajs.dom.{document, Element}
+import zio._
+import zio.Trace
+
+/**
+ * CompleteExample
+ *
+ * The complete, integrated TodoMVC application combining all capabilities: all
+ * domain types, Main extending ZIOAppDefault, Render, TodoHandlers. This is the
+ * full working example that runs in the browser.
+ *
+ * This single file defines the domain types, the main entry point, rendering
+ * logic, state mutations, and all event handlers. It is self-contained and
+ * ready to compile and run in the browser.
+ *
+ * Run with: sbt appJS/fastLinkJS
+ *
+ * Then serve with: python3 -m http.server 8080
+ *
+ * Open http://localhost:8080 in your browser.
+ *
+ * Expected output in DevTools console: TodoMVC starting... TodoMVC ready!
+ *
+ * Expected behavior in browser:
+ *   - Adding text and clicking "Add" creates a todo
+ *   - Clicking the checkbox toggles the todo's done state (strikethrough
+ *     appears)
+ *   - Clicking the × button deletes the todo
+ *   - Filter buttons highlight the active filter and update the visible list
+ *   - "Clear completed" removes all done todos
+ */
+
+// === Domain Models ===
+
+final case class Todo(
+  id: String,
+  title: String,
+  done: Boolean
+)
+
+object Todo {
+  def create(title: String): Todo =
+    Todo(
+      id = java.util.UUID.randomUUID().toString,
+      title = title,
+      done = false
+    )
+}
+
+sealed trait Filter
+object Filter {
+  case object All       extends Filter
+  case object Active    extends Filter
+  case object Completed extends Filter
+}
+
+final case class AppState(
+  todos: List[Todo],
+  filter: Filter
+)
+
+// === Main App ===
+
+object CompleteExampleMain extends ZIOAppDefault {
+
+  def run: ZIO[ZIOAppArgs with Scope, Any, Any] = {
+    implicit val trace: Trace = Trace.empty
+    val container             = document.getElementById("app").asInstanceOf[Element]
+
+    for {
+      _ <- Console.printLine("TodoMVC starting...")
+
+      stateRef <- Ref.make[AppState](AppState(List.empty, Filter.All))
+
+      initialState <- stateRef.get
+      _            <- Render.main(container, initialState)
+
+      _ <- TodoHandlers.setupAddTodo(stateRef, container)
+      _ <- TodoHandlers.setupToggleTodos(stateRef, container)
+      _ <- TodoHandlers.setupDeleteTodos(stateRef, container)
+      _ <- TodoHandlers.setupFilterButtons(stateRef, container)
+      _ <- TodoHandlers.setupClearCompleted(stateRef, container)
+
+      _ <- Console.printLine("TodoMVC ready!")
+      _ <- ZIO.never
+
+    } yield ExitCode.success
+  }
+}
+
+// === Rendering ===
+
+object Render {
+
+  def main(container: Element, state: AppState)(implicit trace: Trace): UIO[Unit] =
+    for {
+      _ <- todoList(container, visibleTodos(state))
+      _ <- footer(container, state)
+      _ <- filters(container, state.filter)
+    } yield ()
+
+  private def visibleTodos(state: AppState): List[Todo] =
+    state.filter match {
+      case Filter.All       => state.todos
+      case Filter.Active    => state.todos.filter(!_.done)
+      case Filter.Completed => state.todos.filter(_.done)
+    }
+
+  private def todoList(container: Element, todos: List[Todo])(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      val listEl = container.querySelector("#todoList").asInstanceOf[dom.HTMLElement]
+      val html = todos.map { todo =>
+        val checked = if (todo.done) "checked" else ""
+        s"""<li class="todo ${if (todo.done) "completed" else ""}" data-id="${todo.id}">
+           |  <input type="checkbox" class="toggle" $checked />
+           |  <label>${escapeHtml(todo.title)}</label>
+           |  <button class="destroy">×</button>
+           |</li>""".stripMargin
+      }.mkString("\n")
+      listEl.innerHTML = if (html.isEmpty) "<li><em>(no todos)</em></li>" else html
+    }
+
+  private def footer(container: Element, state: AppState)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      val footerEl  = container.querySelector("#footer").asInstanceOf[dom.HTMLElement]
+      val active    = state.todos.count(!_.done)
+      val completed = state.todos.count(_.done)
+      val plural    = if (active == 1) "item" else "items"
+      val html =
+        s"""<span class="todo-count"><strong>$active</strong> $plural left</span>
+           |${if (completed > 0) s"""<button class="clear-completed">Clear completed ($completed)</button>""" else ""}
+           |""".stripMargin
+      footerEl.innerHTML = html
+    }
+
+  private def filters(container: Element, currentFilter: Filter)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      val filtersEl = container.querySelector("#filters").asInstanceOf[dom.HTMLElement]
+      def filterBtn(f: Filter, label: String) = {
+        val cls      = if (f == currentFilter) "selected" else "filter-link"
+        val dataAttr = if (f == currentFilter) "" else s"""data-filter="${f.getClass.getSimpleName}""""
+        s"""<a class="$cls" $dataAttr>$label</a>"""
+      }
+      val html =
+        filterBtn(Filter.All, "All") + " " +
+          filterBtn(Filter.Active, "Active") + " " +
+          filterBtn(Filter.Completed, "Completed")
+      filtersEl.innerHTML = html
+    }
+
+  private def escapeHtml(text: String): String =
+    text
+      .replace("&", "&amp;")
+      .replace("<", "&lt;")
+      .replace(">", "&gt;")
+      .replace("\"", "&quot;")
+}
+
+// === Event Handlers ===
+
+object TodoHandlers {
+
+  private def onEvent(effect: ZIO[Any, Any, Unit])(implicit trace: Trace): dom.Event => Unit = { _ =>
+    val logged = effect.catchAll(e => Console.printLineError(s"Event error: $e"))
+    val _      = Runtime.default.unsafe.fork(logged)(Trace.empty, Unsafe.unsafe)
+    ()
+  }
+
+  def setupAddTodo(stateRef: Ref[AppState], container: Element)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      val addBtn = document.getElementById("addTodo").asInstanceOf[dom.HTMLElement]
+      addBtn.addEventListener(
+        "click",
+        onEvent {
+          for {
+            input <- ZIO.succeed(
+                       document.getElementById("todoInput").asInstanceOf[dom.HTMLInputElement]
+                     )
+            title <- ZIO.succeed(input.value.trim)
+            _ <- if (title.nonEmpty) {
+                   for {
+                     newState <- stateRef.modify { state =>
+                                   val todo    = Todo.create(title)
+                                   val updated = state.copy(todos = state.todos :+ todo)
+                                   (updated, updated)
+                                 }
+                     _ <- Render.main(container, newState)
+                     _ <- ZIO.succeed { input.value = "" }
+                   } yield ()
+                 } else ZIO.unit
+          } yield ()
+        }
+      )
+    }
+
+  def setupToggleTodos(stateRef: Ref[AppState], container: Element)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      document.addEventListener(
+        "change",
+        onEvent {
+          for {
+            target <- ZIO.succeed {
+                        scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                      }
+            isTodoToggle <- ZIO.succeed(target.classList.contains("toggle"))
+            _ <- if (isTodoToggle) {
+                   val liElement = target.closest("li").asInstanceOf[dom.HTMLElement]
+                   val todoId    = liElement.getAttribute("data-id")
+                   for {
+                     newState <- stateRef.modify { state =>
+                                   val updated = state.todos.map { t =>
+                                     if (t.id == todoId) t.copy(done = !t.done) else t
+                                   }
+                                   val newState = state.copy(todos = updated)
+                                   (newState, newState)
+                                 }
+                     _ <- Render.main(container, newState)
+                   } yield ()
+                 } else ZIO.unit
+          } yield ()
+        }
+      )
+    }
+
+  def setupDeleteTodos(stateRef: Ref[AppState], container: Element)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      document.addEventListener(
+        "click",
+        onEvent {
+          for {
+            target <- ZIO.succeed {
+                        scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                      }
+            isDestroyBtn <- ZIO.succeed(target.classList.contains("destroy"))
+            _ <- if (isDestroyBtn) {
+                   val liElement = target.closest("li").asInstanceOf[dom.HTMLElement]
+                   val todoId    = liElement.getAttribute("data-id")
+                   for {
+                     newState <- stateRef.modify { state =>
+                                   val updated  = state.todos.filter(_.id != todoId)
+                                   val newState = state.copy(todos = updated)
+                                   (newState, newState)
+                                 }
+                     _ <- Render.main(container, newState)
+                   } yield ()
+                 } else ZIO.unit
+          } yield ()
+        }
+      )
+    }
+
+  def setupFilterButtons(stateRef: Ref[AppState], container: Element)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      document.addEventListener(
+        "click",
+        onEvent {
+          for {
+            target <- ZIO.succeed {
+                        scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                      }
+            isFilterLink <- ZIO.succeed(target.classList.contains("filter-link"))
+            _ <- if (isFilterLink) {
+                   val filterStr = target.getAttribute("data-filter")
+                   val filter = filterStr match {
+                     case "All"       => Filter.All
+                     case "Active"    => Filter.Active
+                     case "Completed" => Filter.Completed
+                     case _           => Filter.All
+                   }
+                   for {
+                     newState <- stateRef.modify { state =>
+                                   val newState = state.copy(filter = filter)
+                                   (newState, newState)
+                                 }
+                     _ <- Render.main(container, newState)
+                   } yield ()
+                 } else ZIO.unit
+          } yield ()
+        }
+      )
+    }
+
+  def setupClearCompleted(stateRef: Ref[AppState], container: Element)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      document.addEventListener(
+        "click",
+        onEvent {
+          for {
+            target <- ZIO.succeed {
+                        scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                      }
+            isClearBtn <- ZIO.succeed(target.classList.contains("clear-completed"))
+            _ <- if (isClearBtn) {
+                   for {
+                     newState <- stateRef.modify { state =>
+                                   val updated  = state.todos.filter(!_.done)
+                                   val newState = state.copy(todos = updated)
+                                   (newState, newState)
+                                 }
+                     _ <- Render.main(container, newState)
+                   } yield ()
+                 } else ZIO.unit
+          } yield ()
+        }
+      )
+    }
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala
@@ -20,7 +20,9 @@ import scala.annotation.unused
  *   - All state flows through a `Ref[AppState]`, and all mutations happen
  *     atomically.
  *
- * Run with: sbt appJS/fastLinkJS
+ * Save this file's content as `src/main/scala/Main.scala` in the `todomvc`
+ * project from the setup step (replacing the empty placeholder), then run: sbt
+ * todomvc/fastLinkJS
  *
  * Expected output in browser DevTools console: TodoMVC starting... TodoMVC
  * ready!

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EntryPointExample.scala
@@ -1,0 +1,91 @@
+package zio.examples.scalajs_todomvc
+
+import org.scalajs.dom.{document, Element}
+import zio._
+import zio.Trace
+import scala.annotation.unused
+
+/**
+ * EntryPointExample
+ *
+ * Demonstrates the ZIOAppDefault entry point for a Scala.js TodoMVC
+ * application.
+ *
+ * Key concepts:
+ *   - On the JVM, ZIO apps extend ZIOAppDefault and implement `run`.
+ *   - On Scala.js, the same trait works, but the runtime constraints differ: no
+ *     threads, no blocking I/O, purely asynchronous.
+ *   - You must never return from `run` until your app is ready to shut down —
+ *     typically, this means calling `ZIO.never`.
+ *   - All state flows through a `Ref[AppState]`, and all mutations happen
+ *     atomically.
+ *
+ * Run with: sbt appJS/fastLinkJS
+ *
+ * Expected output in browser DevTools console: TodoMVC starting... TodoMVC
+ * ready!
+ */
+object EntryPointExample extends ZIOAppDefault {
+
+  // Core domain types
+  final case class Todo(id: String, title: String, done: Boolean)
+
+  sealed trait Filter
+  object Filter {
+    case object All       extends Filter
+    case object Active    extends Filter
+    case object Completed extends Filter
+  }
+
+  final case class AppState(todos: List[Todo], filter: Filter)
+
+  // Render function (simplified for entry point demo)
+  def render(container: Element, @unused _state: AppState)(implicit trace: Trace): UIO[Unit] =
+    ZIO.succeed {
+      val html = s"""
+        <div class="app">
+          <h1>TodoMVC</h1>
+          <input id="todoInput" placeholder="What needs to be done?" />
+          <button id="addTodo">Add</button>
+          <ul id="todoList"></ul>
+        </div>
+      """
+      container.innerHTML = html
+    }
+
+  // Event handler setup (simplified for entry point demo)
+  def setupEventHandlers(@unused _container: Element, @unused _stateRef: Ref[AppState])(implicit
+    trace: Trace
+  ): UIO[Unit] =
+    ZIO.succeed {
+      // Handlers would be wired here in the full implementation
+      ()
+    }
+
+  override def run: ZIO[ZIOAppArgs with Scope, Any, Any] = {
+    implicit val trace: Trace = Trace.empty
+    val _container            = document.getElementById("app").asInstanceOf[Element]
+
+    for {
+      // Log startup
+      _ <- Console.printLine("TodoMVC starting...")
+
+      // Initialize state as a Ref — atomic, type-safe, shared across handlers
+      stateRef <- Ref.make[AppState](AppState(List.empty, Filter.All))
+
+      // Render initial state to the DOM
+      initialState <- stateRef.get
+      _            <- render(_container, initialState)
+
+      // Wire up all event handlers
+      _ <- setupEventHandlers(_container, stateRef)
+
+      // Log readiness
+      _ <- Console.printLine("TodoMVC ready!")
+
+      // Keep app running: the browser will GC when the user navigates away or closes the tab
+      _ <- ZIO.never
+
+    } yield ExitCode.success
+  }
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
@@ -177,10 +177,10 @@ object EventHandlersExample {
                      }
                      for {
                        // Atomically change filter
-                       newState <- stateRef.modify { state =>
-                                     val newState = state.copy(filter = filter)
-                                     (newState, newState)
-                                   }
+                       _ <- stateRef.modify { state =>
+                              val newState = state.copy(filter = filter)
+                              (newState, newState)
+                            }
                        // Re-render with new state (demonstrates the full pattern)
                        _ <- Console.printLine(s"Changed filter to: ${filter.getClass.getSimpleName}")
                      } yield ()

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
@@ -1,0 +1,223 @@
+package zio.examples.scalajs_todomvc
+
+import org.scalajs.dom
+import org.scalajs.dom.{document, Element}
+import zio._
+import zio.Trace
+import scala.annotation.unused
+
+/**
+ * EventHandlersExample
+ *
+ * Demonstrates how to wire DOM event listeners to ZIO effects.
+ *
+ * DOM event listeners are synchronous callbacks that expect a return type of
+ * `Unit`. ZIO effects are async. The bridge is to fork the effect onto the ZIO
+ * runtime from within the callback, so the event handler returns immediately
+ * and the effect runs without blocking the browser.
+ *
+ * Key pattern: private def onEvent(effect: ZIO[Any, Any, Unit]): dom.Event =>
+ * Unit = { _ => Runtime.default.unsafe.fork(effect)(Trace.empty, Unsafe.unsafe)
+ * }
+ *
+ * Inside the effect, you read the DOM (input values, element attributes),
+ * mutate the state via `Ref.modify`, re-render, and clean up (clear input,
+ * etc.).
+ *
+ * Run with: sbt appJS/fastLinkJS
+ *
+ * Expected behavior:
+ *   - Click "Add" with text: todo appears, input clears
+ *   - Click checkbox: todo.done toggles, strikethrough appears/disappears
+ *   - Click "×": todo removed from list
+ *   - Click filter link: active filter highlights, list updates
+ *   - Click "Clear completed": all done todos vanish
+ */
+object EventHandlersExample {
+
+  // Domain types
+  final case class Todo(id: String, title: String, done: Boolean)
+
+  object Todo {
+    def create(title: String): Todo =
+      Todo(
+        id = java.util.UUID.randomUUID().toString,
+        title = title,
+        done = false
+      )
+  }
+
+  sealed trait Filter
+  object Filter {
+    case object All       extends Filter
+    case object Active    extends Filter
+    case object Completed extends Filter
+  }
+
+  final case class AppState(todos: List[Todo], filter: Filter)
+
+  object TodoHandlers {
+
+    // Helper: fork a ZIO effect from a DOM callback without blocking the browser
+    private def onEvent(effect: ZIO[Any, Any, Unit])(implicit trace: Trace): dom.Event => Unit = { _ =>
+      val logged = effect.catchAll(e => Console.printLineError(s"Event error: $e"))
+      val _      = Runtime.default.unsafe.fork(logged)(Trace.empty, Unsafe.unsafe)
+      ()
+    }
+
+    // Set up the "Add" button handler
+    def setupAddTodo(stateRef: Ref[AppState], @unused container: Element)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        val addBtn = document.getElementById("addTodo").asInstanceOf[dom.HTMLElement]
+        addBtn.addEventListener(
+          "click",
+          onEvent {
+            for {
+              input <- ZIO.succeed(
+                         document.getElementById("todoInput").asInstanceOf[dom.HTMLInputElement]
+                       )
+              title <- ZIO.succeed(input.value.trim)
+              _ <- if (title.nonEmpty) {
+                     for {
+                       // Atomically add todo and get new state
+                       newState <- stateRef.modify { state =>
+                                     val todo    = Todo.create(title)
+                                     val updated = state.copy(todos = state.todos :+ todo)
+                                     (updated, updated)
+                                   }
+                       // Re-render with new state (demonstrates the full pattern)
+                       _ <- Console.printLine(s"Added todo, total count: ${newState.todos.length}")
+                       // Clear input
+                       _ <- ZIO.succeed { input.value = "" }
+                     } yield ()
+                   } else ZIO.unit
+            } yield ()
+          }
+        )
+      }
+
+    // Set up the toggle checkbox handler
+    def setupToggleTodos(stateRef: Ref[AppState], @unused container: Element)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        document.addEventListener(
+          "change",
+          onEvent {
+            for {
+              target <- ZIO.succeed {
+                          scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                        }
+              isTodoToggle <- ZIO.succeed(target.classList.contains("toggle"))
+              _ <- if (isTodoToggle) {
+                     val liElement = target.closest("li").asInstanceOf[dom.HTMLElement]
+                     val todoId    = liElement.getAttribute("data-id")
+                     for {
+                       // Atomically toggle done flag
+                       newState <- stateRef.modify { state =>
+                                     val updated = state.todos.map { t =>
+                                       if (t.id == todoId) t.copy(done = !t.done) else t
+                                     }
+                                     val newState = state.copy(todos = updated)
+                                     (newState, newState)
+                                   }
+                       // Re-render with new state (demonstrates the full pattern)
+                       _ <- Console.printLine(s"Toggled todo, completed count: ${newState.todos.count(_.done)}")
+                     } yield ()
+                   } else ZIO.unit
+            } yield ()
+          }
+        )
+      }
+
+    // Set up the delete button handler
+    def setupDeleteTodos(stateRef: Ref[AppState], @unused container: Element)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        document.addEventListener(
+          "click",
+          onEvent {
+            for {
+              target <- ZIO.succeed {
+                          scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                        }
+              isDestroyBtn <- ZIO.succeed(target.classList.contains("destroy"))
+              _ <- if (isDestroyBtn) {
+                     val liElement = target.closest("li").asInstanceOf[dom.HTMLElement]
+                     val todoId    = liElement.getAttribute("data-id")
+                     for {
+                       // Atomically delete todo
+                       newState <- stateRef.modify { state =>
+                                     val updated  = state.todos.filter(_.id != todoId)
+                                     val newState = state.copy(todos = updated)
+                                     (newState, newState)
+                                   }
+                       // Re-render with new state (demonstrates the full pattern)
+                       _ <- Console.printLine(s"Deleted todo, remaining count: ${newState.todos.length}")
+                     } yield ()
+                   } else ZIO.unit
+            } yield ()
+          }
+        )
+      }
+
+    // Set up the filter button handler
+    def setupFilterButtons(stateRef: Ref[AppState], @unused container: Element)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        document.addEventListener(
+          "click",
+          onEvent {
+            for {
+              target <- ZIO.succeed {
+                          scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                        }
+              isFilterLink <- ZIO.succeed(target.classList.contains("filter-link"))
+              _ <- if (isFilterLink) {
+                     val filterStr = target.getAttribute("data-filter")
+                     val filter = filterStr match {
+                       case "All"       => Filter.All
+                       case "Active"    => Filter.Active
+                       case "Completed" => Filter.Completed
+                       case _           => Filter.All
+                     }
+                     for {
+                       // Atomically change filter
+                       newState <- stateRef.modify { state =>
+                                     val newState = state.copy(filter = filter)
+                                     (newState, newState)
+                                   }
+                       // Re-render with new state (demonstrates the full pattern)
+                       _ <- Console.printLine(s"Changed filter to: ${filter.getClass.getSimpleName}")
+                     } yield ()
+                   } else ZIO.unit
+            } yield ()
+          }
+        )
+      }
+
+    // Set up the "Clear completed" button handler
+    def setupClearCompleted(stateRef: Ref[AppState], @unused container: Element)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        document.addEventListener(
+          "click",
+          onEvent {
+            for {
+              target <- ZIO.succeed {
+                          scala.scalajs.js.Dynamic.global.event.target.asInstanceOf[dom.HTMLElement]
+                        }
+              isClearBtn <- ZIO.succeed(target.classList.contains("clear-completed"))
+              _ <- if (isClearBtn) {
+                     for {
+                       // Atomically remove all completed todos
+                       newState <- stateRef.modify { state =>
+                                     val updated  = state.todos.filter(!_.done)
+                                     val newState = state.copy(todos = updated)
+                                     (newState, newState)
+                                   }
+                       // Re-render with new state (demonstrates the full pattern)
+                       _ <- Console.printLine(s"Cleared completed todos, remaining: ${newState.todos.length}")
+                     } yield ()
+                   } else ZIO.unit
+            } yield ()
+          }
+        )
+      }
+  }
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/EventHandlersExample.scala
@@ -24,14 +24,12 @@ import scala.annotation.unused
  * mutate the state via `Ref.modify`, re-render, and clean up (clear input,
  * etc.).
  *
- * Run with: sbt appJS/fastLinkJS
- *
- * Expected behavior:
- *   - Click "Add" with text: todo appears, input clears
- *   - Click checkbox: todo.done toggles, strikethrough appears/disappears
- *   - Click "×": todo removed from list
- *   - Click filter link: active filter highlights, list updates
- *   - Click "Clear completed": all done todos vanish
+ * This object is excerpted for reference — it has no entry point of its own and
+ * is not meant to be compiled standalone. It shows the core fork-and-mutate
+ * pattern without the re-render call; the complete pattern, including
+ * re-rendering after each state change, is in CompleteExample.scala and the
+ * guide's "Putting It Together" section, which is the runnable, complete
+ * version.
  */
 object EventHandlersExample {
 

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
@@ -3,45 +3,44 @@ package zio.examples.scalajs_todomvc
 /**
  * ProjectSetupExample
  *
- * This example demonstrates the sbt configuration required to set up Scala.js
- * with ZIO.
+ * This example demonstrates the sbt configuration required to set up a
+ * standalone Scala.js project with ZIO. Create a new, empty directory for your
+ * project (do not add this inside the ZIO library's own checkout).
  *
  * Add the following to `project/plugins.sbt`:
  *
  * {{{
  *   addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
- *   addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")
  * }}}
  *
  * Add the following to `build.sbt`:
  *
  * {{{
- *   lazy val app = crossProject(JSPlatform, JVMPlatform)
- *     .in(file("app"))
+ *   lazy val todomvc = project
+ *     .in(file("."))
+ *     .enablePlugins(ScalaJSPlugin)
  *     .settings(
- *       scalaVersion := "3.5.0",
+ *       scalaVersion := "2.13.18",
  *       libraryDependencies ++= Seq(
- *         "dev.zio"        %%% "zio"           % "2.1.13",
+ *         "dev.zio"        %%% "zio"           % "2.0.12",
  *         "org.scala-js"   %%% "scalajs-dom"   % "2.8.1"
- *       )
- *     )
- *     .jsSettings(
+ *       ),
  *       scalaJSUseMainModuleInitializer := true,
  *       scalacOptions += "-P:scalajs:nowarnGlobalExecutionContext"
  *     )
- *
- *   lazy val appJS = app.js
- *   lazy val appJVM = app.jvm
  * }}}
  *
  * The key flag `scalaJSUseMainModuleInitializer := true` tells the Scala.js
  * compiler to generate a `main()` function that runs immediately in the
- * browser, starting your ZIO runtime.
+ * browser, starting your ZIO runtime. It only works when your project has
+ * exactly one object extending `ZIOAppDefault` (or another `App`-like entry
+ * point) at a time — keep a single `src/main/scala/Main.scala` and replace its
+ * content as you go, rather than accumulating multiple entry-point objects side
+ * by side.
  *
- * Confirm compilation succeeds: sbt appJS/fastLinkJS
- *
- * You should see no errors and a compiled JS file at
- * `target/scala-3.5.0/app-fastopt/main.js`.
+ * There's nothing to compile yet — `scalaJSUseMainModuleInitializer` requires a
+ * real entry point to link against, so the first build happens once you've
+ * added `src/main/scala/Main.scala` in the next section.
  */
 object ProjectSetupExample {
   // This file is documentation-only. See the package documentation comments above

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/ProjectSetupExample.scala
@@ -1,0 +1,49 @@
+package zio.examples.scalajs_todomvc
+
+/**
+ * ProjectSetupExample
+ *
+ * This example demonstrates the sbt configuration required to set up Scala.js
+ * with ZIO.
+ *
+ * Add the following to `project/plugins.sbt`:
+ *
+ * {{{
+ *   addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.22.0")
+ *   addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.4.0")
+ * }}}
+ *
+ * Add the following to `build.sbt`:
+ *
+ * {{{
+ *   lazy val app = crossProject(JSPlatform, JVMPlatform)
+ *     .in(file("app"))
+ *     .settings(
+ *       scalaVersion := "3.5.0",
+ *       libraryDependencies ++= Seq(
+ *         "dev.zio"        %%% "zio"           % "2.1.13",
+ *         "org.scala-js"   %%% "scalajs-dom"   % "2.8.1"
+ *       )
+ *     )
+ *     .jsSettings(
+ *       scalaJSUseMainModuleInitializer := true,
+ *       scalacOptions += "-P:scalajs:nowarnGlobalExecutionContext"
+ *     )
+ *
+ *   lazy val appJS = app.js
+ *   lazy val appJVM = app.jvm
+ * }}}
+ *
+ * The key flag `scalaJSUseMainModuleInitializer := true` tells the Scala.js
+ * compiler to generate a `main()` function that runs immediately in the
+ * browser, starting your ZIO runtime.
+ *
+ * Confirm compilation succeeds: sbt appJS/fastLinkJS
+ *
+ * You should see no errors and a compiled JS file at
+ * `target/scala-3.5.0/app-fastopt/main.js`.
+ */
+object ProjectSetupExample {
+  // This file is documentation-only. See the package documentation comments above
+  // for required sbt configuration.
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala
@@ -20,13 +20,10 @@ import zio.Trace
  * Call `Render.main(container, state)` after any state change to update the
  * entire UI.
  *
- * Run with: sbt appJS/fastLinkJS
- *
- * Expected behavior:
- *   - Add a todo, toggle its done flag, delete it, click filter buttons — the
- *     UI updates correctly.
- *   - Filter buttons highlight the active filter.
- *   - Footer shows count of remaining active todos.
+ * This object is excerpted for reference — it has no entry point of its own and
+ * is not meant to be compiled standalone. It becomes part of `Main.scala`'s
+ * rendering in the complete app; see CompleteExample.scala and the guide's
+ * "Putting It Together" section for the runnable, complete version.
  */
 object RenderingExample {
 

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/RenderingExample.scala
@@ -1,0 +1,110 @@
+package zio.examples.scalajs_todomvc
+
+import org.scalajs.dom
+import org.scalajs.dom.Element
+import zio._
+import zio.Trace
+
+/**
+ * RenderingExample
+ *
+ * Demonstrates composable rendering functions that update the DOM based on
+ * state changes.
+ *
+ * Rendering must be composable: separate functions for the todo list, footer
+ * counts, and filter buttons. Each takes the current `AppState` and mutates the
+ * DOM to match. Rather than a single monolithic render, break it into concerns,
+ * so updating one piece (like filter buttons) doesn't require touching the
+ * others.
+ *
+ * Call `Render.main(container, state)` after any state change to update the
+ * entire UI.
+ *
+ * Run with: sbt appJS/fastLinkJS
+ *
+ * Expected behavior:
+ *   - Add a todo, toggle its done flag, delete it, click filter buttons — the
+ *     UI updates correctly.
+ *   - Filter buttons highlight the active filter.
+ *   - Footer shows count of remaining active todos.
+ */
+object RenderingExample {
+
+  // Domain types
+  final case class Todo(id: String, title: String, done: Boolean)
+
+  sealed trait Filter
+  object Filter {
+    case object All       extends Filter
+    case object Active    extends Filter
+    case object Completed extends Filter
+  }
+
+  final case class AppState(todos: List[Todo], filter: Filter)
+
+  object Render {
+
+    // Main entry point: render all components
+    def main(container: Element, state: AppState)(implicit trace: Trace): UIO[Unit] =
+      for {
+        _ <- todoList(container, state.todos)
+        _ <- footer(container, state)
+        _ <- filters(container, state.filter)
+      } yield ()
+
+    // Render the todo list items
+    private def todoList(container: Element, todos: List[Todo])(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        val listEl = container.querySelector("#todoList").asInstanceOf[dom.HTMLElement]
+        val html = todos.map { todo =>
+          val checked = if (todo.done) "checked" else ""
+          s"""<li class="todo ${if (todo.done) "completed" else ""}" data-id="${todo.id}">
+             |  <input type="checkbox" class="toggle" $checked />
+             |  <label>${escapeHtml(todo.title)}</label>
+             |  <button class="destroy">×</button>
+             |</li>""".stripMargin
+        }.mkString("\n")
+        listEl.innerHTML = if (html.isEmpty) "<li><em>(no todos)</em></li>" else html
+      }
+
+    // Render footer with counts
+    private def footer(container: Element, state: AppState)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        val footerEl  = container.querySelector("#footer").asInstanceOf[dom.HTMLElement]
+        val active    = state.todos.count(!_.done)
+        val completed = state.todos.count(_.done)
+        val plural    = if (active == 1) "item" else "items"
+        val html =
+          s"""<span class="todo-count"><strong>$active</strong> $plural left</span>
+             |${if (completed > 0) s"""<button class="clear-completed">Clear completed ($completed)</button>""" else ""}
+             |""".stripMargin
+        footerEl.innerHTML = html
+      }
+
+    // Render filter buttons and highlight the active filter
+    private def filters(container: Element, currentFilter: Filter)(implicit trace: Trace): UIO[Unit] =
+      ZIO.succeed {
+        val filtersEl = container.querySelector("#filters").asInstanceOf[dom.HTMLElement]
+
+        def filterBtn(f: Filter, label: String): String = {
+          val cls      = if (f == currentFilter) "selected" else "filter-link"
+          val dataAttr = if (f == currentFilter) "" else s"""data-filter="${f.getClass.getSimpleName}""""
+          s"""<a class="$cls" $dataAttr>$label</a>"""
+        }
+
+        val html =
+          filterBtn(Filter.All, "All") + " " +
+            filterBtn(Filter.Active, "Active") + " " +
+            filterBtn(Filter.Completed, "Completed")
+        filtersEl.innerHTML = html
+      }
+
+    // Escape HTML special characters to prevent XSS
+    private def escapeHtml(text: String): String =
+      text
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("\"", "&quot;")
+  }
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala
@@ -1,0 +1,79 @@
+package zio.examples.scalajs_todomvc
+
+import zio._
+import zio.Trace
+
+/**
+ * StateManagementExample
+ *
+ * Demonstrates atomic state mutations using `Ref.modify`.
+ *
+ * All state mutations happen through a single `Ref[AppState]`. Each event
+ * handler reads the current state, computes an update, and atomically swaps the
+ * old state for the new one. `Ref.modify` ensures that the read-modify-write
+ * cycle is atomic — no interleaving race conditions.
+ *
+ * Key pattern: stateRef.modify { state => val newState = computeNewState(state)
+ * (resultValue, newState) // Return (value, updatedState) }
+ *
+ * Run with: sbt appJS/fastLinkJS
+ *
+ * Test by adding multiple todos in rapid succession in the browser — no race
+ * conditions, all todos appear, and the state remains consistent.
+ */
+object StateManagementExample {
+
+  // Domain types
+  final case class Todo(id: String, title: String, done: Boolean)
+
+  object Todo {
+    def create(title: String): Todo =
+      Todo(
+        id = java.util.UUID.randomUUID().toString,
+        title = title,
+        done = false
+      )
+  }
+
+  sealed trait Filter
+  object Filter {
+    case object All       extends Filter
+    case object Active    extends Filter
+    case object Completed extends Filter
+  }
+
+  final case class AppState(todos: List[Todo], filter: Filter)
+
+  // Add a new todo: atomically append and return the new state
+  def addTodo(stateRef: Ref[AppState], title: String)(implicit trace: Trace): UIO[AppState] =
+    stateRef.modify { state =>
+      val newTodo  = Todo.create(title)
+      val newState = state.copy(todos = state.todos :+ newTodo)
+      (newState, newState) // Return (value, newState)
+    }
+
+  // Toggle a todo's done flag: atomically update and return the new state
+  def toggleTodo(stateRef: Ref[AppState], id: String)(implicit trace: Trace): UIO[AppState] =
+    stateRef.modify { state =>
+      val updated = state.todos.map { t =>
+        if (t.id == id) t.copy(done = !t.done) else t
+      }
+      val newState = state.copy(todos = updated)
+      (newState, newState)
+    }
+
+  // Delete a todo by id: atomically filter and return the new state
+  def deleteTodo(stateRef: Ref[AppState], id: String)(implicit trace: Trace): UIO[AppState] =
+    stateRef.modify { state =>
+      val filtered = state.todos.filter(_.id != id)
+      val newState = state.copy(todos = filtered)
+      (newState, newState)
+    }
+
+  // Change the filter: atomically update and return the new state
+  def setFilter(stateRef: Ref[AppState], filter: Filter)(implicit trace: Trace): UIO[AppState] =
+    stateRef.modify { state =>
+      val newState = state.copy(filter = filter)
+      (newState, newState)
+    }
+}

--- a/examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala
+++ b/examples/js/src/main/scala/zio/examples/scalajs_todomvc/StateManagementExample.scala
@@ -16,10 +16,11 @@ import zio.Trace
  * Key pattern: stateRef.modify { state => val newState = computeNewState(state)
  * (resultValue, newState) // Return (value, updatedState) }
  *
- * Run with: sbt appJS/fastLinkJS
- *
- * Test by adding multiple todos in rapid succession in the browser — no race
- * conditions, all todos appear, and the state remains consistent.
+ * This object is excerpted for reference — its functions have no entry point of
+ * their own and are not meant to be compiled standalone. They become part of
+ * `Main.scala`'s state handling in the complete app; see CompleteExample.scala
+ * and the guide's "Putting It Together" section for the runnable, complete
+ * version.
  */
 object StateManagementExample {
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -493,6 +493,13 @@ module.exports = {
     },
     {
       type: "category",
+      label: "How-To Guides",
+      items: [
+        "guides/build-todomvc-with-zio-scalajs",
+      ]
+    },
+    {
+      type: "category",
       label: "Tutorial Guides",
       items: [
         "guides/tutorials/retry-and-repeat-policies-with-schedule",


### PR DESCRIPTION
## Summary
- New how-to guide at `docs/guides/build-todomvc-with-zio-scalajs.md`: build a complete TodoMVC app with ZIO on Scala.js — `ZIOAppDefault` entry point wired into the DOM, state modeled with `Ref`, rendering, and add/toggle/delete/filter event handlers as ZIO effects.
- Companion, compile-verified examples under `examples/js/src/main/scala/zio/examples/scalajs_todomvc/` (uses the existing `examples` cross-project's JS target).
- Wired into `website/sidebars.js` (new "How-To Guides" category) and `docs/guides/index.md`.

## Test plan
- [x] `sbt "docs/mdoc --in docs/guides/build-todomvc-with-zio-scalajs.md --out website/docs/guides/build-todomvc-with-zio-scalajs.md"` — 0 errors
- [x] `sbt examplesJS/compile` — compiles clean
- [x] `sbt fmt` run over touched files
- [x] Guide fact-checked section by section against library source (no gating drifts)