### PR TITLE
Slide in bulk instead of one slot at a time (#10885)

### DIFF
--- a/benchmarks/src/main/scala/zio/QueueSlidingBenchmark.scala
+++ b/benchmarks/src/main/scala/zio/QueueSlidingBenchmark.scala
@@ -1,0 +1,69 @@
+package zio
+
+import org.openjdk.jmh.annotations.{Scope => JScope, _}
+import zio.BenchmarkUtil._
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Exercises `Queue.Strategy.Sliding.handleSurplus`, which only runs once the
+ * queue is full: until then offers land in free space and the strategy is never
+ * consulted. The queue is filled once and never taken from, so it stays full
+ * for the whole trial and every measured offer slides.
+ *
+ * The `contended` variants run several fibers offering into the same full
+ * queue, so producers race for the space each slide frees. That is the case the
+ * bulk reservation is meant to help; the sequential ones are the control.
+ */
+@State(JScope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Measurement(iterations = 5, timeUnit = TimeUnit.SECONDS, time = 1)
+@Warmup(iterations = 3, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(1)
+class QueueSlidingBenchmark {
+
+  val queueSize   = 64
+  val batch       = 8
+  val parallelism = 4
+
+  var zioQ: Queue[Int]             = _
+  var values: List[Int]            = _
+  var offerOne: UIO[Unit]          = _
+  var offerMany: UIO[Unit]         = _
+  var offerOneParallel: UIO[Unit]  = _
+  var offerManyParallel: UIO[Unit] = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    zioQ = unsafeRun(Queue.sliding[Int](queueSize))
+    values = List.range(0, batch)
+    offerOne = zioQ.offer(0).unit
+    offerMany = zioQ.offerAll(values).unit
+    offerOneParallel = ZIO.forkAll(List.fill(parallelism)(zioQ.offer(0).unit)).flatMap(_.join).unit
+    offerManyParallel = ZIO.forkAll(List.fill(parallelism)(zioQ.offerAll(values).unit)).flatMap(_.join).unit
+    // fill to capacity so every measured offer goes through handleSurplus;
+    // nothing is ever taken, so the queue stays full for the whole trial
+    unsafeRun(zioQ.offerAll(List.range(0, queueSize)).unit)
+  }
+
+  /** One value into a full sliding queue: the `Chunk.single` path. */
+  @Benchmark
+  def slidingOffer(): Unit =
+    unsafeRun(offerOne)
+
+  /** A batch into a full sliding queue: where bulk reservation should pay. */
+  @Benchmark
+  def slidingOfferAll(): Unit =
+    unsafeRun(offerMany)
+
+  /** Single-value slides racing each other for the freed space. */
+  @Benchmark
+  def slidingOfferContended(): Unit =
+    unsafeRun(offerOneParallel)
+
+  /** Batched slides racing each other for the freed space. */
+  @Benchmark
+  def slidingOfferAllContended(): Unit =
+    unsafeRun(offerManyParallel)
+}

--- a/core-tests/shared/src/test/scala/zio/HubSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/HubSpec.scala
@@ -5,6 +5,46 @@ import zio.test.Assertion._
 
 object HubSpec extends ZIOBaseSpec {
 
+  /**
+   * A hub whose bulk `publishAll` rejects its first `failures` attempts,
+   * returning every value unplaced, simulating a competing publisher that
+   * claims the space freed by a concurrent `slide`.
+   *
+   * Only the members `unsafeSlidingPublish` actually calls are implemented.
+   */
+  final class FlakyPublishHub[A](failures: Int) extends zio.internal.Hub[A] {
+    private[this] var remaining: Int   = failures
+    private[this] var acceptedReversed = List.empty[A]
+
+    var publishAllCalls: Int = 0
+    var slideCalls: Int      = 0
+
+    def accepted: List[A] = acceptedReversed.reverse
+
+    val capacity: Int = 2
+
+    def publishAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
+      publishAllCalls += 1
+      if (remaining > 0) {
+        remaining -= 1
+        Chunk.fromIterable(as)
+      } else {
+        acceptedReversed = as.toList.reverse ::: acceptedReversed
+        Chunk.empty
+      }
+    }
+
+    def slide(): Unit = slideCalls += 1
+
+    // the stub never actually holds values, so it always has room
+    def size(): Int = 0
+
+    def publish(a: A): Boolean                        = ???
+    def isEmpty(): Boolean                            = ???
+    def isFull(): Boolean                             = ???
+    def subscribe(): zio.internal.Hub.Subscription[A] = ???
+  }
+
   val smallInt: Gen[Any, Int] =
     Gen.small(Gen.const(_), 1)
 
@@ -440,6 +480,32 @@ object HubSpec extends ZIOBaseSpec {
             assert(values2.filter(_ < 0))(equalTo(as.map(-_)))
         }
       }
-    )
+    ),
+    suite("sliding strategy loses the publish race (i10885)")(
+      test("retries the unplaced values rather than dropping them") {
+        // Simulates a competing publisher that claims the space freed by the
+        // `slide` inside `unsafeSlidingPublish`: the first `failures` bulk
+        // publishes come back entirely unplaced. The loop must retry with
+        // exactly those values, or they are silently dropped.
+        val failures = 1000
+        val hub      = new FlakyPublishHub[Int](failures)
+        Hub.Strategy.Sliding[Int]().unsafeSlidingPublish(Chunk(1, 2, 3), hub)
+        assertTrue(
+          // capacity is 2, so 1 cannot survive the slide
+          hub.accepted == List(2, 3),
+          hub.publishAllCalls == failures + 1,
+          // the stub always reports room, so nothing ever needs sliding out
+          hub.slideCalls == 0
+        )
+      },
+      test("terminates when the first bulk publish succeeds") {
+        val hub = new FlakyPublishHub[Int](0)
+        Hub.Strategy.Sliding[Int]().unsafeSlidingPublish(Chunk(1, 2, 3), hub)
+        assertTrue(
+          hub.accepted == List(2, 3),
+          hub.publishAllCalls == 1
+        )
+      }
+    ) @@ TestAspect.timeout(30.seconds)
   )
 }

