### PR TITLE
make Semaphore 3.5x to 16x faster

### DIFF
--- a/benchmarks/src/main/scala/zio/SemaphoreContendedBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphoreContendedBenchmark.scala
@@ -1,0 +1,96 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Measures `withPermit` with real suspended fibers, in the regime where permits
+ * are scarcer than fibers so that most acquisitions have to queue.
+ *
+ * This exists because `SemaphorePermitBenchmark` is too noisy to resolve
+ * changes to the contended path: its 10-fiber rows come back with error bars
+ * around 20%, which is wider than any plausible improvement. Three things are
+ * done differently here:
+ *
+ *   - The effect each fiber runs is built once in `@Setup` rather than inside
+ *     the measured op. `repeat(n)` chains `n` effects with `*>`, so building it
+ *     per op allocated on the order of a thousand `FlatMap` nodes per fiber and
+ *     put that allocation, and the GC it caused, inside the measurement.
+ *   - The semaphore is created once per trial rather than per op, so the op is
+ *     acquire/release traffic rather than construction.
+ *   - The guarded effect is a counter increment rather than a `Blackhole`
+ *     consume, so the body is a few nanoseconds and what dominates is the
+ *     acquire/release pair and the suspension it causes.
+ *
+ * What remains inside the op is forking the fibers and joining them, which
+ * cannot be hoisted: the contention being measured only exists while several
+ * fibers are running at once. [[baseline]] measures exactly that much with the
+ * semaphore removed, so the difference is what acquisition costs.
+ *
+ * Run this with at least 5 forks. The remaining variance is between forks
+ * rather than within them -- how the JIT and the scheduler happen to settle for
+ * a given JVM -- so iterations do not damp it but forks do. At `-f 2` the
+ * single-permit row lands around 16% error, at `-f 5` around 2%:
+ *
+ * {{{
+ * benchmarks/jmh:run -f 5 -wi 10 -i 10 zio.SemaphoreContendedBenchmark
+ * }}}
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(2)
+class SemaphoreContendedBenchmark {
+
+  /** Fibers competing for the semaphore. */
+  @Param(Array("10"))
+  var fibers: Int = _
+
+  /** Permits available; below `fibers`, so most acquisitions have to queue. */
+  @Param(Array("1", "2", "5"))
+  var permits: Int = _
+
+  /** Acquisitions per fiber per op. */
+  final val ops: Int = 1000
+
+  /**
+   * Incremented by the guarded effect so that neither the body nor the
+   * acquisition can be optimised away, and read in `@TearDown` so the counter
+   * itself stays live.
+   */
+  private[this] val counter = new AtomicLong(0L)
+
+  private var withSem: List[ZIO[Any, Nothing, Unit]]    = _
+  private var withoutSem: List[ZIO[Any, Nothing, Unit]] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    val sem  = unsafeRun(Semaphore.make(permits.toLong))
+    val body = ZIO.succeed(counter.incrementAndGet()).unit
+
+    withSem = List.fill(fibers)(repeat(ops)(sem.withPermit(body)))
+    withoutSem = List.fill(fibers)(repeat(ops)(body))
+  }
+
+  @TearDown(Level.Trial)
+  def tearDown(): Unit =
+    if (counter.get() == 0L) throw new AssertionError("benchmark body never ran")
+
+  /** Fibers contending for `permits` permits. */
+  @Benchmark
+  def contended(): Unit =
+    unsafeRun(ZIO.forkAll(withSem).flatMap(_.join).unit)
+
+  /**
+   * The same fibers over the same number of effects with no semaphore: the
+   * floor imposed by forking, scheduling and joining alone.
+   */
+  @Benchmark
+  def baseline(): Unit =
+    unsafeRun(ZIO.forkAll(withoutSem).flatMap(_.join).unit)
+}

--- a/benchmarks/src/main/scala/zio/SemaphoreDrainBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphoreDrainBenchmark.scala
@@ -1,0 +1,32 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.internal.SemaphorePlatform
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Measures the uncontended acquire/release pair on `SemaphorePlatform`
+ * directly, with no fiber runtime in the way, so that the cost of the release
+ * path itself is visible.
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(2)
+class SemaphoreDrainBenchmark {
+
+  var sem: SemaphorePlatform = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = sem = new SemaphorePlatform(1L, true)
+
+  @Benchmark
+  def acquireRelease(): Boolean = {
+    val ok = sem.tryAcquire(1L)
+    sem.release(1L)
+    ok
+  }
+}

--- a/benchmarks/src/main/scala/zio/SemaphoreDrainQueuedBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphoreDrainQueuedBenchmark.scala
@@ -1,0 +1,50 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.internal.SemaphorePlatform
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Measures the acquire/release pair while the waiter queue is non-empty, so
+ * that `drain` actually reaches the drain lock rather than stopping at its
+ * empty-queue early-out.
+ *
+ * `SemaphoreDrainBenchmark` leaves the queue empty, so `drain` returns at
+ * `waiters.peek() eq null` and never touches the lock or the request counter.
+ * That makes it blind to changes in the locking protocol, which is what this
+ * benchmark exists to expose.
+ *
+ * A single waiter asking for more permits than the semaphore will ever hold
+ * keeps the queue occupied for the whole run without ever being granted, so
+ * each release walks the full drain path and finds nothing to hand out.
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(2)
+class SemaphoreDrainQueuedBenchmark {
+
+  var sem: SemaphorePlatform = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    sem = new SemaphorePlatform(1L, fair = false)
+    // Unsatisfiable: pins the queue non-empty without ever being granted.
+    sem.enqueue(1000L)
+    ()
+  }
+
+  /**
+   * Unfair mode, so `tryAcquire` still succeeds despite the queued waiter and
+   * the pair stays symmetric; the release then runs the full drain.
+   */
+  @Benchmark
+  def acquireRelease(): Boolean = {
+    val ok = sem.tryAcquire(1L)
+    sem.release(1L)
+    ok
+  }
+}

--- a/benchmarks/src/main/scala/zio/SemaphoreFastPathBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphoreFastPathBenchmark.scala
@@ -1,0 +1,143 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+import zio.BenchmarkUtil._
+import zio.internal.SemaphorePlatform
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Isolates the interpreter cost of an uncontended `withPermit`, which is what
+ * any attempt to shorten the fast path has to move.
+ *
+ * ==Why a separate benchmark==
+ *
+ * [[SemaphorePermitBenchmark]] at `fibers = 1` already measures an uncontended
+ * acquisition, but it forks a fiber and joins it around every thousand
+ * acquisitions. Forking and joining cost far more than one acquisition does, so
+ * a change worth a few percent per acquisition is hard to see there. This runs
+ * the chain directly on the calling thread's fiber, so the measured region is
+ * the acquisitions and nothing else.
+ *
+ * ==What the rows separate==
+ *
+ * Profiling the uncontended path attributes its RUNNABLE time to the run loop
+ * rather than to the semaphore: the dispatch loop takes about 22% of samples,
+ * the two stack-unwind loops about 11% between them, and no `SemaphorePlatform`
+ * frame appears at all. The cost is the interpreter nodes `withPermits` builds,
+ * so the rows here are chosen to price those nodes individually:
+ *
+ *   - [[withPermit]] is the thing being optimized.
+ *   - [[baseline]] is the same body with no semaphore: the floor.
+ *   - [[maskOnly]] is `uninterruptibleMask` plus `restore` around the body,
+ *     with no semaphore at all. The difference from [[baseline]] is what the
+ *     two `UpdateRuntimeFlagsWithin` nodes cost.
+ *   - [[exitWithOnly]] is `exitWith` around the body. The difference from
+ *     [[baseline]] is what one `FoldCauseZIO` frame plus its `Exit` allocation
+ *     costs.
+ *   - [[acquireReleaseOnly]] calls `tryAcquire`/`release` directly inside a
+ *     single `ZIO.succeed`, with no mask and no fold. This is the semaphore
+ *     work with none of the effect graph around it, so `withPermit -
+ *     acquireReleaseOnly` is the whole of what the interpreter adds.
+ *
+ * Together those bracket the change: a fused acquire/body/release node should
+ * move [[withPermit]] toward the sum of [[baseline]] and
+ * [[acquireReleaseOnly]], and leave the control rows alone.
+ *
+ * ==What it measured when it was written==
+ *
+ * On 16 Xeon 8168 cores under Linux, JDK 25, at `-f 5 -wi 8 -i 5`, converting
+ * each row to nanoseconds per acquisition and subtracting the baseline:
+ *
+ * {{{
+ * baseline (body only)     3599 ops/s    27.8 ns/acq        -
+ * acquireReleaseOnly       2589 ops/s    38.6 ns/acq    +10.8   semaphore work
+ * exitWithOnly             2340 ops/s    42.7 ns/acq    +14.9   fold + Exit
+ * maskOnly                 1310 ops/s    76.3 ns/acq    +48.5   the two flag nodes
+ * withPermit                844 ops/s   118.4 ns/acq    +90.7   all of it
+ * }}}
+ *
+ * So the `uninterruptibleMask` and its `restore` are 54% of what guarding
+ * costs, against 16% for the `exitWith` fold and 12% for the semaphore's own
+ * CAS and release. The parts sum to 74.3ns against 90.7ns measured; the
+ * residual is interaction, more live frames and more dispatch iterations.
+ *
+ * That ordering is the point of this benchmark: it says to attack the flag
+ * nodes first, which is not where the effort would naturally go.
+ *
+ * ==Running it==
+ *
+ * {{{
+ * benchmarks/jmh:run -f 5 -wi 8 -i 5 zio.SemaphoreFastPathBenchmark
+ * }}}
+ *
+ * The same warning as the other semaphore benchmarks applies: absolute figures
+ * move between machines and sessions, so take the rows a conclusion rests on in
+ * one session, back to back. The deltas above are what should reproduce, not
+ * the ops/s.
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 8, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(5)
+class SemaphoreFastPathBenchmark {
+
+  /**
+   * Acquisitions per measured operation. Large enough that the fixed cost of
+   * `unsafeRun` is amortized away, small enough that one operation stays short.
+   */
+  val ops: Int = 10000
+
+  private var withPermitChain: ZIO[Any, Nothing, Unit]     = _
+  private var baselineChain: ZIO[Any, Nothing, Unit]       = _
+  private var maskChain: ZIO[Any, Nothing, Unit]           = _
+  private var exitWithChain: ZIO[Any, Nothing, Unit]       = _
+  private var acquireReleaseChain: ZIO[Any, Nothing, Unit] = _
+
+  @Setup(Level.Trial)
+  def setup(bh: Blackhole): Unit = {
+    val body = ZIO.succeed(bh.consume(1))
+
+    val sem = unsafeRun(Semaphore.make(1L))
+    withPermitChain = repeat(ops)(sem.withPermit(body))
+
+    baselineChain = repeat(ops)(body)
+    maskChain = repeat(ops)(ZIO.uninterruptibleMask(restore => restore(body)))
+    exitWithChain = repeat(ops)(body.exitWith(exit => exit))
+
+    // The semaphore's own work with no effect graph around it: one node total.
+    // Uses `SemaphorePlatform` directly, as the drain benchmarks do, rather
+    // than widening `Semaphore`'s API for a benchmark's sake.
+    val platform = new SemaphorePlatform(1L, true)
+    acquireReleaseChain = repeat(ops) {
+      ZIO.succeed {
+        val acquired = platform.tryAcquire(1L)
+        try bh.consume(1)
+        finally if (acquired) platform.release(1L)
+      }
+    }
+  }
+
+  /** The path being optimized: an uncontended `withPermit`. */
+  @Benchmark
+  def withPermit(): Unit = unsafeRun(withPermitChain)
+
+  /** The body alone. Everything above this is what guarding costs. */
+  @Benchmark
+  def baseline(): Unit = unsafeRun(baselineChain)
+
+  /** The two `UpdateRuntimeFlagsWithin` nodes, without the semaphore. */
+  @Benchmark
+  def maskOnly(): Unit = unsafeRun(maskChain)
+
+  /** One `FoldCauseZIO` frame and its `Exit`, without the semaphore. */
+  @Benchmark
+  def exitWithOnly(): Unit = unsafeRun(exitWithChain)
+
+  /** The acquire/release pair with no mask and no fold around it. */
+  @Benchmark
+  def acquireReleaseOnly(): Unit = unsafeRun(acquireReleaseChain)
+}

