### PR TITLE
docs(website): center markdown tables

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -686,3 +686,11 @@ html.homepage-snap .fp-section {
     scroll-behavior: auto;
   }
 }
+
+/* ── Docs content: center markdown tables ─────────────────────────────── */
+/* Tables default to left-aligned within the content column when narrower
+   than it (e.g. artifact/platform-support matrices). Center them like images. */
+.markdown table {
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
## Summary
- Tables narrower than the content column currently render left-aligned, leaving unbalanced whitespace on the right (e.g. the Module Support table on the Platforms page added in #11212).
- Adds `.markdown table { margin-left: auto; margin-right: auto; }` in `custom.css` to center them site-wide, the same way images are already centered.