--- a/core-tests/shared/src/test/scala/zio/QueueSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/QueueSpec.scala
@@ -2,6 +2,7 @@ package zio
 
 import zio.QueueSpecUtil._
 import zio.concurrent.CountdownLatch
+import zio.internal.MutableConcurrentQueue
 import zio.test.Assertion._
 import zio.test.TestAspect.{exceptJS, jvm, nonFlaky, samples, sequential}
 import zio.test._
@@ -933,11 +934,152 @@ object QueueSpec extends ZIOBaseSpec {
           } yield assertTrue(total == 5)
         )
         .map(_.foldLeft(assertTrue(true))(_ && _))
-    } @@ exceptJS(nonFlaky)
+    } @@ exceptJS(nonFlaky),
+    suite("sliding strategy loses the offer race (i10885)")(
+      test("retries the unplaced values rather than dropping them") {
+        // Simulates a competing producer that claims the space freed by the
+        // drop inside `unsafeSlidingOffer`: the first `failures` bulk offers
+        // come back entirely unplaced. The loop must retry with exactly those
+        // values, or they are silently dropped.
+        val failures = 1000
+        val queue    = new FlakyOfferQueue[Int](failures)
+        Queue.Strategy.Sliding[Int]().unsafeSlidingOffer(Chunk(1, 2, 3), queue)
+        assertTrue(
+          // capacity is 2, so 1 cannot survive the slide
+          queue.accepted == List(2, 3),
+          queue.offerAllCalls == failures + 1,
+          // the queue reports one free slot and two values are in hand, so
+          // each round drops exactly the one slot it is short
+          queue.pollCalls == failures + 1
+        )
+      },
+      test("terminates when the first bulk offer succeeds") {
+        val queue = new FlakyOfferQueue[Int](0)
+        Queue.Strategy.Sliding[Int]().unsafeSlidingOffer(Chunk(1, 2, 3), queue)
+        assertTrue(
+          queue.accepted == List(2, 3),
+          queue.offerAllCalls == 1
+        )
+      },
+      test("places every value against a producer that keeps stealing the space") {
+        // The queue starts full of another producer's values and refills every
+        // slot we free, for the first two rounds. `Enqueue.offerAll` documents
+        // that the sliding strategy "removes the old elements and enqueues the
+        // new ones" and "always returns no leftovers", so the loop must keep
+        // displacing until our values are in -- it may not give up, and the
+        // number of values it displaces to get there is not bounded.
+        var next  = 0
+        val queue = new EvictionWitnessQueue[Int](4, () => { next -= 1; next })
+        Queue.Strategy.Sliding[Int]().unsafeSlidingOffer(Chunk(1, 2, 3, 4), queue)
+        assertTrue(queue.contents == List(1, 2, 3, 4))
+      }
+    ) @@ TestAspect.timeout(30.seconds)
   )
 }
 
 object QueueSpecUtil {
+
+  /**
+   * A queue whose bulk `offerAll` rejects its first `failures` attempts,
+   * returning every value unplaced, simulating a competing producer that claims
+   * the space freed by a concurrent drop.
+   *
+   * It reports one free slot, so a drop sized by the shortfall and one sized by
+   * the whole batch differ, and `pollCalls` tells them apart.
+   *
+   * Only the members `unsafeSlidingOffer` calls are implemented.
+   */
+  final class FlakyOfferQueue[A](failures: Int) extends MutableConcurrentQueue[A] {
+    private[this] var remaining: Int   = failures
+    private[this] var acceptedReversed = List.empty[A]
+
+    var offerAllCalls: Int = 0
+    var pollCalls: Int     = 0
+
+    def accepted: List[A] = acceptedReversed.reverse
+
+    override val capacity: Int = 2
+
+    override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
+      offerAllCalls += 1
+      if (remaining > 0) {
+        remaining -= 1
+        Chunk.fromIterable(as)
+      } else {
+        acceptedReversed = as.toList.reverse ::: acceptedReversed
+        Chunk.empty
+      }
+    }
+
+    override def poll(default: A): A = {
+      pollCalls += 1
+      default
+    }
+
+    // one slot free, so the shortfall for the two values in hand is one, not
+    // two: a drop sized by `remaining.length` instead would poll twice
+    override def size(): Int = capacity - 1
+
+    override def offer(a: A): Boolean       = ???
+    override def pollUpTo(n: Int): Chunk[A] = ???
+    override def enqueuedCount(): Long      = ???
+    override def dequeuedCount(): Long      = ???
+    override def isEmpty(): Boolean         = ???
+    override def isFull(): Boolean          = ???
+  }
+
+  /**
+   * A full queue that hands every slot to a concurrent producer the moment we
+   * free one, so each round sees a queue that is full again of values we did
+   * not place.
+   *
+   * `evicted` records the values destroyed by our drops, for debugging a
+   * failure here; the contract this pins is that every value is placed, which
+   * `contents` shows.
+   */
+  final class EvictionWitnessQueue[A](override val capacity: Int, stolen: () => A) extends MutableConcurrentQueue[A] {
+    private[this] var rounds = 0
+
+    var contents: List[A] = Nil
+    var evicted: List[A]  = Nil
+
+    // start full of values belonging to someone else
+    contents = List.fill(capacity)(stolen())
+
+    override def poll(default: A): A =
+      contents match {
+        case Nil => default
+        case head :: rest =>
+          contents = rest
+          evicted = evicted :+ head
+          head
+      }
+
+    override def offerAll[A1 <: A](as: Iterable[A1]): Chunk[A1] = {
+      rounds += 1
+      val room = capacity - contents.length
+      // a competing producer refills every slot we freed before we can use it,
+      // for the first two rounds
+      if (rounds <= 2) {
+        contents = contents ::: List.fill(room)(stolen())
+        Chunk.fromIterable(as)
+      } else {
+        val (placed, unplaced) = as.toList.splitAt(room)
+        contents = contents ::: placed
+        Chunk.fromIterable(unplaced)
+      }
+    }
+
+    override def size(): Int = contents.length
+
+    override def offer(a: A): Boolean       = ???
+    override def pollUpTo(n: Int): Chunk[A] = ???
+    override def enqueuedCount(): Long      = ???
+    override def dequeuedCount(): Long      = ???
+    override def isEmpty(): Boolean         = ???
+    override def isFull(): Boolean          = ???
+  }
+
   def waitForValue[T](ref: UIO[T], value: T): UIO[T] =
     Live.live((ref <* Clock.sleep(10.millis)).repeatUntil(_ == value))
 

