### PR TITLE
docs(test): add Installation section, wire orphaned pages, add SEO frontmatter

### DIFF
--- a/docs/reference/test/index.md
+++ b/docs/reference/test/index.md
@@ -5,6 +5,22 @@ title: "Introduction to ZIO Test"
 
 **ZIO Test** is a zero dependency testing library that makes it easy to test effectual programs. In **ZIO Test**, all tests are immutable values and tests are tightly integrated with ZIO, so testing effectual programs is as natural as testing pure ones. 
 
+## Installation
+
+In order to use ZIO Test, we need to add the following lines to our `build.sbt` file:
+
+````scala mdoc:passthrough
+
+println("""```scala""")
+println(s"""libraryDependencies ++= Seq(
+  "dev.zio" %% "zio-test"     % "${zio.BuildInfo.version.split('+').head}" % Test,
+  "dev.zio" %% "zio-test-sbt" % "${zio.BuildInfo.version.split('+').head}" % Test
+)""")
+println("""```""")
+````
+
+For more details, including support for older sbt versions, the `zio-test-magnolia` module, and testing with live services, see the [Installation](installation.md) page.
+
 ## Motivation
 
 We can easily assert ordinary values and data types to test them:

--- a/docs/reference/test/index.md
+++ b/docs/reference/test/index.md
@@ -1,6 +1,12 @@
 ---
 id: index
 title: "Introduction to ZIO Test"
+description: "Learn how ZIO Test makes tests first-class, effectful values that are tightly integrated with ZIO, so testing effectual programs is as natural as testing pure ones."
+keywords:
+  - "ZIO Test"
+  - "Effectual Testing"
+  - "Testing Framework"
+  - "Property-Based Testing"
 ---
 
 **ZIO Test** is a zero dependency testing library that makes it easy to test effectual programs. In **ZIO Test**, all tests are immutable values and tests are tightly integrated with ZIO, so testing effectual programs is as natural as testing pure ones. 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -413,6 +413,7 @@ module.exports = {
             "reference/test/assertions/built-in-assertions",
           ]
         },
+        "reference/test/zio-test-diff",
         "reference/test/test-hierarchies-and-organization",
         "reference/test/sharing-layers-within-the-same-file",
         "reference/test/sharing-layers-between-multiple-files",
@@ -462,6 +463,7 @@ module.exports = {
             "reference/test/property-testing/getting-started",
             "reference/test/property-testing/how-generators-work",
             "reference/test/property-testing/built-in-generators",
+            "reference/test/property-testing/operators",
             "reference/test/property-testing/shrinking",
           ]
         }


### PR DESCRIPTION
## Summary
- Add a `## Installation` section to the ZIO Test introduction page (`docs/reference/test/index.md`) — ZIO Test ships as its own module (`zio-test`, `zio-test-sbt`), but the intro never showed the dependency needed to get started, only a full dedicated `installation.md` page not linked from the intro.
- Wire two orphaned pages into `website/sidebars.js` that existed on disk but weren't reachable from site navigation: `docs/reference/test/difference.md` (`zio.test.Diff`) and `docs/reference/test/property-testing/operators.md` (generator combinators).
- Add missing `description`/`keywords` front matter to the ZIO Test intro page, matching the convention used by sibling module intros (e.g. `docs/reference/sync/index.md`), for SEO/search consistency.

## Test plan
- [x] `sbt scalafmtAll` — clean
- [x] `sbt docs/mdoc` — 0 errors; only pre-existing, unrelated warnings (zio-aws/zio-blocks broken links); confirmed the new Installation section's `mdoc:passthrough` version interpolation renders correctly (`2.0.12`)
- [x] `sbt "++2.13; check"` — passes
- [x] `node --check website/sidebars.js` — valid syntax