### PR TITLE
Fix assertTrue lifting inside flatMap on Scala 2

### DIFF
--- a/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/SmartAssertionSpec.scala
@@ -21,6 +21,16 @@ object SmartAssertionSpec extends ZIOBaseSpec {
   private val company: Company = Company("Ziverge", List(User("Bobo", List.tabulate(2)(n => Post(s"Post #$n")))))
 
   def spec = suite("SmartAssertionSpec")(
+    test("assertTrue can be lifted inside flatMap") {
+      ZIO.succeed(1).flatMap(value => assertTrue(value == 1))
+    },
+    test("multiple assertTrue expressions can be lifted inside flatMap") {
+      ZIO.succeed(1).flatMap(value => assertTrue(value == 1, value > 0))
+    },
+    test("assertTrue can be lifted to an effect without requirements or errors") {
+      val effect: UIO[TestResult] = assertTrue(1 == 1)
+      effect
+    },
     suite("Array")(
       suite("==")(
         test("success") {

--- a/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
+++ b/test-tests/shared/src/test/scala/zio/test/TestSpec.scala
@@ -99,6 +99,19 @@ object TestSpec extends ZIOBaseSpec {
             not(containsString("3 == 4"))
         )
     },
+    test("fail-fast assertion by automatic lifting inside flatMap") {
+      for {
+        ref <- Ref.make(false)
+        spec = test("test") {
+                 ZIO.succeed(1).flatMap(value => assertTrue(value == 2, value > 0)) *>
+                   ref.set(true).as(assertCompletes)
+               }
+        summary   <- execute(spec)
+        continued <- ref.get
+      } yield assertTrue(!continued) &&
+        assert(summary.fail)(equalTo(1)) &&
+        assert(summary.failureDetails.unstyled)(containsString("value == 2"))
+    },
     test("composed assertions are lifted to ZIO and fully evaluated") {
       for {
         ref <- Ref.make(0)

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -55,8 +55,7 @@ object TestResult {
   def anySuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     anySuccesses(!assertCompletes, asserts.toSeq: _*)
 
-  // Assertions require no environment and fail with a defect. Keep R and E for source compatibility.
-  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[Any, Nothing, TestResult] =
+  implicit def liftTestResultToZIO(result: TestResult)(implicit trace: Trace): ZIO[Any, Nothing, TestResult] =
     if (result.isSuccess)
       ZIO.succeed(result)
     else

--- a/test/shared/src/main/scala/zio/test/TestArrow.scala
+++ b/test/shared/src/main/scala/zio/test/TestArrow.scala
@@ -55,7 +55,8 @@ object TestResult {
   def anySuccesses(asserts: Iterable[TestResult])(implicit trace: Trace, sourceLocation: SourceLocation): TestResult =
     anySuccesses(!assertCompletes, asserts.toSeq: _*)
 
-  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[R, E, TestResult] =
+  // Assertions require no environment and fail with a defect. Keep R and E for source compatibility.
+  implicit def liftTestResultToZIO[R, E](result: TestResult)(implicit trace: Trace): ZIO[Any, Nothing, TestResult] =
     if (result.isSuccess)
       ZIO.succeed(result)
     else


### PR DESCRIPTION
Fixes #8668.

On Scala 2, `foo.flatMap(value => assertTrue(value == 1))` can prevent the surrounding test suite from compiling with `macro has not been expanded`. The assertion macro expands, but the implicit `TestResult` conversion leaves an environment type unresolved, delaying `validateEnv`.

Give the conversion the concrete return type `ZIO[Any, Nothing, TestResult]`, matching its existing behavior: it requires no environment and either succeeds or dies. Remove its unused type parameters. The implementation and fail-fast behavior stay the same.

Regression coverage checks single and multiple assertions inside `flatMap`, conversion to `UIO[TestResult]`, and preservation of a failed assertion without executing the continuation.

Validation on the latest revision:

- The original reproduction and direct-call/effect-annotation smoke cases compile against the built fixed library. The original example and new `flatMap` regressions were confirmed to fail on unchanged upstream.
- Focused `SmartAssertionSpec` and `TestSpec` pass on Scala 2.13.18 (156 passed), 2.12.21 (154 passed, 2 ignored), and 3.3.8 (155 passed, 1 ignored).
- MiMa against `zio-test` 2.1.26 passes on all three Scala versions, without added compatibility filters. Scoped formatting checks pass.
- Before the unused-type-parameter cleanup, the full Scala 2.13 test-framework suite passed (924 passed, 29 ignored), core and streams test sources compiled on all three Scala versions, and the complete hosted CI matrix passed.

Prepared with OpenAI Codex assistance and tested locally.
