### PR TITLE
fix(zlayer): share sub-graphs in the layer macro instead of expanding every path

### DIFF
--- a/core-tests/shared/src/test/scala/zio/internal/macros/GraphSharingSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/internal/macros/GraphSharingSpec.scala
@@ -1,0 +1,136 @@
+package zio.internal.macros
+
+import zio.ZIOBaseSpec
+import zio.test._
+
+/**
+ * Regression tests for https://github.com/zio/zio/issues/11053.
+ *
+ * `Graph.buildNode` used to expand the dependency DAG into a tree, emitting one
+ * copy of a node's whole sub-graph for every distinct path that reached it. For
+ * a densely connected set of layers that is exponential in the number of
+ * layers: a ~100 layer application produced a `LayerTree` with tens of
+ * thousands of nodes, each of which becomes a real `ZipWithPar` (two forked
+ * fibers) at runtime. On the happy path `MemoMap` hid the cost, but when a
+ * layer failed the resulting interrupt `Cause`s were combined pairwise across
+ * the whole structure and exhausted the heap.
+ *
+ * These tests pin the structural property that prevents it: the emitted tree is
+ * linear in the size of the graph, not in the number of paths through it.
+ */
+object GraphSharingSpec extends ZIOBaseSpec {
+
+  private def node(value: String, inputs: List[String], outputs: List[String]): Node[String, String] =
+    Node(inputs, outputs, value)
+
+  /**
+   * Counts constructors up to `limit`, then stops. Bounding the walk matters:
+   * if sharing regresses, the tree really does contain hundreds of millions of
+   * nodes, and an unbounded traversal would hang (or stack overflow) instead of
+   * failing the assertion.
+   */
+  private def sizeUpTo(tree: LayerTree[String], limit: Int): Int = {
+    var count = 0
+    def loop(t: LayerTree[String]): Unit =
+      if (count <= limit) t match {
+        case LayerTree.Empty            => ()
+        case LayerTree.Value(_)         => count += 1
+        case LayerTree.ComposeH(l, r)   => count += 1; loop(l); loop(r)
+        case LayerTree.ComposeV(l, r)   => count += 1; loop(l); loop(r)
+        case LayerTree.Shared(_, t0)    => loop(t0)
+        case LayerTree.Ref(_)           => ()
+        case LayerTree.Defs(defs, body) =>
+          // Each definition is emitted once, so they all count toward the size.
+          defs.foreach { case (_, t0) => loop(t0) }
+          loop(body)
+      }
+    loop(tree)
+    count
+  }
+
+  /**
+   * A "diamond chain" of `n` layers where layer `i` depends on `i - 1` and `i -
+   * 2`. The number of distinct paths from the root to the leaves grows like the
+   * Fibonacci sequence, so the fully expanded tree is exponential in `n` while
+   * the graph itself has only `n` nodes.
+   */
+  private def diamondChain(n: Int): Graph[String, String] = {
+    val nodes = (0 until n).toList.map { i =>
+      val inputs = List(i - 1, i - 2).filter(_ >= 0).map(j => s"T$j")
+      node(s"layer$i", inputs, List(s"T$i"))
+    }
+    Graph(nodes, (a: String, b: String) => a == b, (_: String) => None)
+  }
+
+  def spec = suite("GraphSharingSpec")(
+    test("shares sub-graphs reachable by multiple paths") {
+      val graph = diamondChain(4)
+      graph.buildComplete(List("T3")) match {
+        case Left(errors) => assertNever(s"failed to build: $errors")
+        case Right(tree)  =>
+          // T3 depends on T2 and T1, and T2 also depends on T1, so T1 is
+          // reachable by two paths. It must be emitted once, as a `Shared`
+          // sub-tree that the second path reaches through a `Ref`.
+          //
+          // T0 is deliberately excluded: it has no inputs, and leaf nodes are
+          // not shared (a leaf is a single `Value`, so a `Ref` to it saves
+          // nothing, and sharing it risks conflating nodes that must stay
+          // distinct). It is therefore expected to appear more than once.
+          //
+          // Note this counts the *shared* representation. `fold` deliberately
+          // inlines `Ref`s, so folding would legitimately see T1 twice.
+          def emitted(t: LayerTree[String]): List[String] = t match {
+            case LayerTree.Empty          => Nil
+            case LayerTree.Value(v)       => List(v)
+            case LayerTree.ComposeH(l, r) => emitted(l) ++ emitted(r)
+            case LayerTree.ComposeV(l, r) => emitted(l) ++ emitted(r)
+            case LayerTree.Shared(_, t0)  => emitted(t0)
+            case LayerTree.Ref(_)         => Nil
+            case LayerTree.Defs(defs, body) =>
+              defs.flatMap { case (_, t0) => emitted(t0) } ++ emitted(body)
+          }
+
+          val values = emitted(tree)
+          assertTrue(
+            values.count(_ == "layer1") == 1,
+            values.count(_ == "layer2") == 1,
+            values.count(_ == "layer3") == 1
+          )
+      }
+    },
+    test("tree size stays linear in the number of layers") {
+      // A 26-layer diamond chain has 317,810 distinct root-to-leaf paths. With
+      // sharing the emitted tree is a couple of hundred nodes.
+      //
+      // `n` is deliberately modest: the old algorithm's cost is in *building*
+      // the tree, not walking it, so a larger chain would make a regression
+      // hang here rather than fail. At 26 the unshared tree is still built in
+      // well under a second, and the assertion below fails decisively.
+      val n = 26
+      // Generous: the shared tree is ~200 nodes, the unshared one 317,810. Any
+      // value between the two separates them, so the exact bound is not
+      // load-bearing. It only has to be far from both.
+      val limit = 2000
+      val graph = diamondChain(n)
+      graph.buildComplete(List(s"T${n - 1}")) match {
+        case Left(errors) => assertNever(s"failed to build: $errors")
+        case Right(tree) =>
+          val size = sizeUpTo(tree, limit)
+          assertTrue(size < limit)
+      }
+    },
+    test("expanding fold observes the same layers as the shared tree") {
+      // `fold` inlines `Ref`s so that rendering and unused-layer warnings see
+      // the logical graph. It must agree with the shared representation on
+      // which layers are present, regardless of `Shared`/`Ref` ordering.
+      val n     = 12
+      val graph = diamondChain(n)
+      graph.buildComplete(List(s"T${n - 1}")) match {
+        case Left(errors) => assertNever(s"failed to build: $errors")
+        case Right(tree) =>
+          val expected = (0 until n).map(i => s"layer$i").toSet
+          assertTrue(tree.toSet == expected, tree.toList.toSet == expected)
+      }
+    }
+  )
+}

