### PR TITLE
Add `getBytes` method to `zio.Config.Secret`

### DIFF
--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -69,17 +69,32 @@ object ConfigSpec extends ZIOBaseSpec {
         test("getBytes") {
           val secret = Secret("secret")
 
+          val charsets = Chunk(
+            java.nio.charset.StandardCharsets.US_ASCII,
+            java.nio.charset.StandardCharsets.ISO_8859_1,
+            java.nio.charset.StandardCharsets.UTF_8,
+            java.nio.charset.StandardCharsets.UTF_16,
+            java.nio.charset.StandardCharsets.UTF_16BE,
+            java.nio.charset.StandardCharsets.UTF_16LE,
+          )
+
           assertTrue(
-            secret.getBytes(java.nio.charset.StandardCharsets.UTF_8) ==
-              Chunk.fromArray("secret".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+            charsets.forall(charset => secret.getBytes(charset) == Chunk.fromArray("secret".getBytes(charset)))
           )
         } +
         test("getBytes with non-ASCII characters") {
           val secret = Secret("sécrét€")
 
+          val charsets = Chunk(
+            java.nio.charset.StandardCharsets.ISO_8859_1,
+            java.nio.charset.StandardCharsets.UTF_8,
+            java.nio.charset.StandardCharsets.UTF_16,
+            java.nio.charset.StandardCharsets.UTF_16BE,
+            java.nio.charset.StandardCharsets.UTF_16LE,
+          )
+
           assertTrue(
-            secret.getBytes(java.nio.charset.StandardCharsets.UTF_8) ==
-              Chunk.fromArray("sécrét€".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+            charsets.forall(charset => secret.getBytes(charset) == Chunk.fromArray("sécrét€".getBytes(charset)))
           )
         } +
         test("toString") {

--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -66,6 +66,22 @@ object ConfigSpec extends ZIOBaseSpec {
           Secret("abc": CharSequence)
           assertCompletes
         } +
+        test("getBytes") {
+          val secret = Secret("secret")
+
+          assertTrue(
+            secret.getBytes(java.nio.charset.StandardCharsets.UTF_8) ==
+              Chunk.fromArray("secret".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          )
+        } +
+        test("getBytes with non-ASCII characters") {
+          val secret = Secret("sécrét€")
+
+          assertTrue(
+            secret.getBytes(java.nio.charset.StandardCharsets.UTF_8) ==
+              Chunk.fromArray("sécrét€".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+          )
+        } +
         test("toString") {
           assertTrue(Secret("secret").toString() == "Secret(<redacted>)")
         } +

--- a/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/ConfigSpec.scala
@@ -5,7 +5,21 @@ import zio.test.Assertion._
 
 import zio.Config.Secret
 
+import java.nio.charset.{Charset, StandardCharsets}
+
 object ConfigSpec extends ZIOBaseSpec {
+
+  private val anyCharset: Gen[Any, Charset] =
+    Gen.fromIterable(
+      Chunk(
+        StandardCharsets.US_ASCII,
+        StandardCharsets.ISO_8859_1,
+        StandardCharsets.UTF_8,
+        StandardCharsets.UTF_16,
+        StandardCharsets.UTF_16BE,
+        StandardCharsets.UTF_16LE
+      )
+    )
 
   def boxTest[A](
     slow: ZIO[Any, Throwable, A],
@@ -66,36 +80,10 @@ object ConfigSpec extends ZIOBaseSpec {
           Secret("abc": CharSequence)
           assertCompletes
         } +
-        test("getBytes") {
-          val secret = Secret("secret")
-
-          val charsets = Chunk(
-            java.nio.charset.StandardCharsets.US_ASCII,
-            java.nio.charset.StandardCharsets.ISO_8859_1,
-            java.nio.charset.StandardCharsets.UTF_8,
-            java.nio.charset.StandardCharsets.UTF_16,
-            java.nio.charset.StandardCharsets.UTF_16BE,
-            java.nio.charset.StandardCharsets.UTF_16LE,
-          )
-
-          assertTrue(
-            charsets.forall(charset => secret.getBytes(charset) == Chunk.fromArray("secret".getBytes(charset)))
-          )
-        } +
-        test("getBytes with non-ASCII characters") {
-          val secret = Secret("sécrét€")
-
-          val charsets = Chunk(
-            java.nio.charset.StandardCharsets.ISO_8859_1,
-            java.nio.charset.StandardCharsets.UTF_8,
-            java.nio.charset.StandardCharsets.UTF_16,
-            java.nio.charset.StandardCharsets.UTF_16BE,
-            java.nio.charset.StandardCharsets.UTF_16LE,
-          )
-
-          assertTrue(
-            charsets.forall(charset => secret.getBytes(charset) == Chunk.fromArray("sécrét€".getBytes(charset)))
-          )
+        test("getBytes encodes like String#getBytes, for any content and charset") {
+          check(Gen.string, anyCharset) { (value, charset) =>
+            assertTrue(Secret(value).getBytes(charset) == Chunk.fromArray(value.getBytes(charset)))
+          }
         } +
         test("toString") {
           assertTrue(Secret("secret").toString() == "Secret(<redacted>)")

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -188,11 +188,15 @@ object Config {
      * materializing an intermediate `String`.
      */
     def getBytes(charset: java.nio.charset.Charset): Chunk[Byte] = {
-      val charBuffer = java.nio.CharBuffer.wrap(raw)
-      val byteBuffer = charset.encode(charBuffer)
-      val bytes      = Chunk.fromByteBuffer(byteBuffer)
-      if (byteBuffer.hasArray) java.util.Arrays.fill(byteBuffer.array(), 0.toByte)
-      bytes
+      val encoded = charset.encode(java.nio.CharBuffer.wrap(raw))
+      try {
+        val result = new Array[Byte](encoded.remaining())
+        encoded.get(result)
+        Chunk.fromArray(result)
+      } finally
+        // `encode` sizes its buffer from the charset's maximum bytes-per-char, so
+        // it generally holds more than `result`. Wipe all of it, slack included.
+        if (encoded.hasArray) java.util.Arrays.fill(encoded.array(), 0.toByte)
     }
   }
   object Secret extends (Chunk[Char] => Secret) {

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -181,6 +181,19 @@ object Config {
     def value: Chunk[Char] = Chunk.fromArray(raw)
 
     def stringValue = new String(raw)
+
+    /**
+     * Returns the bytes of this secret, encoded using the specified charset.
+     * The underlying characters are encoded directly, without ever
+     * materializing an intermediate `String`.
+     */
+    def getBytes(charset: java.nio.charset.Charset): Chunk[Byte] = {
+      val charBuffer = java.nio.CharBuffer.wrap(raw)
+      val byteBuffer = charset.encode(charBuffer)
+      val bytes      = Chunk.fromByteBuffer(byteBuffer)
+      if (byteBuffer.hasArray) java.util.Arrays.fill(byteBuffer.array(), 0.toByte)
+      bytes
+    }
   }
   object Secret extends (Chunk[Char] => Secret) {
     def apply(chunk: Chunk[Char]): Secret = new Secret(chunk.toArray)

--- a/core/shared/src/main/scala/zio/Config.scala
+++ b/core/shared/src/main/scala/zio/Config.scala
@@ -194,8 +194,10 @@ object Config {
         encoded.get(result)
         Chunk.fromArray(result)
       } finally
-        // `encode` sizes its buffer from the charset's maximum bytes-per-char, so
-        // it generally holds more than `result`. Wipe all of it, slack included.
+        // `encoded` holds the secret in plaintext; clear it rather than leave it
+        // on the heap until the GC happens to collect it. `encode` sizes the
+        // buffer from the charset's maximum bytes-per-char, so it is usually
+        // longer than the secret: zero all of it, not just the encoded region.
         if (encoded.hasArray) java.util.Arrays.fill(encoded.array(), 0.toByte)
     }
   }


### PR DESCRIPTION
## Summary

Adds `getBytes(charset: Charset): Chunk[Byte]` to `Config.Secret`, encoding the secret's characters straight to bytes.

The point is what it *doesn't* do. Today the only way to get bytes out of a `Secret` is `stringValue.getBytes(...)`, and that intermediate `String` is immutable: it can't be wiped and stays on the heap until the GC gets to it. That undercuts the reason `Secret` holds a mutable `char[]` in the first place (see `unsafe.wipe`). This goes from the underlying `Array[Char]` through `CharBuffer`/`Charset#encode` without ever materializing a `String`.

The encoder's own output buffer also holds the secret in plaintext, so it is zeroed in a `finally` before returning. `Charset#encode` sizes that buffer from the charset's maximum bytes-per-char, so it is usually longer than the secret — the whole array is cleared, not just the encoded region.

To be clear about the limits, since this is a `Secret`: that wipe is defence-in-depth, not a guarantee. The returned `Chunk[Byte]` is itself plaintext (that is what the caller asked for), and a moving GC can relocate an array before we clear it. What it does remove is the one extra copy this method creates and can reach.

## Implementation notes

`Chunk.fromArray` wraps rather than copies, so the result costs one allocation and one bulk copy. The copy is unavoidable: the encoder's buffer is over-allocated and has to be wiped, so its array can't be handed out directly.

## Testing

- `coreTestsJVM/testOnly zio.ConfigSpec -- -t Secret` — 13 tests pass. `getBytes` is covered by a property checking it agrees with `String#getBytes` for generated content across US-ASCII, ISO-8859-1, UTF-8, UTF-16, UTF-16BE and UTF-16LE.
- The change is in `core/shared`, so it was compiled on all three platforms: `coreJVM`, `coreJS` and `coreNative`.