--- a/core/js/src/main/scala/zio/internal/Sync.scala
+++ b/core/js/src/main/scala/zio/internal/Sync.scala
@@ -23,4 +23,10 @@ private[zio] object Sync {
     val _ = anyRef
     f
   }
+
+  /**
+   * Scala.js is single threaded, so there is no other thread that could clear
+   * the contended state and nothing to wait for.
+   */
+  @inline def onSpinWait(): Unit = ()
 }

--- a/core/jvm-native/src/main/scala/zio/internal/Sync.scala
+++ b/core/jvm-native/src/main/scala/zio/internal/Sync.scala
@@ -20,4 +20,10 @@ import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 private[zio] object Sync {
   def apply[A](anyRef: AnyRef)(f: => A): A = anyRef.synchronized(f)
+
+  /**
+   * Hints to the runtime that the caller is in a busy-wait loop, so that it can
+   * avoid burning the carrier thread while the contended state clears.
+   */
+  @inline def onSpinWait(): Unit = Thread.onSpinWait()
 }

--- a/core/shared/src/main/scala/zio/Hub.scala
+++ b/core/shared/src/main/scala/zio/Hub.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.{MutableConcurrentQueue, Platform}
+import zio.internal.{MutableConcurrentQueue, Platform, Sync}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -308,7 +308,7 @@ object Hub {
    * A `Strategy[A]` describes the protocol for how publishers and subscribers
    * will communicate with each other through the hub.
    */
-  private sealed abstract class Strategy[A] {
+  private[zio] sealed abstract class Strategy[A] {
 
     /**
      * Describes how publishers should signal to subscribers that they are
@@ -384,7 +384,7 @@ object Hub {
     }
   }
 
-  private object Strategy {
+  private[zio] object Strategy {
 
     /**
      * A strategy that applies back pressure to publishers when the hub is at
@@ -503,27 +503,77 @@ object Hub {
         subscribers: java.util.Set[(internal.Hub.Subscription[A], MutableConcurrentQueue[Promise[Nothing, A]])],
         as: Iterable[A],
         isShutdown: AtomicBoolean
-      )(implicit trace: Trace): UIO[Boolean] = {
-        def unsafeSlidingPublish(as: Iterable[A]): Unit =
-          if (as.nonEmpty && hub.capacity > 0) {
-            val iterator = as.iterator
-            var a        = iterator.next()
-            var loop     = true
-            while (loop) {
-              hub.slide()
-              val published = hub.publish(a)
-              if (published && iterator.hasNext) {
-                a = iterator.next()
-              } else if (published && !iterator.hasNext) {
-                loop = false
-              }
-            }
-          }
-
+      )(implicit trace: Trace): UIO[Boolean] =
         ZIO.succeed {
-          unsafeSlidingPublish(as)
+          unsafeSlidingPublish(as, hub)
           unsafeCompleteSubscribers(hub, subscribers)
           true
+        }
+
+      /**
+       * Publishes values to the hub, dropping the oldest values to make room
+       * for the new ones.
+       *
+       * Only the last `capacity` values can survive, so we take those and
+       * publish them in bulk. There is no bulk `slide`, but `publishAll`
+       * reserves its space in one compare-and-set on the bounded hubs, rather
+       * than racing for one slot per value.
+       *
+       * We slide only the shortfall, the room the hub lacks, rather than once
+       * per value we still hold. Sliding `remaining.length` times every round
+       * would drop whatever occupies those slots now, which on a retry round
+       * can be values a concurrent publisher has already been told were
+       * accepted. `size` is approximate under concurrency, so the shortfall is
+       * a hint: too low costs another round, while too high destroys someone
+       * else's values, and we bias to the former.
+       *
+       * `publishAll` returns the values it could not place, which is what we
+       * retry with, never fewer, so a value is not dropped without being
+       * published. If a whole round places nothing then a concurrent publisher
+       * took the space we just freed, so hint that we are spinning.
+       *
+       * Exposed for testing.
+       */
+      private[zio] def unsafeSlidingPublish(as: Iterable[A], hub: internal.Hub[A]): Unit = {
+        val capacity = hub.capacity
+        if (as.nonEmpty && capacity > 0) {
+          val chunk = Chunk.fromIterable(as)
+          if (chunk.length == 1) unsafeSlidingPublishOne(chunk(0), hub)
+          else {
+            var remaining = chunk.takeRight(capacity)
+            while (remaining.nonEmpty) {
+              unsafeSlide(hub, remaining.length - (capacity - hub.size()))
+              val surplus = hub.publishAll(remaining)
+              if (surplus.length == remaining.length) Sync.onSpinWait()
+              remaining = surplus
+            }
+          }
+        }
+      }
+
+      /**
+       * The single value case, which `publish` always takes. Going through the
+       * bulk path would allocate a slice and a surplus chunk to move one value,
+       * so slide and publish it directly.
+       */
+      private def unsafeSlidingPublishOne(a: A, hub: internal.Hub[A]): Unit = {
+        var loop = true
+        while (loop) {
+          if (hub.size() >= hub.capacity) hub.slide()
+          if (hub.publish(a)) loop = false
+          else Sync.onSpinWait()
+        }
+      }
+
+      /**
+       * Slides up to `n` values out. There's no bulk `slide`, so this drops
+       * them one at a time, mirroring `Queue.Strategy.Sliding.unsafeDrop`.
+       */
+      private def unsafeSlide(hub: internal.Hub[A], n: Int): Unit = {
+        var i = n
+        while (i > 0) {
+          hub.slide()
+          i -= 1
         }
       }
 

--- a/core/shared/src/main/scala/zio/Queue.scala
+++ b/core/shared/src/main/scala/zio/Queue.scala
@@ -16,7 +16,7 @@
 
 package zio
 
-import zio.internal.MutableConcurrentQueue
+import zio.internal.{MutableConcurrentQueue, Sync}
 import zio.stacktracer.TracingImplicits.disableAutoTrace
 
 import java.util.concurrent.atomic.AtomicBoolean
@@ -319,7 +319,7 @@ object Queue extends QueuePlatformSpecific {
       }
   }
 
-  private sealed abstract class Strategy[A] {
+  private[zio] sealed abstract class Strategy[A] {
     private[this] val draining = new AtomicBoolean(false)
 
     def handleSurplus(
@@ -381,7 +381,7 @@ object Queue extends QueuePlatformSpecific {
       }
   }
 
-  private object Strategy {
+  private[zio] object Strategy {
 
     final case class BackPressure[A]() extends Strategy[A] {
       private[this] val notifying = new AtomicBoolean(false)
@@ -496,28 +496,79 @@ object Queue extends QueuePlatformSpecific {
         queue: MutableConcurrentQueue[A],
         takers: ConcurrentDeque[Promise[Nothing, A]],
         isShutdown: AtomicBoolean
-      )(implicit trace: Trace): UIO[Boolean] = {
-        def unsafeSlidingOffer(as: Iterable[A]): Unit =
-          if (!as.isEmpty && queue.capacity > 0) {
-            val iterator = as.iterator
-            var a        = iterator.next()
-            var loop     = true
-            val empty    = null.asInstanceOf[A]
-            while (loop) {
-              queue.poll(empty)
-              val offered = queue.offer(a)
-              if (offered && iterator.hasNext) {
-                a = iterator.next()
-              } else if (offered && !iterator.hasNext) {
-                loop = false
-              }
-            }
-          }
-
+      )(implicit trace: Trace): UIO[Boolean] =
         ZIO.succeed {
-          unsafeSlidingOffer(as)
+          unsafeSlidingOffer(as, queue)
           unsafeCompleteTakers(queue, takers)
           true
+        }
+
+      /**
+       * Slides values into the queue, dropping the oldest values to make room
+       * for the new ones.
+       *
+       * Only the last `capacity` values can survive, so we take those and move
+       * them in bulk: on a `RingBuffer` each of `pollUpTo` and `offerAll`
+       * reserves its space with a single compare-and-set, rather than racing
+       * for one slot per value.
+       *
+       * We drop only the shortfall, the room the queue lacks, rather than one
+       * slot per value we still hold. Dropping `remaining.length` every round
+       * would evict whatever occupies those slots now, which on a retry round
+       * can be values a concurrent producer has already been told were
+       * accepted. `size` is approximate under concurrency, so the shortfall is
+       * a hint: too low costs another round, while too high destroys someone
+       * else's values, and we bias to the former.
+       *
+       * `offerAll` returns the values it could not place, which is what we
+       * retry with, never fewer, so a value is not dropped without being
+       * offered. If a whole round places nothing then a concurrent producer
+       * took the space we just freed, so hint that we are spinning.
+       *
+       * Exposed for testing.
+       */
+      private[zio] def unsafeSlidingOffer(as: Iterable[A], queue: MutableConcurrentQueue[A]): Unit = {
+        val capacity = queue.capacity
+        if (as.nonEmpty && capacity > 0) {
+          val chunk = Chunk.fromIterable(as)
+          if (chunk.length == 1) unsafeSlidingOfferOne(chunk(0), queue)
+          else {
+            var remaining = chunk.takeRight(capacity)
+            while (remaining.nonEmpty) {
+              unsafeDrop(queue, remaining.length - (capacity - queue.size()))
+              val surplus = queue.offerAll(remaining)
+              if (surplus.length == remaining.length) Sync.onSpinWait()
+              remaining = surplus
+            }
+          }
+        }
+      }
+
+      /**
+       * The single value case, which `offer` always takes. Going through the
+       * bulk path would allocate a slice and a surplus chunk to move one value,
+       * so poll and offer it directly.
+       */
+      private def unsafeSlidingOfferOne(a: A, queue: MutableConcurrentQueue[A]): Unit = {
+        val empty = null.asInstanceOf[A]
+        var loop  = true
+        while (loop) {
+          if (queue.size() >= queue.capacity) queue.poll(empty)
+          if (queue.offer(a)) loop = false
+          else Sync.onSpinWait()
+        }
+      }
+
+      /**
+       * Drops up to `n` values. `pollUpTo` would build a chunk of them only for
+       * it to be discarded, so poll them one at a time instead.
+       */
+      private def unsafeDrop(queue: MutableConcurrentQueue[A], n: Int): Unit = {
+        val empty = null.asInstanceOf[A]
+        var i     = n
+        while (i > 0) {
+          queue.poll(empty)
+          i -= 1
         }
       }
 


### PR DESCRIPTION
Fixes the unbounded spin in `Queue.Strategy.Sliding` and `Hub.Strategy.Sliding` reported in #10885, and a data-loss bug found along the way.

## The problem

The `Sliding` strategies on `Queue` and `Hub` freed one slot and filled it per value, retrying the single `offer`/`publish` whenever a concurrent producer claimed that slot first:

```scala
while (loop) {
  queue.poll(empty)
  val offered = queue.offer(a)
  if (offered && iterator.hasNext) a = iterator.next()
  else if (offered && !iterator.hasNext) loop = false
  // !offered: neither branch fires, so retry with no backoff and no bound
}
```

Two defects, not one:

1. **The spin**, as reported: an unbounded, non-yielding retry that can pin a carrier thread under sustained contention.
2. **Over-dropping**, not previously reported: every lost round still calls `poll`/`slide` before the failed offer, so a contended sliding queue discards strictly more values than sliding semantics require, one extra per lost race with nothing inserted in exchange.

## The change

Take the last `capacity` values, since only those can survive a slide. Drop just the shortfall the queue lacks room for, then place the rest with one `offerAll`, which reserves its space in a single compare-and-set on a `RingBuffer` instead of racing per value. `offerAll` returns what it could not place, and that becomes the next round's input.

A lone value takes a direct poll-and-offer path, since routing it through the bulk machinery would allocate a slice and a surplus chunk to move one element. The bulk path drops with repeated `poll` rather than `pollUpTo`, whose chunk of dropped values would only be discarded.

## Benchmarks

New `QueueSlidingBenchmark`, against a full capacity-64 sliding queue. One JMH fork, 3x1s warmup, 5x1s measurement, so treat the throughput error bars as wide.

| Benchmark | Before | After | Alloc before | Alloc after |
| --- | --- | --- | --- | --- |
| `slidingOffer` | 16.183 ops/us | 16.283 ops/us | 520 B/op | 504 B/op |
| `slidingOfferAll` | 5.956 ops/us | 5.399 ops/us | 744 B/op | 720 B/op |

Throughput is at parity on the single-value path and within the noise on the batch path, while both allocate slightly less per operation.

Contended has no before number to compare against. Four fibers offering into one full sliding queue finish in 40s on this change; the same benchmark and parameters ran more than five minutes against the previous code without completing a single method.

An intermediate version lacking the single-value and allocation-free-drop paths cost 20% throughput and 104 B/op more on both shapes, which is what motivated them.

## What this does not do

The loop is still unbounded, non-yielding, and inside `ZIO.succeed`, so it remains uninterruptible. This narrows the busy-wait window rather than closing it.

Bounding the retries is not available. `Enqueue.offerAll` documents that the sliding strategy "removes the old elements and enqueues the new ones" and "always returns no leftovers", so the loop may not give up while values remain unplaced. Against a producer that keeps reclaiming the freed space it will keep displacing until its own values are in. Making it genuinely interruptible means lifting the retry out of the single `ZIO.succeed` and looping at the ZIO level, which is a larger change with its own costs.

## A note on the reported root cause

The issue describes the bug as "the iterator never advances". Not advancing is actually correct: the value has not been placed yet, so retrying the same value is what keeps it from being dropped. Acting on that reading literally, by advancing the iterator on the failure path, would silently lose a value per contended round.

## Testing

113 tests in `QueueSpec` and `HubSpec`, including stub-driven tests that drive the strategy loops directly. `unsafeSlidingOffer`/`unsafeSlidingPublish` are hoisted out of `handleSurplus` and take the queue/hub as a parameter so a stub can be injected; `Strategy` and its companion widen from `private` to `private[zio]` to allow that. Verified MiMa-clean.

- `FlakyOfferQueue` pins the shortfall: sizing the drop by the whole batch instead takes its `pollCalls` from 1001 to 2002.
- `EvictionWitnessQueue` pins the documented contract, that every value is placed and none returned, against a producer that keeps stealing the space.

## Caveats for reviewers

- Benchmarks are one JMH fork on a single Windows machine, so cross-JVM variance is uncaptured. The `slidingOfferAll` before-figure carried a +/-32% error bar. Worth a re-run at `-f 3` if the numbers matter to a decision.
- Scala Native is verified by CI only; it was not built or tested locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQ2xiByHcWiaBvt6tZCNF7
