### PR TITLE
docs(control-flow): enrich reference page with cond, whenDiscard, and cross-links

### DIFF
--- a/docs/reference/control-flow/index.md
+++ b/docs/reference/control-flow/index.md
@@ -1,6 +1,14 @@
 ---
 id: index
 title: "Introduction to ZIO's Control Flow Operators"
+description: "Control-flow operators in ZIO: conditional branching (when, unless, cond), looping (loop, iterate, foreach), and resource bracketing."
+keywords:
+  - "Control Flow"
+  - "Conditional Operators"
+  - "Loop Operators"
+  - "foreach"
+  - "ZIO.cond"
+  - "Resource Bracketing"
 sidebar_label: "Control Flow"
 ---
 
@@ -47,6 +55,8 @@ def validateWeightOrFailZIO[R](weight: ZIO[R, Nothing, Double]): ZIO[R, String, 
 ```
 
 ## Conditional Operators
+
+ZIO provides several conditional combinators that let you branch on a boolean predicate or pattern-match an effectful value — the functional equivalents of Scala's `if` and `match` expressions.
 
 ### `when`
 
@@ -101,9 +111,52 @@ def myApp =
   }
 ```
 
+When the result of the conditional effect is not needed, use `ZIO#whenDiscard` or `ZIO.whenDiscard` — they return `Unit` instead of `Option[A]`, skipping the allocation. The effectful-predicate counterpart is `ZIO#whenZIODiscard`. The following example records an audit event only when the acting user is an administrator:
+
+```scala mdoc:compile-only
+import zio._
+
+def recordAuditEvent(event: String): ZIO[Any, Nothing, Unit] = ZIO.unit // placeholder
+
+def handleRequest(isAdmin: Boolean, event: String): ZIO[Any, Nothing, Unit] =
+  recordAuditEvent(event).whenDiscard(isAdmin)
+```
+
 ### `unless`
 
-The `ZIO.unless` and `ZIO#unless` operators are like `when` operators, but they are moral equivalent for the `if (!p) expression` construct.
+`ZIO#unless` runs an effect when a condition is **false** and returns `Option[A]` — the negated dual of `ZIO#when`. Reach for it any time you would write `effect.when(!condition)`, because `unless` expresses the intent as natural prose.
+
+A common pattern is a guard that skips side-effectful work when a condition is already satisfied. For example, sending a welcome notification only when the user has not opted out of emails reads clearly with `ZIO#unlessZIODiscard`:
+
+```scala mdoc:compile-only
+import zio._
+
+trait NotificationService {
+  def sendWelcome(userId: Long): ZIO[Any, Nothing, Unit]
+}
+
+trait UserRepository {
+  def hasOptedOut(userId: Long): ZIO[Any, Nothing, Boolean]
+}
+
+def onboardUser(
+  notifications: NotificationService,
+  users: UserRepository,
+  userId: Long
+): ZIO[Any, Nothing, Unit] =
+  notifications.sendWelcome(userId).unlessZIODiscard(users.hasOptedOut(userId))
+```
+
+When the result does not matter, prefer the `Discard` variants — they return `Unit` and skip the `Option` allocation:
+
+| Predicate type | Result needed | Right choice |
+|----------------|---------------|--------------|
+| Pure           | Yes           | `ZIO#unless` |
+| Pure           | No            | `ZIO#unlessDiscard` |
+| Effectful      | Yes           | `ZIO#unlessZIO` |
+| Effectful      | No            | `ZIO#unlessZIODiscard` |
+
+The companion-object forms (`ZIO.unless(p)(effect)` and `ZIO.unlessZIO(p)(effect)`) accept the effect as a second argument instead of as the receiver — useful when the effect is not naturally expressed as a method chain.
 
 ### `ifZIO`
 
@@ -121,6 +174,40 @@ def flipTheCoin: ZIO[Any, IOException, Unit] =
     onFalse = Console.printLine("Tail")
   )
 ```
+
+### `cond`
+
+`ZIO.cond` lifts a pure predicate into an effect that either succeeds with `result` or fails with `error` — a concise alternative to writing `if (predicate) ZIO.succeed(result) else ZIO.fail(error)`. Use it for validation logic that has a clear success path and a typed failure (see the [Error Management](../error-management/index.md) reference for how typed failures compose). It differs from `ZIO.when`, which returns `Option` rather than failing, and from `ZIO.ifZIO`, which takes an effectful predicate and effectful branches:
+
+```scala
+object ZIO {
+  def cond[E, A](predicate: => Boolean, result: => A, error: => E): IO[E, A]
+}
+```
+
+A typical use case is input validation before calling a downstream service. The following example rejects a withdrawal when the account balance is insufficient:
+
+```scala mdoc:compile-only
+import zio._
+
+case class Account(id: Long, balance: Double)
+case class InsufficientFunds(requested: Double, available: Double)
+
+def withdraw(account: Account, amount: Double): IO[InsufficientFunds, Account] =
+  ZIO.cond(
+    account.balance >= amount,
+    account.copy(balance = account.balance - amount),
+    InsufficientFunds(requested = amount, available = account.balance)
+  )
+```
+
+The table below contrasts the three operators for branching on a pure condition:
+
+| Operator      | Predicate | On false              | Return type              |
+|---------------|-----------|-----------------------|--------------------------|
+| `ZIO.cond`    | pure      | fail with typed error | `IO[E, A]`               |
+| `ZIO.when`    | pure      | return `None`         | `ZIO[R, E, Option[A]]`   |
+| `ZIO.ifZIO`   | effectful | run `onFalse` effect  | `ZIO[R, E, A]`           |
 
 ## Loop Operators
 
@@ -164,9 +251,9 @@ object MainApp extends scala.App {
 // 3
 ```
 
