### PR TITLE
docs(core): gardening pass on reference/core section

### DIFF
--- a/docs/reference/core/cause.md
+++ b/docs/reference/core/cause.md
@@ -1,6 +1,13 @@
 ---
 id: cause
 title: "Cause"
+description: "Cause[E] losslessly encodes the full story of a fiber failure, including expected errors, defects, interruptions, and their sequential or parallel composition."
+keywords:
+  - "Cause"
+  - "Fiber Failure"
+  - "Error Handling"
+  - "Defects"
+  - "Interruption"
 ---
 
 The `ZIO[R, E, A]` effect is polymorphic in values of type `E` and we can work with any error type that we want, but there is a lot of information that is not inside an arbitrary `E` value. So as a result ZIO needs somewhere to store things like **unexpected errors or defects**, **stack and execution traces**, **cause of fiber interruptions**, and so forth.

--- a/docs/reference/core/cause.md
+++ b/docs/reference/core/cause.md
@@ -18,7 +18,7 @@ The following snippet shows how `Cause` is designed as a semiring data structure
 ```scala
 sealed abstract class Cause[+E] extends Product with Serializable { self =>
   import Cause._
-  def trace: Trace = ???
+  def trace: StackTrace = ???
 
   final def ++[E1 >: E](that: Cause[E1]): Cause[E1] = Then(self, that)
   final def &&[E1 >: E](that: Cause[E1]): Cause[E1] = Both(self, that)
@@ -26,9 +26,9 @@ sealed abstract class Cause[+E] extends Product with Serializable { self =>
 
 object Cause extends Serializable {
   case object Empty extends Cause[Nothing]
-  final case class Fail[+E](value: E, override val trace: Trace) extends Cause[E]
-  final case class Die(value: Throwable, override val trace: Trace) extends Cause[Nothing]
-  final case class Interrupt(fiberId: FiberId, override val trace: Trace) extends Cause[Nothing]
+  final case class Fail[+E](value: E, override val trace: StackTrace) extends Cause[E]
+  final case class Die(value: Throwable, override val trace: StackTrace) extends Cause[Nothing]
+  final case class Interrupt(fiberId: FiberId, override val trace: StackTrace) extends Cause[Nothing]
   final case class Stackless[+E](cause: Cause[E], stackless: Boolean) extends Cause[E]
   final case class Then[+E](left: Cause[E], right: Cause[E]) extends Cause[E]
   final case class Both[+E](left: Cause[E], right: Cause[E]) extends Cause[E]

--- a/docs/reference/core/exit.md
+++ b/docs/reference/core/exit.md
@@ -12,7 +12,7 @@ keywords:
 ---
 
 An `Exit[E, A]` value describes [how fibers end life](../fiber/fiber.md). It has two possible values:
-- `Exit.Success` contain a success value of type `A`. 
+- `Exit.Success` contains a success value of type `A`. 
 - `Exit.Failure` contains a failure [Cause](cause.md) of type `E`.
 
 This is how the `Exit` data type is defined:

--- a/docs/reference/core/exit.md
+++ b/docs/reference/core/exit.md
@@ -18,7 +18,7 @@ An `Exit[E, A]` value describes [how fibers end life](../fiber/fiber.md). It has
 This is how the `Exit` data type is defined:
 
 ```scala
