### PR TITLE
fix(semaphore): reject requests exceeding maximum permits

### DIFF
--- a/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
+++ b/core-tests/shared/src/test/scala/zio/SemaphoreSpec.scala
@@ -78,6 +78,54 @@ object SemaphoreSpec extends ZIOBaseSpec {
         result == Exit.fail("exception")
       )
     },
+    test("make succeeds with 0 permits and available reports 0") {
+      for {
+        semaphore <- Semaphore.make(0L)
+        permits   <- semaphore.available
+      } yield assertTrue(permits == 0L)
+    },
+    test("withPermits acquires 0 permits from a semaphore created with 0 permits") {
+      for {
+        semaphore <- Semaphore.make(0L)
+        ans       <- semaphore.withPermits(0L)(ZIO.succeed("I got executed"))
+      } yield assertTrue(ans == "I got executed")
+    },
+    test("withPermit dies acquiring from a semaphore created with 0 permits") {
+      for {
+        semaphore <- Semaphore.make(0L)
+        ans       <- semaphore.withPermit(ZIO.unit).exit
+      } yield assert(ans)(dies(isSubtype[IllegalArgumentException](anything)))
+    },
+    test("tryWithPermit returns None acquiring from a semaphore created with 0 permits") {
+      for {
+        semaphore <- Semaphore.make(0L)
+        ans       <- semaphore.tryWithPermit(ZIO.succeed("Shouldn't get executed"))
+      } yield assertTrue(ans.isEmpty)
+    },
+    test("make succeeds with a negative number of permits and available reports it unchanged") {
+      for {
+        semaphore <- Semaphore.make(-1L)
+        permits   <- semaphore.available
+      } yield assertTrue(permits == -1L)
+    },
+    test("withPermits acquires 0 permits from a semaphore created with negative permits") {
+      for {
+        semaphore <- Semaphore.make(-1L)
+        ans       <- semaphore.withPermits(0L)(ZIO.succeed("I got executed"))
+      } yield assertTrue(ans == "I got executed")
+    },
+    test("withPermit dies acquiring from a semaphore created with negative permits") {
+      for {
+        semaphore <- Semaphore.make(-1L)
+        ans       <- semaphore.withPermit(ZIO.unit).exit
+      } yield assert(ans)(dies(isSubtype[IllegalArgumentException](anything)))
+    },
+    test("tryWithPermit returns None acquiring from a semaphore created with negative permits") {
+      for {
+        semaphore <- Semaphore.make(-1L)
+        ans       <- semaphore.tryWithPermit(ZIO.succeed("Shouldn't get executed"))
+      } yield assertTrue(ans.isEmpty)
+    },
     test("awaiting returns the count of waiting fibers") {
       for {
         semaphore    <- Semaphore.make(1)

--- a/core/shared/src/main/scala/zio/Semaphore.scala
+++ b/core/shared/src/main/scala/zio/Semaphore.scala
@@ -99,7 +99,8 @@ object Semaphore {
   object unsafe {
     def make(permits: Long)(implicit unsafe: Unsafe): Semaphore =
       new Semaphore {
-        val ref = Ref.unsafe.make[Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]](Right(permits))
+        val maxPermits = permits
+        val ref        = Ref.unsafe.make[Either[ScalaQueue[(Promise[Nothing, Unit], Long)], Long]](Right(permits))
 
         def available(implicit trace: Trace): UIO[Long] =
           ref.get.map {
@@ -142,6 +143,7 @@ object Semaphore {
         def tryReserve(n: Long)(implicit trace: Trace): UIO[Option[Reservation]] =
           if (n < 0) ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
           else if (n == 0L) ZIO.succeed(Some(Reservation.zero))
+          else if (n > maxPermits) ZIO.succeed(None)
           else
             ref.modify {
               case Right(permits) if permits >= n =>
@@ -154,6 +156,12 @@ object Semaphore {
             ZIO.die(new IllegalArgumentException(s"Unexpected negative `$n` permits requested."))
           else if (n == 0L)
             ZIO.succeed(Reservation.zero)
+          else if (n > maxPermits)
+            ZIO.die(
+              new IllegalArgumentException(
+                s"Cannot acquire `$n` permits from a semaphore with a maximum of `$maxPermits` permits."
+              )
+            )
           else
             Promise.make[Nothing, Unit].flatMap { promise =>
               ref.modify {


### PR DESCRIPTION
Prevents fibers from hanging indefinitely when requesting more permits than the semaphore's maximum capacity. Instead of queuing an impossible request that can never be satisfied, we now fail fast with a clear IllegalArgumentException.

## Changes

- Added `maxPermits` field to track semaphore capacity
- In `tryReserve()`: Return None if requested permits exceed maximum
- In `reserve()`: Fail with clear error message if requested permits exceed maximum

## Testing

Existing tests continue to pass. The fix handles all cases:
- Requests for exactly maxPermits: Succeeds
- Requests for less than maxPermits: Succeeds or queues if permits exhausted
- Requests for more than maxPermits: Fails immediately with clear error

Closes #11187

/claim #11187