--- a/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-2/zio/internal/macros/LayerMacroUtils.scala
@@ -65,7 +65,21 @@ private[zio] trait LayerMacroUtils {
         q"val ${TermName(memoizedNode.tree.toString)} = $expr"
       }
 
-      val layerExpr = tree.fold[LayerExpr](
+      // Names for shared sub-graphs. Each name denotes a single ZLayer
+      // *instance*, so ZLayer's MemoMap (which is keyed on identity) sees one
+      // entry per shared sub-graph instead of one per path through the
+      // dependency graph.
+      //
+      // `foldShared` emits these in dependency order, where a sub-graph is
+      // always preceded by every sub-graph it references, so a plain `val`
+      // suffices and each name is defined before its first use.
+      val sharedNames = collection.mutable.Map.empty[Int, TermName]
+      val sharedDefs  = collection.mutable.LinkedHashMap.empty[Int, Tree]
+
+      def sharedName(id: Int): TermName =
+        sharedNames.getOrElseUpdate(id, c.freshName(TermName("shared")))
+
+      val layerExpr = tree.foldShared[LayerExpr](
         z = reify(ZLayer.unit),
         value = memoList.toMap,
         composeH = {
@@ -75,7 +89,16 @@ private[zio] trait LayerMacroUtils {
         composeV = (lhs, rhs) => {
           usesCompose = true
           c.Expr(q"$compose($lhs, $rhs)")
-        }
+        },
+        // Recorded idempotently per id: the same sub-graph can be reached more
+        // than once, but must only be defined once. `foldShared` visits them in
+        // dependency order, which `sharedDefs` preserves.
+        shared = (id, layer) => {
+          val name: TermName = sharedName(id)
+          if (!sharedDefs.contains(id)) sharedDefs += (id -> q"val $name = $layer")
+          c.Expr(q"$name")
+        },
+        ref = id => c.Expr(q"${sharedName(id)}")
       )
 
       val traceVal = if (usesEnvironment || usesCompose) {
@@ -100,10 +123,14 @@ private[zio] trait LayerMacroUtils {
         Nil
       }
 
+      // `sharedDefs` is populated by the fold above, so it must be read after
+      // `layerExpr` has been forced. It is emitted in dependency order, after
+      // `definitions` (the individual layers), which its bodies refer to.
       c.Expr(q"""
         ..$traceVal
         ..$composeDef
         ..$definitions
+        ..${sharedDefs.values.toList}
         $layerExpr
       """)
     }

--- a/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
+++ b/core/shared/src/main/scala-3/zio/internal/macros/LayerMacroUtils.scala
@@ -111,7 +111,42 @@ private[zio] object LayerMacroUtils {
           ValDef
             .let(Symbol.spliceOwner, layerExprs.map(_.asTerm)) { idents =>
               val exprMap = layerExprs.zip(idents.map(_.asExprOf[ZLayer[_, E, _]])).toMap
-              tree.fold('{ ZLayer.unit }, exprMap, composeH, composeV).asTerm
+
+              // Bind every shared sub-graph to its own val, so that a sub-graph
+              // reachable by many paths through the dependency graph is built as
+              // a single ZLayer *instance*. ZLayer's MemoMap is keyed on
+              // identity, so this collapses what would otherwise be one copy of
+              // the sub-graph per path (see issue #11053).
+              val sharedRefs = collection.mutable.Map.empty[Int, Expr[ZLayer[_, E, _]]]
+
+              def fold(t: LayerTree[LayerExpr[E]]): LayerExpr[E] =
+                t.foldShared[LayerExpr[E]](
+                  '{ ZLayer.unit },
+                  exprMap,
+                  composeH,
+                  composeV,
+                  // Sub-trees are pre-bound by `bindAll` below, so by the time
+                  // the outer tree is folded every id already has an `Ident`.
+                  (id, _) => sharedRefs(id),
+                  id => sharedRefs(id)
+                )
+
+              // `sharedDefs` lists the sub-graphs in the order they were built,
+              // so each body only references ids bound before it. They become
+              // nested `ValDef.let`s, so every `Ident` exists before its first
+              // use. This is the same dependency ordering the Scala 2 emitter
+              // relies on for its `val` definitions.
+              def bindAll(ids: List[(Int, LayerTree[LayerExpr[E]])]): Term =
+                ids match {
+                  case Nil => fold(tree).asTerm
+                  case (id, body) :: rest =>
+                    ValDef.let(Symbol.spliceOwner, fold(body).asTerm) { ident =>
+                      sharedRefs(id) = ident.asExprOf[ZLayer[_, E, _]]
+                      bindAll(rest)
+                    }
+                }
+
+              bindAll(tree.sharedDefs)
             }
             .asExprOf[ZLayer[_, E, _]]
         }

--- a/core/shared/src/main/scala/zio/internal/macros/Graph.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/Graph.scala
@@ -2,6 +2,8 @@ package zio.internal.macros
 
 import zio.internal.macros.LayerTree._
 
+import scala.collection.mutable
+
 final case class Graph[Key, A](
   nodes: List[Node[Key, A]],
   keyEquals: (Key, Key) => Boolean,
@@ -37,18 +39,67 @@ final case class Graph[Key, A](
   private def findNodeWithOutput(output: Key): Option[Node[Key, A]] =
     nodes.find(_.outputs.exists(keyEquals(_, output))).orElse(unknownLayerFactory(output))
 
+  /**
+   * Assigns each node a stable id the first time it is built, so that a node
+   * reachable by many distinct paths through the dependency DAG contributes a
+   * single `Shared` sub-tree plus a `Ref` at every other use site, rather than
+   * a fresh copy of its whole sub-graph per path.
+   *
+   * Without this the emitted `LayerTree` has one leaf per distinct path through
+   * the graph, which is exponential in the number of layers.
+   */
+  // Keyed by identity, not by `Node`'s structural equality. Two distinct nodes
+  // can compare equal when their types and layer expressions look alike (an
+  // abstract type member such as `spec.Environment` is one way this happens),
+  // and sharing them would substitute one layer for another at runtime.
+  // `nodes` holds one instance per provided layer, so identity is the right
+  // notion here.
+  private val treeCache  = new java.util.IdentityHashMap[Node[Key, A], Integer]
+  private var nextTreeId = 0
+
+  /**
+   * Definitions of the shared sub-graphs, in the order they were built: a
+   * sub-graph is always preceded by every sub-graph it references.
+   *
+   * These are kept here rather than inline in the tree because the tree is
+   * still de-duplicated and recombined after it is built (see `distinct` below
+   * and `buildComplete`/`buildNodes`), which can drop a `Shared` node while
+   * leaving `Ref`s to it elsewhere. Holding the definitions separately means a
+   * `Ref` can never outlive its definition.
+   */
+  private val sharedDefs = mutable.ListBuffer.empty[(Int, LayerTree[A])]
+
+  def sharedSubTrees: List[(Int, LayerTree[A])] = sharedDefs.toList
+
   private def buildNode(
     node: Node[Key, A],
     seen: Set[Node[Key, A]]
   ): Either[::[GraphError[Key, A]], LayerTree[A]] =
-    forEach(node.inputs) { input =>
-      for {
-        out    <- getNodeWithOutput(input, error = GraphError.missingTransitiveDependency(node, input))
-        _      <- assertNonCircularDependency(node, seen, out)
-        result <- buildNode(out, seen + out)
-      } yield result
-    }.map {
-      _.distinct.combineHorizontally >>> LayerTree.succeed(node.value)
+    treeCache.get(node) match {
+      case null =>
+        forEach(node.inputs) { input =>
+          for {
+            out    <- getNodeWithOutput(input, error = GraphError.missingTransitiveDependency(node, input))
+            _      <- assertNonCircularDependency(node, seen, out)
+            result <- buildNode(out, seen + out)
+          } yield result
+        }.map { children =>
+          val body = children.distinct.combineHorizontally >>> LayerTree.succeed(node.value)
+          // A node with no inputs contributes a single leaf, so sharing it buys
+          // nothing and only risks conflating nodes that must stay distinct:
+          // `getNodeWithOutput` matches by subtyping, so one node can be
+          // returned for several different requested types (an abstract type
+          // member such as a spec's `Environment` is one way this arises).
+          if (node.inputs.isEmpty) body
+          else {
+            val id = nextTreeId
+            nextTreeId += 1
+            treeCache.put(node, id)
+            sharedDefs += (id -> body)
+            LayerTree.Shared(id, body)
+          }
+        }
+      case id => Right(LayerTree.Ref(id.intValue))
     }
 
   private def assertNonCircularDependency(

--- a/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerBuilder.scala
@@ -118,7 +118,11 @@ final case class LayerBuilder[Type, Expr](
       for {
         original    <- graph.buildComplete(target)
         sideEffects <- graph.buildNodes(sideEffectNodes)
-      } yield sideEffects ++ original
+      } yield
+      // Sibling de-duplication can drop a `Shared` node while leaving `Ref`s to
+      // it elsewhere in the tree, so the definitions are taken from the graph,
+      // which records every one, rather than from the tree itself.
+      LayerTree.withSharedDefs(sideEffects ++ original, graph.sharedSubTrees)
     }
 
     layerTreeEither match {

--- a/core/shared/src/main/scala/zio/internal/macros/LayerTree.scala
+++ b/core/shared/src/main/scala/zio/internal/macros/LayerTree.scala
@@ -1,6 +1,6 @@
 package zio.internal.macros
 
-import zio.internal.macros.LayerTree.{ComposeH, ComposeV, Empty, Value}
+import zio.internal.macros.LayerTree.{ComposeH, ComposeV, Defs, Empty, Ref, Shared, Value}
 import scala.collection.mutable
 
 sealed abstract class LayerTree[+A] extends Product with Serializable { self =>
@@ -11,17 +11,108 @@ sealed abstract class LayerTree[+A] extends Product with Serializable { self =>
   def ++[A1 >: A](that: LayerTree[A1]): LayerTree[A1] =
     if (self eq Empty) that else if (that eq Empty) self else ComposeH(self, that)
 
-  def fold[B](z: B, value: A => B, composeH: (B, B) => B, composeV: (B, B) => B): B = self match {
-    case Empty         => z
-    case Value(value0) => value(value0)
-    case ComposeH(left, right) =>
-      composeH(left.fold(z, value, composeH, composeV), right.fold(z, value, composeH, composeV))
-    case ComposeV(left, right) =>
-      composeV(left.fold(z, value, composeH, composeV), right.fold(z, value, composeH, composeV))
+  /**
+   * Folds over the tree, transparently expanding any sharing introduced by
+   * [[Shared]] / [[Ref]]. A `Ref` is folded as though the subtree it points at
+   * were inlined at that position, so consumers that care about the logical
+   * shape of the graph (rendering, unused-layer warnings) observe exactly the
+   * same result whether or not sharing is present.
+   */
+  def fold[B](z: B, value: A => B, composeH: (B, B) => B, composeV: (B, B) => B): B = {
+    // Index every shared sub-tree up front so that a `Ref` folds correctly
+    // regardless of whether it appears before or after its `Shared` definition.
+    val shared = mutable.LongMap.empty[LayerTree[A]]
+
+    def index(tree: LayerTree[A]): Unit = tree match {
+      case ComposeH(left, right) => index(left); index(right)
+      case ComposeV(left, right) => index(left); index(right)
+      case Shared(id, tree0)     => shared.update(id.toLong, tree0); index(tree0)
+      case Defs(defs, body) =>
+        defs.foreach { case (id, tree0) => shared.update(id.toLong, tree0) }
+        defs.foreach { case (_, tree0) => index(tree0) }
+        index(body)
+      case _ => ()
+    }
+
+    index(self)
+
+    def loop(tree: LayerTree[A]): B = tree match {
+      case Empty         => z
+      case Value(value0) => value(value0)
+      case ComposeH(left, right) =>
+        composeH(loop(left), loop(right))
+      case ComposeV(left, right) =>
+        composeV(loop(left), loop(right))
+      case Shared(_, tree0) =>
+        loop(tree0)
+      case Defs(_, body) =>
+        loop(body)
+      case Ref(id) =>
+        shared.get(id.toLong) match {
+          case Some(tree0) => loop(tree0)
+          case None        => z
+        }
+    }
+
+    loop(self)
   }
 
-  def map[B](f: A => B): LayerTree[B] =
-    fold[LayerTree[B]](Empty, a => Value(f(a)), ComposeH(_, _), ComposeV(_, _))
+  /**
+   * Folds over the tree without expanding sharing: each [[Shared]] subtree is
+   * visited exactly once and every [[Ref]] to it is folded via `ref`. This is
+   * what code generation uses, so that a shared sub-graph is emitted as a
+   * single `lazy val` and referenced by name everywhere else.
+   */
+  def foldShared[B](
+    z: B,
+    value: A => B,
+    composeH: (B, B) => B,
+    composeV: (B, B) => B,
+    shared: (Int, B) => B,
+    ref: Int => B
+  ): B = {
+    def loop(tree: LayerTree[A]): B = tree match {
+      case Empty         => z
+      case Value(value0) => value(value0)
+      case ComposeH(left, right) =>
+        composeH(loop(left), loop(right))
+      case ComposeV(left, right) =>
+        composeV(loop(left), loop(right))
+      case Defs(_, body) => loop(body)
+      case Shared(id, _) => ref(id)
+      case Ref(id)       => ref(id)
+    }
+
+    // `sharedDefs` lists the sub-graphs in the order they were built, so each
+    // one's body only refers to sub-graphs already folded. Every `Ref` in the
+    // tree therefore resolves to a name that has been bound by the time it is
+    // reached.
+    sharedDefs.foreach { case (id, body) => shared(id, loop(body)) }
+
+    loop(self)
+  }
+
+  /**
+   * The definitions of the shared sub-graphs, in the order they must be bound.
+   * Carried at the root of the tree rather than inline, because sibling
+   * de-duplication can drop a `Shared` node while leaving `Ref`s to it
+   * elsewhere.
+   */
+  def sharedDefs: List[(Int, LayerTree[A])] = self match {
+    case Defs(defs, _) => defs
+    case _             => Nil
+  }
+
+  def map[B](f: A => B): LayerTree[B] = self match {
+    case Empty                 => Empty
+    case Value(value0)         => Value(f(value0))
+    case ComposeH(left, right) => ComposeH(left.map(f), right.map(f))
+    case ComposeV(left, right) => ComposeV(left.map(f), right.map(f))
+    case Shared(id, tree)      => Shared(id, tree.map(f))
+    case Ref(id)               => Ref(id)
+    case Defs(defs, body) =>
+      Defs(defs.map { case (id, tree) => id -> tree.map(f) }, body.map(f))
+  }
 
   def toSet[A1 >: A]: Set[A1] = fold[Set[A1]](Set.empty[A1], Set(_), _ ++ _, _ ++ _)
 
@@ -33,10 +124,35 @@ object LayerTree {
   def succeed[A](value: A): LayerTree[A] = Value(value)
   def empty: LayerTree[Nothing]          = Empty
 
+  /**
+   * Attaches the definitions of the shared sub-graphs referenced by `tree`.
+   * `defs` must be ordered so that each definition only refers to earlier ones.
+   */
+  def withSharedDefs[A](tree: LayerTree[A], defs: List[(Int, LayerTree[A])]): LayerTree[A] =
+    if (defs.isEmpty) tree else Defs(defs, tree)
+
   case object Empty                                                      extends LayerTree[Nothing]
   final case class Value[+A](value: A)                                   extends LayerTree[A]
   final case class ComposeH[+A](left: LayerTree[A], right: LayerTree[A]) extends LayerTree[A]
   final case class ComposeV[+A](left: LayerTree[A], right: LayerTree[A]) extends LayerTree[A]
+
+  /**
+   * Marks `tree` as a shared sub-graph, identified by `id`. It appears exactly
+   * once in the overall tree; every other use site is a [[Ref]] carrying the
+   * same `id`.
+   */
+  final case class Shared[+A](id: Int, tree: LayerTree[A]) extends LayerTree[A]
+
+  /**
+   * Carries the definitions of every shared sub-graph alongside the tree that
+   * uses them. See [[LayerTree.sharedDefs]].
+   */
+  final case class Defs[+A](defs: List[(Int, LayerTree[A])], body: LayerTree[A]) extends LayerTree[A]
+
+  /**
+   * A reference to the [[Shared]] sub-graph with this `id`.
+   */
+  final case class Ref(id: Int) extends LayerTree[Nothing]
 
   implicit final class LayerComposeIterableOps[A](private val self: Iterable[LayerTree[A]]) extends AnyVal {
     def combineHorizontally: LayerTree[A] = self.foldLeft[LayerTree[A]](Empty)(_ ++ _)


### PR DESCRIPTION
Fixes #11053.

## The problem

`ZLayer.make`/`provide` expand the dependency DAG into a *tree*. `Graph.buildNode` recursed into each dependency without memoizing the result, so a node reachable by many paths contributed a fresh copy of its entire sub-graph per path. The `.distinct` in that method only de-duplicates siblings at a single level, never across the tree.

The emitted `LayerTree` therefore had one leaf per *path* rather than one per *layer*, which is exponential in the number of layers. A fan-in-2 chain of 40 layers expands to about 2.7e8 nodes.

Each composition node becomes a real `ZipWithPar` at runtime, which forks three scopes and two fibers (`ZLayer.scala:456`) before consulting the `MemoMap`.

On the happy path this is invisible: the `MemoMap` still builds each layer exactly once, which is why the reporter saw correct behaviour whenever every layer initialised. On failure it is not invisible. Every one of those forks is interrupted, and the interrupt causes are combined pairwise with `Cause.&&` (`Cause.scala:34`), which builds `Both` nodes without flattening or de-duplicating. The cause graph mirrors the whole expanded structure and exhausts the heap.

The user-visible symptom is that a missing config key surfaces as an `OutOfMemoryError` inside `Cause.mapAll` instead of as the underlying error.

## What this does

Memoize `buildNode` per node. The first visit emits a `LayerTree.Shared` sub-tree and every later one a `LayerTree.Ref`, so the tree stays linear in the size of the graph rather than the number of paths through it.

Both emitters bind each shared sub-graph to a single `val`. That is the part that matters at runtime: `MemoMap` is keyed on `ZLayer` *identity* (`ZLayer.scala:2368`), so one name means one instance means one memo entry, instead of one entry per path.

The definitions are held on the `Graph` rather than inline in the tree. Sibling de-duplication can drop a `Shared` node while leaving `Ref`s to it elsewhere, so the tree alone is not a reliable source of definitions; they are attached at the root as `LayerTree.Defs`, recorded in build order with dependencies first. Both emitters rely on that ordering, so each name is defined before its first use. Scala 3's `ValDef.let` binds strictly, and Scala 2 uses a plain `val` for the same reason.

Leaf nodes (those with no inputs) are deliberately not shared. A leaf is a single `Value`, so a `Ref` to it saves nothing, and sharing one risks conflating nodes that must stay distinct: `getNodeWithOutput` matches by subtyping, so a single node can be returned for several different requested types. An abstract type member makes that observable, which is how `ZTestJUnitRunner` first surfaced it: its target mentions `spec.Environment`, and `spec.bootstrap` outputs that same abstract type, so sharing collapsed it against `TestEnvironment.live` and the runner then failed with `Defect in zio.ZEnvironment: ... statically known to be contained within the environment are missing`.

`LayerTree.fold` still expands `Ref`s transparently, so rendering, `ZLayer.Debug` and the unused-layer warnings observe the same logical graph as before and needed no changes.

## Results

Measured on the reproducer from the issue (112 layers), against the real `Graph`/`LayerTree` code:

| | before | after |
| --- | ---: | ---: |
| `LayerTree` nodes | 62,645 | **484** |

End to end, running the reproducer:

| | `series/2.x` | this PR |
| --- | --- | --- |
| `-Xmx1G` | `OutOfMemoryError` after ~39s | reports the missing key, exits in ~5s |
| `-Xmx256M` | n/a | reports the missing key, exits in ~5s |

The three behaviours the issue asks for all hold: initialisation fails promptly, the `tapErrorCause` handler runs, and it names the missing key (`Missing data at config4`, at `CoreDependency8Impl.layer`).

## Tests

Adds `GraphSharingSpec`, which pins the structural property rather than the symptom, because an OOM test would be slow and heap-dependent.

Three tests: that a non-leaf node reachable by several paths is emitted once, that the tree stays linear in the number of layers, and that the expanding fold still observes every layer.

Chain lengths are deliberately modest (the size test uses 26 layers, 317,810 paths). The old algorithm's cost is in *building* the tree, not walking it, so a larger graph makes a regression hang rather than fail; at 26 the unshared tree still builds in well under a second and the assertion fails decisively. The size walk is bounded for the same reason.

Verified to fail without the fix: with memoization disabled, two of the three fail in under a second. (`LargeAutoWireSpec` also stops compiling with "Method too large", which is independent evidence of the code-size blowup.)

`coreTestsJVM/test` and `testJunitRunnerTests/test` pass on Scala 2.12.21 (2874), 2.13 (2887) and 3.3.8 (2889), including the existing layer, wiring-error, unused-layer-warning and finalizer-ordering suites. JS and Native were not exercised locally.

## Notes for review

- `Graph` is now stateful across `buildComplete`/`buildNodes`. That is fine as used, since `LayerBuilder` constructs one per macro expansion, but it is a change in character for the class.
- Leaf nodes are excluded from sharing on purpose (see above). Re-enabling it breaks `ZTestJUnitRunner`, so the exclusion is load-bearing rather than an optimisation.
- **Not fixed here:** the reproducer still reports ~640 nested interrupt causes for 112 layers, and the failure is still echoed ~30 times. That is survivable at 128M where it previously exhausted 1G, but it is more than the graph warrants, and I have not explained it. A single fiber's interrupt appears up to 60 times while the most-depended-on layer has only 24 direct dependents, so it is not simply one copy per dependent; the distinct-fiber count also varies run to run (52 to 77) at a stable ~640 total, which suggests scheduling plays a part.

  Four narrower changes were tried and none is included. Short-circuiting `Cause.&&` on `Empty` breaks two `CauseSpec` properties (`Both.equals`/`Then.equals` distributing `Then` over `Both` in the presence of `Empty`), so that operator's structure is load-bearing and cannot be changed. De-duplicating `&&` by reference never fires, because every call site is `cause.stripFailures && f.cause` and `stripFailures` rebuilds the cause through `foldLog`, allocating fresh nodes. Making `stripFailures` return `self` when there is no failure to strip is correct and passes, but rarely applies here since these causes do contain the config `Fail`. Skipping the `ZipWithPar` scope and fiber forks when both sides are already memoized is correct and passes all 2887 tests including the finalizer-ordering suites, but measured 642 to 630 interrupts, identical runtime, and 93ms versus 92ms on a probe built to hammer that path.

  The common reason is that the primary fix removes the conditions that made these matter: at 484 nodes instead of 62,645 there is little left for them to save. Reducing the remaining causes looks like it needs a change to what parallel failure *reports*, not to how it is stored, which is a larger and separately reviewable question.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV1BjtEjybL4bH4Wue4Sae
