### PR TITLE
Optimize flatMap over already-computed effects

### DIFF
--- a/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
+++ b/benchmarks/src/main/scala/zio/BenchmarkUtil.scala
@@ -42,9 +42,12 @@ object BenchmarkUtil extends Runtime[Any] { self =>
   override val unsafe = super.unsafe
 
   private object NoFiberRootsRuntime extends Runtime[Any] {
+    val environment  = Runtime.default.environment
+    val fiberRefs    = Runtime.default.fiberRefs
+    val runtimeFlags = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)
+    // Must come last: `Runtime.UnsafeAPIV1`s constructor reads `fiberRefs`, so
+    // initializing this first NPEs during class initialization and surfaces as
+    // a `NoClassDefFoundError` at every use site.
     override val unsafe = super.unsafe
-    val environment     = Runtime.default.environment
-    val fiberRefs       = Runtime.default.fiberRefs
-    val runtimeFlags    = RuntimeFlags(RuntimeFlag.CooperativeYielding, RuntimeFlag.Interruption)
   }
 }

--- a/benchmarks/src/main/scala/zio/RefGetBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/RefGetBenchmark.scala
@@ -1,0 +1,106 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Measures binding over an effect that is already a value.
+ *
+ * `Ref#get` is `ZIO.succeed(unsafe.get(..))` ascribed to `UIO[A]`, so the
+ * static type hides the fact that the runtime node is a `Sync`. Binding on it
+ * therefore builds a `FlatMap` whose `first` is already a value -- the shape
+ * that dominates ordinary `Ref`-based application code:
+ *
+ * {{{
+ *   for {
+ *     a <- refA.get
+ *     b <- refB.get
+ *     _ <- refA.set(a + b)
+ *   } yield ()
+ * }}}
+ *
+ * `@OperationsPerInvocation` normalises each score by that benchmark's own unit
+ * of work rather than reporting throughput of the whole loop. Note the units
+ * differ: `refGetFlatMap` and `refUpdateGet` divide by binds (one per
+ * iteration), while `refGetChained` divides by `Ref` reads (three per
+ * iteration, alongside a `map` and the loop's own bind that are not counted).
+ * Each benchmark is therefore comparable against itself across runs, but the
+ * three are not on a common scale with one another.
+ */
+@State(JScope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+@Threads(1)
+class RefGetBenchmark {
+  import BenchmarkUtil.unsafeRun
+  import RefGetBenchmark._
+
+  var ref: Ref[Int] = _
+
+  // Reset per iteration, not per trial, so every iteration starts from the
+  // same state rather than from wherever the preceding iterations left the
+  // counter. `refUpdateGet` boxes an `Integer` per update, and values in
+  // [-128, 127] come from the JVM's cache and allocate nothing, so a fixed
+  // starting point keeps that (small, ~13% at n=1000) effect identical across
+  // iterations and across both arms of an A/B.
+  @Setup(Level.Iteration)
+  def setup(): Unit =
+    ref = unsafeRun(Ref.make(0))
+
+  /** One bind over a `Ref#get`, repeated: the isolated per-bind cost. */
+  @Benchmark
+  @OperationsPerInvocation(size)
+  def refGetFlatMap(): Int = {
+    def loop(i: Int, acc: Int): UIO[Int] =
+      if (i >= size) Exit.succeed(acc)
+      else ref.get.flatMap(v => loop(i + 1, acc + v))
+
+    unsafeRun(loop(0, 0))
+  }
+
+  /**
+   * A for-comprehension over several `Ref` reads, as application code writes
+   * it. Normalised per `Ref` read: each iteration performs 3 of them (which
+   * desugar to two `flatMap`s over a `Sync` and one `map`).
+   */
+  @Benchmark
+  @OperationsPerInvocation(size * 3)
+  def refGetChained(): Int = {
+    def step: UIO[Int] =
+      for {
+        a <- ref.get
+        b <- ref.get
+        c <- ref.get
+      } yield a + b + c
+
+    def loop(i: Int, acc: Int): UIO[Int] =
+      if (i >= size) Exit.succeed(acc)
+      else step.flatMap(v => loop(i + 1, acc + v))
+
+    unsafeRun(loop(0, 0))
+  }
+
+  /** `update` then bind: the common read-modify-write shape. */
+  @Benchmark
+  @OperationsPerInvocation(size)
+  def refUpdateGet(): Int = {
+    def loop(i: Int): UIO[Int] =
+      if (i >= size) ref.get
+      else ref.update(_ + 1).flatMap(_ => loop(i + 1))
+
+    unsafeRun(loop(0))
+  }
+}
+
+object RefGetBenchmark {
+
+  /**
+   * Must be a compile-time constant so it can be used in
+   * `@OperationsPerInvocation`.
+   */
+  final val size = 1000
+}

--- a/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberRuntime.scala
@@ -1196,11 +1196,28 @@ final class FiberRuntime[E, A](fiberId: FiberId.Runtime, fiberRefs0: FiberRefs, 
 
               val first = flatmap.first
 
+              // When the sub-effect is already a value there is nothing to
+              // descend into: pushing a frame only to pop it on the very next
+              // iteration is pure bookkeeping. `ZIO.unit` is itself a `Sync`,
+              // so the check below is a special case that also skips the
+              // closure call.
               if (first eq ZIO.unit) cur = flatmap.successK(())
-              else {
-                stackIndex = pushStackFrame(flatmap, stackIndex)
-                cur = first
-              }
+              else
+                first match {
+                  case sync: Sync[Any] =>
+                    // Match the standalone Sync handler: the trace must be
+                    // current before `eval()` so that a non-fatal throw, which
+                    // is reported from `_lastTrace`, is attributed to the Sync
+                    // rather than to the enclosing flatMap. (The
+                    // `InterruptedException` handler below re-reads `cur.trace`
+                    // and so still attributes to the flatMap here.)
+                    updateLastTrace(sync.trace)
+                    cur = flatmap.successK(sync.eval())
+
+                  case _ =>
+                    stackIndex = pushStackFrame(flatmap, stackIndex)
+                    cur = first
+                }
 
             case fold: FoldZIO[Any, Any, Any, Any, Any] =>
               updateLastTrace(fold.trace)


### PR DESCRIPTION
## What

When a bind's sub-effect *already a value*, apply the continuation directly instead of pushing a stack frame and descending into it.

```scala
// FiberRuntime.runLoop, FlatMap case
if (first eq ZIO.unit) cur = flatmap.successK(())
else first match {
  case sync: Sync[Any] =>
    updateLastTrace(sync.trace)
    cur = flatmap.successK(sync.eval())
  case _ =>
    stackIndex = pushStackFrame(flatmap, stackIndex)
    cur = first
}
```

## Why

For `x.flatMap(k)` where `x` is already a value, the run loop currently:

1. pushes a frame for the `FlatMap`
2. sets `cur = x` and goes round the outer loop again
3. dispatches `x`, evaluates it, and the unwind pops the frame straight back off
4. applies `k`

Steps 1–3 are pure bookkeeping — a full outer-loop iteration (message drain, yield check, type dispatch, trace update) plus a push/pop pair, per bind. The continuation can simply be applied.

This generalises a shortcut already in the code: `if (first eq ZIO.unit)` is the same optimisation applied to one value.

Nothing is allocated that was not allocated before — this removes work rather than trading one object for another.

### The shape is common

`Ref#get` is `ZIO.succeed(unsafe.get(..))` ascribed to `UIO[A]`, so the static type hides the `Sync` and every bind on it builds a node whose `first` is already a value:

```scala
for {
  state  <- stateRef.get        // Sync -> FlatMap(Sync, k)  ← fast path
  config <- configRef.get       // ← fast path
  count  <- counterRef.updateAndGet(_ + 1)   // ← fast path
  result <- process(state, config)
} yield result
```

Effects that genuinely suspend — `Async`, `Stateful`, or a `FlatMap` over another `FlatMap` — still push a frame, as they must.

## Results

4-core Fedora 44 droplet, 7 GB, JDK 25.0.4.1. **The baseline arm was run first**, so ordering bias works against the change.

`RefGetBenchmark` (added in this PR) at `-f 8 -wi 5 -w 1 -i 3 -r 1`:

| Benchmark | before | after | change |
|---|---|---|---|
| `refGetFlatMap` *(isolated per bind)* | 53495257 ± 282060 | **71358738 ± 530654** | **+33.4%** |
| `refGetChained` *(for-comp over 3 `Ref` reads)* | 39741038 ± 190014 | **49557196 ± 592218** | **+24.7%** |
| `refUpdateGet` *(read-modify-write)* | 42945199 ± 839358 | **47838518 ± 465952** | **+11.4%** |

All three separated. An earlier run of the same A/B on different hardware reproduced the direction on every row, with magnitudes ranging from +12% to +33% — so read this as double-digit percent on `Ref`-style bind chains rather than as any single figure.

Two caveats on reading the table. Each row is normalised by its own unit of work, so the rows are comparable against themselves across arms but **not with one another** — `refGetFlatMap` divides by binds, `refGetChained` by `Ref` reads. And in `refGetChained` only 2 of the 4 binds per iteration take the fast path (the `map` and the outer loop bind do not), so its figure reflects a for-comprehension as a whole rather than a per-bind speedup.

**Allocation per op is identical**, confirming the win comes from removed transitions rather than changed allocation:

| Benchmark | before | after |
|---|---|---|
| `refGetFlatMap` | 88.424141 B/op | 88.424106 B/op |
| `refGetChained` | 101.474857 B/op | 101.474820 B/op |
| `refUpdateGet` | 112.460128 B/op | 112.463115 B/op |

`MapBenchmark.zioMap` was used as a control while developing the change: it builds `Mapped` nodes rather than binds over a `Sync`, so the fast path never fires. Across repeated A/Bs it did not move — its small delta overlapped and flipped sign with arm order, marking it as noise.

## For reviewer judgement: interruption and yield granularity are halved

This is the main thing to weigh, and it is a real trade-off rather than a wash.

Interruption is delivered only by `drainQueueWhileRunning` at the top of each run-loop iteration, and `ops` increments once per iteration. A `FlatMap` over a `Sync` previously consumed **two** iterations — one dispatching the `FlatMap`, one dispatching the `Sync` — so two drains and two `ops`. It now consumes **one**.

For a chain such as `def loop(i: Int): UIO[Unit] = ref.update(_ + 1).flatMap(_ => loop(i + 1))` — the shape `refUpdateGet` benchmarks — this means:

- the fiber performs roughly **twice as much work between interrupt checks**, so it takes about twice as long to observe an interrupt;
- an iteration now carries up to 2x the work, so while the `MaxOperationsBeforeYield` bound (10240) still holds *in iterations*, the fiber runs roughly twice as long before yielding, weakening executor fairness by the same factor.

Such chains remain interruptible — this is not a hang — but the wall-clock guarantee is genuinely weaker. The pre-existing `first eq ZIO.unit` shortcut already had this property; this widens it to all binds over a `Sync`.

A related consequence: an interrupt arriving between the `FlatMap` and `Sync` dispatches previously caused the failure unwind to skip the `FlatMap` frame, so `sync.eval()` never ran. It now runs unconditionally within the single iteration, so a side effect in `ZIO.succeed(...)` can fire in a window where interruption previously prevented it. `succeed` side effects are already best-effort, but it is an observable change.

If the reduced granularity is unacceptable, the only way to keep it is to drop the fast path entirely: `Sync` is the sole reachable case, so there is no narrower variant to retreat to.

## Stack safety: unaffected

The fast path is straight-line assignment with no JVM recursion, and since it neither pushes nor pops, `stackIndex` and `_stackSize` stay consistent — including when `sync.eval()` throws, as the outer handler re-enters from `_stackSize`, which was never touched.

The `updateLastTrace(sync.trace)` before `eval()` mirrors the standalone `Sync` handler: a non-fatal throw is reported from `_lastTrace`, so without it the resulting `Cause.die` would be attributed to the enclosing `flatMap` rather than to the `Sync` that actually threw.

One known rough edge: if `sync.eval()` throws `InterruptedException`, the inner handler does `updateLastTrace(cur.trace)` where `cur` is still the `FlatMap`, overwriting the `sync.trace` installed just before `eval()`. The resulting cause therefore carries the `flatMap`'s trace rather than the `Sync`'s. Previously `cur` was the `Sync` at that point and the call was a no-op. This affects only blocking `ZIO.succeed` bodies interrupted via `Thread.interrupt`; the non-fatal path is unaffected, as it reads `_lastTrace` directly.

## For reviewer judgement: `Supervisor.onEffect` sees fewer events

With `OpSupervision` enabled, a supervisor previously received one `onEffect` call for the `FlatMap` and another for the `Sync` it wrapped. The fast path elides the inner effect, so a supervisor counting or logging operations now sees roughly half as many events for `ZIO.succeed(x).flatMap(k)` chains.

Nothing in the repo asserts on this, so it would ship unnoticed. The pre-existing `first eq ZIO.unit` shortcut already behaves this way, so this widens an accepted inconsistency rather than introducing a new one — but it is a real observable change for anyone building profilers or op-counters on `onEffect`, and probably deserves a changelog line.

## The other commit: benchmark additions

`test(benchmarks): add RefGetBenchmark, and fix NoFiberRootsRuntime init order`

Two benchmark-infrastructure changes:

1. **`RefGetBenchmark`** — the `Ref`-bind shape had no coverage; the closest existing benchmark, `ForEachBenchmark.zioForEachIncrementRef`, is dominated by `ZIO.foreach` traversal machinery. Scores are normalised with `@OperationsPerInvocation`, each by its own unit of work (see the class comment: the three are not on a common scale with each other).

2. **`NoFiberRootsRuntime` init order fixed** — it declared `override val unsafe = super.unsafe` ahead of `environment`, `fiberRefs` and `runtimeFlags`, but `Runtime.UnsafeAPIV1`'s constructor reads `self.fiberRefs`, still null at that point, so the initializer threw and every use failed with `NoClassDefFoundError`. `ForkJoinBenchmark.zioForkDaemonJoinNoFiberRoots` is its only caller, so it has been silently producing nothing — meaning the `4812 ops/s` figure in that benchmark's own header comment **cannot currently be reproduced from the tree**. Moving `unsafe` below the vals it reads is sufficient; verified by running the benchmark against the current code (`NoClassDefFoundError`) and against the fix (runs normally).

The second item is unrelated to the run-loop change and separable; it is bundled because a reviewer checking fiber-fork performance is likely to reach for that benchmark and hit the crash.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV1BjtEjybL4bH4Wue4Sae