--- a/benchmarks/src/main/scala/zio/SemaphorePermitBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/SemaphorePermitBenchmark.scala
@@ -1,0 +1,197 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import org.openjdk.jmh.infra.Blackhole
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Semaphore => JSemaphore}
+
+/**
+ * Compares ZIO's `Semaphore` against `java.util.concurrent.Semaphore` across
+ * the uncontended (`fibers <= permits`) and contended (`fibers > permits`)
+ * regimes.
+ *
+ * See https://github.com/zio/zio/issues/9093.
+ *
+ * ==Reading the Java rows==
+ *
+ * The two implementations do fundamentally different things when a permit is
+ * not available. ZIO's suspends the *fiber* and frees the carrier thread;
+ * `java.util.concurrent.Semaphore` parks the *thread*. That makes a direct
+ * comparison sensitive to how the Java one is driven, so both framings are
+ * measured here and they answer different questions:
+ *
+ *   - [[javaSemaphoreThreads]] and [[javaSemaphoreThreadsUnfair]] run it the
+ *     way it is meant to be run, on plain threads with no runtime involved.
+ *     These are the honest targets: what the same hardware can do with a mature
+ *     semaphore and no fibers. Both policies are measured because #9093 names
+ *     the unfair one specifically, and under contention they are far apart --
+ *     at ten threads over one permit, barging is worth about 5x.
+ *   - [[javaSemaphoreOnFibers]] calls it from inside a fiber, which is what
+ *     application code would be doing if it reached for the Java class instead
+ *     of ZIO's. Blocking a scheduler worker there is the thing ZIO's semaphore
+ *     exists to avoid, and this row shows what it costs.
+ *
+ * An earlier version of this benchmark had only the second framing and
+ * presented it as "Java's semaphore", which made ZIO's look far worse than it
+ * is: at 10 fibers and 1 permit, the fiber-blocking framing measures several
+ * times *slower* than ZIO's semaphore, not faster.
+ *
+ * ==Notes on the harness==
+ *
+ * The effects each fiber runs, and the semaphores themselves, are built in
+ * `@Setup`. `repeat(n)` chains `n` effects with `*>`, so building it inside the
+ * measured operation allocated on the order of a thousand `FlatMap` nodes per
+ * fiber per op and put that allocation, and the GC it caused, inside the
+ * measurement.
+ *
+ * The guarded effect is `ZIO.succeed(bh.consume(1))` rather than
+ * `Exit.succeed(bh.consume(1))`: `Exit.succeed` takes its argument by value, so
+ * the latter consumed the blackhole once when the effect was constructed and
+ * then guarded a constant.
+ *
+ * ==Running it==
+ *
+ * The full `@Param` sweep at the annotated settings is 12 combinations across
+ * four benchmarks and takes over an hour. For iterating on a change, name the
+ * benchmarks and pin the parameters:
+ *
+ * {{{
+ * // ~4 minutes, +/-4% on the contended row
+ * benchmarks/jmh:run -f 5 -wi 8 -i 4 -p fibers=10 -p permits=1 \
+ *   zio.SemaphorePermitBenchmark.zioSemaphore \
+ *   zio.SemaphorePermitBenchmark.javaSemaphoreThreads
+ * }}}
+ *
+ * Three things govern precision here, and only one of them is obvious:
+ *
+ *   - '''Forks matter.''' The variance is between forks rather than within
+ *     them, so measurement iterations do not damp it. At `-f 2` the
+ *     10-fiber/1-permit row carries around 16% error; at `-f 5`, around 3%.
+ *   - '''Warmup matters more than measurement.''' Dropping to `-wi 3 -i 3`
+ *     takes this row from about 4% error to 23%, while `-wi 8 -i 4` holds 4%
+ *     and costs less than half the time of `-wi 10 -i 10`. Trim measurement
+ *     iterations before warmup ones.
+ *   - '''Between-session variance dwarfs both.''' The error bars above describe
+ *     spread within one session and say nothing about reproducibility across
+ *     them. The same `javaSemaphoreThreadsUnfair` rows, on the same machine and
+ *     the same commit, have differed by nearly 40% between sessions -- far
+ *     outside any single session's error -- with machine state, thermal
+ *     conditions, background load and JDK all in play. The practical
+ *     consequence: '''figures from different sessions are not comparable''', so
+ *     take every row a conclusion rests on -- ZIO and Java, before and after --
+ *     in one session, back to back. A number carried over from an earlier run
+ *     will silently misstate a comparison by more than most changes being
+ *     measured are worth.
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(5)
+class SemaphorePermitBenchmark {
+
+  @Param(Array("1", "2", "5", "10"))
+  var fibers: Int = _
+
+  @Param(Array("1", "2", "5"))
+  var permits: Int = _
+
+  val ops: Int = 1000
+
+  private var fair: List[ZIO[Any, Nothing, Unit]]     = _
+  private var unfair: List[ZIO[Any, Nothing, Unit]]   = _
+  private var onFibers: List[ZIO[Any, Nothing, Unit]] = _
+  private var javaLock: JSemaphore                    = _
+  private var javaUnfairLock: JSemaphore              = _
+
+  /**
+   * Every row acquires and releases a semaphore that was created once, before
+   * measurement. Construction is not what is being compared, and creating one
+   * per operation would put an allocation and its initialisation into the
+   * measured region for some rows and not others.
+   */
+  @Setup(Level.Trial)
+  def setup(bh: Blackhole): Unit = {
+    val body = ZIO.succeed(bh.consume(1))
+
+    val fairSem = unsafeRun(Semaphore.make(permits.toLong))
+    fair = List.fill(fibers)(repeat(ops)(fairSem.withPermit(body)))
+
+    val unfairSem = unsafeRun(Semaphore.makeUnfair(permits.toLong))
+    unfair = List.fill(fibers)(repeat(ops)(unfairSem.withPermit(body)))
+
+    javaLock = new JSemaphore(permits, true)
+    javaUnfairLock = new JSemaphore(permits, false)
+    onFibers = List.fill(fibers)(repeat(ops) {
+      ZIO.succeed {
+        javaLock.acquire()
+        try bh.consume(1)
+        finally javaLock.release()
+      }
+    })
+  }
+
+  @Benchmark
+  def zioSemaphore(): Unit =
+    unsafeRun(ZIO.forkAll(fair).flatMap(_.join).unit)
+
+  @Benchmark
+  def zioSemaphoreUnfair(): Unit =
+    unsafeRun(ZIO.forkAll(unfair).flatMap(_.join).unit)
+
+  /**
+   * `java.util.concurrent.Semaphore` on plain threads, with no runtime in the
+   * way: what this hardware can do when nothing has to suspend a fiber.
+   *
+   * The threads are started and joined inside the measured operation, which is
+   * the counterpart of the fiber rows forking and joining inside theirs. It is
+   * not an even trade -- an OS thread costs far more to start than a fiber --
+   * so this row understates the Java semaphore somewhat, and the gap it shows
+   * should be read as a lower bound on what a thread-parking implementation can
+   * do.
+   */
+  @Benchmark
+  def javaSemaphoreThreads(bh: Blackhole): Unit =
+    driveThreads(javaLock, bh)
+
+  /**
+   * The same on an unfair `java.util.concurrent.Semaphore`.
+   *
+   * This is the target named by the second goal of #9093, and it is a much
+   * harder one than the fair row under contention: barging lets a thread take a
+   * permit that was just released without going through the queue at all, which
+   * at ten threads over one permit is worth about 5x over the fair policy.
+   */
+  @Benchmark
+  def javaSemaphoreThreadsUnfair(bh: Blackhole): Unit =
+    driveThreads(javaUnfairLock, bh)
+
+  private def driveThreads(lock: JSemaphore, bh: Blackhole): Unit = {
+    val threads = (1 to fibers).map { _ =>
+      val thread = new Thread(() => {
+        var i = 0
+        while (i < ops) {
+          lock.acquire()
+          try bh.consume(1)
+          finally lock.release()
+          i += 1
+        }
+      })
+      thread.start()
+      thread
+    }
+    threads.foreach(_.join())
+  }
+
+  /**
+   * `java.util.concurrent.Semaphore` acquired from inside a fiber, which parks
+   * the carrier thread. Included to show the cost of that, not as the target to
+   * beat.
+   */
+  @Benchmark
+  def javaSemaphoreOnFibers(): Unit =
+    unsafeRun(ZIO.forkAll(onFibers).flatMap(_.join).unit)
+}

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -317,6 +317,74 @@ object SemaphoreSpec extends ZIOBaseSpec {
         quiescent <- sem.available.repeatUntil(_ == 2L)
       } yield assertTrue(queued == 0L, taken.isEmpty, quiescent == 2L)
     } @@ timeout(10.seconds),