-In this example, we wrote a recursive function that prints numbers from 1 to 3. While the last effort doesn't use a mutable variable, it's not a pure solution. We have a `println` statement inside our solution, calling this function is not pure so the whole solution is not pure. We know that we can model effectful functions using the ZIO effect system. So let's try rewrite that using ZIO:
+In this example, we wrote a recursive function that prints numbers from 1 to 3. While the last effort doesn't use a mutable variable, it's not a pure solution. We have a `println` statement inside our solution, calling this function is not pure so the whole solution is not pure. We know that we can model effectful functions using the ZIO effect system. So let's rewrite that using ZIO:
 
-```scala
+```scala mdoc:compile-only
 import zio._
 import java.io.IOException
 
@@ -184,9 +271,8 @@ object MainApp extends ZIOAppDefault {
 
 ZIO provides some loop combinators that help us avoid the need to write explicit recursions. This means that we can do almost anything we want to do without using explicit recursions. Let's rewrite the last solution using `ZIO.loopDiscard`:
 
-```scala
+```scala mdoc:compile-only
 import zio._
-
 import java.io.IOException
 
 object MainApp extends ZIOAppDefault {
@@ -213,6 +299,7 @@ object ZIO {
   def loopDiscard[R, E, S](
     initial: => S
   )(cont: S => Boolean, inc: S => S)(body: S => ZIO[R, E, Any]): ZIO[R, E, Unit]
+}
 ```
 
 `ZIO.loop` collects all intermediate states in a list and returns it finally, while the `ZIO.loopDiscard` discards all results.
@@ -372,7 +459,20 @@ def getNames: ZIO[Any, IOException, List[String]] =
 
 ### `foreach`
 
-Note that, in several cases, we can avoid these low-level operators and instead use high-level ones. For example, let's try to rewrite the `r5` with `ZIO.foreach`:
+`ZIO.foreach` transforms every element of an existing collection by running an effect on each one in sequence, preserving the collection's shape in the result. Use `ZIO.foreach` when you already have an `Iterable`, `Set`, `Array`, `Map`, or `Option`; reach for `ZIO.loop` or `ZIO.iterate` only when the iteration range is computed at call time rather than given by an existing collection.
+
+The most commonly used variants are:
+
+```scala
+object ZIO {
+  def foreach[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]]
+  def foreachDiscard[R, E, A](in: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit]
+  def foreachPar[R, E, A, B](in: Iterable[A])(f: A => ZIO[R, E, B]): ZIO[R, E, List[B]]
+  def foreachParDiscard[R, E, A](in: Iterable[A])(f: A => ZIO[R, E, Any]): ZIO[R, E, Unit]
+}
+```
+
+For example, collecting three user-entered names reads more naturally with `ZIO.foreach` than with a `loop` that manually tracks an index state:
 
 ```scala mdoc:compile-only
 import zio._
@@ -381,14 +481,28 @@ Console.printLine("Please enter three names:") *>
   ZIO.foreach(1 to 3) { index =>
     Console.print(s"$index. ") *> Console.readLine
   }.debug
-// Please enter three names:
-// 1. John
-// 2. Jane
-// 3. Joe
-// Vector(John, Jane, Joe)
 ```
 
-## try/catch/finally
+When the individual effects are independent and can proceed concurrently, use `ZIO.foreachPar`. It runs each element on its own [fiber](../fiber/index.md) and returns results in the same order as the input, regardless of completion order. If any fiber fails, all remaining fibers are interrupted:
+
+```scala mdoc:compile-only
+import zio._
+
+case class UserId(value: Long)
+case class UserProfile(id: UserId, name: String)
+
+def fetchProfile(id: UserId): ZIO[Any, String, UserProfile] =
+  ZIO.succeed(UserProfile(id, s"User ${id.value}"))
+
+val userIds = List(UserId(1L), UserId(2L), UserId(3L))
+
+val profiles: ZIO[Any, String, List[UserProfile]] =
+  ZIO.foreachPar(userIds)(fetchProfile)
+```
+
+When only side effects matter and results are not needed, `ZIO.foreachDiscard` and `ZIO.foreachParDiscard` skip building the result collection and return `Unit` directly, avoiding the allocation cost.
+
+## `try`/`catch`/`finally`
 
 When working with resources, just like Scala's `try`/`catch`/`finally` construct, in ZIO we have a similar operator called `acquireRelease` and also `ensuring`. We discussed them in more detail in the [resource management section](../resource/index.md). But, for now, we want to focus on their control flow behaviors.
 

--- a/docs/reference/control-flow/index.md
+++ b/docs/reference/control-flow/index.md
@@ -201,7 +201,7 @@ def withdraw(account: Account, amount: Double): IO[InsufficientFunds, Account] =
   )
 ```
 
-The table below contrasts the three operators for branching on a pure condition:
+The table below contrasts three conditional-branching operators — `ZIO.cond` and `ZIO.when` accept a pure `Boolean` predicate, while `ZIO.ifZIO` accepts an effectful one:
 
 | Operator      | Predicate | On false              | Return type              |
 |---------------|-----------|-----------------------|--------------------------|

--- a/docs/reference/control-flow/index.md
+++ b/docs/reference/control-flow/index.md
@@ -58,7 +58,7 @@ def validateWeightOrFailZIO[R](weight: ZIO[R, Nothing, Double]): ZIO[R, String, 
 
 ZIO provides several conditional combinators that let you branch on a boolean predicate or pattern-match an effectful value — the functional equivalents of Scala's `if` and `match` expressions.
 
-### `when`
+### `ZIO.when` / `ZIO#when`
 
 We can also use ZIO's combinators that are the moral equivalent to these expressions:
 
@@ -122,7 +122,7 @@ def handleRequest(isAdmin: Boolean, event: String): ZIO[Any, Nothing, Unit] =
   recordAuditEvent(event).whenDiscard(isAdmin)
 ```
 
-### `unless`
+### `ZIO.unless` / `ZIO#unless`
 
 `ZIO#unless` runs an effect when a condition is **false** and returns `Option[A]` — the negated dual of `ZIO#when`. Reach for it any time you would write `effect.when(!condition)`, because `unless` expresses the intent as natural prose.
 
@@ -158,7 +158,7 @@ When the result does not matter, prefer the `Discard` variants — they return `
 
 The companion-object forms (`ZIO.unless(p)(effect)` and `ZIO.unlessZIO(p)(effect)`) accept the effect as a second argument instead of as the receiver — useful when the effect is not naturally expressed as a method chain.
 
-### `ifZIO`
+### `ZIO.ifZIO`
 
 This operator takes an _effectful predicate_, if that predicate is evaluated to true, it will run the `onTrue` effect, otherwise it will run the `onFalse` effect.
 
@@ -175,7 +175,7 @@ def flipTheCoin: ZIO[Any, IOException, Unit] =
   )
 ```
 
-### `cond`
+### `ZIO.cond`
 
 `ZIO.cond` lifts a pure predicate into an effect that either succeeds with `result` or fails with `error` — a concise alternative to writing `if (predicate) ZIO.succeed(result) else ZIO.fail(error)`. Use it for validation logic that has a clear success path and a typed failure (see the [Error Management](../error-management/index.md) reference for how typed failures compose). It differs from `ZIO.when`, which returns `Option` rather than failing, and from `ZIO.ifZIO`, which takes an effectful predicate and effectful branches:
 
@@ -286,7 +286,7 @@ object MainApp extends ZIOAppDefault {
 
 After this short introduction to writing loops in functional Scala, now let us go further into ZIO-specific combinators for writing loops:
 
-### `loop`
+### `ZIO.loop`
 
 The `ZIO.loop` operator takes an initial state, then repeatedly changes the state based on the given `inc` function, until the given `cont` function evaluates to true:
 
@@ -366,7 +366,7 @@ val r5: ZIO[Any, IOException, List[String]] =
 // List(John, Jane, Joe)
 ```
 
-### `iterate`
+### `ZIO.iterate`
 
 To iterate with the given effectful operation we can use the `ZIO.iterate` combinator. During each iteration, it uses an effectful `body` operation to change the state, and it will continue the iteration while the `cont` function evaluates to true:
 
@@ -457,7 +457,7 @@ def getNames: ZIO[Any, IOException, List[String]] =
 // List(John, Jane, Joe)
 ```
 
-### `foreach`
+### `ZIO.foreach`
 
 `ZIO.foreach` transforms every element of an existing collection by running an effect on each one in sequence, preserving the collection's shape in the result. Use `ZIO.foreach` when you already have an `Iterable`, `Set`, `Array`, `Map`, or `Option`; reach for `ZIO.loop` or `ZIO.iterate` only when the iteration range is computed at call time rather than given by an existing collection.
 

--- a/docs/reference/error-management/error-accumulation.md
+++ b/docs/reference/error-management/error-accumulation.md
@@ -30,7 +30,7 @@ object MainApp extends ZIOAppDefault {
 //	at <empty>.MainApp.run(MainApp.scala:12)"
 ```
 
-There is also the `ZIO.foreach` operator that takes a collection and an effectful operation, then tries to apply the transformation to all elements of the collection. This operator also has the same error management behavior. It fails when it encounters the first error:
+There is also the [`ZIO.foreach`](../control-flow/index.md) operator that takes a collection and an effectful operation, then tries to apply the transformation to all elements of the collection. This operator also has the same error management behavior. It fails when it encounters the first error:
 
 ```scala mdoc:compile-only
 import zio._

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -6,20 +6,21 @@ title: "Introduction"
 ZIO contains a few data types that can help you solve complex problems in asynchronous and concurrent programming. ZIO data types categorize into these sections:
 
 1. [Core Data Types](#core-data-types)
-2. [Scheduling](#scheduling)
-3. [Contextual Data Types](#contextual-data-types)
-4. [State Management](#state-management)
-5. [Concurrency](#concurrency)
+2. [Control Flow](#control-flow)
+3. [Scheduling](#scheduling)
+4. [Contextual Data Types](#contextual-data-types)
+5. [State Management](#state-management)
+6. [Concurrency](#concurrency)
     - [Fiber Primitives](#fiber-primitives)
     - [Concurrency Primitives](#concurrency-primitives)
     - [Synchronization Aids](#synchronization-aids)
     - [STM](#stm)
-6. [Resource Management](#resource-management)
-7. [Streaming](#streaming)
-8. [Logging](#logging)
-9. [Metrics](#metrics)
-10. [Testing](#testing)
-11. [Miscellaneous](#miscellaneous)
+7. [Resource Management](#resource-management)
+8. [Streaming](#streaming)
+9. [Logging](#logging)
+10. [Metrics](#metrics)
+11. [Testing](#testing)
+12. [Miscellaneous](#miscellaneous)
 
 ## Core Data Types
 - **[ZIO](core/zio/zio.md)** — `ZIO` is a value that models an effectful program, which might fail or succeed.
@@ -32,6 +33,10 @@ ZIO contains a few data types that can help you solve complex problems in asynch
 - **[Runtime](core/runtime.md)** — `Runtime[R]` is capable of executing tasks within an environment `R`.
 - **[Exit](core/exit.md)** — `Exit[E, A]` describes the result of executing an `IO` value.
 - **[Cause](core/cause.md)** — `Cause[E]` is a description of a full story of a fiber failure.
+
+## Control Flow
+
+- **[Control Flow](control-flow/index.md)** — ZIO's built-in conditional and looping combinators: `when`, `unless`, `cond`, `ifZIO`, `loop`, `iterate`, `foreach`, and `foreachPar`.
 
 ## Scheduling
 


### PR DESCRIPTION
## Summary
- Fixed writing-style violations (bare subheader, non-Title-Case heading, incomplete signature block, a grammar slip) and two mdoc modifier violations (plain ` ```scala ` blocks with runnable code) on `docs/reference/control-flow/index.md`
- Enriched the thin `unless` and `foreach` sections with motivation, contrast tables, and realistic examples
- Added the missing `cond` section and `whenDiscard`/`unlessDiscard` coverage
- Added page metadata (`description`, `keywords`) and outbound links to Error Management and Fiber
- Added Control Flow to the reference landing page's ToC/section list (it was missing entirely) and linked to it from `error-management/error-accumulation.md`

## Test plan
- [x] `sbt "docs/mdoc --in docs/reference/control-flow/index.md --out website/docs/reference/control-flow/index.md"` — 0 errors
- [ ] CI docs build