### PR TITLE
docs(canfail): remove stale ZStreamChunk section

### DIFF
--- a/docs/canfail.md
+++ b/docs/canfail.md
@@ -55,13 +55,6 @@ Code | Rewrite
 `ustream.mapError(f)` | `ustream`
 `ustream.orElse(zstream)` | `ustream`
 
-## ZStreamChunk
-
-Code | Rewrite 
---- | ---
-`ustream.either` | `ustream`
-`ustream.orElse(zstream)` | `ustream`
-
 ## (*) Notes:
 
 - `either`, `option`, `orElseEither`, and `retryOrElseEither` wrap their results in `Some` or `Right` so after rewriting, code calling these methods can be simplified to accept an `A` rather than an `Option[A]` or `Either[E, A]`. 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,7 +18,7 @@ In this page we are going to answer general questions related to the ZIO project
 ## Where should we encode contextual values like `UserId`, `CorrelationId` in my ZIO application?
 
 1. Should we put `CorrelationId` and `UserId` as well into a `FiberLocal`?
-2. Should our effects be something like `val someEffect: ZIO[CorrerlationId & UserId, ErrorType, A]`?
+2. Should our effects be something like `val someEffect: ZIO[CorrelationId & UserId, ErrorType, A]`?
 3. Should we keep writing our effects with explicit params as `def someEffect(c: CorrelationId, u: UserId, params...): ZIO[Any, ErrorType, A]`?
 4. Should we put these context parameters as implicits, like `def someEffect(params..)(implicit c: CorrelationId, u: UserId): ZIO[Any, ErrorType, A]`?
 


### PR DESCRIPTION
## Summary
- Remove the `ZStreamChunk` rewrite table from `docs/canfail.md`. `ZStreamChunk` was a ZIO 1.x type with no equivalent in the current codebase, so the section was stale and misleading.
- Test PR for the new Netlify deploy-preview comment flow (new comment per push, older ones marked outdated).

## Test plan
- [ ] Preview deploys and a comment appears with URL, deploy time, commit link.
- [ ] Push a follow-up commit, confirm a new comment appears and the previous one is marked as outdated.