+    test("releasing a permit inline does not change the releasing fiber's identity") {
+      // A contended release resumes the granted waiter on the releasing
+      // fiber's own thread. That runs the waiter's run loop inside this
+      // fiber's stack, so the `currentFiber` thread-local has to be restored
+      // afterwards; if it is not, this fiber's `FiberRef.asThreadLocal`
+      // accesses would silently read and write the woken fiber's state.
+      // The check has to run inside the releasing fiber in the step right
+      // after the release, since the thread-local is re-established for a
+      // fiber whenever its own drain resumes it.
+      val test = for {
+        sem      <- Semaphore.make(1L)
+        latch    <- Promise.make[Nothing, Unit]
+        held     <- Promise.make[Nothing, Unit]
+        reported <- Promise.make[Nothing, (Option[FiberId], FiberId)]
+        holder <- (for {
+                    self <- ZIO.descriptor.map(_.id)
+                    _    <- sem.withPermit(held.succeed(()) *> latch.await)
+                    seen <- ZIO.succeed(Unsafe.unsafe(implicit unsafe => Fiber.currentFiber().map(_.id)))
+                    _    <- reported.succeed((seen, self))
+                  } yield ()).fork
+        _ <- held.await
+        // Queued behind the holder, so releasing the permit must wake it.
+        waiter <- sem.withPermit(ZIO.unit).fork
+        _      <- sem.awaiting.repeatUntil(_ == 1)
+        _      <- latch.succeed(())
+        _      <- holder.join
+        _      <- waiter.join
+        result <- reported.await
+      } yield assertTrue(result._1.forall(_ == result._2))
+
+      test.provideLayer(Runtime.enableCurrentFiber)
+    } @@ timeout(10.seconds),
+    test("releasing a permit inline preserves identity when the woken fiber changes its flags") {
+      // The inline resume saves and restores `currentFiber` unconditionally,
+      // rather than reading the woken fiber's `CurrentFiber` flag to decide.
+      // Those are two different fibers' flags, and the woken one may change
+      // its own while it runs here: `patchRuntimeFlagsOnly` points the
+      // thread-local at the fiber that enables the flag, so a gated restore
+      // would be deciding on a flag that no longer describes what it is
+      // restoring. Here the woken fiber toggles the flag inside the guarded
+      // body while the releasing fiber holds it enabled throughout.
+      val test = for {
+        sem      <- Semaphore.make(1L)
+        held     <- Promise.make[Nothing, Unit]
+        latch    <- Promise.make[Nothing, Unit]
+        reported <- Promise.make[Nothing, (Option[FiberId], FiberId)]
+        holder <- (for {
+                    self <- ZIO.descriptor.map(_.id)
+                    _    <- sem.withPermit(held.succeed(()) *> latch.await)
+                    seen <- ZIO.succeed(Unsafe.unsafe(implicit unsafe => Fiber.currentFiber().map(_.id)))
+                    _    <- reported.succeed((seen, self))
+                  } yield ()).fork
+        _ <- held.await
+        waiter <- sem
+                    .withPermit(
+                      ZIO.unit.withRuntimeFlags(RuntimeFlags.disable(RuntimeFlag.CurrentFiber)) *>
+                        ZIO.unit.withRuntimeFlags(RuntimeFlags.enable(RuntimeFlag.CurrentFiber))
+                    )
+                    .fork
+        _      <- sem.awaiting.repeatUntil(_ == 1)
+        _      <- latch.succeed(())
+        _      <- holder.join
+        _      <- waiter.join
+        result <- reported.await
+      } yield assertTrue(result._1.forall(_ == result._2))
+
+      test.provideLayer(Runtime.enableCurrentFiber)
+    } @@ timeout(10.seconds),
     suite("unfair")(
       test("available reports the free permits even while a fiber is waiting") {
         for {

--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -1,5 +1,6 @@
 package zio
 
+import zio.internal.SemaphorePlatform
 import zio.test.Assertion._
 import zio.test.TestAspect._
 import zio.test._
@@ -78,6 +79,73 @@ object SemaphoreSpec extends ZIOBaseSpec {
         result == Exit.fail("exception")
       )
     },
+    test("tryWithPermits releases permits if interrupted at the acquisition boundary") {
+      // The interrupt has to land after the permits are taken but before the
+      // guarded effect starts running, so race it against the acquisition at a
+      // range of offsets rather than waiting for the effect to signal.
+      def attempt(yields: Int) =
+        for {
+          sem   <- Semaphore.make(2L)
+          fiber <- sem.tryWithPermits(2L)(ZIO.never).fork
+          _     <- ZIO.yieldNow.repeatN(yields)
+          _     <- fiber.interrupt
+          // Deadlocks instead of completing if the permits were not returned.
+          _       <- sem.withPermits(2L)(ZIO.unit)
+          permits <- sem.available
+        } yield permits
+
+      ZIO
+        .foreach(0 to 8)(yields => ZIO.foreach(1 to 20)(_ => attempt(yields)))
+        .map(results => assertTrue(results.flatten.forall(_ == 2L)))
+    } @@ timeout(30.seconds),
+    test("withPermits releases permits if interrupted on the uncontended fast path") {
+      // `withPermits` takes its permits with a bare CAS when they are free,
+      // ahead of any suspension. If that CAS were to run while the fiber is
+      // still interruptible, an interrupt landing between it and the
+      // installation of the release would lose the permits permanently. Race
+      // an interrupt against the acquisition at a range of offsets.
+      def attempt(yields: Int) =
+        for {
+          sem   <- Semaphore.make(2L)
+          fiber <- sem.withPermits(2L)(ZIO.never).fork
+          _     <- ZIO.yieldNow.repeatN(yields)
+          _     <- fiber.interrupt
+          // Deadlocks instead of completing if the permits were not returned.
+          _       <- sem.withPermits(2L)(ZIO.unit)
+          permits <- sem.available
+        } yield permits
+
+      ZIO
+        .foreach(0 to 8)(yields => ZIO.foreach(1 to 20)(_ => attempt(yields)))
+        .map(results => assertTrue(results.flatten.forall(_ == 2L)))
+    } @@ timeout(30.seconds),
+    test("withPermitsScoped releases permits if interrupted on the uncontended fast path") {
+      def attempt(yields: Int) =
+        for {
+          sem     <- Semaphore.make(2L)
+          fiber   <- ZIO.scoped(sem.withPermitsScoped(2L) *> ZIO.never).fork
+          _       <- ZIO.yieldNow.repeatN(yields)
+          _       <- fiber.interrupt
+          _       <- sem.withPermits(2L)(ZIO.unit)
+          permits <- sem.available
+        } yield permits
+
+      ZIO
+        .foreach(0 to 8)(yields => ZIO.foreach(1 to 20)(_ => attempt(yields)))
+        .map(results => assertTrue(results.flatten.forall(_ == 2L)))
+    } @@ timeout(30.seconds),
+    test("withPermits body remains interruptible on the uncontended fast path") {
+      // The fast path must not leak the acquisition's uninterruptible region
+      // into the guarded effect.
+      for {
+        sem     <- Semaphore.make(1L)
+        started <- Promise.make[Nothing, Unit]
+        fiber   <- sem.withPermits(1L)(started.succeed(()) *> ZIO.never).fork
+        _       <- started.await
+        _       <- fiber.interrupt
+        permits <- sem.available
+      } yield assertTrue(permits == 1L)
+    },
     test("awaiting returns the count of waiting fibers") {
       for {
         semaphore    <- Semaphore.make(1)
@@ -87,6 +155,223 @@ object SemaphoreSpec extends ZIOBaseSpec {
         _            <- promise.succeed(())
         waitingEnd   <- semaphore.awaiting.repeatUntil(_ == 0)
       } yield assertTrue(waitingStart == 10, waitingEnd == 0)
-    } @@ timeout(10.seconds)
+    } @@ timeout(10.seconds),
+    test("cancelled waiters do not accumulate behind a blocked head waiter") {
+      // The head waiter asks for more permits than will ever be free, so it
+      // never leaves the queue and tombstones are never reaped by reaching the
+      // head. Every waiter behind it is then cancelled, as interruption does.
+      val sem = new SemaphorePlatform(1L, fair = true)
+      ZIO.succeed {
+        val head = sem.enqueue(2L)
+        var i    = 0
+        while (i < 10000) {
+          sem.cancel(sem.enqueue(1L))
+          i += 1
+        }
+        (sem.queueSize(), sem.awaiting(), head)
+      }.map { case (queued, awaiting, head) =>
+        assertTrue(
+          // Bounded by the sweep threshold rather than growing with the number
+          // of cancellations.
+          queued < 100L,
+          // Only the blocked head waiter is still live.
+          awaiting == 1L,
+          !head.isDone
+        )
+      }
+    },
+    test("awaiting is unaffected by cancelled waiters") {
+      val sem = new SemaphorePlatform(0L, fair = true)
+      ZIO.succeed {
+        val kept      = List.fill(3)(sem.enqueue(1L))
+        val cancelled = List.fill(5)(sem.enqueue(1L))
+        cancelled.foreach(sem.cancel)
+        val afterCancel = sem.awaiting()
+        kept.foreach(sem.cancel)
+        (afterCancel, sem.awaiting())
+      }.map { case (afterCancel, afterAll) =>
+        assertTrue(afterCancel == 3L, afterAll == 0L)
+      }
+    },
+    test("waiters interrupted behind a blocked head waiter are eventually reaped") {
+      for {
+        sem <- Semaphore.make(2L)
+        // Holds one permit forever, so a waiter for two permits can never be
+        // satisfied and pins the head of the queue.
+        held    <- Promise.make[Nothing, Unit]
+        holder  <- sem.withPermit(held.succeed(()) *> ZIO.never).fork
+        _       <- held.await
+        blocked <- sem.withPermits(2L)(ZIO.unit).fork
+        _       <- sem.awaiting.repeatUntil(_ == 1)
+        _ <- ZIO.foreachDiscard(1 to 200) { _ =>
+               sem.withPermit(ZIO.never).fork.flatMap(_.interrupt)
+             }
+        // Every interrupted fiber has left, so only the blocked waiter remains.
+        awaiting <- sem.awaiting.repeatUntil(_ == 1)
+        _        <- blocked.interrupt
+        _        <- holder.interrupt
+        permits  <- sem.available
+      } yield assertTrue(awaiting == 1L, permits == 2L)
+    } @@ timeout(30.seconds),
+    test("permits are released when the effect fails") {
+      for {
+        sem     <- Semaphore.make(2L)
+        _       <- sem.withPermits(2L)(ZIO.fail("boom")).exit
+        permits <- sem.available
+      } yield assertTrue(permits == 2L)
+    },
+    test("withPermits(0) does not consume permits") {
+      for {
+        sem     <- Semaphore.make(1L)
+        result  <- sem.withPermits(0L)(sem.withPermit(ZIO.succeed(42)))
+        permits <- sem.available
+      } yield assertTrue(result == 42, permits == 1L)
+    },
+    test("withPermits fails if requested permits is negative") {
+      for {
+        sem <- Semaphore.make(3L)
+        ans <- sem.withPermits(-1L)(ZIO.unit).exit
+      } yield assert(ans)(dies(isSubtype[IllegalArgumentException](anything)))
+    },
+    test("a waiter requesting more permits than are free waits until enough are released") {
+      for {
+        sem    <- Semaphore.make(2L)
+        latch  <- Promise.make[Nothing, Unit]
+        held   <- Promise.make[Nothing, Unit]
+        fiber1 <- sem.withPermit(held.succeed(()) *> latch.await).fork
+        _      <- held.await
+        fiber2 <- sem.withPermits(2L)(ZIO.unit).fork
+        _      <- sem.awaiting.repeatUntil(_ == 1)
+        _      <- latch.succeed(())
+        _      <- fiber1.join
+        _      <- fiber2.join
+        // Both fibers have finished, so all permits must have been returned
+        permits <- sem.available
+      } yield assertTrue(permits == 2L)
+    } @@ timeout(10.seconds),
+    test("interrupting a waiting fiber does not lose the permits it was granted") {
+      for {
+        sem   <- Semaphore.make(1L)
+        held  <- Promise.make[Nothing, Unit]
+        latch <- Promise.make[Nothing, Unit]
+        // Holds the only permit until `latch` completes
+        holder <- sem.withPermit(held.succeed(()) *> latch.await).fork
+        _      <- held.await
+        // Queues up behind the holder, then is interrupted while waiting
+        waiter <- sem.withPermit(ZIO.unit).fork
+        _      <- sem.awaiting.repeatUntil(_ == 1)
+        _      <- waiter.interrupt
+        _      <- latch.succeed(())
+        _      <- holder.join
+        // Whether the waiter was interrupted before or after being granted the
+        // permit, the permit must end up back in the semaphore
+        permits <- sem.available.repeatUntil(_ == 1L)
+      } yield assertTrue(permits == 1L)
+    } @@ timeout(10.seconds),
+    test("permits are conserved under concurrent acquisition and interruption") {
+      val n = 50
+      for {
+        sem     <- Semaphore.make(4L)
+        fibers  <- ZIO.foreach(1 to n)(_ => sem.withPermits(2L)(ZIO.yieldNow).fork)
+        _       <- ZIO.foreachDiscard(fibers.take(n / 2))(_.interrupt)
+        _       <- ZIO.foreachDiscard(fibers)(_.await)
+        permits <- sem.available.repeatUntil(_ == 4L)
+      } yield assertTrue(permits == 4L)
+    } @@ timeout(30.seconds),
+    test("a fair semaphore grants permits in the order they were requested") {
+      val n = 20
+      for {
+        sem   <- Semaphore.make(1L)
+        held  <- Promise.make[Nothing, Unit]
+        latch <- Promise.make[Nothing, Unit]
+        order <- Ref.make(Chunk.empty[Int])
+        // Take the only permit so that everyone below has to queue up
+        holder <- sem.withPermit(held.succeed(()) *> latch.await).fork
+        _      <- held.await
+        // Fork the contenders one at a time, waiting until each is queued, so
+        // that their arrival order at the semaphore is deterministic
+        fibers <- ZIO.foreach(1 to n) { i =>
+                    for {
+                      fiber <- sem.withPermit(order.update(_ :+ i)).fork
+                      _     <- sem.awaiting.repeatUntil(_ == i)
+                    } yield fiber
+                  }
+        _      <- latch.succeed(())
+        _      <- holder.join
+        _      <- ZIO.foreachDiscard(fibers)(_.join)
+        result <- order.get
+      } yield assertTrue(result == Chunk.fromIterable(1 to n))
+    } @@ timeout(30.seconds),
+    test("available reports 0 while a fiber is waiting for more permits than are free") {
+      for {
+        sem <- Semaphore.make(2L)
+        // Queues up for 5 permits, which this semaphore can never satisfy. The
+        // 2 free permits are now reserved for this fiber, and in fair mode no
+        // other fiber may take them, so none are available.
+        waiter <- sem.withPermits(5L)(ZIO.unit).fork
+        _      <- sem.awaiting.repeatUntil(_ == 1)
+        queued <- sem.available
+        taken  <- sem.tryWithPermit(ZIO.unit)
+        // Once the waiter gives up, the permits are up for grabs again
+        _         <- waiter.interrupt
+        quiescent <- sem.available.repeatUntil(_ == 2L)
+      } yield assertTrue(queued == 0L, taken.isEmpty, quiescent == 2L)
+    } @@ timeout(10.seconds),
+    suite("unfair")(
+      test("available reports the free permits even while a fiber is waiting") {
+        for {
+          sem <- Semaphore.makeUnfair(2L)
+          // Queues up for 5 permits, which this semaphore can never satisfy.
+          // Barging is allowed here, so the 2 free permits really are up for
+          // grabs and are reported as available.
+          waiter    <- sem.withPermits(5L)(ZIO.unit).fork
+          _         <- sem.awaiting.repeatUntil(_ == 1)
+          queued    <- sem.available
+          taken     <- sem.tryWithPermits(2L)(ZIO.unit)
+          _         <- waiter.interrupt
+          quiescent <- sem.available.repeatUntil(_ == 2L)
+        } yield assertTrue(queued == 2L, taken.isDefined, quiescent == 2L)
+      } @@ timeout(10.seconds),
+      test("acquires and releases permits") {
+        for {
+          sem     <- Semaphore.makeUnfair(2L)
+          result  <- sem.withPermits(2L)(ZIO.succeed(42))
+          permits <- sem.available
+        } yield assertTrue(result == 42, permits == 2L)
+      },
+      test("waiting fibers are eventually granted permits") {
+        for {
+          sem     <- Semaphore.makeUnfair(1L)
+          held    <- Promise.make[Nothing, Unit]
+          latch   <- Promise.make[Nothing, Unit]
+          holder  <- sem.withPermit(held.succeed(()) *> latch.await).fork
+          _       <- held.await
+          waiter  <- sem.withPermit(ZIO.succeed(42)).fork
+          _       <- sem.awaiting.repeatUntil(_ == 1)
+          _       <- latch.succeed(())
+          _       <- holder.join
+          result  <- waiter.join
+          permits <- sem.available
+        } yield assertTrue(result == 42, permits == 1L)
+      } @@ timeout(10.seconds),
+      test("withPermit automatically releases the permit if the effect is interrupted") {
+        for {
+          promise   <- Promise.make[Nothing, Unit]
+          semaphore <- Semaphore.makeUnfair(1)
+          effect     = semaphore.withPermit(promise.succeed(()) *> ZIO.never)
+          fiber     <- effect.fork
+          _         <- promise.await
+          _         <- fiber.interrupt
+          permits   <- semaphore.available
+        } yield assertTrue(permits == 1L)
+      },
+      test("permits are conserved under concurrent acquisition") {
+        for {
+          sem     <- Semaphore.makeUnfair(4L)
+          _       <- ZIO.foreachParDiscard(1 to 50)(_ => sem.withPermits(2L)(ZIO.yieldNow))
+          permits <- sem.available
+        } yield assertTrue(permits == 4L)
+      } @@ timeout(30.seconds)
+    )
   ) @@ exceptJS(nonFlaky)
 }

--- a/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/ZScheduler.scala
@@ -62,6 +62,29 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
   override private[zio] def isCurrentThreadInExecutor: Boolean =
     Thread.currentThread().isInstanceOf[ZScheduler.Worker]
 