-sealed abstract class Exit[+E, +A] extends Product with Serializable { self =>
+sealed trait Exit[+E, +A] extends ZIO[Any, E, A] { self =>
   // Exit operators
 }
 object Exit {

--- a/docs/reference/core/runtime.md
+++ b/docs/reference/core/runtime.md
@@ -25,7 +25,7 @@ So the most important thing we should keep in mind when we are working with a fu
 
 So how can ZIO run these workflows? This is where the ZIO Runtime System comes into play. Whenever we run an `unsafe.run` function, the Runtime System is responsible for stepping through all the instructions described by the ZIO effect and executing them.
 
-To simplify everything, we can think of a Runtime System like a black box that takes both the ZIO effect (`ZIO[R, E, A]`) and its environment (`R`). It will run this effect and return its result as an `Either[E, A]` value.
+To simplify everything, we can think of a Runtime System like a black box that takes both the ZIO effect (`ZIO[R, E, A]`) and its environment (`R`). It will run this effect and return its result as an [`Exit[E, A]`](exit.md) value.
 
 
 ![ZIO Runtime System](/img/zio-runtime-system.svg)

--- a/docs/reference/core/runtime.md
+++ b/docs/reference/core/runtime.md
@@ -1,6 +1,13 @@
 ---
 id: runtime
 title: "Runtime"
+description: "Runtime[R] executes ZIO effects within an environment R, bundling a thread pool, environment, and runtime configuration."
+keywords:
+  - "Runtime"
+  - "Runtime System"
+  - "Executor"
+  - "Fiber"
+  - "ZIO Effect Execution"
 ---
 ```scala mdoc:invisible
 import zio.{FiberRefs, Runtime, RuntimeFlags, Task, UIO, Unsafe, URIO, ZEnvironment, ZIO}

--- a/docs/reference/core/zio/io.md
+++ b/docs/reference/core/zio/io.md
@@ -1,6 +1,11 @@
 ---
-id: io
+id: "io"
 title: "IO"
+description: "Type alias for ZIO[Any, E, A] representing an effect with no environment requirements that may fail with an E or succeed with a value A."
+keywords:
+  - "IO"
+  - "ZIO Type Alias"
+  - "Effect Type"
 ---
 
 `IO[E, A]` is a type alias for `ZIO[Any, E, A]`, which represents an effect that has no requirements, and may fail with an `E`, or succeed with an `A`.

--- a/docs/reference/core/zio/io.md
+++ b/docs/reference/core/zio/io.md
@@ -30,7 +30,7 @@ So `IO` is equal to a `ZIO` that doesn't need any requirement.
 
 :::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
+[The `ZIO` data type](zio.md) is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
 Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 

--- a/docs/reference/core/zio/io.md
+++ b/docs/reference/core/zio/io.md
@@ -36,3 +36,7 @@ Often, we don't need such a piece of powerful machinery. So as a rule of thumb, 
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::
+
+## See Also
+
+- [Exceptional and Unexceptional Effects](../../error-management/exceptional-and-unexceptional-effects.md)

--- a/docs/reference/core/zio/rio.md
+++ b/docs/reference/core/zio/rio.md
@@ -1,6 +1,12 @@
 ---
-id: rio 
+id: "rio"
 title: "RIO"
+description: "Type alias for ZIO[R, Throwable, A] representing an effect requiring environment R that may fail with a Throwable or succeed with value A."
+keywords:
+  - "RIO"
+  - "ZIO Type Alias"
+  - "Throwable Effect"
+  - "Effect Type"
 ---
 
 `RIO[R, A]` is a type alias for `ZIO[R, Throwable, A]`, which represents an effect that requires an `R`, and may fail with a `Throwable` value, or succeed with an `A`.

--- a/docs/reference/core/zio/rio.md
+++ b/docs/reference/core/zio/rio.md
@@ -28,9 +28,9 @@ type RIO[-R, +A]  = ZIO[R, Throwable, A]
 So `RIO` is equal to a `ZIO` that requires `R`, and whose error channel is `Throwable`. It succeeds with `A`.
 
 
-:::note _Principle of Least Power_
+:::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
+[The `ZIO` data type](zio.md) is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
 Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 

--- a/docs/reference/core/zio/rio.md
+++ b/docs/reference/core/zio/rio.md
@@ -36,3 +36,7 @@ Often, we don't need such a piece of powerful machinery. So as a rule of thumb, 
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::
+
+## See Also
+
+- [Exceptional and Unexceptional Effects](../../error-management/exceptional-and-unexceptional-effects.md)

--- a/docs/reference/core/zio/task.md
+++ b/docs/reference/core/zio/task.md
@@ -1,6 +1,12 @@
 ---
-id: task 
+id: "task"
 title: "Task"
+description: "Type alias for ZIO[Any, Throwable, A] representing an effect with no environment requirements that may fail with a Throwable or succeed with a value."
+keywords:
+  - "Task"
+  - "ZIO Type Alias"
+  - "Throwable Effect"
+  - "Effect Type"
 ---
 
 `Task[A]` is a type alias for `ZIO[Any, Throwable, A]`, which represents an effect that has no requirements, and may fail with a `Throwable` value, or succeed with an `A`.

--- a/docs/reference/core/zio/task.md
+++ b/docs/reference/core/zio/task.md
@@ -34,7 +34,7 @@ If we want to be less precise and eliminate the need to think about requirements
 
 :::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
+[The `ZIO` data type](zio.md) is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
 Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 

--- a/docs/reference/core/zio/task.md
+++ b/docs/reference/core/zio/task.md
@@ -40,3 +40,7 @@ Often, we don't need such a piece of powerful machinery. So as a rule of thumb, 
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::
+
+## See Also
+
+- [Exceptional and Unexceptional Effects](../../error-management/exceptional-and-unexceptional-effects.md)

--- a/docs/reference/core/zio/uio.md
+++ b/docs/reference/core/zio/uio.md
@@ -51,7 +51,7 @@ def fib(n: Int): UIO[Int] =
 
 :::note Principle of Least Power
 
-The `ZIO` data type is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
+[The `ZIO` data type](zio.md) is the most powerful effect in the ZIO library. It helps us to model various types of workflows. On the other hand, the type aliases are a way of specializing the `ZIO` type for less powerful workflows. 
 
 Often, we don't need such a piece of powerful machinery. So as a rule of thumb, whenever we require a less powerful effect, it's better to use the appropriate specialized type alias.
 

--- a/docs/reference/core/zio/uio.md
+++ b/docs/reference/core/zio/uio.md
@@ -23,7 +23,7 @@ Let's see how the `UIO` type alias is defined:
 import zio.ZIO
 ```
 
-```scala
+```scala mdoc:silent
 type UIO[+A] = ZIO[Any, Nothing, A]
 ```
 
@@ -57,3 +57,7 @@ Often, we don't need such a piece of powerful machinery. So as a rule of thumb, 
 
 So there is no need to convert type aliases to the `ZIO` data type, and whenever the `ZIO` data type is required, we can use the most precise type alias to fit our workflow requirement.
 :::
+
+## See Also
+
+- [Exceptional and Unexceptional Effects](../../error-management/exceptional-and-unexceptional-effects.md)

--- a/docs/reference/core/zio/urio.md
+++ b/docs/reference/core/zio/urio.md
@@ -4,6 +4,9 @@ title: "URIO"
 description: "Type alias for ZIO[R, Nothing, A] representing an effect requiring environment R that cannot fail but succeeds with value A."
 keywords:
   - "URIO"
+  - "ZIO Type Alias"
+  - "Environment Effect"
+  - "Effect Type"
 ---
 
 `URIO[R, A]` is a type alias for `ZIO[R, Nothing, A]`, which represents an effect that requires an `R`, and cannot fail, but can succeed with an `A`.

--- a/docs/reference/core/zio/zio.md
+++ b/docs/reference/core/zio/zio.md
@@ -465,6 +465,8 @@ val suspendedEffect: RIO[Any, ZIO[Any, IOException, Unit]] =
 
 ## Mapping
 
+ZIO provides several ways to transform the success value of an effect.
+
 ### map
 
 We can change an `IO[E, A]` to an `IO[E, B]` by calling the `map` method with a function `A => B`. This lets us transform values produced by actions into other values.
@@ -629,6 +631,8 @@ ZIO.succeed("Hello").timeout(10.seconds)
 If an effect times out, then instead of continuing to execute in the background, it will be interrupted so no resources will be wasted.
 
 ## Error Management
+
+ZIO provides a rich set of combinators for surfacing, catching, falling back from, folding over, and retrying errors.
 
 ### Either
 

--- a/docs/reference/core/zio/zio.md
+++ b/docs/reference/core/zio/zio.md
@@ -163,7 +163,6 @@ val r3: ZIO[Any, NumberFormatException, Int] =
 4. **`ZIO.noneOrFail`**— It lifts an option into a ZIO value. If the option is empty it succeeds with `Unit` and if the option is defined it fails with a proper error type:
 
 - `ZIO.noneOrFail` fails with the content of the optional value.
-- `ZIO.noneOrFailUnit` fails with the `Unit` error type.
 - `ZIO.noneOrFailWith` fails with custom error type.
 
 ```scala mdoc:compile-only
@@ -219,12 +218,11 @@ The error type of the resulting effect will always be `Throwable`, because `Try`
 
 #### Future
 
-| Function              | Input Type                                       | Output Type        |
-|-----------------------|--------------------------------------------------|--------------------|
-| `fromFuture`          | `ExecutionContext => scala.concurrent.Future[A]` | `Task[A]`          |
-| `fromFutureJava`      | `java.util.concurrent.Future[A]`                 | `RIO[Blocking, A]` |
-| `fromFunctionFuture`  | `R => scala.concurrent.Future[A]`                | `RIO[R, A]`        |
-| `fromFutureInterrupt` | `ExecutionContext => scala.concurrent.Future[A]` | `Task[A]`          |
+| Function              | Input Type                                       | Output Type |
+|-----------------------|--------------------------------------------------|-------------|
+| `fromFuture`          | `ExecutionContext => scala.concurrent.Future[A]` | `Task[A]`   |
+| `fromFutureJava`      | `java.util.concurrent.Future[A]`                 | `Task[A]`   |
+| `fromFutureInterrupt` | `ExecutionContext => scala.concurrent.Future[A]` | `Task[A]`   |
 
 A `Future` can be converted into a ZIO effect using `ZIO.fromFuture`:
 
@@ -336,13 +334,13 @@ val printLine2: IO[IOException, String] =
 
 ##### Blocking Synchronous Side-Effects
 
-| Function                    | Input Type                          | Output Type                     |
-|-----------------------------|-------------------------------------|---------------------------------|
-| `blocking`                  | `ZIO[R, E, A]`                      | `ZIO[R, E, A]`                  |
-| `attemptBlocking`           | `A`                                 | `RIO[Blocking, A]`              |
-| `attemptBlockingCancelable` | `effect: => A`, `cancel: UIO[Unit]` | `RIO[Blocking, A]`              |
-| `attemptBlockingInterrupt`  | `A`                                 | `RIO[Blocking, A]`              |
-| `attemptBlockingIO`         | `A`                                 | `ZIO[Blocking, IOException, A]` |
+| Function                    | Input Type                                | Output Type          |
+|-----------------------------|--------------------------------------------|-----------------------|
+| `blocking`                  | `ZIO[R, E, A]`                            | `ZIO[R, E, A]`        |
+| `attemptBlocking`           | `A`                                       | `Task[A]`             |
+| `attemptBlockingCancelable` | `effect: => A`, `cancel: => URIO[R, Any]` | `RIO[R, A]`           |
+| `attemptBlockingInterrupt`  | `A`                                       | `Task[A]`              |
+| `attemptBlockingIO`         | `A`                                       | `IO[IOException, A]`  |
 
 By default, ZIO is asynchronous and all effects will be executed on a default primary thread pool which is optimized for asynchronous operations. As ZIO uses a fiber-based concurrency model, if we run **Blocking I/O** or **CPU Work** workloads on a primary thread pool, they are going to monopolize all threads of **primary thread pool**.
 

--- a/docs/reference/core/zio/zio.md
+++ b/docs/reference/core/zio/zio.md
@@ -663,11 +663,11 @@ def sqrt(io: UIO[Double]): IO[String, Double] =
 | `ZIO#catchAll`        | `E => ZIO[R1, E2, A1]`                                      | `ZIO[R1, E2, A1]` |
 | `ZIO#catchAllCause`   | `Cause[E] => ZIO[R1, E2, A1]`                               | `ZIO[R1, E2, A1]` |
 | `ZIO#catchAllDefect`  | `Throwable => ZIO[R1, E1, A1]`                              | `ZIO[R1, E1, A1]` |
-| `ZIO#catchAllTrace`   | `((E, Option[StackTrace])) => ZIO[R1, E2, A1]`              | `ZIO[R1, E2, A1]` |
+| `ZIO#catchAllTrace`   | `((E, StackTrace)) => ZIO[R1, E2, A1]`              | `ZIO[R1, E2, A1]` |
 | `ZIO#catchSome`       | `PartialFunction[E, ZIO[R1, E1, A1]]`                       | `ZIO[R1, E1, A1]` |
 | `ZIO#catchSomeCause`  | `PartialFunction[Cause[E], ZIO[R1, E1, A1]]`                | `ZIO[R1, E1, A1]` |
 | `ZIO#catchSomeDefect` | `PartialFunction[Throwable, ZIO[R1, E1, A1]]`               | `ZIO[R1, E1, A1]` |
-| `ZIO#catchSomeTrace`  | `PartialFunction[(E, Option[StackTrace]), ZIO[R1, E1, A1]]` | `ZIO[R1, E1, A1]` |
+| `ZIO#catchSomeTrace`  | `PartialFunction[(E, StackTrace), ZIO[R1, E1, A1]]` | `ZIO[R1, E1, A1]` |
 
 #### Catching All Errors
 
@@ -726,7 +726,7 @@ val primaryOrBackupData: IO[IOException, Array[Byte]] =
 | `foldCause`    | `failure: Cause[E] => B, success: A => B`                                            | `URIO[R, B]`     |
 | `foldZIO`      | `failure: E => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]`                         | `ZIO[R1, E2, B]` |
 | `foldCauseZIO` | `failure: Cause[E] => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]`                  | `ZIO[R1, E2, B]` |
-| `foldTraceZIO` | `failure: ((E, Option[StackTrace])) => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]` | `ZIO[R1, E2, B]` |
+| `foldTraceZIO` | `failure: ((E, StackTrace)) => ZIO[R1, E2, B], success: A => ZIO[R1, E2, B]` | `ZIO[R1, E2, B]` |
 
 Scala's `Option` and `Either` data types have `fold`, which lets us handle both failure and success at the same time. In a similar fashion, `ZIO` effects also have several methods that allow us to handle both failure and success.
 

--- a/docs/reference/core/zioapp.md
+++ b/docs/reference/core/zioapp.md
@@ -14,7 +14,7 @@ keywords:
 The `ZIOApp` trait is an entry point for a ZIO application that allows sharing layers between applications. It also
 provides us the ability to compose multiple ZIO applications.
 
-There is another simpler version of `ZIOApp` called `ZIOAppDefault`. We usually use `ZIOAppDefault` which uses the default ZIO environment (`ZEnv`).
+There is another simpler version of `ZIOApp` called `ZIOAppDefault`. We usually use `ZIOAppDefault`, which requires no environment (`Environment = Any`) beyond the built-in default services ZIO always provides (Clock, Console, Random, System).
 
 ## Running a ZIO effect
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -18,7 +18,8 @@ module.exports = {
     "reference/index",
     {
       type: "category",
-      label: "Core",
+      label: "Core Data Types",
+      link: { type: "doc", id: "reference/core/index" },
       collapsed: false,
       items: [
         "reference/core/zio/zio",


### PR DESCRIPTION
## Summary

Iterative gardening pass over `docs/reference/core/**` (ZIO, ZIO Type Aliases, ZIOApp, Runtime, Exit, Cause): fact-checked every type/method signature and behavioral claim against the actual ZIO source, fixed consistency and cross-link gaps, and cleaned up writing style.

- Removed stale ZIO 1.x claims (`Blocking` module references, `ZEnv`), corrected wrong return types (`Runtime.run` returns `Exit`, not `Either`; `attemptBlocking*`/`fromFutureJava` return types), removed docs for nonexistent methods (`noneOrFailUnit`, `fromFunctionFuture`)
- Fixed a `Trace`/`StackTrace` type mixup in `cause.md` and a stale `Exit` type definition in `exit.md`
- Fixed wrong `Option[StackTrace]` vs `StackTrace` signatures in `zio.md`'s trace-combinator tables
- Filled in missing/thin frontmatter (`description`, `keywords`) across `cause.md`, `runtime.md`, `task.md`, `rio.md`, `io.md`
- Added missing "See Also" cross-links and `ZIO` data-type links across the type-alias pages (`uio`/`urio`/`task`/`rio`/`io`) for structural parity
- Minor writing-style and grammar fixes
- Renamed sidebar label "Core" → "Core Data Types" to match actual content, and added the missing sidebar-to-index doc link so the category header navigates to `reference/core/index.md`

## Test plan

- [x] Manual fact-check of every changed signature/claim against `core/shared/src/main/scala/zio/` source
- [x] Verified all internal cross-links resolve to existing files
- [ ] CI build (mdoc/docs build, lint)