### PR TITLE
docs: add Books and Courses sections to Resources page

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -14,6 +14,11 @@ Looking for something specific? It's probably already got a home:
 - [Zionomicon](https://www.zionomicon.com/) — the comprehensive book on ZIO, by John A. De Goes, Adam Fraser, and Milad Khajavi
 - [Effect-Oriented Programming](https://effectorientedprogramming.com/) — building complex applications with ZIO, by Bill Frasure, Bruce Eckel, and James Ward
 
+## Courses
+
+- [Alvin Alexander's ZIO video courses](https://www.learnscala.dev/my-courses) — free YouTube courses covering ZIO fundamentals, ZIO Streams, ZIO Kafka, and ZIO HTTP + Caliban
+- [Daniel Ciocîrlan's ZIO courses on Rock the JVM](https://rockthejvm.com/courses/zio) — paid courses covering ZIO fundamentals and the full-stack [ZIO Rite of Passage](https://rockthejvm.com/courses/zio-rite-of-passage)
+
 ## Stay in the loop
 
 - [Discord](https://discord.gg/2ccFBr4) — the most active place for ZIO discussion, help, and links to new community content as it's published

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -9,6 +9,11 @@ Looking for something specific? It's probably already got a home:
 - **Talks & conference recordings** → [Events](../events/index.md) (Functional Scala, ZIO World, weekly Zymposiums)
 - **API docs** → [Scaladoc](https://javadoc.io/doc/dev.zio/zio_3/latest/index.html)
 
+## Books
+
+- [Zionomicon](https://www.zionomicon.com/) — the comprehensive book on ZIO, by John A. De Goes, Adam Fraser, and Milad Khajavi
+- [Effect-Oriented Programming](https://effectorientedprogramming.com/) — building complex applications with ZIO, by Bill Frasure, Bruce Eckel, and James Ward
+
 ## Stay in the loop
 
 - [Discord](https://discord.gg/2ccFBr4) — the most active place for ZIO discussion, help, and links to new community content as it's published


### PR DESCRIPTION
## Summary
- Add a Books section to the Resources page: Zionomicon, Effect-Oriented Programming
- Add a Courses section: Alvin Alexander's free YouTube ZIO courses, Daniel Ciocîrlan's Rock the JVM ZIO courses

## Test plan
- [x] Rendered docs page locally to confirm markdown/links format correctly