+  /**
+   * The current thread's worker, but only when this scheduler owns it. A worker
+   * of some other `ZScheduler` is not a thread this scheduler may run anything
+   * on, and its inline budget is not this scheduler's to spend.
+   */
+  private[this] def ownWorkerOrNull(): ZScheduler.Worker = {
+    val worker = workerOrNull()
+    if ((worker ne null) && (worker.scheduler eq parent)) worker else null
+  }
+
+  override private[zio] def claimInlineExecution(): Boolean = {
+    val worker = ownWorkerOrNull()
+    if ((worker ne null) && worker.inlineExecutions < ZScheduler.MaxInlineExecutions) {
+      worker.inlineExecutions += 1
+      true
+    } else false
+  }
+
+  override private[zio] def releaseInlineExecution(): Unit = {
+    val worker = ownWorkerOrNull()
+    if (worker ne null) worker.inlineExecutions -= 1
+  }
+
   def metrics(implicit unsafe: Unsafe): Option[ExecutionMetrics] = {
     val metrics = new ExecutionMetrics {
       def capacity: Int =
@@ -282,6 +305,7 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
     new ZScheduler.Worker {
       self =>
       override val submittedLocations: ZScheduler.Locations = makeLocations()
+      override val scheduler: AnyRef                        = parent
 
       final override def run(): Unit = {
         // Store parent mutable object references in stack memory to avoid fetching it from the heap every time
@@ -464,6 +488,22 @@ private final class ZScheduler(autoBlocking: Boolean) extends Executor { parent 
 private object ZScheduler {
   private val poolSize = java.lang.Runtime.getRuntime.availableProcessors
 
+  /**
+   * How deep a chain of inline fiber executions may go on one worker before
+   * further fibers are handed back to the run queue.
+   *
+   * Each level costs a fixed handful of stack frames, not a run loop's worth:
+   * `runLoop` iterates rather than recursing, and `MaxDepthBeforeTrampoline`
+   * separately bounds what recursion it does by moving the continuation to the
+   * fiber's inbox. What this limit protects is the worker: a thread that runs
+   * an unbounded chain of other fibers' work is not serving its own run queue
+   * meanwhile. Measured on a semaphore passing one permit between ten fibers,
+   * where the chains are as deep as anything is likely to make them: a limit of
+   * 8 gives up almost all of the benefit, while 128 recovers most of what an
+   * unbounded chain achieves.
+   */
+  private final val MaxInlineExecutions = 128
+
   def markCurrentWorkerAsBlocking(): Unit = {
     val worker = workerOrNull()
     if (worker ne null) {
@@ -539,6 +579,19 @@ private object ZScheduler {
     val submittedLocations: Locations
 
     /**
+     * The scheduler that owns this worker.
+     *
+     * Several checks only ask whether the current thread is a `Worker` at all,
+     * which is not the same question as whether it is one of *this*
+     * scheduler's: more than one `ZScheduler` can be alive at once, since
+     * `Executor.makeDefault` builds a fresh one and the default runtime already
+     * adds a second for blocking work. Running a fiber on a worker belonging to
+     * a different scheduler would escape the executor it was locked to, so the
+     * inline path identifies the owner rather than the type.
+     */
+    val scheduler: AnyRef
+
+    /**
      * Whether this worker is currently active.
      */
     @volatile
@@ -578,6 +631,18 @@ private object ZScheduler {
     @volatile
     var opCount: Long =
       0L
+
+    /**
+     * How many fibers are currently being run inline on this worker's stack,
+     * one nested inside the next.
+     *
+     * Only ever read and written by this worker's own thread, so it needs no
+     * synchronization. It lives here rather than in a `ThreadLocal` because
+     * this is precisely per-worker state, and the scheduler already keeps its
+     * other per-worker bookkeeping in these fields.
+     */
+    var inlineExecutions: Int =
+      0
 
     def markAsBlocking(): Unit
 

--- a/core/shared/src/main/scala/zio/Executor.scala
+++ b/core/shared/src/main/scala/zio/Executor.scala
@@ -88,6 +88,29 @@ abstract class Executor extends ExecutorPlatformSpecific { self =>
    */
   private[zio] def isCurrentThreadInExecutor: Boolean =
     false
+
+  /**
+   * Claims permission to run a fiber inline on the calling thread, returning
+   * `true` if it was granted.
+   *
+   * A fiber resumed inline runs until it suspends or finishes, and whatever it
+   * does may resume further fibers on the same stack, so the nesting has to be
+   * bounded somewhere. The bound belongs to the thread rather than to any
+   * fiber: the chain spans several different fibers, and what is being limited
+   * is the depth of one call stack.
+   *
+   * Every claim that returns `true` must be matched by a
+   * [[releaseInlineExecution]] in a `finally`. The default refuses, so an
+   * executor that does not track this simply never runs fibers inline.
+   */
+  private[zio] def claimInlineExecution(): Boolean =
+    false
+
+  /**
+   * Releases a claim taken by [[claimInlineExecution]].
+   */
+  private[zio] def releaseInlineExecution(): Unit =
+    ()
 }
 
 object Executor extends DefaultExecutors with Serializable {

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -155,11 +155,14 @@ object Semaphore {
       else if (n == 0L) zio
       else
         ZIO.uninterruptibleMask { restore =>
-          val body =
-            restore(zio).exitWith { exit =>
-              state.release(n)
-              exit
-            }
+          // The release is installed as an `OnExitEffect` continuation rather
+          // than an `exitWith`. Both run the release on every exit path, but
+          // `exitWith` compiles to a `FoldCauseZIO` frame and allocates an
+          // `Exit` on the success path in order to hand the exit to a closure
+          // that never reads it. This pushes a frame and calls a function.
+          // Measured at about 15ns per acquisition on the uncontended path,
+          // against a total guarding cost there of about 90ns.
+          val body = ZIO.OnExitEffect(trace, restore(zio), () => state.release(n))
 
           if (state.tryAcquire(n)) body
           else enqueueAndAwait(n, restore).flatMap(_ => body)

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -154,19 +154,28 @@ object Semaphore {
       if (n < 0L) die(n)
       else if (n == 0L) zio
       else
-        ZIO.uninterruptibleMask { restore =>
-          // The release is installed as an `OnExitEffect` continuation rather
-          // than an `exitWith`. Both run the release on every exit path, but
-          // `exitWith` compiles to a `FoldCauseZIO` frame and allocates an
-          // `Exit` on the success path in order to hand the exit to a closure
-          // that never reads it. This pushes a frame and calls a function.
-          // Measured at about 15ns per acquisition on the uncontended path,
-          // against a total guarding cost there of about 90ns.
-          val body = ZIO.OnExitEffect(trace, restore(zio), () => state.release(n))
+        ZIO.AcquireReleaseInline(
+          trace,
+          () => state.tryAcquire(n),
+          zio,
+          () => state.release(n),
+          // Only the queueing path needs the uninterruptible region. The fast
+          // path takes its permits and installs their release inside a single
+          // dispatch of the run loop, which cannot be interrupted partway, so it
+          // pays for no flag changes at all. Queueing has to suspend, and a
+          // suspension is interruptible by construction, so the waiter has to be
+          // enqueued and awaited under a mask that `enqueueAndAwait` restores
+          // around the suspension itself.
+          //
+          // By name: on the path this exists to make cheap, it is never built.
+          () =>
+            ZIO.uninterruptibleMask { restore =>
+              val body = ZIO.OnExitEffect(trace, restore(zio), () => state.release(n))
 
-          if (state.tryAcquire(n)) body
-          else enqueueAndAwait(n, restore).flatMap(_ => body)
-        }
+              if (state.tryAcquire(n)) body
+              else enqueueAndAwait(n, restore).flatMap(_ => body)
+            }
+        )
 
     def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
       if (n < 0L) die(n)

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -17,10 +17,8 @@
 package zio
 
 import zio.stacktracer.TracingImplicits.disableAutoTrace
+import zio.internal.SemaphorePlatform
 import zio.stm.TSemaphore
-
-import scala.annotation.tailrec
-import scala.collection.immutable.{Queue => ScalaQueue}
 
 /**
  * An asynchronous semaphore, which is a generalization of a mutex. Semaphores
@@ -35,7 +33,12 @@ import scala.collection.immutable.{Queue => ScalaQueue}
 sealed trait Semaphore extends Serializable {
 
   /**
-   * Returns the number of available permits.
+   * Returns the number of permits that are available to be acquired.
+   *
+   * For a fair semaphore this is `0` whenever another fiber is already waiting
+   * for permits, since a waiting fiber must be served first and no other fiber
+   * may acquire ahead of it, even if the semaphore is holding permits that the
+   * waiting fiber is not yet able to use.
    */
   def available(implicit trace: Trace): UIO[Long]
 
@@ -92,116 +95,130 @@ object Semaphore {
 
   /**
    * Creates a new `Semaphore` with the specified number of permits.
+   *
+   * The returned semaphore is fair: permits are granted to fibers in the order
+   * in which they were requested, and a fiber will not acquire a permit while
+   * another fiber is already waiting for one.
    */
   def make(permits: => Long)(implicit trace: Trace): UIO[Semaphore] =
     ZIO.succeed(unsafe.make(permits)(Unsafe.unsafe))
 
+  /**
+   * Creates a new unfair `Semaphore` with the specified number of permits.
+   *
+   * An unfair semaphore allows a fiber to acquire an available permit even when
+   * other fibers are already waiting, a policy commonly known as "barging",
+   * trading the FIFO ordering guarantee of [[make]] for the chance to skip a
+   * suspend/reschedule round trip.
+   *
+   * Note that with an unfair semaphore a waiting fiber is not guaranteed to
+   * make progress if permits are continuously acquired by other fibers.
+   *
+   * Be aware that unfairness buys much less here than it does for a semaphore
+   * that parks threads: under `withPermit` the cost of contention is dominated
+   * by suspending and rescheduling fibers through the runtime rather than by
+   * the queueing policy. Benchmarks show this within noise of [[make]]
+   * uncontended, and ahead of it in only one measured contended configuration,
+   * ten fibers over five permits. For comparison, barging is worth nearly 2x to
+   * `java.util.concurrent.Semaphore` at ten threads over one permit. Reach for
+   * this when you specifically do not need ordering, and measure before
+   * assuming it is faster for your workload.
+   */
+  def makeUnfair(permits: => Long)(implicit trace: Trace): UIO[Semaphore] =
+    ZIO.succeed(unsafe.makeUnfair(permits)(Unsafe.unsafe))
+
   object unsafe {
     def make(permits: Long)(implicit unsafe: Unsafe): Semaphore =
-      new Semaphore {
-        val ref = Ref.unsafe.make[Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]](Right(permits))
+      new ConcurrentSemaphore(permits, fair = true)
 
-        def available(implicit trace: Trace): UIO[Long] =
-          ref.get.map {
-            case Left(_)        => 0L
-            case Right(permits) => permits
-          }
+    def makeUnfair(permits: Long)(implicit unsafe: Unsafe): Semaphore =
+      new ConcurrentSemaphore(permits, fair = false)
+  }
 
-        override def awaiting(implicit trace: Trace): UIO[Long] =
-          ref.get.map {
-            case Left(queue) => queue.size.toLong
-            case Right(_)    => 0L
-          }
+  private final class ConcurrentSemaphore(permits: Long, fair: Boolean) extends Semaphore {
+    private[this] val state = new SemaphorePlatform(permits, fair)
 
-        def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          withPermits(1L)(zio)
+    def available(implicit trace: Trace): UIO[Long] =
+      ZIO.succeed(state.available())
 
-        def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          withPermitsScoped(1L)
+    override def awaiting(implicit trace: Trace): UIO[Long] =
+      ZIO.succeed(state.awaiting())
 
-        def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
-          ZIO.acquireReleaseWith(reserve(n))(_.release)(_.acquire *> zio)
+    def withPermit[R, E, A](zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      withPermits(1L)(zio)
 
-        def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
-          ZIO.acquireRelease(reserve(n))(_.release).flatMap(_.acquire)
+    def withPermitScoped(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      withPermitsScoped(1L)
 
-        override def tryWithPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
-          ZIO.acquireReleaseWith(tryReserve(n)) {
-            case Some(reservation) => reservation.release
-            case _                 => Exit.unit
-          } {
-            case _: Some[?] => zio.asSome
-            case _          => Exit.none
-          }
+    def withPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, A] =
+      if (n < 0L) die(n)
+      else if (n == 0L) zio
+      else
+        ZIO.uninterruptibleMask { restore =>
+          val body =
+            restore(zio).exitWith { exit =>
+              state.release(n)
+              exit
+            }
 
-        case class Reservation(acquire: UIO[Unit], release: UIO[Any])
-        object Reservation {
-          private[zio] val zero = Reservation(ZIO.unit, ZIO.unit)
+          if (state.tryAcquire(n)) body
+          else enqueueAndAwait(n, restore).flatMap(_ => body)
         }
 
-        def tryReserve(n: Long)(implicit trace: Trace): UIO[Option[Reservation]] =
-          if (n < 0) ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
-          else if (n == 0L) ZIO.succeed(Some(Reservation.zero))
-          else
-            ref.modify {
-              case Right(permits) if permits >= n =>
-                Some(Reservation(ZIO.unit, releaseN(n))) -> Right(permits - n)
-              case other => None -> other
-            }
+    def withPermitsScoped(n: Long)(implicit trace: Trace): ZIO[Scope, Nothing, Unit] =
+      if (n < 0L) die(n)
+      else if (n == 0L) Exit.unit
+      else
+        ZIO.uninterruptibleMask { restore =>
+          def register = ZIO.addFinalizer(ZIO.succeed(state.release(n))).unit
 
-        def reserve(n: Long)(implicit trace: Trace): UIO[Reservation] =
-          if (n < 0)
-            ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
-          else if (n == 0L)
-            ZIO.succeed(Reservation.zero)
-          else
-            Promise.make[Nothing, Unit].flatMap { promise =>
-              ref.modify {
-                case Right(permits) if permits >= n =>
-                  Reservation(ZIO.unit, releaseN(n)) -> Right(permits - n)
-                case Right(permits) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(ScalaQueue(promise -> (n - permits)))
-                case Left(queue) =>
-                  Reservation(promise.await, restore(promise, n)) -> Left(queue.enqueue(promise -> n))
-              }
-            }
-
-        def restore(promise: Promise[Nothing, Unit], n: Long)(implicit trace: Trace): UIO[Any] =
-          ref.modify {
-            case Left(queue) =>
-              queue
-                .find(_._1 == promise)
-                .fold(releaseN(n) -> Left(queue)) { case (_, permits) =>
-                  releaseN(n - permits) -> Left(queue.filter(_._1 != promise))
-                }
-            case Right(permits) => ZIO.unit -> Right(permits + n)
-          }.flatten
-
-        def releaseN(n: Long)(implicit trace: Trace): UIO[Any] = {
-
-          @tailrec
-          def loop(
-            n: Long,
-            state: Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long],
-            acc: UIO[Any]
-          ): (UIO[Any], Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]) =
-            state match {
-              case Right(permits) => acc -> Right(permits + n)
-              case Left(queue) =>
-                queue.dequeueOption match {
-                  case None => acc -> Right(n)
-                  case Some(((promise, permits), queue)) =>
-                    if (n > permits)
-                      loop(n - permits, Left(queue), acc *> promise.succeedUnit)
-                    else if (n == permits)
-                      (acc *> promise.succeedUnit) -> Left(queue)
-                    else
-                      acc -> Left((promise -> (permits - n)) +: queue)
-                }
-            }
-
-          ref.modify(loop(n, _, ZIO.unit)).flatten
+          if (state.tryAcquire(n)) register
+          else enqueueAndAwait(n, restore).flatMap(_ => register)
         }
-      }
+
+    override def tryWithPermits[R, E, A](n: Long)(zio: ZIO[R, E, A])(implicit trace: Trace): ZIO[R, E, Option[A]] =
+      if (n < 0L) die(n)
+      else if (n == 0L) zio.asSome
+      else
+        ZIO.uninterruptibleMask { restore =>
+          if (!state.tryAcquire(n)) Exit.none
+          else
+            restore(zio).asSome.exitWith { exit =>
+              state.release(n)
+              exit
+            }
+        }
+
+    /**
+     * Enqueues a waiter for `n` permits and suspends until it is granted them.
+     *
+     * The two are one method because a waiter that is enqueued and then not
+     * awaited strands its permits: nothing else will ever claim them, and the
+     * fiber that queued it never learns it was granted.
+     *
+     * Both halves run while this is being built, in the same block of
+     * interpreter work as the `tryAcquire` that failed. Splitting them across
+     * effect nodes would put a yield point between them, and two fibers
+     * arriving in order could then be queued out of order, breaking the FIFO
+     * guarantee of a fair semaphore.
+     *
+     * The suspension itself runs interruptibly, since a fiber blocked on a
+     * semaphore has to remain interruptible, and must return its permits if it
+     * is interrupted after having been granted them.
+     */
+    private def enqueueAndAwait(n: Long, restore: ZIO.InterruptibilityRestorer)(implicit
+      trace: Trace
+    ): ZIO[Any, Nothing, Unit] = {
+      val waiter = state.enqueue(n)
+      restore {
+        ZIO.async[Any, Nothing, Unit](
+          cb => if (!waiter.register(cb)) cb(Exit.unit),
+          FiberId.None
+        )
+      }.onInterrupt(ZIO.succeed(state.cancel(waiter)))
+    }
+
+    private def die(n: Long)(implicit trace: Trace): UIO[Nothing] =
+      ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
   }
 }

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6238,6 +6238,51 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
   ) extends Continuation
       with ZIO[R, E, A]
 
+  /**
+   * The frame [[OnExitEffect]] and [[AcquireReleaseInline]] leave on the stack:
+   * run `finalizer` as the stack unwinds past it, on every exit path, then
+   * carry on unwinding with the value or cause unchanged.
+   *
+   * This is a continuation only, never an effect to evaluate, which is why it
+   * carries no inner effect the way [[OnExitEffect]] does.
+   */
+  private[zio] final case class RunFinalizer(trace: Trace, finalizer: () => Unit) extends Continuation
+
+  /**
+   * Attempts `acquire`; on success runs `onAcquired` with `release` installed
+   * to run as the stack unwinds past it, and on failure runs `onUnavailable`.
+   *
+   * The point of this node is what it does *not* need. Guarding a body with a
+   * resource normally has to hold the acquisition and the installation of its
+   * release in one uninterruptible region, because an interrupt landing between
+   * them leaks the resource; that costs a pair of [[UpdateRuntimeFlagsWithin]]
+   * nodes to disable interruption and restore it, which `Semaphore.withPermits`
+   * measured at about 48ns per acquisition, against 90ns for everything
+   * guarding costs there.
+   *
+   * The run loop polls for interrupts once per dispatch, at the top of its
+   * loop, before the effect is matched. So an acquisition and a stack push
+   * performed inside a single `case` cannot be separated by an interrupt at
+   * all, and need no flag changes to protect them. An interrupt that arrives
+   * before this node is dispatched replaces it with a failure and `acquire`
+   * never runs; one that arrives after is handled by the installed release,
+   * exactly as for any other frame.
+   *
+   * `acquire` and `release` therefore run on the fiber's own thread inside the
+   * run loop: both must be cheap, non-suspending and non-throwing.
+   * `onUnavailable` is a full effect and carries no such restriction, which is
+   * where a caller puts the path that has to queue and wait.
+   */
+  private[zio] final case class AcquireReleaseInline[R, E, A](
+    trace: Trace,
+    acquire: () => Boolean,
+    onAcquired: ZIO[R, E, A],
+    release: () => Unit,
+    // A thunk rather than an effect: the unavailable path is typically a whole
+    // subtree, and on the path this node exists to make cheap it is never used.
+    onUnavailable: () => ZIO[R, E, A]
+  ) extends ZIO[R, E, A]
+
   private[zio] sealed trait UpdateRuntimeFlagsWithin[R, E, A] extends ZIO[R, E, A] {
     def update: RuntimeFlags.Patch
     def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A]

--- a/core/shared/src/main/scala/zio/ZIO.scala
+++ b/core/shared/src/main/scala/zio/ZIO.scala
@@ -6213,6 +6213,31 @@ object ZIO extends ZIOCompanionPlatformSpecific with ZIOCompanionVersionSpecific
       extends Continuation
       with ZIO[Any, Nothing, Unit]
 
+  /**
+   * Runs `first`, then runs `finalizer` as the stack unwinds past this frame,
+   * on every exit path, leaving the value or cause unchanged.
+   *
+   * This exists for release actions that are a plain side effect and need no
+   * access to the exit value, as `Semaphore.withPermits` does. Expressing one
+   * as `exitWith` costs a [[FoldZIO]] frame, an `Exit` allocation on the
+   * success path, and a closure invocation that receives an exit it does not
+   * read; this costs a frame and a call. `Semaphore.withPermits` measured the
+   * difference at about 15ns per acquisition, against a total guarding cost
+   * there of about 90ns.
+   *
+   * It is deliberately not public. The finalizer runs while the fiber is
+   * unwinding, so it must not throw, must not suspend, and must be cheap. Those
+   * are the same obligations [[UpdateRuntimeFlags]] carries, and this is
+   * modelled on it. It is not a substitute for `ensuring` or `acquireRelease`,
+   * which handle effectful finalizers and their own failures.
+   */
+  private[zio] final case class OnExitEffect[R, E, A](
+    trace: Trace,
+    first: ZIO[R, E, A],
+    finalizer: () => Unit
+  ) extends Continuation
+      with ZIO[R, E, A]
+
   private[zio] sealed trait UpdateRuntimeFlagsWithin[R, E, A] extends ZIO[R, E, A] {
     def update: RuntimeFlags.Patch
     def scope(oldRuntimeFlags: RuntimeFlags): ZIO[R, E, A]

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1141,6 +1141,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
 
+                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
+                    onExit.finalizer()
+
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
                     if (!ignoreFlagsUpdate(updateFlags.update, stackIndex)) {
@@ -1178,6 +1181,9 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
+
+                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
+                    onExit.finalizer()
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1325,6 +1331,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case updateFlags: ZIO.UpdateRuntimeFlags if !ignoreFlagsUpdate(updateFlags.update, stackIndex) =>
                     cause = patchRuntimeFlagsCause(updateFlags.update, cause)
 
+                  // Must come before the catch-all: a release action has to run
+                  // when the body fails or is interrupted, not only when it
+                  // succeeds, or the permits are lost.
+                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
+                    onExit.finalizer()
+
                   case _ => ()
                 }
               }
@@ -1339,6 +1351,12 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
             case updateRuntimeFlags: UpdateRuntimeFlags =>
               updateLastTrace(updateRuntimeFlags.trace)
               cur = patchRuntimeFlags(updateRuntimeFlags.update, null, Exit.unit)
+
+            case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
+              updateLastTrace(onExit.trace)
+
+              stackIndex = pushStackFrame(onExit, stackIndex)
+              cur = onExit.first
 
             case effect =>
               throw new MatchError(effect)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1141,8 +1141,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
 
-                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
-                    onExit.finalizer()
+                  case fin: ZIO.RunFinalizer =>
+                    fin.finalizer()
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1182,8 +1182,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   case map: ZIO.Mapped[Any, Any, Any, Any] =>
                     value = map.successK(value)
 
-                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
-                    onExit.finalizer()
+                  case fin: ZIO.RunFinalizer =>
+                    fin.finalizer()
 
                   case update =>
                     val updateFlags = update.asInstanceOf[ZIO.UpdateRuntimeFlags]
@@ -1334,8 +1334,8 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
                   // Must come before the catch-all: a release action has to run
                   // when the body fails or is interrupted, not only when it
                   // succeeds, or the permits are lost.
-                  case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
-                    onExit.finalizer()
+                  case fin: ZIO.RunFinalizer =>
+                    fin.finalizer()
 
                   case _ => ()
                 }
@@ -1353,10 +1353,27 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
               cur = patchRuntimeFlags(updateRuntimeFlags.update, null, Exit.unit)
 
             case onExit: ZIO.OnExitEffect[Any, Any, Any] =>
-              updateLastTrace(onExit.trace)
+              val trace = onExit.trace
+              updateLastTrace(trace)
 
-              stackIndex = pushStackFrame(onExit, stackIndex)
+              stackIndex = pushStackFrame(ZIO.RunFinalizer(trace, onExit.finalizer), stackIndex)
               cur = onExit.first
+
+            case ar: ZIO.AcquireReleaseInline[Any, Any, Any] =>
+              val trace = ar.trace
+              updateLastTrace(trace)
+
+              // The acquisition and the installation of its release happen here,
+              // in one dispatch, with no interrupt poll between them: the loop
+              // polls once per iteration, above, before this match. That is what
+              // lets this node do without the uninterruptible region such a pair
+              // would otherwise need, and it is the whole point of the node.
+              if (ar.acquire()) {
+                stackIndex = pushStackFrame(ZIO.RunFinalizer(trace, ar.release), stackIndex)
+                cur = ar.onAcquired
+              } else {
+                cur = ar.onUnavailable()
+              }
 
             case effect =>
               throw new MatchError(effect)

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1525,6 +1525,65 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
     if (running.compareAndSet(false, true)) drainQueueLaterOnExecutor(false)
   }
 
+  /**
+   * Resumes this fiber, running it on the calling thread when that thread
+   * already belongs to the fiber's executor, rather than handing it to the
+   * scheduler.
+   *
+   * The ordinary [[tell]] publishes the fiber to a run queue and may `unpark` a
+   * worker to collect it, so a resume costs a scheduling round trip even when
+   * the calling thread is about to have nothing to do. Running the fiber here
+   * skips the queue, the wakeup, and the round trip. This is the same trick
+   * [[interruptAs]] already uses, for the same reason.
+   *
+   * '''This runs the woken fiber's run loop inside the caller's stack''', so
+   * the caller must be somewhere it can afford to run arbitrary other work. It
+   * is meant for a caller that has just handed this fiber a resource and is
+   * about to stop running, as when a semaphore grants away its last permit.
+   *
+   * The resumed fiber runs until it suspends or finishes, and what it does can
+   * resume further fibers on the same stack, so the nesting is bounded by the
+   * executor through `claimInlineExecution`. Passing that bound, or running on
+   * a thread the executor does not own, falls back to what [[tell]] does.
+   */
+  private[zio] def tellResumeInline(message: FiberMessage): Unit = {
+    inbox.add(message)
+
+    if (running.compareAndSet(false, true)) {
+      val executor = getCurrentExecutor()
+
+      if (executor.isCurrentThreadInExecutor && executor.claimInlineExecution()) {
+        // `drainQueueOnCurrentThread` points `Fiber._currentFiber` at the fiber
+        // it drains and restores only `running`, because its other callers are
+        // the fiber itself and so have nothing to put back. Here the caller is
+        // a different fiber that keeps running once this returns, so the
+        // thread-local has to be saved and put back. Otherwise that fiber's
+        // `FiberRef.asThreadLocal` reads and writes would land on the fiber
+        // woken here.
+        //
+        // Both halves are unconditional, unlike `start`, which gates them on
+        // the runtime flag. The flags read here are the woken fiber's, and it
+        // may change them while it runs: a fiber that enables `CurrentFiber`
+        // mid-run has `patchRuntimeFlagsOnly` point the thread-local at itself,
+        // so a gated restore would decide on a flag that no longer describes
+        // the state it is restoring. Saving and restoring whatever was there is
+        // correct whichever way both fibers have the flag set, and costs a
+        // thread-local read on a path that is already running a fiber.
+        val previousFiber = Fiber._currentFiber.get()
+        try drainQueueOnCurrentThread(0)
+        finally {
+          Fiber._currentFiber.set(previousFiber)
+          executor.releaseInlineExecution()
+        }
+      } else {
+        // Either this thread has already nested inline executions up to its
+        // limit, or it is not one of the executor's, so hand this one to the
+        // scheduler.
+        drainQueueLaterOnExecutor(false)
+      }
+    }
+  }
+
   private[zio] def tellAddChild(child: Fiber.Runtime[_, _]): Unit =
     tell(FiberMessage.Stateful(parentFiber => parentFiber.addChild(child)))
 
@@ -1694,7 +1753,7 @@ object FiberRuntime {
    *   def apply(callback: Callback, onInterrupt: ZIO.Erased): AsyncContWith
    * }}}
    */
-  private class AsyncContWith private (private val value: AnyRef) extends AnyVal {
+  private[zio] class AsyncContWith private (private val value: AnyRef) extends AnyVal {
     import AsyncContWith.Callback
 
     def callback: Callback = value match {
@@ -1709,7 +1768,7 @@ object FiberRuntime {
     }
   }
 
-  private object AsyncContWith {
+  private[zio] object AsyncContWith {
 
     /**
      * Callback to be invoked when an asynchronous effect completes.
@@ -1734,6 +1793,19 @@ object FiberRuntime {
       def completeCause(cause: Cause[Nothing]): Boolean =
         if (compareAndSet(false, true)) {
           fiber.tell(FiberMessage.Resume(Exit.Failure(cause)))
+          true
+        } else {
+          false
+        }
+
+      /**
+       * Resumes the fiber on the calling thread when that thread belongs to its
+       * executor, rather than through the scheduler. See
+       * [[FiberRuntime.tellResumeInline]] for what that asks of the caller.
+       */
+      def completeZIOInline(effect: ZIO.Erased): Boolean =
+        if (compareAndSet(false, true)) {
+          fiber.tellResumeInline(FiberMessage.Resume(effect))
           true
         } else {
           false

--- a/core/shared/src/main/scala/zio/internal/SemaphorePlatform.scala
+++ b/core/shared/src/main/scala/zio/internal/SemaphorePlatform.scala
@@ -1,0 +1,569 @@
+/*
+ * Copyright 2018-2024 John A. De Goes and the ZIO Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zio.internal
+
+import zio._
+import zio.stacktracer.TracingImplicits.disableAutoTrace
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.locks.ReentrantLock
+import java.util.concurrent.atomic.{AtomicLong, AtomicReference}
+import scala.annotation.tailrec
+
+/**
+ * Implementation of [[zio.Semaphore]] built on an `AtomicLong` permit counter
+ * plus a queue of waiters, rather than a `Ref` holding a boxed `Either[Queue,
+ * Long]`.
+ *
+ * The design goal is that the uncontended path (acquiring a permit that is
+ * immediately available) allocates nothing at all. In that case the whole
+ * acquisition is a single successful CAS on the counter, and release is a
+ * `getAndAdd` plus a check for waiters. Only a fiber that actually has to wait
+ * allocates a [[SemaphoreWaiter]].
+ *
+ * Two fairness policies are supported:
+ *
+ *   - `fair`: a fiber may take permits from the counter only when no other
+ *     fiber is already queued ahead of it, giving FIFO ordering and preventing
+ *     barging. This matches the semantics of the original `Semaphore`.
+ *   - unfair: a fiber may always take an available permit, even when others are
+ *     queued. This allows barging, at the cost of ordering guarantees, matching
+ *     `java.util.concurrent.Semaphore(n, false)`. Measurements show it on par
+ *     with the fair policy uncontended and when permits are scarce, and ahead
+ *     of it only when several fibers contend for several permits: under
+ *     `withPermit` the cost of contention is dominated by fiber suspension
+ *     rather than by queueing, so barging has much less to win than it does for
+ *     a semaphore that parks threads.
+ */
+private[zio] final class SemaphorePlatform(initialPermits: Long, fair: Boolean) extends Serializable {
+  import SemaphorePlatform._
+
+  private[this] val permits = new AtomicLong(initialPermits)
+  private[this] val waiters = new ConcurrentLinkedQueue[SemaphoreWaiter]
+
+  /**
+   * Guards the handing out of permits to queued waiters. Acquiring and
+   * releasing permits never touches this lock, since both are a single CAS on
+   * `permits`, so the uncontended path stays entirely lock-free. It is taken
+   * only when there are waiters to serve, and never held across user code.
+   */
+  private[this] val drainLock = new ReentrantLock()
+
+  /**
+   * Counts requests to hand out permits that have not yet been served. A thread
+   * that cannot take [[drainLock]] records its request here rather than
+   * leaving, so its permits cannot be stranded by a lock holder that has
+   * already taken its last look at the counter.
+   */
+  private[this] val drainRequests = new AtomicLong(0L)
+
+  /**
+   * Serializes [[enqueue]] against itself, so that fibers are queued in the
+   * order they arrive. Held only across the counter bump and the insertion,
+   * never across a drain or any user code, and never taken by the uncontended
+   * acquire/release path.
+   */
+  private[this] val enqueueLock = new ReentrantLock()
+
+  /**
+   * The number of waiters that are still live: enqueued, and neither granted
+   * nor cancelled. Incremented in [[enqueue]] and decremented by whichever side
+   * wins a waiter's terminal CAS, so it is exactly the number of fibers still
+   * waiting for permits. This keeps [[awaiting]] O(1).
+   */
+  private[this] val liveCount = new AtomicLong(0L)
+
+  /**
+   * The number of nodes physically present in [[waiters]], tombstones included.
+   * `ConcurrentLinkedQueue.size` is itself O(n), so we track this ourselves in
+   * order to learn in O(1) how many tombstones are outstanding, which is
+   * `queuedCount - liveCount`.
+   */
+  private[this] val queuedCount = new AtomicLong(0L)
+
+  /**
+   * The number of permits that can actually be acquired right now.
+   *
+   * In fair mode a queued waiter blocks every other fiber from taking permits,
+   * so while any fiber is waiting this reports `0` even though the counter may
+   * be non-zero: those permits are spoken for by the queued waiters and no
+   * other fiber may take them. This preserves the semantics of the original
+   * `Ref`-based `Semaphore`, which reported `0` whenever fibers were queued.
+   *
+   * In unfair mode barging is allowed, so a queued waiter does not prevent
+   * anybody from acquiring, and the raw count is reported as-is.
+   */
+  def available(): Long =
+    if (fair && hasLiveWaiter) 0L else permits.get()
+
+  /**
+   * The number of fibers currently waiting for permits.
+   *
+   * This is O(1): cancelled waiters can linger in the queue as tombstones, so
+   * rather than walking the queue we keep a live count that both of a waiter's
+   * terminal transitions maintain.
+   */
+  def awaiting(): Long = liveCount.get()
+
+  /**
+   * The number of nodes the waiter queue is physically holding on to, live
+   * waiters and not-yet-reaped tombstones alike. Exposed for tests, which use
+   * it to check that tombstones do not accumulate without bound.
+   */
+  private[zio] def queueSize(): Long = queuedCount.get()
+
+  /**
+   * Attempts to take `n` permits without queueing. Returns `true` if the
+   * permits were taken.
+   *
+   * In fair mode this refuses to take permits while any fiber is queued, so
+   * that a fiber cannot barge ahead of one that is already waiting.
+   */
+  @tailrec
+  def tryAcquire(n: Long): Boolean =
+    if (fair && hasLiveWaiter) false
+    else {
+      val current = permits.get()
+      if (current < n) false
+      else if (permits.compareAndSet(current, current - n)) true
+      else tryAcquire(n)
+    }
+
+  /**
+   * Whether any fiber is waiting for permits.
+   *
+   * This counts rather than inspecting the queue. Cancelled waiters are left in
+   * the queue as tombstones, so "the head is dead" and "nobody is waiting" are
+   * not the same question: a dead head can have live waiters behind it. Every
+   * tombstone is in practice reaped at the head by the `drain` that [[cancel]]
+   * runs, so peeking would usually agree, but it agrees by relying on that
+   * timing rather than on the thing being asked.
+   *
+   * The original `Ref`-based `Semaphore` held its state in a single
+   * `Either[Queue, Long]` and dropped a cancelled waiter from the queue
+   * outright, so any queued waiter at all put the state into `Left`: no other
+   * fiber could take permits, and `available` read as `0`. `liveCount` counts
+   * exactly the waiters that implementation would have kept queued, so testing
+   * it against zero reproduces those semantics directly, and in O(1).
+   */
+  private def hasLiveWaiter: Boolean = liveCount.get() > 0L
+
+  /**
+   * Enqueues a waiter for `n` permits, which `Semaphore.enqueueAndAwait` then
+   * awaits. A waiter that is enqueued and never awaited strands its permits.
+   *
+   * After enqueueing we re-run the release loop, because permits may have been
+   * returned between our failed [[tryAcquire]] and the enqueue, in which case
+   * nobody else would wake us.
+   */
+  def enqueue(n: Long): SemaphoreWaiter = {
+    val waiter = new SemaphoreWaiter(n, liveCount)
+    // The counter bump and the insertion are done together under `enqueueLock`,
+    // so that two fibers arriving in order are queued in that order. They are
+    // not one atomic step by themselves: `liveCount` has to go up before the
+    // node is published (so that no observer can see a queued waiter that is
+    // not yet counted, which is what fair mode's gating and `available` rely
+    // on), which leaves a window in which a fiber that has been counted has not
+    // yet been inserted. A second fiber that then runs the whole of `enqueue`
+    // inside that window lands in the queue ahead of the first, inverting FIFO
+    // order. The lock is uncontended except between simultaneous enqueues, and
+    // is never taken on the fast path, which does not enqueue at all.
+    enqueueLock.lock()
+    try {
+      liveCount.incrementAndGet()
+      queuedCount.incrementAndGet()
+      waiters.add(waiter)
+    } finally enqueueLock.unlock()
+    drain()
+    waiter
+  }
+
+  /**
+   * Returns `n` permits and hands as many as possible to queued waiters.
+   */
+  def release(n: Long): Unit = {
+    permits.getAndAdd(n)
+    drain()
+    ()
+  }
+
+  /**
+   * Cancels a waiter that is no longer interested in its permits, as happens
+   * when the acquiring fiber is interrupted. If the waiter had already been
+   * granted its permits, they are returned to the semaphore.
+   */
+  def cancel(waiter: SemaphoreWaiter): Unit =
+    if (waiter.cancel()) {
+      // We cancelled before any permits were granted to us. We deliberately do
+      // not remove ourselves from the queue here: `remove(Object)` scans the
+      // whole queue, and the cancelled waiter is already inert because
+      // `drainLoop` discards any waiter that is done. It is dropped in O(1) the
+      // next time it reaches the head.
+      //
+      // Draining is still necessary: in fair mode nobody may take permits while
+      // a waiter is queued, so if we were at the head there could be permits
+      // sitting free with no one to hand them out.
+      drain()
+    } else {
+      // We had already been granted the permits, so they are ours to return.
+      release(waiter.n)
+    }
+
+  /**
+   * Hands out permits, ensuring that the work happens even when several threads
+   * ask at once.
+   *
+   * Only one thread hands out permits at a time: the work is a handful of CAS
+   * operations on the head of the queue, the counter, and the waiter state
+   * together, and a thread that cannot get in has already done its part by
+   * returning its permits to the counter.
+   *
+   * When the queue is empty there is nothing to hand out at all and the whole
+   * dance is skipped, so an uncontended release is a `getAndAdd` plus a `peek`.
+   *
+   * A thread that fails to take the lock must not simply leave, or its permits
+   * could be stranded: the holder may have already made its last read of the
+   * counter. Instead it bumps `drainRequests`, and the holder re-runs until it
+   * sees no new requests, so the permits are always eventually handed out.
+   *
+   * Neither path holds the lock across the wake-ups; see [[tryDrainAndWake]].
+   */
+  private def drain(): Unit = {
+    // Nothing is queued, so there is nobody to hand permits to and no
+    // tombstones to sweep. This has to come before the increment below: an
+    // early-out taken after it would leave `drainRequests` permanently
+    // non-zero and send the next real drain round its loop for nothing.
+    //
+    // A waiter enqueued just after this read cannot be stranded, because
+    // `enqueue` drains itself after publishing the node, and `release` adds its
+    // permits to the counter before calling us, so that drain sees them.
+    if (waiters.peek() eq null) return
+
+    // Fast path: nobody else is draining, so there is nobody to signal. Taking
+    // the lock first makes the whole request-counter protocol unnecessary in
+    // the common case, where drains do not overlap.
+    //
+    // This is not limited to a single waiter. `drainLoop` re-reads the head and
+    // the permit counter on every iteration and only ever grants by CAS, so a
+    // thread holding the lock correctly serves as many waiters as the permits
+    // allow, picking up concurrent releases as it goes. What the counter
+    // protects against is a *second drainer* being turned away, not a backlog
+    // of waiters.
+    if (tryDrainAndWake(clearRequests = false)) {
+      // Somebody may have been turned away while we held the lock, after we had
+      // already made our last read of the counter. Their request is recorded,
+      // so serve it.
+      if (drainRequests.get() != 0L) drainContended()
+    } else drainContended()
+  }
+
+  /**
+   * The slow half of [[drain]], taken once a `tryLock` has failed or a request
+   * arrived too late for the drain that was in flight.
+   *
+   * The increment must happen before the `tryLock` attempt. A thread that
+   * incremented and then failed to take the lock is guaranteed to be served:
+   * either the holder has yet to run `drainLoop`, in which case it will see the
+   * permits, or it has already cleared the counter, in which case our increment
+   * lands after that clear and its exit re-check sees it.
+   */
+  private def drainContended(): Unit = {
+    var continue = true
+    while (continue) {
+      // Signal that there is work to do. A thread that cannot take the lock has
+      // still recorded its request here, and the lock holder will see it.
+      drainRequests.incrementAndGet()
+
+      if (tryDrainAndWake(clearRequests = true)) {
+        // Re-check after releasing: if somebody asked while we were inside,
+        // their permits still need handing out.
+        continue = drainRequests.get() != 0L
+      } else {
+        // Somebody else holds the lock. Our request is recorded, so they (or
+        // whoever takes the lock next) will do our work for us.
+        continue = false
+      }
+    }
+  }
+
+  /**
+   * Takes [[drainLock]], hands out permits, releases the lock, and only then
+   * wakes whoever was granted. Returns `false` if the lock was not free.
+   *
+   * This is the only place the lock is taken, so the deferred wake is a
+   * property of the drain rather than something each caller has to remember:
+   * waking runs `FiberRuntime.tell`, which offers to the scheduler's run queue
+   * and may `LockSupport.unpark` a parked worker, so waking under the lock
+   * would hold it across a syscall per granted waiter.
+   *
+   * `clearRequests` is set by the contended path, which must take ownership of
+   * the outstanding requests inside the lock: any request arriving after that
+   * bumps the counter again and sends it round its loop once more.
+   */
+  private def tryDrainAndWake(clearRequests: Boolean): Boolean =
+    if (drainLock.tryLock()) {
+      val wakes =
+        try {
+          if (clearRequests) drainRequests.set(0L)
+          drainLoop()
+        } finally drainLock.unlock()
+      wake(wakes)
+      true
+    } else false
+
+  /**
+   * Hands permits to queued waiters for as long as the waiter at the head of
+   * the queue can be satisfied. Must be called while holding [[drainLock]].
+   *
+   * Only the head is ever considered, which preserves FIFO order and prevents a
+   * waiter requesting many permits from being starved by later waiters
+   * requesting few.
+   *
+   * Returns the wake-ups the caller must perform once it has released the lock:
+   * `null` if there are none, a single callback if exactly one waiter was
+   * granted, and otherwise a `WakeList` of them in the order they were granted.
+   * The permits themselves are handed out here, under the lock, so who gets
+   * what is fully decided before any of these run; all that is deferred is
+   * telling the fibers about it.
+   */
+  private def drainLoop(): AnyRef = {
+    // The overwhelmingly common case is granting zero or one waiter, so the
+    // first callback is kept in a local and no list is allocated unless a
+    // single drain actually grants more than one.
+    var firstWake: AnyRef   = null
+    var moreWakes: WakeList = null
+
+    var continue = true
+    while (continue) {
+      val head = waiters.peek()
+      if (head eq null) continue = false
+      else if (head.isDone) {
+        // Cancelled, or already granted. Drop it and carry on.
+        if (waiters.poll() ne null) queuedCount.decrementAndGet()
+      } else {
+        val n       = head.n
+        val current = permits.get()
+        if (current < n) continue = false
+        else if (permits.compareAndSet(current, current - n)) {
+          // We hold the drain lock, so `head` is still the head and this poll
+          // returns it. `poll` rather than `remove(Object)` keeps this O(1):
+          // `remove` scans the queue, making a drain of k waiters O(k^2).
+          if (waiters.poll() ne null) queuedCount.decrementAndGet()
+          // A concurrent cancellation may still beat us to the waiter, in which
+          // case the permits are ours to return.
+          head.claim() match {
+            case SemaphorePlatform.Claim.Cancelled => permits.getAndAdd(n)
+            case SemaphorePlatform.Claim.NoWaiter  => ()
+            case cb =>
+              if (firstWake eq null) firstWake = cb
+              else {
+                if (moreWakes eq null) {
+                  moreWakes = new WakeList
+                  moreWakes += firstWake
+                }
+                moreWakes += cb
+              }
+          }
+        }
+        // else: a concurrent release or fast-path acquire changed the counter
+      }
+    }
+
+    sweepIfNeeded()
+
+    if (moreWakes eq null) firstWake else moreWakes
+  }
+
+  /**
+   * Runs the wake-ups returned by [[drainLoop]]. Must be called only after
+   * [[drainLock]] has been released: each of these hands a fiber back to the
+   * runtime, which offers to the scheduler's run queue and may `unpark` a
+   * worker thread.
+   */
+  private def wake(wakes: AnyRef): Unit =
+    wakes match {
+      case null => ()
+      case list: WakeList =>
+        list.runAllButLast()
+        wakeOne(list.last)
+      case cb => wakeOne(cb)
+    }
+
+  /**
+   * Wakes one granted waiter by completing the callback it registered, which
+   * hands its fiber to the scheduler.
+   */
+  private def wakeOne(cb: AnyRef): Unit =
+    cb.asInstanceOf[Exit[Nothing, Unit] => Unit](Exit.unit)
+
+  /**
+   * Drops tombstones from the middle of the queue when too many have piled up.
+   * Must be called while holding [[drainLock]].
+   *
+   * Cancelled waiters are normally reaped in O(1) as they reach the head, which
+   * costs nothing and is all that is needed while the queue is draining. But
+   * the head only advances when it can be satisfied: a head waiter asking for
+   * more permits than will be free for a while pins the queue, and every
+   * cancellation behind it is then retained indefinitely. Without this sweep a
+   * workload that interrupts heavily behind a stuck head waiter grows the queue
+   * without bound.
+   *
+   * The sweep is a single O(k) pass with `Iterator.remove`, rather than the
+   * O(k^2) that removing tombstones one at a time would cost, and it runs only
+   * once tombstones both outnumber the live waiters and exceed
+   * [[SweepThreshold]]. That leaves the common case untouched: an isolated
+   * cancellation never scans, and the amortized cost per tombstone is O(1).
+   */
+  private def sweepIfNeeded(): Unit = {
+    val queued = queuedCount.get()
+    val dead   = queued - liveCount.get()
+    if (dead >= SweepThreshold && dead * 2 >= queued) {
+      var removed = 0L
+      val it      = waiters.iterator()
+      while (it.hasNext) {
+        if (it.next().isDone) {
+          it.remove()
+          removed += 1L
+        }
+      }
+      if (removed != 0L) queuedCount.addAndGet(-removed)
+    }
+  }
+}
+
+private[zio] object SemaphorePlatform {
+
+  /**
+   * The number of unreaped tombstones that must accumulate before a drain will
+   * sweep them out of the middle of the queue. Small enough that memory stays
+   * bounded in absolute terms, large enough that the O(k) sweep is amortized
+   * over many cancellations.
+   */
+  private final val SweepThreshold = 32L
+
+  /**
+   * A fiber waiting for permits.
+   *
+   * The state machine is `Pending -> (Granted | Cancelled)`, with both terminal
+   * states reached by a single CAS, so that a grant racing a cancellation has
+   * exactly one winner and the permits are never lost or double-counted. The
+   * winner of that CAS is also the one that decrements `liveCount`, so the
+   * semaphore's count of waiting fibers drops exactly once per waiter.
+   */
+  final class SemaphoreWaiter(val n: Long, liveCount: AtomicLong) extends AtomicReference[AnyRef](Pending) {
+
+    def isDone: Boolean = {
+      val s = get()
+      (s eq Granted) || (s eq Cancelled)
+    }
+
+    /**
+     * Registers the continuation to run when permits are granted.
+     *
+     * Returns `false` if the callback was not installed, in which case the
+     * permits are already this waiter's and the caller must proceed immediately
+     * rather than suspend.
+     *
+     * A single CAS decides it. `Pending` is the only state a callback can be
+     * installed from, and every transition out of it is terminal, so a lost CAS
+     * is final and there is nothing to retry: whoever moved the waiter out of
+     * `Pending` did so to grant it. Publishing the callback and observing a
+     * grant therefore go through the same CAS, giving a registration racing a
+     * grant exactly one winner and invoking the callback exactly once, by
+     * whichever side loses the race.
+     */
+    def register(cb: Exit[Nothing, Unit] => Unit): Boolean =
+      compareAndSet(Pending, cb)
+
+    /**
+     * Takes this waiter for a grant, without waking it.
+     *
+     * Returns [[Claim.Cancelled]] if the waiter had already been cancelled, in
+     * which case the caller must return the permits to the semaphore;
+     * [[Claim.NoWaiter]] if it was taken but there is nobody to wake (already
+     * granted, or granted before it suspended); and otherwise the callback the
+     * caller must invoke to wake the fiber.
+     *
+     * The wake is kept separate so that a drain can do all of its state
+     * transitions under the drain lock and wake the fibers after releasing it.
+     * Waking runs `FiberRuntime.tell`, which offers to the scheduler's run
+     * queue and can `LockSupport.unpark` a parked worker thread, so waking
+     * inline would hold the drain lock across a syscall per granted waiter.
+     */
+    @tailrec
+    def claim(): AnyRef =
+      get() match {
+        case Cancelled => Claim.Cancelled
+        case Granted   => Claim.NoWaiter
+        case state =>
+          if (compareAndSet(state, Granted)) {
+            liveCount.decrementAndGet()
+            if (state eq Pending) Claim.NoWaiter else state
+          } else claim()
+      }
+
+    @tailrec
+    def cancel(): Boolean =
+      get() match {
+        case Granted   => false
+        case Cancelled => true
+        case state =>
+          if (compareAndSet(state, Cancelled)) {
+            liveCount.decrementAndGet()
+            true
+          } else cancel()
+      }
+  }
+
+  private val Pending: AnyRef   = new Object
+  private val Granted: AnyRef   = new Object
+  private val Cancelled: AnyRef = new Object
+
+  /**
+   * Sentinels distinguishing the outcomes of [[SemaphoreWaiter.claim]] from the
+   * callback it returns when there is a fiber to wake.
+   */
+  private[internal] object Claim {
+    val Cancelled: AnyRef = new Object
+    val NoWaiter: AnyRef  = new Object
+  }
+
+  /**
+   * The pending wake-ups of a drain that granted more than one waiter, in the
+   * order they were granted.
+   */
+  private[internal] final class WakeList {
+    private[this] val elems = new scala.collection.mutable.ArrayBuffer[AnyRef](8)
+
+    def +=(cb: AnyRef): Unit = {
+      elems += cb
+      ()
+    }
+
+    /** Wakes everything except the last, which the caller handles. */
+    def runAllButLast(): Unit = {
+      val n = elems.size
+      var i = 0
+      while (i < n - 1) {
+        elems(i).asInstanceOf[Exit[Nothing, Unit] => Unit](Exit.unit)
+        i += 1
+      }
+    }
+
+    def last: AnyRef = elems(elems.size - 1)
+  }
+}

--- a/core/shared/src/main/scala/zio/internal/SemaphorePlatform.scala
+++ b/core/shared/src/main/scala/zio/internal/SemaphorePlatform.scala
@@ -404,11 +404,33 @@ private[zio] final class SemaphorePlatform(initialPermits: Long, fair: Boolean) 
     }
 
   /**
-   * Wakes one granted waiter by completing the callback it registered, which
-   * hands its fiber to the scheduler.
+   * Wakes one granted waiter, running its fiber on this thread when this thread
+   * already belongs to the fiber's executor.
+   *
+   * The thread that just released a permit is the natural one to run the fiber
+   * it unblocked: its cache is warm and, in the contended case, it is about to
+   * go looking for work anyway. Going through the scheduler instead costs a
+   * queue offer and possibly an `unpark`, which is the bulk of what a contended
+   * acquisition pays.
+   *
+   * What makes this worth so much is not that it makes a wake-up cheaper but
+   * that it prevents most wake-ups from happening at all. Resuming the waiter
+   * here lets it take the permit and carry on immediately, so the ping-ponging
+   * that otherwise generates a wake-up per acquisition collapses: instrumenting
+   * the wake site over ten fibers and three thousand acquisitions counted nine
+   * wake-ups at one permit and six at five. Everything else took the fast path.
+   *
+   * Only the last waiter of a drain is resumed this way, since the thread can
+   * only run one of them; the rest go through the scheduler as before.
    */
   private def wakeOne(cb: AnyRef): Unit =
-    cb.asInstanceOf[Exit[Nothing, Unit] => Unit](Exit.unit)
+    cb match {
+      case c: FiberRuntime.AsyncContWith.Callback =>
+        c.completeZIOInline(Exit.unit)
+        ()
+      case other =>
+        other.asInstanceOf[Exit[Nothing, Unit] => Unit](Exit.unit)
+    }
 
   /**
    * Drops tombstones from the middle of the queue when too many have piled up.


### PR DESCRIPTION
Towards #9093.

## What this does

`Semaphore` was built on a `Ref[Either[Queue[(Promise, Long)], Long]]`. Every acquisition, even a completely uncontended one, allocated a `Promise` before it looked at the permit count, boxed the state into an `Either`, and went through `acquireReleaseWith`.

This replaces that with an `AtomicLong` permit counter plus a queue of waiters, in a new `zio.internal.SemaphorePlatform`, and then shortens the path the runtime takes to get there. Five commits, each measured on its own:

1. **`perf(semaphore)`** the data structure itself.
2. **`perf(runtime)`** resume a granted fiber on the releasing thread rather than through the scheduler.
3. **`bench(semaphore)`** a benchmark that prices the interpreter nodes an uncontended `withPermit` builds.
4. **`perf(core)`** an `OnExitEffect` continuation, replacing the `exitWith` that installs the release.
5. **`perf(core)`** an `AcquireReleaseInline` node, so the fast path acquires and installs its release in one dispatch and needs no uninterruptible region.

Also adds `Semaphore.makeUnfair`, which permits barging rather than granting in FIFO order.

## Results

JMH, 5 forks, 8 warmup and 4 measurement iterations, 20 samples per row, ops/s with the 99.9% error. Measured on 16 dedicated Xeon Platinum 8168 cores, one thread per core, Fedora 44, JDK 25.0.4. Every row was taken on that machine in one session, back to back.

Columns are grouped by queueing policy, since that governs who may fairly be compared with whom. `series/2.x` appears only in the fair group: it has no unfair mode, which `makeUnfair` adds.

Uncontended, one fiber:

| permits | fair: series/2.x | fair: this PR | fair: java | unfair: this PR | unfair: java |
| ------: | ---------------: | ------------: | ---------: | --------------: | -----------: |
| 1 | 2150 ± 41 | **12690 ± 427** | 7455 ± 134 | **13044 ± 394** | 7433 ± 77 |
| 2 | 2186 ± 49 | **13065 ± 218** | 7451 ± 57 | **12839 ± 422** | 7475 ± 72 |
| 5 | 2182 ± 39 | **13022 ± 232** | 7429 ± 54 | **12989 ± 200** | 7359 ± 132 |
| 10 | 2192 ± 26 | **12947 ± 392** | 7450 ± 55 | **12267 ± 711** | 7433 ± 87 |

Contended, ten fibers:

| permits | fair: series/2.x | fair: this PR | fair: java | unfair: this PR | unfair: java |
| ------: | ---------------: | ------------: | ---------: | --------------: | -----------: |
| 1 | 56.6 ± 2.5 | **928 ± 144** | 586 ± 83 | **1024 ± 119** | 1111 ± 8 |
| 2 | 79.3 ± 11.1 | **903 ± 38** | 695 ± 79 | **802 ± 70** | 1106 ± 13 |
| 5 | 111.3 ± 5.2 | **639 ± 74** | 918 ± 111 | **659 ± 115** | 1096 ± 12 |
| 10 | 202.3 ± 12.4 | **711 ± 102** | 1098 ± 14 | **742 ± 129** | 1107 ± 7 |

Against the goals in #9093:

1. **"Comparable performance to Java's Semaphore when `threads < permits`"**: met, with room to spare. Uncontended this is **5.9x `series/2.x`** and **1.7x** either Java policy, where the issue reported ZIO being 5-6x slower than Java.
2. **"Comparable or better than `Semaphore(fair = false)` when `threads > permits`"**: not met at any permit count. This runs 16% behind at one permit, 18% at two, and 36-42% at five and ten. It is 3.5x to 16.4x faster than `series/2.x` throughout, so the regression against the goal is a gap to Java rather than to what ZIO had before.
3. **Specialized `permits = 1` implementation**: not done, and these numbers do not call for it. One permit is the strongest contended row relative to Java's fair policy, 1.58x, and it carries the largest gain over `series/2.x` of any row measured, 16.4x.

Against the *fair* Java semaphore, which is the policy-matched comparison, the contended picture is better than the headline goal suggests: 1.58x at one permit, 1.30x at two, then 0.70x and 0.65x at five and ten. Java's own fair policy pays a similar price for ordering, dropping to 586 at one permit where its unfair policy holds 1111, so a good part of the remaining gap against `fair = false` is the cost of FIFO ordering rather than of this implementation.

The one-permit contended row is the least stable measurement here. Repeated runs of it on this machine ranged from 928 to 1093 ops/s while the java column beside it held to within 1%, and its error bar varies with it. The table gives the most recent run; a reader reproducing this should expect that row to move.

## How the contended case got faster

Waking a granted waiter used to go through `FiberRuntime.tell`, which offers the fiber to a run queue and may `unpark` a worker to collect it. A JFR recording of the contended case put that single `ConcurrentLinkedQueue.offer` at 75 of 347 samples, the hottest leaf in the profile, above `runLoop` itself.

`FiberRuntime.tellResumeInline` instead runs the woken fiber on the calling thread when that thread already belongs to the fiber's executor. This is the same thing `interruptAs` has always done, for the same reason: the thread that just handed over a resource is the natural one to run whoever was waiting for it.

The gain is far larger than removing a queue offer would explain, because the effect is to stop wake-ups happening at all: the resumed fiber takes the permit and carries on rather than being scheduled behind the fiber that woke it. Instrumenting the wake site over ten fibers and three thousand acquisitions counted **nine** wake-ups at one permit and six at five, with everything else taking the fast path.

Measured by flipping the single call site that activates it, ten fibers, same session back to back: 8.4x at one permit, 9.9x at two, and no effect at all at five, where the intervals overlap completely. Without it the data structure alone measures 110 and 93 ops/s at one and two permits.

The nesting is bounded by a per-`Worker` counter capped at 128, claimed only on a worker this scheduler owns rather than any `ZScheduler.Worker`, since more than one scheduler can be live at once. The cap keeps a worker available to its own run queue; it is the number most worth questioning in review, and commit 2 records what lowering it costs.

## How the uncontended case got faster

`SemaphoreFastPathBenchmark` prices the interpreter nodes an uncontended `withPermit` builds, by running the acquisition chain directly rather than forking a fiber around every thousand acquisitions the way `SemaphorePermitBenchmark` does. As nanoseconds per acquisition over the cost of the guarded body alone:

| method | ops/s | ns/acq | over `baseline` | what it prices |
| ------ | ----: | -----: | --------------: | -------------- |
| `baseline` | 3599 | 27.8 | | the guarded body alone |
| `acquireReleaseOnly` | 2589 | 38.6 | +10.8 | the semaphore's CAS and release |
| `exitWithOnly` | 2340 | 42.7 | +14.9 | the fold and its `Exit` |
| `maskOnly` | 1310 | 76.3 | +48.5 | the two flag nodes |
| `withPermit` | 844 | 118.4 | +90.7 | all of it |

That ordering is the point: the `uninterruptibleMask` and its `restore` are 54% of what guarding costs, against 16% for the `exitWith` fold and 12% for the semaphore's own CAS and release. The fold looks like the obvious target and is worth a third of what the flag nodes are.

Both were then addressed. All three rows below are `withPermit`, built at three points of the branch and run in one session:

| `withPermit` at | ops/s | ns/acq | overhead | step |
| --------------- | ----: | -----: | -------: | ---: |
| before this branch | 845.1 ± 8.1 | 118.3 | 90.6 ns | |
| after `OnExitEffect` | 932.5 ± 25.6 | 107.2 | 78.0 ns | +10.3% |
| after `AcquireReleaseInline` | **1995.9 ± 9.7** | **50.1** | **22.1 ns** | +114.0% |

2.36x end to end on that path, with guarding overhead down 76%. The benchmark's other methods, which do not call `withPermits`, vary by 2.4% to 5.5% across the three builds, so the gain is this change and not drift. Re-measured at the tip of the branch, after the commits that follow, `withPermit` reads 1986 ± 17.

The second step is the interesting one. The uninterruptible region cannot simply be dropped: `runLoop` polls for interrupts once per dispatch, so an interrupt can land between taking the permits and installing their release, which is the leak `SemaphoreSpec` covers with a test that races an interrupt against the acquisition at a range of offsets. But the window only has to be *closed*, not made uninterruptible. The poll happens before the effect is matched, so an acquisition and a stack push performed inside a single `case` cannot be separated by one. `ZIO.AcquireReleaseInline` does exactly that, and the body then runs at the caller's own interruptibility without changing the flags twice to get there.

## Reviewer notes

- **This reaches outside `Semaphore`, deliberately and in separable commits.** `Executor` gains two `private[zio]` methods that default to refusing; `FiberRuntime` gains `tellResumeInline`; `ZIO` gains three `private[zio]` nodes. Nothing but `Semaphore` uses any of them today. Commit 2 states explicitly that it is not required for correctness, so a reviewer who wants the rewrite without the runtime hook can drop it and still have a working, faster `Semaphore`. Every addition is `private[zio]`.
- **The runtime additions have been surveyed for other callers and there are none.** Every other site in core that completes a waiter is either a one-shot latch, where the saving is a single scheduling round trip per call, or sits inside a drain loop where resuming inline would run user code while iteration state is held. `Queue` was tried and measured: it improves in seven of nine producer/consumer configurations and regresses 14-16% in the other two, so it is not part of this PR.
- **`makeUnfair` is not a performance switch.** Contended it is within the error bars of `make` at one, five and ten permits, and measurably *behind* it at two. Compare Java, where barging is worth 1111 against 586 at one permit. Under `withPermit` the cost of contention is dominated by suspending and rescheduling fibers rather than by the queueing policy, so the policy has proportionally less to win. The scaladoc says so.
- **Fair-mode semantics are preserved.** `available` still reports 0 whenever a fiber is queued, matching the `Ref`-based implementation, and FIFO ordering is tested.

## On reproducing these numbers

Absolute figures from these benchmarks are not stable across machines or sessions, and the variation can be larger than the differences being discussed. Earlier in this work a 32-core Windows host and this Linux one disagreed by more than 2x on ZIO's uncontended rows while agreeing within about 25% on the *Java* rows measured beside them. A difference falling almost entirely on the ZIO side points at the runtime and its scheduler rather than at the harness, and it means a figure carried over from another machine can invert a comparison outright.

So every conclusion above rests on rows measured against each other in one session on one machine, which is why the whole table, `series/2.x` column included, was re-taken at the tip of this branch rather than assembled from earlier runs. The java columns double as a control: they exercise no ZIO code, and they held to within 1% across sessions while the ZIO rows beside them moved by more, which is how the unstable one-permit row was identified as variance rather than as a change in this implementation. `SemaphorePermitBenchmark`'s scaladoc records the same warning next to its notes on fork and warmup counts.

## Tests and benchmarks

`SemaphoreSpec` goes from 9 to 31 tests, all under `nonFlaky`, covering FIFO ordering, permit conservation under concurrent acquisition and interruption, the granted-then-interrupted race, the unfair variant, interruption at the acquisition boundary on both the fast and slow paths, and the tombstone sweep. They are worth more than their line count suggests: the permit-conservation tests are what caught a double-grant race during development, and the two interruption-at-the-boundary tests are what would fail if `AcquireReleaseInline` got its window wrong.

Five benchmarks. `SemaphorePermitBenchmark` is the headline comparison and measures the Java semaphore two ways, because the framing matters more than it looks: driven on plain threads it is the honest target, while acquired from inside a fiber it parks a scheduler worker, the very thing ZIO's `Semaphore` exists to avoid, and scores several times *worse* than ZIO's. Only the thread-driven rows are quoted above. `SemaphoreFastPathBenchmark` prices the interpreter nodes on the uncontended path. `SemaphoreDrainBenchmark` and `SemaphoreDrainQueuedBenchmark` measure the acquire/release pair on `SemaphorePlatform` directly with an empty and a non-empty waiter queue, and `SemaphoreContendedBenchmark` carries a no-semaphore `baseline` row so the semaphore's share of a contended run can be read off directly.

Each benchmark's scaladoc records how to run it quickly and what governs its precision, since the full parameter sweep across all five takes over an hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV1BjtEjybL4bH4Wue4Sae